### PR TITLE
Treat `[NullString]::Value` as the string type when resolving methods

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -833,7 +833,7 @@ namespace System.Management.Automation
                 return GetArgumentType(PSObject.Base(psref.Value), isByRefParameter: false);
             }
 
-            return GetObjectType(argument, skipBasing: true);
+            return GetObjectType(argument, debase: false);
         }
 
         internal static ConversionRank GetArgumentConversionRank(object argument, Type parameterType, bool isByRef, bool allowCastingToByRefLikeType)
@@ -1678,13 +1678,13 @@ namespace System.Management.Automation
 
             if (arg is object[] array && array.Length > 0)
             {
-                Type firstType = GetObjectType(array[0], skipBasing: false);
+                Type firstType = GetObjectType(array[0], debase: true);
                 if (firstType is not null)
                 {
                     bool allSameType = true;
                     for (int j = 1; j < array.Length; ++j)
                     {
-                        if (firstType != GetObjectType(array[j], skipBasing: false))
+                        if (firstType != GetObjectType(array[j], debase: true))
                         {
                             allSameType = false;
                             break;
@@ -1698,12 +1698,12 @@ namespace System.Management.Automation
                 }
             }
 
-            return GetObjectType(arg, skipBasing: true);
+            return GetObjectType(arg, debase: false);
         }
 
-        internal static Type GetObjectType(object obj, bool skipBasing)
+        internal static Type GetObjectType(object obj, bool debase)
         {
-            if (!skipBasing)
+            if (debase)
             {
                 obj = PSObject.Base(obj);
             }

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -833,7 +833,7 @@ namespace System.Management.Automation
                 return GetArgumentType(PSObject.Base(psref.Value), isByRefParameter: false);
             }
 
-            return argument.GetType();
+            return GetObjectType(argument, skipBasing: true);
         }
 
         internal static ConversionRank GetArgumentConversionRank(object argument, Type parameterType, bool isByRef, bool allowCastingToByRefLikeType)
