### PR TITLE
Fix typo in EventResource.resx

### DIFF
--- a/src/System.Management.Automation/resources/EventResource.resx
+++ b/src/System.Management.Automation/resources/EventResource.resx
@@ -550,7 +550,7 @@ Parameters = {7}</value>
     <value>Test analytic message</value>
 </data>
 <data name="PS_PROVIDEReventE_A_RUNSPACE_WSMANCONNECTIONINFO" xml:space="preserve">
-    <value>Connection Paramters are
+    <value>Connection Parameters are
  Connection URI: {0}
  Resource URI: {1}
  User: {2}
@@ -707,16 +707,16 @@ Exception StackTrace: {2}</value>
  	 Type cast inner exception: {3}</value>
 </data>
 <data name="PS_PROVIDEReventE_A_SERIALIZER_DEPTH_OVERRIDE" xml:space="preserve">
-    <value>Serialization depth has been overriden.
+    <value>Serialization depth has been overridden.
  	 Serialized type name: {0}
  	 Original depth: {1}
- 	 Overriden depth: {2}
+ 	 Overridden depth: {2}
  	 Current depth below top level: {3}</value>
 </data>
 <data name="PS_PROVIDEReventE_A_SERIALIZER_MODE_OVERRIDE" xml:space="preserve">
-    <value>Serialization mode has been overriden.
+    <value>Serialization mode has been overridden.
  	 Serialized type name: {0}
- 	 Overriden mode: {1}</value>
+ 	 Overridden mode: {1}</value>
 </data>
 <data name="PS_PROVIDEReventE_A_SERIALIZER_SCRIPT_PROPERTY_WITHOUT_RUNSPACE" xml:space="preserve">
     <value>Serialization of a script property has been skipped, because there is no runspace to use for evaluation of the property.


### PR DESCRIPTION




# PR Summary
## PR Context
Overriden -> Overridden
Paramters -> Parameters

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
