### PR TITLE
Refactor to use standard IDisposable pattern

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -437,6 +437,17 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         //
         public void Dispose()
         {
+            Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
             if (_hDataSource != null && !_hDataSource.IsInvalid)
             {
                 _hDataSource.Dispose();
@@ -451,8 +462,6 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             {
                 _hQuery.Dispose();
             }
-
-            GC.SuppressFinalize(this);
         }
 
         //

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
@@ -1078,6 +1078,8 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
                 _cimSensitiveValueConverter.Dispose();
                 _cancellationTokenSource.Dispose();
             }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -281,12 +281,10 @@ namespace Microsoft.PowerShell.Commands
             CleanUp();
         }
 
-        /// <summary>
-        /// InternalDispose.
-        /// </summary>
-        protected override void InternalDispose()
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
         {
-            base.InternalDispose();
+            base.Dispose(disposing);
             CleanUp();
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseCommand.cs
@@ -251,20 +251,24 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             if (disposing)
             {
+                if (this.implementation != null)
+                {
+                    this.implementation.Dispose();
+                    this.implementation = null;
+                }
+
+#pragma warning disable CS0618 // Type or member is obsolete - Call is required for backwards compatibility
                 InternalDispose();
+#pragma warning restore CS0618 // Type or member is obsolete - Call is required for backwards compatibility
             }
         }
 
         /// <summary>
         /// Do-nothing implementation: derived classes will override as see fit.
         /// </summary>
+        [Obsolete("Derived classes should override Dispose(bool disposing) instead.", false)]
         protected virtual void InternalDispose()
         {
-            if (this.implementation == null)
-                return;
-
-            this.implementation.Dispose();
-            this.implementation = null;
         }
         #endregion
     }

--- a/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
@@ -141,16 +141,10 @@ namespace Microsoft.PowerShell.Commands
             base.EndProcessing();
         }
 
-        /// <summary>
-        /// Revert transcription state on Dispose.
-        /// </summary>
-        protected override void InternalDispose()
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
         {
-            try
-            {
-                base.InternalDispose();
-            }
-            finally
+            if (disposing)
             {
                 if (_transcribeOnlyCookie != null)
                 {
@@ -158,6 +152,8 @@ namespace Microsoft.PowerShell.Commands
                     _transcribeOnlyCookie = null;
                 }
             }
+
+            base.Dispose(disposing);
         }
 
         private List<PSObject> _outVarResults = null;


### PR DESCRIPTION
# PR Summary

Instead of a custom `InternalDispose()` method, `Dipose(bool disposing)` should be overridden. The former method is left in for compatibility, because `BaseCommand` is public.

## PR Context

This change improves the handling of disposable objects (ie. implementing `IDisposable`) in accordance with the default implementation pattern. Partly addresses the currently disable compiler warnings of the CA2213 and CA2215 type. Partially addresses the violations mentioned in #15803.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
