### PR TITLE
Handle PSObject argument specially in method invocation logging

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3561,12 +3561,13 @@ namespace System.Management.Automation
 
                 // The argument is not a PSObject, or is a PSObject with a base object.
                 case string:
-                case Uri:
+                case var _ when baseType.IsEnum || baseType.IsPrimitive:
                 case Guid:
+                case Uri:
                 case Version:
                 case SemanticVersion:
                 case BigInteger:
-                case var _ when baseType.IsEnum || baseType.IsPrimitive:
+                case decimal:
                     return baseObj.ToString();
 
                 default: return baseType.FullName;

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3545,25 +3545,6 @@ namespace System.Management.Automation
             }
         );
 
-        private static string StringifyArgument(object arg)
-        {
-            object baseObj = PSObject.Base(arg);
-
-            if (baseObj is null)
-            {
-                // The argument is null or AutomationNull.Value.
-                return "null";
-            }
-
-            if (baseObj is PSObject)
-            {
-                // The argument is a PSObject instance without a base object.
-                return "PSObject{}";
-            }
-
-            return baseObj.ToString();
-        }
-
         internal static void LogMemberInvocation(string targetName, string name, object[] args)
         {
             try
@@ -3573,7 +3554,16 @@ namespace System.Management.Automation
 
                 for (int i = 0; i < args.Length; i++)
                 {
-                    string value = StringifyArgument(args[i]);
+                    object baseObj = PSObject.Base(args[i]);
+                    string value = baseObj switch
+                    {
+                        // The argument is null or AutomationNull.Value.
+                        null => "null",
+                        // The argument is a pure PSObject without a base object.
+                        PSObject => "PSObject{}",
+                        // Convert the base object to string.
+                        _ => baseObj.ToString()
+                    };
 
                     if (i > 0)
                     {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3561,8 +3561,7 @@ namespace System.Management.Automation
                 return "PSObject{}";
             }
 
-            string value = baseObj.ToString();
-            return arg is PSObject ? $"PSObject{{{value}}}" : value;
+            return baseObj.ToString();
         }
 
         internal static void LogMemberInvocation(string targetName, string name, object[] args)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3545,6 +3545,26 @@ namespace System.Management.Automation
             }
         );
 
+        private static string StringifyArgument(object arg)
+        {
+            object baseObj = PSObject.Base(arg);
+
+            if (baseObj is null)
+            {
+                // The argument is null or AutomationNull.Value.
+                return "null";
+            }
+
+            if (baseObj is PSObject)
+            {
+                // The argument is a PSObject instance without a base object.
+                return "PSObject{}";
+            }
+
+            string value = baseObj.ToString();
+            return arg is PSObject ? $"PSObject{{{value}}}" : value;
+        }
+
         internal static void LogMemberInvocation(string targetName, string name, object[] args)
         {
             try
@@ -3554,7 +3574,7 @@ namespace System.Management.Automation
 
                 for (int i = 0; i < args.Length; i++)
                 {
-                    string value = args[i] is null ? "null" : args[i].ToString();
+                    string value = StringifyArgument(args[i]);
 
                     if (i > 0)
                     {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3561,6 +3561,10 @@ namespace System.Management.Automation
 
                 // The argument is not a PSObject, or is a PSObject with a base object.
                 case string:
+                case Uri:
+                case Guid:
+                case Version:
+                case SemanticVersion:
                 case BigInteger:
                 case var _ when baseType.IsEnum || baseType.IsPrimitive:
                     return baseObj.ToString();

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3561,7 +3561,7 @@ namespace System.Management.Automation
                         null => "null",
                         // The argument is a pure PSObject without a base object.
                         PSObject => "PSObject{}",
-                        // Convert the base object to string.
+                        // The argument is not a PSObject, or is a PSObject with a base object.
                         _ => baseObj.ToString()
                     };
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #18033

The `ToString` implementation of `PSObject` does extra work on the base object, for example, unrolling the base object if it's enumerable, which is very expensive.

For method invocation logging, we should avoid calling `ToString` on a `PSObject` argument. Instead,
- If the argument is a pure `PSObject`, we represent it as `"PSObject{}"`.
- If the argument is not a `PSObject`, or is a `PSObject` wrapping a base object, we represent it as `baseObj.ToString()`.

Here are some log messages with this change:
```
=== Amsi notification report content ===
<System.IO.File>.Open(<D:\yard\temp\srcFile>, <Open>, <Read>, <Read>)
=== Amsi notification report success: True ===

=== Amsi notification report content ===
<System.IO.File>.Open(<D:\yard\temp\dstFile>, <Create>, <Write>, <Read>)
=== Amsi notification report success: True ===

=== Amsi notification report content ===
<System.IO.FileStream>.Write(<System.Byte[]>, <0>, <1048576>)
=== Amsi notification report success: True ===

=== Amsi notification report content ===
<System.IO.FileStream>.Read(<System.Byte[]>, <0>, <1048576>)
=== Amsi notification report success: True ===
```
```
./copytest.ps1 -UseNewObject

Operation   Count Time
---------   ----- ----
Read      1048576 1.23
Write     1048576 0.80
Read      1048576 0.83
Write     1048576 0.79
Read      1048576 0.68
Write     1048576 0.63
Read      1048576 0.57
Write     1048576 0.70
Read      1048576 0.57
Write     1048576 0.58
Read      1048576 0.54
Write     1048576 0.74
Read      1048576 0.56
Write     1048576 0.56
Read      1048576 0.65
Write     1048576 0.70
Read      1048576 0.62
Write     1048576 0.80
Read      1048576 0.73
Write     1048576 0.86
Read            0 0.37
----------
Time Total:  21.6844
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
