### PR TITLE
Complete the progress bar rendering in `Invoke-WebRequest` when downloading is complete or cancelled

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -326,17 +326,19 @@ namespace Microsoft.PowerShell.Commands
             catch (OperationCanceledException)
             {
             }
-
-            if (wroteProgress)
+            finally
             {
-                // Write out the completion progress record only if we did render the progress.
-                record.StatusDescription = StringUtil.Format(
-                    copyTask.IsCompleted
-                        ? WebCmdletStrings.WriteRequestComplete
-                        : WebCmdletStrings.WriteRequestCancelled,
-                    output.Position);
-                record.RecordType = ProgressRecordType.Completed;
-                cmdlet.WriteProgress(record);
+                if (wroteProgress)
+                {
+                    // Write out the completion progress record only if we did render the progress.
+                    record.StatusDescription = StringUtil.Format(
+                        copyTask.IsCompleted
+                            ? WebCmdletStrings.WriteRequestComplete
+                            : WebCmdletStrings.WriteRequestCancelled,
+                        output.Position);
+                    record.RecordType = ProgressRecordType.Completed;
+                    cmdlet.WriteProgress(record);
+                }
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -298,6 +298,7 @@ namespace Microsoft.PowerShell.Commands
 
             Task copyTask = input.CopyToAsync(output, cancellationToken);
 
+            bool wroteProgress = false;
             ProgressRecord record = new(
                 ActivityId,
                 WebCmdletStrings.WriteRequestProgressActivity,
@@ -313,22 +314,29 @@ namespace Microsoft.PowerShell.Commands
                         Utils.DisplayHumanReadableFileSize(output.Position),
                         totalDownloadSize);
 
-                    if (contentLength != null && contentLength > 0)
+                    if (contentLength > 0)
                     {
                         record.PercentComplete = Math.Min((int)(output.Position * 100 / (long)contentLength), 100);
                     }
 
                     cmdlet.WriteProgress(record);
-                }
-
-                if (copyTask.IsCompleted)
-                {
-                    record.StatusDescription = StringUtil.Format(WebCmdletStrings.WriteRequestComplete, output.Position);
-                    cmdlet.WriteProgress(record);
+                    wroteProgress = true;
                 }
             }
             catch (OperationCanceledException)
             {
+            }
+
+            if (wroteProgress)
+            {
+                // Write out the completion progress record only if we did render the progress.
+                record.StatusDescription = StringUtil.Format(
+                    copyTask.IsCompleted
+                        ? WebCmdletStrings.WriteRequestComplete
+                        : WebCmdletStrings.WriteRequestCancelled,
+                    output.Position);
+                record.RecordType = ProgressRecordType.Completed;
+                cmdlet.WriteProgress(record);
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -199,7 +199,7 @@
     <value>The cmdlet cannot run because the following parameter is missing: Proxy. Provide a valid proxy URI for the Proxy parameter when using the ProxyCredential or ProxyUseDefaultCredentials parameters, then retry.</value>
   </data>
   <data name="ReadResponseComplete" xml:space="preserve">
-    <value>Reading web response stream completed. Downloaded: {0}</value>
+    <value>Reading web response stream completed. Bytes downloaded: {0}</value>
   </data>
   <data name="ReadResponseProgressActivity" xml:space="preserve">
     <value>Reading web response stream</value>
@@ -218,6 +218,9 @@
   </data>
   <data name="WriteRequestComplete" xml:space="preserve">
     <value>Web request completed. (Number of bytes processed: {0})</value>
+  </data>
+  <data name="WriteRequestCancelled" xml:space="preserve">
+    <value>Web request cancelled. (Number of bytes processed: {0})</value>
   </data>
   <data name="WriteRequestProgressActivity" xml:space="preserve">
     <value>Web request status</value>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Complete the progress bar rendering in `Invoke-WebRequest` when downloading is successful or cancelled.

The `WriteToStream` method doesn't complete the progress bar rendering when the download is complete or cancelled, and this causes the progress bar to linger around and hide the output from external commands that runs right after `Invoke-WebRequest`.

### Old behavior

**Note that**, the string `This is a string` written by `[Console]::WriteLine` is not displayed after execution:

![old-behavior](https://user-images.githubusercontent.com/127450/191133763-a92ff321-4e3a-4d8a-810e-2459434f0c4b.gif)

### New behavior

**Note that**, the string `This is a string` is displayed after execution as expected:

![new-behavior](https://user-images.githubusercontent.com/127450/191133784-b8fa3f8a-18de-4173-84cf-76f16f4cc6e9.gif)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
