### PR TITLE
Make the static constructor of `PSVersionInfo` run faster for stable PowerShell releases

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -45,13 +45,12 @@ namespace Microsoft.PowerShell
                 var principal = new WindowsPrincipal(identity);
                 if (principal.IsInRole(WindowsBuiltInRole.Administrator))
                 {
-                    // check using Regex if the window already has Administrator: prefix
-                    // (i.e. from the parent console process)
-                    string template = ConsoleHostRawUserInterfaceStrings.WindowTitleTemplate;
-                    string windowTitle = WindowTitle;
-                    if (!windowTitle.AsSpan().StartsWith(template.AsSpan(0, template.IndexOf('{'))))
+                    // Check if the window already has the "Administrator: " prefix (i.e. from the parent console process).
+                    ReadOnlySpan<char> prefix = ConsoleHostRawUserInterfaceStrings.WindowTitleElevatedPrefix;
+                    ReadOnlySpan<char> windowTitle = WindowTitle;
+                    if (!windowTitle.StartsWith(prefix))
                     {
-                        WindowTitle = StringUtil.Format(template, windowTitle);
+                        WindowTitle = string.Concat(prefix, windowTitle);
                     }
                 }
             });

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -41,23 +41,17 @@ namespace Microsoft.PowerShell
             //   (we may load resources which can take some time)
             Task.Run(() =>
             {
-                WindowsIdentity identity = WindowsIdentity.GetCurrent();
-                WindowsPrincipal principal = new WindowsPrincipal(identity);
+                var identity = WindowsIdentity.GetCurrent();
+                var principal = new WindowsPrincipal(identity);
                 if (principal.IsInRole(WindowsBuiltInRole.Administrator))
                 {
-                    string prefix = ConsoleHostRawUserInterfaceStrings.WindowTitleElevatedPrefix;
-
                     // check using Regex if the window already has Administrator: prefix
                     // (i.e. from the parent console process)
-                    string titlePattern = ConsoleHostRawUserInterfaceStrings.WindowTitleTemplate;
-                    titlePattern = Regex.Escape(titlePattern)
-                        .Replace(@"\{1}", ".*")
-                        .Replace(@"\{0}", Regex.Escape(prefix));
-                    if (!Regex.IsMatch(this.WindowTitle, titlePattern))
+                    string template = ConsoleHostRawUserInterfaceStrings.WindowTitleTemplate;
+                    string windowTitle = WindowTitle;
+                    if (!windowTitle.AsSpan().StartsWith(template.AsSpan(0, template.IndexOf('{'))))
                     {
-                        this.WindowTitle = StringUtil.Format(ConsoleHostRawUserInterfaceStrings.WindowTitleTemplate,
-                            prefix,
-                            this.WindowTitle);
+                        WindowTitle = StringUtil.Format(template, windowTitle);
                     }
                 }
             });

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostRawUserInterfaceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostRawUserInterfaceStrings.resx
@@ -171,7 +171,7 @@
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
     <value>Window title cannot be longer than {0} characters.</value>
   </data>
-  <data name="WindowTitleTemplate" xml:space="preserve">
-    <value>Administrator: {0}</value>
+  <data name="WindowTitleElevatedPrefix" xml:space="preserve">
+    <value>Administrator: </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostRawUserInterfaceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostRawUserInterfaceStrings.resx
@@ -171,10 +171,7 @@
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
     <value>Window title cannot be longer than {0} characters.</value>
   </data>
-  <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator</value>
-  </data>
   <data name="WindowTitleTemplate" xml:space="preserve">
