### PR TITLE
Dispose TraceSources when they're not used any more

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/Job2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job2.cs
@@ -197,6 +197,17 @@ namespace System.Management.Automation
             base.SetJobState(state, reason);
         }
 
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _tracer.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         #endregion Protected Methods
 
         #region State Management
@@ -2023,6 +2034,7 @@ namespace System.Management.Automation
 
                 _jobRunning?.Dispose();
                 _jobSuspendedOrAborted?.Dispose();
+                _tracer.Dispose();
             }
             finally
             {

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionHyperVSocket.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionHyperVSocket.cs
@@ -327,6 +327,8 @@ namespace System.Management.Automation.Remoting
                 try { HyperVSocket.Dispose(); }
                 catch (ObjectDisposedException) { }
             }
+
+            _tracer.Dispose();
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -225,175 +225,176 @@ namespace System.Management.Automation.Remoting
             Dbg.Assert(xmlReader != null, "xmlReader cannot be null.");
             Dbg.Assert(xmlReader.NodeType == XmlNodeType.Element, "xmlReader's NodeType should be of type Element");
 
-            PowerShellTraceSource tracer = PowerShellTraceSourceFactory.GetTraceSource();
-
-            switch (xmlReader.LocalName)
+            using (PowerShellTraceSource tracer = PowerShellTraceSourceFactory.GetTraceSource())
             {
-                case OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG:
-                    {
-                        // A <Data> should have 1 attribute identifying the stream
-                        if (xmlReader.AttributeCount != 2)
+                switch (xmlReader.LocalName)
+                {
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG:
                         {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForDataElement,
-                                RemotingErrorIdStrings.IPCWrongAttributeCountForDataElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_STREAM_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG);
+                            // A <Data> should have 1 attribute identifying the stream
+                            if (xmlReader.AttributeCount != 2)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForDataElement,
+                                    RemotingErrorIdStrings.IPCWrongAttributeCountForDataElement,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_STREAM_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG);
+                            }
+
+                            string stream = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_STREAM_ATTRIBUTE);
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+
+                            // Now move the reader to the data portion
+                            if (!xmlReader.Read())
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCInsufficientDataforElement,
+                                    RemotingErrorIdStrings.IPCInsufficientDataforElement,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG);
+                            }
+
+                            if (xmlReader.NodeType != XmlNodeType.Text)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCOnlyTextExpectedInDataElement,
+                                    RemotingErrorIdStrings.IPCOnlyTextExpectedInDataElement,
+                                    xmlReader.NodeType, OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG, XmlNodeType.Text);
+                            }
+
+                            string data = xmlReader.Value;
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_DATA received, psGuid : " + psGuid.ToString());
+                            byte[] rawData = Convert.FromBase64String(data);
+                            callbacks.DataPacketReceived(rawData, stream, psGuid);
                         }
 
-                        string stream = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_STREAM_ATTRIBUTE);
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-
-                        // Now move the reader to the data portion
-                        if (!xmlReader.Read())
+                        break;
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_DATA_ACK_TAG:
                         {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCInsufficientDataforElement,
-                                RemotingErrorIdStrings.IPCInsufficientDataforElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG);
+                            if (xmlReader.AttributeCount != 1)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
+                                    RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_DATA_ACK_TAG);
+                            }
+
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_DATA_ACK received, psGuid : " + psGuid.ToString());
+                            callbacks.DataAckPacketReceived(psGuid);
                         }
 
-                        if (xmlReader.NodeType != XmlNodeType.Text)
+                        break;
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_TAG:
                         {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCOnlyTextExpectedInDataElement,
-                                RemotingErrorIdStrings.IPCOnlyTextExpectedInDataElement,
-                                xmlReader.NodeType, OutOfProcessUtils.PS_OUT_OF_PROC_DATA_TAG, XmlNodeType.Text);
+                            if (xmlReader.AttributeCount != 1)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
+                                    RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_TAG);
+                            }
+
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_COMMAND received, psGuid : " + psGuid.ToString());
+                            callbacks.CommandCreationPacketReceived(psGuid);
                         }
 
