### PR TITLE
Fix the verbose message when using `dotnet-install.sh`

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1896,7 +1896,7 @@ function Install-Dotnet {
 
             $bashArgs += @('-skipnonversionedfiles')
 
-            $bashArgs | Out-String | Write-Verbose -Verbose
+            $bashArgs -join ' ' | Write-Verbose -Verbose
 
         Start-NativeExecution {
             bash @bashArgs


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the verbose message when using `dotnet-install.sh`.

Before the fix:

![image](https://user-images.githubusercontent.com/127450/192900110-72b88e77-85d5-4eca-877c-7a99a26af5c6.png)

After the fix, it will be `VERBOSE: ./dotnet-install.sh -v 7.0.100-rtm.22476.1 -skipnonversionedfiles`



## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
