### PR TITLE
Make PowerShell class not affiliate with Runspace when declaring the `NoRunspaceAffinity` attribute

### DIFF
--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -1472,4 +1472,18 @@ namespace System.Management.Automation.Language
             }
         }
     }
+
+    /// <summary>
+    /// The attribute for a PowerShell class to not affiliate with a particular Runspace\SessionState.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class NoRunspaceAffinityAttribute : ParsingBaseAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the attribute.
+        /// </summary>
+        public NoRunspaceAffinityAttribute()
+        {
+        }
+    }
 }

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -750,6 +750,7 @@ namespace System.Management.Automation
                     { typeof(CimConverter),                                new[] { "cimconverter" } },
                     { typeof(ModuleSpecification),                         null },
                     { typeof(IPEndPoint),                                  new[] { "IPEndpoint" } },
+                    { typeof(NoRunspaceAffinityAttribute),                 new[] { "NoRunspaceAffinity" } },
                     { typeof(NullString),                                  new[] { "NullString" } },
                     { typeof(OutputTypeAttribute),                         new[] { "OutputType" } },
                     { typeof(object[]),                                    null },

--- a/src/System.Management.Automation/engine/runtime/Operations/ClassOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/ClassOps.cs
@@ -22,7 +22,7 @@ namespace System.Management.Automation.Internal
     /// <summary>
     /// Every Runspace in one process contains SessionStateInternal per module (module SessionState).
     /// Every RuntimeType is associated to only one SessionState in the Runspace, which creates it:
