### PR TITLE
Use `MemoryExtensions.IndexOfAny` in `WildcardPattern`

### DIFF
--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -57,11 +57,11 @@ namespace System.Management.Automation
         // The size is less than MaxShortPath = 260.
         private const int StackAllocThreshold = 256;
 
+        // chars that are considered special in a wildcard pattern
+        private const string SpecialChars = "*?[]`";
+
         // we convert a wildcard pattern to a predicate
         private Predicate<string> _isMatch;
-
-        // chars that are considered special in a wildcard pattern
-        private static readonly char[] s_specialChars = new[] { '*', '?', '[', ']', '`' };
 
         // static match-all delegate that is shared by all WildcardPattern instances
         private static readonly Predicate<string> s_matchAll = _ => true;
@@ -173,8 +173,8 @@ namespace System.Management.Automation
                 return;
             }
 
-            int index = Pattern.IndexOfAny(s_specialChars);
-            if (index == -1)
+            int index = Pattern.AsSpan().IndexOfAny(SpecialChars);
+            if (index < 0)
             {
                 // No special characters present in the pattern, so we can just do a string comparison.
                 _isMatch = str => string.Equals(str, Pattern, GetStringComparison());


### PR DESCRIPTION
Use `IndexOfAny<T>(ReadOnlySpan<T>, ReadOnlySpan<T>)`.

Avoid unnecessary static initialization of `s_specialChars` field

cc: @daxian-dbw