-    <value>{0}: {1}</value>
+    <value>Administrator: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -76,9 +76,6 @@ namespace System.Management.Automation
         // Static Constructor.
         static PSVersionInfo()
         {
-            var watch = new System.Diagnostics.Stopwatch();
-            watch.Start();
-
             s_psVersionTable = new PSVersionHashTable(StringComparer.OrdinalIgnoreCase);
 
             Assembly currentAssembly = typeof(PSVersionInfo).Assembly;
@@ -118,9 +115,6 @@ namespace System.Management.Automation
             s_psVersionTable[WSManStackVersionName] = GetWSManStackVersion();
             s_psVersionTable[PSPlatformName] = Environment.OSVersion.Platform.ToString();
             s_psVersionTable[PSOSName] = Runtime.InteropServices.RuntimeInformation.OSDescription;
-
-            watch.Stop();
-            Console.WriteLine(watch.Elapsed.TotalMilliseconds);
         }
 
         private static (int major, int minor, int patch, string preReleaseLabel) FastParsePSVersion(ReadOnlySpan<char> mainVersion)

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -97,8 +97,8 @@ namespace System.Management.Automation
             ReadOnlySpan<char> mainVersion = ProductVersion.AsSpan(0, index);
 
             string rawGitCommitId = ProductVersion.AsSpan(index).StartsWith(" Commits: ")
-                ? "v" + ProductVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g")
-                : string.Concat("v".AsSpan(), mainVersion);
+                ? ProductVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g")
+                : new string(mainVersion);
 
             var r = FastParsePSVersion(mainVersion);
             s_psSemVersion = r.preReleaseLabel is null

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -7,7 +7,7 @@ Describe "PSVersionTable" -Tags "CI" {
         $formattedVersion = $sma.VersionInfo.ProductVersion
 
         $mainVersionPattern = "(\d+\.\d+\.\d+)(-.+)?"
-        $fullVersionPattern = "^(\d+\.\d+\.\d+)(-.+)?-(\d+)-g(.+)$"
+        $fullVersionPattern = "^v(\d+\.\d+\.\d+)(-.+)?-(\d+)-g(.+)$"
 
         $expectedPSVersion = ($formattedVersion -split " ")[0]
         $expectedVersionPattern = "^$mainVersionPattern$"

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -6,8 +6,8 @@ Describe "PSVersionTable" -Tags "CI" {
         $sma = Get-Item (Join-Path $PSHOME "System.Management.Automation.dll")
         $formattedVersion = $sma.VersionInfo.ProductVersion
 
-        $mainVersionPattern = "v(\d+\.\d+\.\d+)(-.+)?"
-        $fullVersionPattern = "^v(\d+\.\d+\.\d+)(-.+)?-(\d+)-g(.+)$"
+        $mainVersionPattern = "(\d+\.\d+\.\d+)(-.+)?"
+        $fullVersionPattern = "^(\d+\.\d+\.\d+)(-.+)?-(\d+)-g(.+)$"
 
         $expectedPSVersion = ($formattedVersion -split " ")[0]
         $expectedVersionPattern = "^$mainVersionPattern$"

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -6,7 +6,7 @@ Describe "PSVersionTable" -Tags "CI" {
         $sma = Get-Item (Join-Path $PSHOME "System.Management.Automation.dll")
         $formattedVersion = $sma.VersionInfo.ProductVersion
 
-        $mainVersionPattern = "(\d+\.\d+\.\d+)(-.+)?"
+        $mainVersionPattern = "v(\d+\.\d+\.\d+)(-.+)?"
         $fullVersionPattern = "^v(\d+\.\d+\.\d+)(-.+)?-(\d+)-g(.+)$"
 
         $expectedPSVersion = ($formattedVersion -split " ")[0]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Make the static constructor of `PSVersionInfo` run faster for stable PowerShell releases.

Major changes are:
1. ~Fast parse the pre-defined PowerShell version string, instead of going through `SemanticVersion.Parse(string)`.~
    - ~For stable versions, this can avoid all overhead in constructing the `SemanticVersion` object.~
    - ~For preview versions, a regex matching is still needed when constructing the `SementicVersion` object.~
    - This change has been moved to https://github.com/PowerShell/PowerShell/pull/15603
2. Change all legacy versions to use `Version` instead of `SemanticVersion`, to avoid the overhead of casting when using them for `$PSVersionTable.PSCompatibleVersions`.
3. Simplify the constructor of `ConsoleHostRawUserInterface` to not use `Regex`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