-    /// it's ever global state or a module state.
+    /// it's either global state or a module state.
     /// In the former case, module can be imported from the different runspaces in the same process.
     /// And so runspaces will share RuntimeType. But in every runspace, Type is associated with just one SessionState.
     /// We want type methods to be able access $script: variables and module-specific methods.

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -2300,8 +2300,13 @@ namespace System.Management.Automation
                 Diagnostics.Assert(t.Type != null, "TypeDefinitionAst.Type cannot be null");
                 if (t.IsClass)
                 {
-                    var helperType =
-                        t.Type.Assembly.GetType(t.Type.FullName + "_<staticHelpers>");
+                    if (t.Type.IsDefined(typeof(NoRunspaceAffinityAttribute), inherit: true))
+                    {
+                        // Skip the initialization for session state affinity.
+                        continue;
+                    }
+
+                    var helperType = t.Type.Assembly.GetType(t.Type.FullName + "_<staticHelpers>");
                     Diagnostics.Assert(helperType != null, "no corresponding " + t.Type.FullName + "_<staticHelpers> type found");
                     foreach (var p in helperType.GetFields(BindingFlags.Static | BindingFlags.NonPublic))
                     {

--- a/test/powershell/Language/Classes/Scripting.Classes.NoRunspaceAffinity.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.NoRunspaceAffinity.Tests.ps1
@@ -7,6 +7,11 @@ Describe "Class can be defined without Runspace affinity" -Tags "CI" {
         [NoRunspaceAffinity()]
         class NoAffinity {
             [string] $Name;
+            [int] $RunspaceId;
+
+            NoAffinity() {
+               $this.RunspaceId = [runspace]::DefaultRunspace.Id
+            }
 
             static [int] Echo() {
                 return [runspace]::DefaultRunspace.Id
@@ -23,25 +28,22 @@ Describe "Class can be defined without Runspace affinity" -Tags "CI" {
 
         ## Running directly should use the current Runspace/SessionState.
         $t::Echo() | Should -Be $Host.Runspace.Id
+        $o.RunspaceId | Should -Be $Host.Runspace.Id
         $o.SetAndEcho('Blue') | Should -Be $Host.Runspace.Id
         $o.Name | Should -Be 'Blue'
 
         ## Running in a new Runspace should use that Runspace and its current SessionState.
         try {
             $ps = [powershell]::Create()
-            $ps.AddScript('function CallEcho($type) { $type::Echo() }').Invoke() > $null
-            $ps.Commands.Clear()
-            $ps.AddScript('function CallSetAndEcho($obj) { $obj.SetAndEcho(''Hello world'') }').Invoke() > $null
-            $ps.Commands.Clear()
-            $ps.AddScript('function GetName($obj) { $obj.Name }').Invoke() > $null
-            $ps.Commands.Clear()
+            $ps.AddScript('function CallEcho($type) { $type::Echo() }').Invoke() > $null; $ps.Commands.Clear()
+            $ps.AddScript('function CallSetAndEcho($obj) { $obj.SetAndEcho(''Hello world'') }').Invoke() > $null; $ps.Commands.Clear()
+            $ps.AddScript('function GetName($obj) { $obj.Name }').Invoke() > $null; $ps.Commands.Clear()
+            $ps.AddScript('function NewObj($type) { $type::new().RunspaceId }').Invoke() > $null; $ps.Commands.Clear()
 
-            $ps.AddCommand('CallEcho').AddArgument($t).Invoke() | Should -Be $ps.Runspace.Id
-            $ps.Commands.Clear()
-            $ps.AddCommand('CallSetAndEcho').AddArgument($o).Invoke() | Should -Be $ps.Runspace.Id
-            $ps.Commands.Clear()
-            $ps.AddCommand('GetName').AddArgument($o).Invoke() | Should -Be 'Hello world'
-            $ps.Commands.Clear()
+            $ps.AddCommand('CallEcho').AddArgument($t).Invoke() | Should -Be $ps.Runspace.Id; $ps.Commands.Clear()
+            $ps.AddCommand('CallSetAndEcho').AddArgument($o).Invoke() | Should -Be $ps.Runspace.Id; $ps.Commands.Clear()
+            $ps.AddCommand('GetName').AddArgument($o).Invoke() | Should -Be 'Hello world'; $ps.Commands.Clear()
+            $ps.AddCommand('NewObj').AddArgument($t).Invoke() | Should -Be $ps.Runspace.Id; $ps.Commands.Clear()
         }
         finally {
             $ps.Dispose()

--- a/test/powershell/Language/Classes/Scripting.Classes.NoRunspaceAffinity.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.NoRunspaceAffinity.Tests.ps1
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Class can be defined without Runspace affinity" -Tags "CI" {
+
+    It "Applying the 'NoRunspaceAffinity' attribute make the class not affiliate with a particular Runspace/SessionState" {
+        [NoRunspaceAffinity()]
+        class NoAffinity {
+            [string] $Name;
+
+            static [int] Echo() {
+                return [runspace]::DefaultRunspace.Id
+            }
+
+            [int] SetAndEcho([string] $value) {
+                $this.Name = $value
+                return [runspace]::DefaultRunspace.Id
+            }
+        }
+
+        $t = [NoAffinity]
+        $o = [NoAffinity]::new()
+
+        ## Running directly should use the current Runspace/SessionState.
+        $t::Echo() | Should -Be $Host.Runspace.Id
+        $o.SetAndEcho('Blue') | Should -Be $Host.Runspace.Id
+        $o.Name | Should -Be 'Blue'
+
+        ## Running in a new Runspace should use that Runspace and its current SessionState.
+        try {
+            $ps = [powershell]::Create()
+            $ps.AddScript('function CallEcho($type) { $type::Echo() }').Invoke() > $null
+            $ps.Commands.Clear()
+            $ps.AddScript('function CallSetAndEcho($obj) { $obj.SetAndEcho(''Hello world'') }').Invoke() > $null
+            $ps.Commands.Clear()
+            $ps.AddScript('function GetName($obj) { $obj.Name }').Invoke() > $null
+            $ps.Commands.Clear()
+
+            $ps.AddCommand('CallEcho').AddArgument($t).Invoke() | Should -Be $ps.Runspace.Id
+            $ps.Commands.Clear()
+            $ps.AddCommand('CallSetAndEcho').AddArgument($o).Invoke() | Should -Be $ps.Runspace.Id
+            $ps.Commands.Clear()
+            $ps.AddCommand('GetName').AddArgument($o).Invoke() | Should -Be 'Hello world'
+            $ps.Commands.Clear()
+        }
+        finally {
+            $ps.Dispose()
+        }
+    }
+}

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -410,15 +410,20 @@ Describe "Type accelerators" -Tags "CI" {
                     Accelerator = 'ordered'
                     Type        = [System.Collections.Specialized.OrderedDictionary]
                 }
+                @
+                {
+                    Accelerator = 'NoRunspaceAffinity'
+                    Type        = [System.Management.Automation.Language.NoRunspaceAffinityAttribute]
+                }
             )
 
             if ( !$IsWindows )
             {
-                $totalAccelerators = 101
+                $totalAccelerators = 102
             }
             else
             {
-                $totalAccelerators = 106
+                $totalAccelerators = 107
 
                 $extraFullPSAcceleratorTestCases = @(
                     @{

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -410,8 +410,7 @@ Describe "Type accelerators" -Tags "CI" {
                     Accelerator = 'ordered'
                     Type        = [System.Collections.Specialized.OrderedDictionary]
                 }
-                @
-                {
+                @{
                     Accelerator = 'NoRunspaceAffinity'
                     Type        = [System.Management.Automation.Language.NoRunspaceAffinityAttribute]
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #12801

Make PowerShell class not affiliate with Runspace when declaring the `NoRunspaceAffinity` attribute.

By default, a PowerShell class is affiliated with the Runspace where it's created. This makes it not work in a parallel workflow, such as `ForEach-Object -Parallel` -- method invocations on the class would be marshalled back to the Runspace it was created, which could cause corruption to the state of that Runsapce or a deadlock. See https://github.com/PowerShell/PowerShell/issues/4003 and https://github.com/PowerShell/PowerShell/issues/3651 for examples.

With this PR, if the attribute `NoRunspaceAffinity` is declared for a PowerShell class, then the PowerShell class will not be affiliated with a particular Runspace/SessionState, and its method invocation (both instance and static) will use the default Runspace of the running thread and its current session state.

Of course, once declaring the attribute to the class, the class implementation should not depend on any states of a particular session state, because there is no guarantee the dependencies would be available at runtime.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9231
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