-                        string data = xmlReader.Value;
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_DATA received, psGuid : " + psGuid.ToString());
-                        byte[] rawData = Convert.FromBase64String(data);
-                        callbacks.DataPacketReceived(rawData, stream, psGuid);
-                    }
-
-                    break;
-                case OutOfProcessUtils.PS_OUT_OF_PROC_DATA_ACK_TAG:
-                    {
-                        if (xmlReader.AttributeCount != 1)
+                        break;
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_ACK_TAG:
                         {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
+                            if (xmlReader.AttributeCount != 1)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
+                                    RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_ACK_TAG);
+                            }
+
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_COMMAND_ACK received, psGuid : " + psGuid.ToString());
+                            callbacks.CommandCreationAckReceived(psGuid);
+                        }
+
+                        break;
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_TAG:
+                        {
+                            if (xmlReader.AttributeCount != 1)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
+                                    RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_TAG);
+                            }
+
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_CLOSE received, psGuid : " + psGuid.ToString());
+                            callbacks.ClosePacketReceived(psGuid);
+                        }
+
+                        break;
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_ACK_TAG:
+                        {
+                            if (xmlReader.AttributeCount != 1)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
                                 RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_DATA_ACK_TAG);
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_ACK_TAG);
+                            }
+
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_CLOSE_ACK received, psGuid : " + psGuid.ToString());
+                            callbacks.CloseAckPacketReceived(psGuid);
                         }
 
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_DATA_ACK received, psGuid : " + psGuid.ToString());
-                        callbacks.DataAckPacketReceived(psGuid);
-                    }
-
-                    break;
-                case OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_TAG:
-                    {
-                        if (xmlReader.AttributeCount != 1)
+                        break;
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_TAG:
                         {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
+                            if (xmlReader.AttributeCount != 1)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
                                 RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_TAG);
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_TAG);
+                            }
+
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_SIGNAL received, psGuid : " + psGuid.ToString());
+                            callbacks.SignalPacketReceived(psGuid);
                         }
 
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_COMMAND received, psGuid : " + psGuid.ToString());
-                        callbacks.CommandCreationPacketReceived(psGuid);
-                    }
-
-                    break;
-                case OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_ACK_TAG:
-                    {
-                        if (xmlReader.AttributeCount != 1)
+                        break;
+                    case OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_ACK_TAG:
                         {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
+                            if (xmlReader.AttributeCount != 1)
+                            {
+                                throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
                                 RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_COMMAND_ACK_TAG);
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
+                                    OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_ACK_TAG);
+                            }
+
+                            string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
+                            Guid psGuid = new Guid(psGuidString);
+                            tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_SIGNAL_ACK received, psGuid : " + psGuid.ToString());
+                            callbacks.SignalAckPacketReceived(psGuid);
                         }
 
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_COMMAND_ACK received, psGuid : " + psGuid.ToString());
-                        callbacks.CommandCreationAckReceived(psGuid);
-                    }
-
-                    break;
-                case OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_TAG:
-                    {
-                        if (xmlReader.AttributeCount != 1)
-                        {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
-                                RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_TAG);
-                        }
-
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_CLOSE received, psGuid : " + psGuid.ToString());
-                        callbacks.ClosePacketReceived(psGuid);
-                    }
-
-                    break;
-                case OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_ACK_TAG:
-                    {
-                        if (xmlReader.AttributeCount != 1)
-                        {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
-                            RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_CLOSE_ACK_TAG);
-                        }
-
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_CLOSE_ACK received, psGuid : " + psGuid.ToString());
-                        callbacks.CloseAckPacketReceived(psGuid);
-                    }
-
-                    break;
-                case OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_TAG:
-                    {
-                        if (xmlReader.AttributeCount != 1)
-                        {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
-                            RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_TAG);
-                        }
-
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_SIGNAL received, psGuid : " + psGuid.ToString());
-                        callbacks.SignalPacketReceived(psGuid);
-                    }
-
-                    break;
-                case OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_ACK_TAG:
-                    {
-                        if (xmlReader.AttributeCount != 1)
-                        {
-                            throw new PSRemotingTransportException(PSRemotingErrorId.IPCWrongAttributeCountForElement,
-                            RemotingErrorIdStrings.IPCWrongAttributeCountForElement,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE,
-                                OutOfProcessUtils.PS_OUT_OF_PROC_SIGNAL_ACK_TAG);
-                        }
-
-                        string psGuidString = xmlReader.GetAttribute(OutOfProcessUtils.PS_OUT_OF_PROC_PSGUID_ATTRIBUTE);
-                        Guid psGuid = new Guid(psGuidString);
-                        tracer.WriteMessage("OutOfProcessUtils.ProcessElement : PS_OUT_OF_PROC_SIGNAL_ACK received, psGuid : " + psGuid.ToString());
-                        callbacks.SignalAckPacketReceived(psGuid);
-                    }
-
-                    break;
-                default:
-                    throw new PSRemotingTransportException(PSRemotingErrorId.IPCUnknownElementReceived,
-                    RemotingErrorIdStrings.IPCUnknownElementReceived,
-                        xmlReader.LocalName);
+                        break;
+                    default:
+                        throw new PSRemotingTransportException(PSRemotingErrorId.IPCUnknownElementReceived,
+                        RemotingErrorIdStrings.IPCUnknownElementReceived,
+                            xmlReader.LocalName);
+                }
             }
         }
 
@@ -497,7 +498,7 @@ namespace System.Management.Automation.Remoting.Client
         private OutOfProcessUtils.DataProcessingDelegates _dataProcessingCallbacks;
         private readonly Dictionary<Guid, OutOfProcessClientCommandTransportManager> _cmdTransportManagers;
         private readonly Timer _closeTimeOutTimer;
-        internal PowerShellTraceSource _tracer;
+        internal readonly PowerShellTraceSource _tracer;
         internal OutOfProcessTextWriter _messageWriter;
 
         #endregion
@@ -658,6 +659,7 @@ namespace System.Management.Automation.Remoting.Client
                 _cmdTransportManagers.Clear();
                 _closeTimeOutTimer.Dispose();
                 DisposeMessageQueue();
+                _tracer.Dispose();
             }
         }
 
@@ -1669,7 +1671,6 @@ namespace System.Management.Automation.Remoting.Client
         #endregion
 
         #region Overrides
-
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);


### PR DESCRIPTION
# PR Summary

Please hide white spaces at review https://github.com/PowerShell/PowerShell/pull/18205/files?diff=split&w=1


A few previously non-disposed `PowerShellTraceSourcEe` instances are now being disposed correctly when they go out of scope.

## PR Context

This change improves the handling of disposable objects (ie. implementing `IDisposable`) in accordance with the default implementation pattern. Partly addresses the currently disable compiler warnings of the CA2213 and CA2215 type. Partially addresses the violations mentioned in #15803.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