@@ -1670,18 +1670,21 @@ namespace System.Management.Automation
 
         internal static Type EffectiveArgumentType(object arg)
         {
-            if (arg != null)
+            arg = PSObject.Base(arg);
+            if (arg is null)
             {
-                arg = PSObject.Base(arg);
-                object[] argAsArray = arg as object[];
-                if (argAsArray != null && argAsArray.Length > 0 && PSObject.Base(argAsArray[0]) != null)
-                {
-                    Type firstType = PSObject.Base(argAsArray[0]).GetType();
-                    bool allSameType = true;
+                return typeof(LanguagePrimitives.Null);
+            }
 
-                    for (int j = 1; j < argAsArray.Length; ++j)
+            if (arg is object[] array && array.Length > 0)
+            {
+                Type firstType = GetObjectType(array[0], skipBasing: false);
+                if (firstType is not null)
+                {
+                    bool allSameType = true;
+                    for (int j = 1; j < array.Length; ++j)
                     {
-                        if (argAsArray[j] == null || firstType != PSObject.Base(argAsArray[j]).GetType())
+                        if (firstType != GetObjectType(array[j], skipBasing: false))
                         {
                             allSameType = false;
                             break;
@@ -1693,13 +1696,19 @@ namespace System.Management.Automation
                         return firstType.MakeArrayType();
                     }
                 }
+            }
 
-                return arg.GetType();
-            }
-            else
+            return GetObjectType(arg, skipBasing: true);
+        }
+
+        internal static Type GetObjectType(object obj, bool skipBasing)
+        {
+            if (!skipBasing)
             {
-                return typeof(LanguagePrimitives.Null);
+                obj = PSObject.Base(obj);
             }
+
+            return obj == NullString.Value ? typeof(string) : obj?.GetType();
         }
 
         internal static void SetReferences(object[] arguments, MethodInformation methodInformation, object[] originalArguments)

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7351,7 +7351,7 @@ namespace System.Management.Automation.Language
 
             foreach (object element in args)
             {
-                if (Adapter.GetObjectType(element, skipBasing: false) != typeof(T))
+                if (Adapter.GetObjectType(element, debase: true) != typeof(T))
                 {
                     return false;
                 }
@@ -7387,7 +7387,7 @@ namespace System.Management.Automation.Language
 
             for (int i = 1; i < args.Length; i++)
             {
-                if (Adapter.GetObjectType(args[i], skipBasing: false) != firstType)
+                if (Adapter.GetObjectType(args[i], debase: true) != firstType)
                 {
                     return true;
                 }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7349,11 +7349,15 @@ namespace System.Management.Automation.Language
                 return false;
             }
 
-            return args.All(element =>
-                            {
-                                var obj = PSObject.Base(element);
-                                return obj != null && obj.GetType().Equals(typeof(T));
-                            });
+            foreach (object element in args)
+            {
+                if (Adapter.GetObjectType(element, skipBasing: false) != typeof(T))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         internal static bool IsHeterogeneousArray(object[] args)
@@ -7381,11 +7385,15 @@ namespace System.Management.Automation.Language
                 return true;
             }
 
-            return args.Skip(1).Any(element =>
-                                    {
-                                        var obj = PSObject.Base(element);
-                                        return obj == null || !firstType.Equals(obj.GetType());
-                                    });
+            for (int i = 1; i < args.Length; i++)
+            {
+                if (Adapter.GetObjectType(args[i], skipBasing: false) != firstType)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal static object InvokeAdaptedMember(object obj, string methodName, object[] args)

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -90,4 +90,43 @@ Describe "Scripting.Followup.Tests" -Tags "CI" {
 
         TestFunc2 | Should -Be @("1", "2")
     }
+
+    It "'[NullString]::Value' should be treated as string type when resolving .NET method" {
+
+        $testType = 'NullStringTest' -as [type]
+        if (-not $testType) {
+            Add-Type -TypeDefinition @"
+    using System;
+    public class NullStringTest {
+        public static string Test(bool argument)
+        {
+            return "bool";
+        }
+
+        public static string Test(string argument)
+        {
+            return "string";
+        }
+
+        public static string Get<T>(T argument)
+        {
+            string ret = typeof(T).FullName;
+            if (argument is string[] array)
+            {
+                if (array[1] == null)
+                {
+                    return ret + "; 2nd element is NULL";
+                }
+            }
+
+            return ret;
+        }
+    }
+"@
+        }
+
+        [NullStringTest]::Test([NullString]::Value) | Should -BeExactly 'string'
+        [NullStringTest]::Get([NullString]::Value) | Should -BeExactly 'System.String'
+        [NullStringTest]::Get(@('foo', [NullString]::Value, 'bar')) | Should -BeExactly 'System.String[]; 2nd element is NULL'
+    }
 }

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -92,37 +92,36 @@ Describe "Scripting.Followup.Tests" -Tags "CI" {
     }
 
     It "'[NullString]::Value' should be treated as string type when resolving .NET method" {
-
         $testType = 'NullStringTest' -as [type]
         if (-not $testType) {
-            Add-Type -TypeDefinition @"
-    using System;
-    public class NullStringTest {
-        public static string Test(bool argument)
-        {
-            return "bool";
-        }
-
-        public static string Test(string argument)
-        {
-            return "string";
-        }
-
-        public static string Get<T>(T argument)
-        {
-            string ret = typeof(T).FullName;
-            if (argument is string[] array)
-            {
-                if (array[1] == null)
-                {
-                    return ret + "; 2nd element is NULL";
-                }
-            }
-
-            return ret;
-        }
+            Add-Type -TypeDefinition @'
+using System;
+public class NullStringTest {
+    public static string Test(bool argument)
+    {
+        return "bool";
     }
-"@
+
+    public static string Test(string argument)
+    {
+        return "string";
+    }
+
+    public static string Get<T>(T argument)
+    {
+        string ret = typeof(T).FullName;
+        if (argument is string[] array)
+        {
+            if (array[1] == null)
+            {
+                return ret + "; 2nd element is NULL";
+            }
+        }
+
+        return ret;
+    }
+}
+'@
         }
 
         [NullStringTest]::Test([NullString]::Value) | Should -BeExactly 'string'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #18072
Treat `[NullString]::Value` as the string type when resolving methods.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
