### PR TITLE
Refactor Escape() method

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4401,9 +4401,9 @@ namespace System.Management.Automation
                 var relativePaths = context.GetOption("RelativePaths", @default: defaultRelative);
                 var useLiteralPath = context.GetOption("LiteralPaths", @default: false);
 
-                if (useLiteralPath && LocationGlobber.StringContainsGlobCharacters(wordToComplete))
+                if (useLiteralPath)
                 {
-                    wordToComplete = WildcardPattern.Escape(wordToComplete, Utils.Separators.StarOrQuestion);
+                    wordToComplete = WildcardPattern.Escape(wordToComplete, escapeOnlyBrackets: true);
                 }
 
                 if (!defaultRelative && wordToComplete.Length >= 2 && wordToComplete[1] == ':' && char.IsLetter(wordToComplete[0]) && executionContext != null)
@@ -6137,7 +6137,7 @@ namespace System.Management.Automation
             string memberName,
             Func<object, bool> filter,
             bool isStatic,
-            HashSet<string> excludedMembers = null, 
+            HashSet<string> excludedMembers = null,
             bool addMethodParenthesis = true)
         {
             bool extensionMethodsAdded = false;

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -214,6 +214,11 @@ namespace System.Management.Automation
         /// </returns>
         internal static string Escape(string pattern, bool escapeOnlyBrackets)
         {
+            if (pattern == null)
+            {
+                throw PSTraceSource.NewArgumentNullException(nameof(pattern));
+            }
+
             if (pattern == string.Empty)
             {
                 return pattern;

--- a/test/xUnit/csharp/test_WildcardPattern.cs
+++ b/test/xUnit/csharp/test_WildcardPattern.cs
@@ -33,10 +33,10 @@ namespace PSTests.Parallel
         [Theory]
         [InlineData("a", "a")]
         [InlineData("a*", "a*")]
-        [InlineData("*?[]", "*?[]")]
-        public void TestEscape_String_NotEscape(string source, string expected)
+        [InlineData("*?[]", "*?`[`]")]
+        public void TestEscape_String_OnlyBrackets(string source, string expected)
         {
-            Assert.Equal(WildcardPattern.Escape(source, new[] { '*', '?', '[', ']' }), expected);
+            Assert.Equal(WildcardPattern.Escape(source, true), expected);
         }
 
         [Fact]


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Moved from #18154 

Exclude using LINQ and Utils.Separators.StarOrQuestion (the const is not removed in the PR to avoid merge conflitcs).

``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19044.2006/21H2/November2021Update)
Intel Core i5-2410M CPU 2.30GHz (Sandy Bridge), 1 CPU, 4 logical and 2 physical cores
.NET SDK=7.0.100-rc.1.22431.12
  [Host]     : .NET 7.0.0 (7.0.22.42610), X64 RyuJIT AVX
  DefaultJob : .NET 7.0.0 (7.0.22.42610), X64 RyuJIT AVX


```
|              Method | Categories |                 path |      Mean | Ratio | Code Size | Allocated | Alloc Ratio |
|-------------------- |----------- |--------------------- |----------:|------:|----------:|----------:|------------:|
|     **Orig_Escape_All** |        **All** |                  **c:\\** |  **15.45 ns** |  **1.00** |     **511 B** |         **-** |          **NA** |
|      New_Escape_All |        All |                  c:\ |  13.64 ns |  0.88 |     516 B |         - |          NA |
|                     |            |                      |           |       |           |           |             |
|     **Orig_Escape_All** |        **All** |                 **c:\\*** |  **48.22 ns** |  **1.00** |     **511 B** |      **32 B** |        **1.00** |
|      New_Escape_All |        All |                 c:\\* |  35.58 ns |  0.75 |     516 B |      32 B |        1.00 |
|                     |            |                      |           |       |           |           |             |
|     **Orig_Escape_All** |        **All** | **c:\us(...)ents\ [24]** |  **74.39 ns** |  **1.00** |     **511 B** |         **-** |          **NA** |
|      New_Escape_All |        All | c:\us(...)ents\ [24] |  72.20 ns |  0.97 |     516 B |         - |          NA |
|                     |            |                      |           |       |           |           |             |
|     **Orig_Escape_All** |        **All** | **c:\us(...)nts\\* [25]** | **115.30 ns** |  **1.00** |     **511 B** |      **80 B** |        **1.00** |
|      New_Escape_All |        All | c:\us(...)nts\\* [25] |  98.49 ns |  0.85 |     516 B |      80 B |        1.00 |
|                     |            |                      |           |       |           |           |             |
| **Old_Escape_Brackets** |   **Brackets** |                  **c:\\** |  **15.58 ns** |     **?** |     **511 B** |         **-** |           **?** |
| New_Escape_Brackets |   Brackets |                  c:\ |  12.48 ns |     ? |     519 B |         - |           ? |
|                     |            |                      |           |       |           |           |             |
| **Old_Escape_Brackets** |   **Brackets** |                 **c:\\[** |  **48.80 ns** |     **?** |     **511 B** |      **32 B** |           **?** |
| New_Escape_Brackets |   Brackets |                 c:\\[ |  34.37 ns |     ? |     519 B |      32 B |           ? |
|                     |            |                      |           |       |           |           |             |
| **Old_Escape_Brackets** |   **Brackets** | **c:\us(...)ents\ [24]** |  **75.06 ns** |     **?** |     **511 B** |         **-** |           **?** |
| New_Escape_Brackets |   Brackets | c:\us(...)ents\ [24] |  60.08 ns |     ? |     519 B |         - |           ? |
|                     |            |                      |           |       |           |           |             |
| **Old_Escape_Brackets** |   **Brackets** | **c:\us(...)nts\\[ [25]** | **116.00 ns** |     **?** |     **511 B** |      **80 B** |           **?** |
| New_Escape_Brackets |   Brackets | c:\us(...)nts\\[ [25] |  86.48 ns |     ? |     519 B |      80 B |           ? |


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
