### PR TITLE
Remove some static initializations in `StringManipulationHelper`

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -330,6 +330,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private const char SoftHyphen = '\u00AD';
         private const char HardHyphen = '\u2011';
         private const char NonBreakingSpace = '\u00A0';
+
         private static readonly Collection<string> s_cultureCollection = new Collection<string>();
 
         static StringManipulationHelper()

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -813,7 +813,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return string.Empty;
             }
 
-            int lineBreak = s.IndexOfAny(s_lineBreakChars);
+            int lineBreak = s.AsSpan().IndexOfAny('\n', '\r');
 
             if (lineBreak < 0)
             {
@@ -827,8 +827,5 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             return StringUtil.Padding(count) + val;
         }
-
-        private static readonly char[] s_newLineChar = new char[] { '\n' };
-        private static readonly char[] s_lineBreakChars = new char[] { '\n', '\r' };
     }
 }

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -327,9 +327,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal sealed class StringManipulationHelper
     {
-        private static readonly char s_softHyphen = '\u00AD';
-        private static readonly char s_hardHyphen = '\u2011';
-        private static readonly char s_nonBreakingSpace = '\u00A0';
+        private const char SoftHyphen = '\u00AD';
+        private const char HardHyphen = '\u2011';
+        private const char NonBreakingSpace = '\u00A0';
         private static readonly Collection<string> s_cultureCollection = new Collection<string>();
 
         static StringManipulationHelper()
@@ -377,13 +377,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 string delimiter = null;
-                if (s[i] == ' ' || s[i] == '\t' || s[i] == s_softHyphen)
+                if (s[i] is ' ' or '\t' or SoftHyphen)
                 {
                     // Soft hyphen = \u00AD - Should break, and add a hyphen if needed.
                     // If not needed for a break, hyphen should be absent.
                     delimiter = new string(s[i], 1);
                 }
-                else if (s[i] == s_hardHyphen || s[i] == s_nonBreakingSpace)
+                else if (s[i] is HardHyphen or NonBreakingSpace)
                 {
                     // Non-breaking space = \u00A0 - ideally shouldn't wrap.
                     // Hard hyphen = \u2011 - Should not break.
@@ -596,9 +596,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     string suffix = null;
 
                     // Handle soft hyphen
-                    if (word.Delim.Length == 1 && word.Delim[0] == s_softHyphen)
+                    if (word.Delim.Length == 1 && word.Delim[0] is SoftHyphen)
                     {
-                        int wordWidthWithHyphen = displayCells.Length(wordToAdd) + displayCells.Length(s_softHyphen);
+                        int wordWidthWithHyphen = displayCells.Length(wordToAdd) + displayCells.Length(SoftHyphen);
 
                         // Add hyphen only if necessary
                         if (wordWidthWithHyphen == spacesLeft)


### PR DESCRIPTION
* Avoid static initialization of `s_lineBreakChars` field using `IndexOfAny<T>(ReadOnlySpan<T>, ReadOnlySpan<T>)`.
* Remove unused `s_newLineChar` field.
* Replace some `static readonly` with `const` and use pattern matching.