### PR TITLE
Allow partial culture matching in Update-Help

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1561,10 +1561,13 @@ namespace System.Management.Automation.Internal
         internal static bool UseDebugAmsiImplementation;
         internal static bool BypassAppLockerPolicyCaching;
         internal static bool BypassOnlineHelpRetrieval;
-        internal static bool ThrowHelpCultureNotSupported;
         internal static bool ForcePromptForChoiceDefaultOption;
         internal static bool NoPromptForPassword;
         internal static bool ForceFormatListFixedLabelWidth;
+
+        // Update-Help tests
+        internal static bool ThrowHelpCultureNotSupported;
+        internal static CultureInfo CurrentUICulture;
 
         // Stop/Restart/Rename Computer tests
         internal static bool TestStopComputer;

--- a/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
@@ -550,7 +550,8 @@ namespace Microsoft.PowerShell.Commands
 #endif
                 catch (UpdatableHelpSystemException e)
                 {
-                    if (e.FullyQualifiedErrorId == "HelpCultureNotSupported")
+                    if (e.FullyQualifiedErrorId == "HelpCultureNotSupported"
+                            || e.FullyQualifiedErrorId == "UnableToRetrieveHelpInfoXml")
                     {
                         installed = false;
 

--- a/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
@@ -665,7 +665,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Culture check
-            if (!newHelpInfo.IsCultureSupported(culture))
+            if (!newHelpInfo.IsCultureSupported(culture.Name))
             {
                 throw new UpdatableHelpSystemException("HelpCultureNotSupported",
                     StringUtil.Format(HelpDisplayStrings.HelpCultureNotSupported,

--- a/src/System.Management.Automation/help/UpdatableHelpInfo.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpInfo.cs
@@ -43,9 +43,11 @@ namespace System.Management.Automation.Help
         /// <summary>
         /// Enumerates fallback chain (parents) of the culture, including itself.
         /// </summary>
+        /// <param name="culture">Culture to enumerate</param>
         /// <example>
+        /// Examples:
         /// en-GB => { en-GB, en }
-        /// zh-Hans-CN => { zh-Hans-CN, zh-Hans, zh }
+        /// zh-Hans-CN => { zh-Hans-CN, zh-Hans, zh }.
         /// </example>
         /// <returns>An enumerable list of culture names.</returns>
         internal static IEnumerable<string> GetCultureFallbackChain(CultureInfo culture)
@@ -72,7 +74,7 @@ namespace System.Management.Automation.Help
         /// <returns>True if supported, false if not.</returns>
         internal bool IsCultureSupported(string cultureName)
         {
-            Debug.Assert(cultureName != null);
+            Debug.Assert(cultureName != null, $"{nameof(cultureName)} may not be null");
             return GetCultureFallbackChain(Culture).Any(fallback => fallback == cultureName);
         }
     }
@@ -141,7 +143,7 @@ namespace System.Management.Automation.Help
         /// <returns>True if supported, false if not.</returns>
         internal bool IsCultureSupported(string cultureName)
         {
-            Debug.Assert(cultureName != null);
+            Debug.Assert(cultureName != null, $"{nameof(cultureName)} may not be null");
             return UpdatableHelpItems.Any(item => item.IsCultureSupported(cultureName));
         }
 

--- a/src/System.Management.Automation/help/UpdatableHelpInfo.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpInfo.cs
@@ -47,9 +47,11 @@ namespace System.Management.Automation.Help
         /// en-GB => { en-GB, en }
         /// zh-Hans-CN => { zh-Hans-CN, zh-Hans, zh }
         /// </example>
-        /// <returns>An enumerable list of cultures.</returns>
-        internal static IEnumerable<CultureInfo> GetCultureFallbackChain(CultureInfo culture)
+        /// <returns>An enumerable list of culture names.</returns>
+        internal static IEnumerable<string> GetCultureFallbackChain(CultureInfo culture)
         {
+            // We use just names instead because comparing two CultureInfo objects
+            // can fail if they are created using different means
             while (culture != null)
             {
                 if (string.IsNullOrEmpty(culture.Name))
@@ -57,7 +59,7 @@ namespace System.Management.Automation.Help
                     yield break;
                 }
 
-                yield return culture;
+                yield return culture.Name;
 
                 culture = culture.Parent;
             }
@@ -66,13 +68,12 @@ namespace System.Management.Automation.Help
         /// <summary>
         /// Checks if a culture is supported.
         /// </summary>
-        /// <param name="other">Culture to check.</param>
+        /// <param name="cultureName">Name of the culture to check.</param>
         /// <returns>True if supported, false if not.</returns>
-        internal bool IsCultureSupported(CultureInfo other)
+        internal bool IsCultureSupported(string cultureName)
         {
-            Debug.Assert(other != null);
-            // Check by name, as cultures created from different sources can sometime not match
-            return GetCultureFallbackChain(Culture).Any(fallback => fallback.Name == other.Name);
+            Debug.Assert(cultureName != null);
+            return GetCultureFallbackChain(Culture).Any(fallback => fallback == cultureName);
         }
     }
 
@@ -136,12 +137,12 @@ namespace System.Management.Automation.Help
         /// <summary>
         /// Checks if a culture is supported.
         /// </summary>
-        /// <param name="culture">Culture to check.</param>
+        /// <param name="cultureName">Name of the culture to check.</param>
         /// <returns>True if supported, false if not.</returns>
-        internal bool IsCultureSupported(CultureInfo culture)
+        internal bool IsCultureSupported(string cultureName)
         {
-            Debug.Assert(culture != null);
-            return UpdatableHelpItems.Any(item => item.IsCultureSupported(culture));
+            Debug.Assert(cultureName != null);
+            return UpdatableHelpItems.Any(item => item.IsCultureSupported(cultureName));
         }
 
         /// <summary>

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -293,6 +293,13 @@ namespace System.Management.Automation.Help
         internal IEnumerable<string> GetCurrentUICulture()
         {
             CultureInfo culture = CultureInfo.CurrentUICulture;
+
+            // Allow tests to override system culture
+            if (InternalTestHooks.CurrentUICulture != null)
+            {
+                culture = InternalTestHooks.CurrentUICulture;
+            }
+
             return CultureSpecificUpdatableHelp.GetCultureFallbackChain(culture);
         }
 

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -293,20 +293,10 @@ namespace System.Management.Automation.Help
         internal IEnumerable<string> GetCurrentUICulture()
         {
             CultureInfo culture = CultureInfo.CurrentUICulture;
-
-            while (culture != null)
+            foreach (var fallback in CultureSpecificUpdatableHelp.GetCultureFallbackChain(culture))
             {
-                if (string.IsNullOrEmpty(culture.Name))
-                {
-                    yield break;
-                }
-
-                yield return culture.Name;
-
-                culture = culture.Parent;
+                yield return fallback.Name;
             }
-
-            yield break;
         }
 
         #region Help Metadata Retrieval
@@ -591,13 +581,11 @@ namespace System.Management.Automation.Help
 
             if (!string.IsNullOrEmpty(currentCulture))
             {
-                IEnumerable<WildcardPattern> patternList = SessionStateUtilities.CreateWildcardsFromStrings(
-                    globPatterns: new[] { currentCulture },
-                    options: WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant);
-
+                // TODO: dkaszews: linq
+                // TOOD: dkaszews CultureInfo currentCulture
                 for (int i = 0; i < updatableHelpItem.Length; i++)
                 {
-                    if (SessionStateUtilities.MatchesAnyWildcardPattern(updatableHelpItem[i].Culture.Name, patternList, true))
+                    if (updatableHelpItem[i].IsCultureSupported(new CultureInfo(currentCulture)))
                     {
                         helpInfo.HelpContentUriCollection.Add(new UpdatableHelpUri(moduleName, moduleGuid, updatableHelpItem[i].Culture, uri));
                     }

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -293,10 +293,7 @@ namespace System.Management.Automation.Help
         internal IEnumerable<string> GetCurrentUICulture()
         {
             CultureInfo culture = CultureInfo.CurrentUICulture;
-            foreach (var fallback in CultureSpecificUpdatableHelp.GetCultureFallbackChain(culture))
-            {
-                yield return fallback.Name;
-            }
+            return CultureSpecificUpdatableHelp.GetCultureFallbackChain(culture);
         }
 
         #region Help Metadata Retrieval
@@ -581,11 +578,9 @@ namespace System.Management.Automation.Help
 
             if (!string.IsNullOrEmpty(currentCulture))
             {
-                // TODO: dkaszews: linq
-                // TOOD: dkaszews CultureInfo currentCulture
                 for (int i = 0; i < updatableHelpItem.Length; i++)
                 {
-                    if (updatableHelpItem[i].IsCultureSupported(new CultureInfo(currentCulture)))
+                    if (updatableHelpItem[i].IsCultureSupported(currentCulture))
                     {
                         helpInfo.HelpContentUriCollection.Add(new UpdatableHelpUri(moduleName, moduleGuid, updatableHelpItem[i].Culture, uri));
                     }

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -614,7 +614,7 @@ Describe 'help renders when using a PAGER with a space in the path' -Tags 'CI' {
     }
 }
 
-Describe 'Help allows partial matches' -Tags 'CI', 'dkaszews' {
+Describe 'Help allows partial matches' -Tags 'CI' {
     BeforeAll {
         function Test-UpdateHelpAux($UICulture, $Pass)
         {

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -637,7 +637,7 @@ Describe 'Update-Help allows partial culture matches' -Tags 'CI' {
     }
 
     AfterEach {
-        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('CurrentUICultre', $null)
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('CurrentUICulture', $null)
     }
 
     It 'Checks culture match against en-US: <UICulture>' -TestCases @(

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -614,18 +614,21 @@ Describe 'help renders when using a PAGER with a space in the path' -Tags 'CI' {
     }
 }
 
-Describe 'Help allows partial matches' -Tags 'CI' {
+Describe 'Update-Help allows partial culture matches' -Tags 'CI' {
     BeforeAll {
         function Test-UpdateHelpAux($UICulture, $Pass)
         {
             # If null (in system culture tests), omit entirely
             $CultureArg = $UICulture ? @{ UICulture = $UICulture } : @{}
-            $ModuleName = 'Microsoft.PowerShell.Core'
-            $HelpContentPath = Join-Path $PSScriptRoot 'assets'
-            $ErrorAction = $Pass ? 'Stop' : 'SilentlyContinue'
-            $ErrorVariable = $null
+            $Args = @{
+                Module = 'Microsoft.PowerShell.Core'
+                SourcePath = Join-Path $PSScriptRoot 'assets'
+                Force = $true
+                ErrorAction = $Pass ? 'Stop' : 'SilentlyContinue'
+                ErrorVariable = 'ErrorVariable'
+            }
 
-            Update-Help -Module $ModuleName -SourcePath $HelpContentPath -Force @CultureArg -ErrorAction $ErrorAction -ErrorVariable 'ErrorVariable'
+            Update-Help @Args @CultureArg
 
             if (-not $Pass) {
                 $ErrorVariable | Should -Match 'Failed to update Help for the module.*'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Allows the help locale to match, if it is in the list of parents (fallback chain) of the provided (or implicit) one.

Fixes #18021 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Currently, if the help has locale `'en-US'` as most do, only the following will work and everything else will throw an error:
```pwsh
> Update-Help -UICulture 'en-US'
> Update-Help  # when system's culture is also "en-US"
```

The PR changes it so that the following will also work:
```pwsh
> Update-Help -UICulture 'en'
> Update-Help  # when system's culture is 'en' or child of 'en', because system culture also uses fallback chain
```

Explicit `Update-Help -UICulture 'en-GB'` will still not work, because explicit culture does not use fallback chain.

This solves the bug of fallback chain not actually working, as fallback culture `'en'` did not match anything. It was supposed to work by use of globbing, but lack of `+ "*"` meant that the glob still used exact matching. It also allows the user to use explicit `-UICulture 'en'` to mean "any English will do, regardless of region". 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
