### PR TITLE
Do not discover assemblies loaded by `Assembly.LoadFile`

### DIFF
--- a/test/powershell/engine/Basic/Assembly.LoadBytesAndLoadFile.Tests.ps1
+++ b/test/powershell/engine/Basic/Assembly.LoadBytesAndLoadFile.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe "Assembly loaded in IndividualAssemblyLoadContext should be visible to PowerShell" -Tags "CI" {
+Describe "Discoverability of assemblies loaded by 'Assembly.Load(byte[])' and 'Assembly.LoadFile'" -Tags "CI" {
     BeforeAll {
         $code1 = @'
         namespace LoadBytes {
@@ -39,9 +39,13 @@ Describe "Assembly loaded in IndividualAssemblyLoadContext should be visible to 
         [LoadBytes.MyLoadBytesTest]::GetName() | Should -BeExactly "MyLoadBytesTest"
     }
 
-    It "Assembly loaded via 'Assembly.LoadFile' should be discoverable" {
-        [System.Reflection.Assembly]::LoadFile($loadFileFile) > $null
+    It "Assembly loaded via 'Assembly.LoadFile' should NOT be discoverable" {
+        ## Reflection should work fine.
+        $asm = [System.Reflection.Assembly]::LoadFile($loadFileFile)
+        $type = $asm.GetType('LoadFile.MyLoadFileTest')
+        $type::GetName() | Should -BeExactly "MyLoadFileTest"
 
-        [LoadFile.MyLoadFileTest]::GetName() | Should -BeExactly "MyLoadFileTest"
+        ## Type resolution should not work.
+        { [LoadFile.MyLoadFileTest] } | Should -Throw -ErrorId "TypeNotFound"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

For modules that target both Windows PowerShell and PowerShell Core, they are usually built against either `netstandard2.0`, or `net462`, so that one single set of assemblies can work on both .NET Framework and .NET Core.

For those modules, the API `Assembly.LoadFile` is usually used to load a dependency assembly into a separate load context when working in PowerShell Core to isolate the dependency, so as to avoid assembly loading conflicts with other modules. This usually happens when the dependency is commonly used by modules, such as `Newtonsoft.Json` and `YamlDotNet`.

Today, assemblies loaded by `Assembly.LoadFile` are discoverable by PowerShell's type resolution, and this breaks the isolation those modules are looking for when using `Assembly.LoadFile`. Since they are built against `netstandard2.0` and `net462`, they cannot use the `AssemblyLoadContext` APIs for creating a custom load context but have to depend on `Assembly.LoadFile` which loads an assembly in a separate assembly load context.

This PR is a breaking change.

## PR Context

Assemblies loaded by `Assembly.LoadFile` are made discoverable by https://github.com/PowerShell/PowerShell/pull/12203.
However, the original issues that PR was to address is just for assemblies loaded from memory by `Assembly.Load(byte[])`, and `Assembly.LoadFile` was never the ask.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
