### PR TITLE
Dispose disposables in CommandSearcher and DscResourceSearcher

### DIFF
--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1639,8 +1639,24 @@ namespace System.Management.Automation
 
             _currentMatch = null;
             _currentState = SearchState.SearchingAliases;
-            _matchingAlias = null;
-            _matchingCmdlet = null;
+
+            if (_matchingAlias != null)
+            {
+                _matchingAlias.Dispose();
+                _matchingAlias = null;
+            }
+
+            if (_matchingCmdlet != null)
+            {
+                _matchingCmdlet.Dispose();
+                _matchingCmdlet = null;
+            }
+
+            if (_matchingFunctionEnumerator != null)
+            {
+                _matchingFunctionEnumerator.Dispose();
+                _matchingFunctionEnumerator = null;
+            }
         }
 
         internal CommandOrigin CommandOrigin

--- a/src/System.Management.Automation/engine/DscResourceSearcher.cs
+++ b/src/System.Management.Automation/engine/DscResourceSearcher.cs
@@ -29,6 +29,7 @@ namespace System.Management.Automation
 
         private readonly string _resourceName = null;
         private readonly ExecutionContext _context = null;
+        private bool _disposed;
         private DscResourceInfo _currentMatch = null;
         private IEnumerator<DscResourceInfo> _matchingResource = null;
         private Collection<DscResourceInfo> _matchingResourceList = null;
@@ -43,7 +44,12 @@ namespace System.Management.Automation
         public void Reset()
         {
             _currentMatch = null;
-            _matchingResource = null;
+
+            if (_matchingResource != null)
+            {
+                _matchingResource.Dispose();
+                _matchingResource = null;
+            }
         }
 
         /// <summary>
@@ -51,7 +57,7 @@ namespace System.Management.Automation
         /// </summary>
         public void Dispose()
         {
-            Reset();
+            Dispose(true);
             GC.SuppressFinalize(this);
         }
 
@@ -107,6 +113,21 @@ namespace System.Management.Automation
             {
                 return ((IEnumerator<DscResourceInfo>)this).Current;
             }
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed || !disposing)
+            {
+                return;
+            }
+
+            Reset();
+            _disposed = true;
         }
 
         #endregion
@@ -197,7 +218,7 @@ namespace System.Management.Automation
 
             if (!_matchingResource.MoveNext())
             {
-                _matchingResource = null;
+                Reset();
             }
             else
             {


### PR DESCRIPTION
# PR Summary

Dispose `IDisposable` search results in `CommandSearcher` and `DscResourceSearcher` when they run out of scope/the owner instances do get disposed.

## PR Context

This change improves the handling of disposable objects (ie. implementing `IDisposable`) in accordance with the default implementation pattern. Partly addresses the currently disable compiler warnings of the CA2213 and CA2215 type. Partially addresses the violations mentioned in #15803.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
