### PR TITLE
Improve startup time by triggering initialization of additional types on background thread.

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -47,19 +47,24 @@ namespace System.Management.Automation.Runspaces
             // Amsi initialize can be a little slow.
             Task.Run(() => AmsiUtils.WinScanContent(content: string.Empty, sourceMetadata: string.Empty, warmUp: true));
 #endif
+            // Initialize the types 'Compiler', 'CachedReflectionInfo', and 'ExpressionCache'.
+            // Their type initializers do a lot of reflection operations.
+            // We will access 'Compiler' members when creating the first session state.
             Task.Run(() => _ = Compiler.DottedLocalsTupleType);
 
             // One other task for other stuff that's faster, but still a little slow.
             Task.Run(() =>
             {
-                // Loading the resources for System.Management.Automation can be expensive, so force that to
-                // happen early on a background thread.
+                // Loading the resources for System.Management.Automation can be expensive,
+                // so force that to happen early on a background thread.
                 _ = RunspaceInit.OutputEncodingDescription;
 
                 // This will init some tables and could load some assemblies.
+                // We will access 'LanguagePrimitives' when binding built-in variables for the Runspace.
                 LanguagePrimitives.GetEnumerator(null);
 
                 // This will init some tables and could load some assemblies.
+                // We will access 'TypeAccelerators' when auto-loading the PSReadLine module, which happens last.
                 _ = TypeAccelerators.builtinTypeAccelerators;
             });
         }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -44,9 +44,10 @@ namespace System.Management.Automation.Runspaces
 
             // We shouldn't create too many tasks.
 #if !UNIX
-            // Amsi initialize can be a little slow
+            // Amsi initialize can be a little slow.
             Task.Run(() => AmsiUtils.WinScanContent(content: string.Empty, sourceMetadata: string.Empty, warmUp: true));
 #endif
+            Task.Run(() => _ = Compiler.DottedLocalsTupleType);
 
             // One other task for other stuff that's faster, but still a little slow.
             Task.Run(() =>
@@ -56,10 +57,10 @@ namespace System.Management.Automation.Runspaces
                 _ = RunspaceInit.OutputEncodingDescription;
 
                 // This will init some tables and could load some assemblies.
-                _ = TypeAccelerators.builtinTypeAccelerators;
+                LanguagePrimitives.GetEnumerator(null);
 
                 // This will init some tables and could load some assemblies.
-                LanguagePrimitives.GetEnumerator(null);
+                _ = TypeAccelerators.builtinTypeAccelerators;
             });
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Improve startup time by triggering initialization of additional types on background thread.
There are 2 changes:
1. Trigger the type initializers of `Compiler`, `CachedReflectionInfo`, and `ExpressionCache`, which involves lots of reflection operations.
2. Reverse the order of `LanguagePrimitives` and `TypeAccelerators`, because the former is needed earlier in the startup process.

## PR Context

The change improves the startup time of `pwsh.exe` by about `30%` on my dev machine.
The benchmark result below is from comparing "_a release build with the change (V73Wip)_" with "_a release build without the change (V730)_" (both has R2R images).

```
## Warm startup -- with module analysis cache pre-populated
## PowerShell is built with 'Release' configuration and R2R images.
Test scenario: pwsh.exe -noprofile -c echo 1


BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.521)
Intel Xeon W-2235 CPU 3.80GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=7.0.100-rc.1.22431.12
  [Host]     : .NET 7.0.0 (7.0.22.42610), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.0 (7.0.22.42610), X64 RyuJIT AVX2


|            Method |     Mean |    Error |   StdDev | Ratio | Code Size |
|------------------ |---------:|---------:|---------:|------:|----------:|
|   V730StartupTime | 557.2 ms | 10.83 ms | 10.64 ms |  1.00 |      41 B |
| V73WipStartupTime | 386.3 ms |  6.81 ms |  6.03 ms |  0.69 |      41 B |


Benchmark_pwsh_startup.V730StartupTime: DefaultJob
-------------------- Histogram --------------------
[539.780 ms ; 552.371 ms) | @@@@
[552.371 ms ; 572.428 ms) | @@@@@@@@@@
[572.428 ms ; 584.997 ms) | @@
---------------------------------------------------

Benchmark_pwsh_startup.V73WipStartupTime: DefaultJob
-------------------- Histogram --------------------
[374.236 ms ; 387.432 ms) | @@@@@@@@@
[387.432 ms ; 401.417 ms) | @@@@@
---------------------------------------------------
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
