### PR TITLE
Use `MemoryExtensions.IndexOfAny` in `SessionStateInternal`

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
@@ -231,27 +231,11 @@ namespace System.Management.Automation
 
         private static bool IsValidDriveName(string name)
         {
-            bool result = true;
+            const string CharactersInvalidInDriveName = ":/\\.~";
 
-            do
-            {
-                if (string.IsNullOrEmpty(name))
-                {
-                    result = false;
-                    break;
-                }
-
-                if (name.IndexOfAny(s_charactersInvalidInDriveName) >= 0)
-                {
-                    result = false;
-                    break;
-                }
-            } while (false);
-
-            return result;
+            return !string.IsNullOrEmpty(name)
+                && name.AsSpan().IndexOfAny(CharactersInvalidInDriveName) < 0;
         }
-
-        private static readonly char[] s_charactersInvalidInDriveName = new char[] { ':', '/', '\\', '.', '~' };
 
         /// <summary>
         /// Tries to resolve the drive root as an MSH path. If it successfully resolves


### PR DESCRIPTION
* Use `IndexOfAny<T>(ReadOnlySpan<T>, ReadOnlySpan<T>)`.
* Avoid unnecessary static initialization of `s_charactersInvalidInDriveName` field.
* Refactored `do ...  while(false)` loop.

cc: @daxian-dbw, @iSazonov
