### PR TITLE
Update `WriteConsole` to not use `stackalloc` for buffer with too large size

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2580,7 +2580,9 @@ namespace Microsoft.PowerShell
             int size = outBuffer.Length + lineEnding.Length;
 
             // We expect the 'size' will often be small, and thus optimize that case with 'stackalloc'.
-            Span<char> buffer = size <= MaxStackAllocSize ? stackalloc char[size] : default;
+            Span<char> buffer = size <= MaxStackAllocSize
+                ? (stackalloc char[MaxStackAllocSize]).Slice(0, size)
+                : default;
 
             try
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2580,10 +2580,7 @@ namespace Microsoft.PowerShell
             int size = outBuffer.Length + lineEnding.Length;
 
             // We expect the 'size' will often be small, and thus optimize that case with 'stackalloc'.
-            // Using 'stackalloc' with constant size and then slicing is more performant than using it with variable size.
-            Span<char> buffer = size <= MaxStackAllocSize
-                ? (stackalloc char[MaxStackAllocSize]).Slice(0, size)
-                : default;
+            Span<char> buffer = size <= MaxStackAllocSize ? stackalloc char[size] : default;
 
             try
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -2580,6 +2580,7 @@ namespace Microsoft.PowerShell
             int size = outBuffer.Length + lineEnding.Length;
 
             // We expect the 'size' will often be small, and thus optimize that case with 'stackalloc'.
+            // Using 'stackalloc' with constant size and then slicing is more performant than using it with variable size.
             Span<char> buffer = size <= MaxStackAllocSize
                 ? (stackalloc char[MaxStackAllocSize]).Slice(0, size)
                 : default;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update `WriteConsole` to not use `stackalloc` for buffer with too large size.
This PR is a follow-up on the comment https://github.com/PowerShell/PowerShell/pull/17982/files#r962493720

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
