### PR TITLE
Add `-FuzzyMinimumDistance` parameter to `Get-Command`

### DIFF
--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -507,17 +507,16 @@ namespace Microsoft.PowerShell.Commands
 
             if (UseFuzzyMatching)
             {
-                _commandScores = _commandScores
+                results = _commandScores
                     .Where(x => x.Score <= FuzzyMinimumDistance)
                     .OrderBy(static x => x.Score)
+                    .Select(static x => x.Command)
                     .ToList();
-                results = _commandScores.Select(static x => x.Command);
             }
 
             int count = 0;
             foreach (CommandInfo result in results)
             {
-                count += 1;
                 // Only write the command if it is visible to the requestor
                 if (SessionState.IsVisible(origin, result))
                 {
@@ -545,7 +544,7 @@ namespace Microsoft.PowerShell.Commands
                             if (UseFuzzyMatching)
                             {
                                 PSObject obj = new PSObject(result);
-                                obj.Properties.Add(new PSNoteProperty("Score", _commandScores[count].Score);
+                                obj.Properties.Add(new PSNoteProperty("Score", _commandScores[count].Score));
                                 WriteObject(obj);
                             }
                             else
@@ -555,6 +554,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                 }
+                count += 1;
             }
 
 #if LEGACYTELEMETRY

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -554,6 +554,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                 }
+
                 count += 1;
             }
 

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -345,7 +345,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "AllCommandSet")]
         public uint FuzzyMinimumDistance { get; set; } = 5;
 
-        private readonly List<CommandScore> _commandScores = new List<CommandScore>();
+        private List<CommandScore> _commandScores = new List<CommandScore>();
 
         /// <summary>
         /// Gets or sets the parameter that determines if return cmdlets based on abbreviation expansion.
@@ -507,11 +507,11 @@ namespace Microsoft.PowerShell.Commands
 
             if (UseFuzzyMatching)
             {
-                results = _commandScores
+                _commandScores = _commandScores
                     .Where(x => x.Score <= FuzzyMinimumDistance)
                     .OrderBy(static x => x.Score)
-                    .Select(static x => x.Command)
                     .ToList();
+                results = _commandScores.Select(static x => x.Command);
             }
 
             int count = 0;

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -545,7 +545,7 @@ namespace Microsoft.PowerShell.Commands
                             if (UseFuzzyMatching)
                             {
                                 PSObject obj = new PSObject(result);
-                                obj.Properties.Add(new PSNoteProperty("Score", _commandScores.First(x => x.Command == result).Score));
+                                obj.Properties.Add(new PSNoteProperty("Score", _commandScores[count].Score);
                                 WriteObject(obj);
                             }
                             else

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -507,7 +507,11 @@ namespace Microsoft.PowerShell.Commands
 
             if (UseFuzzyMatching)
             {
-                results = _commandScores.Where(x => x.Score <= FuzzyMinimumDistance).OrderBy(static x => x.Score).Select(static x => x.Command).ToList();
+                _commandScores = _commandScores
+                    .Where(x => x.Score <= FuzzyMinimumDistance)
+                    .OrderBy(static x => x.Score)
+                    .ToList();
+                results = _commandScores.Select(static x => x.Command);
             }
 
             int count = 0;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -7,6 +7,7 @@ Describe "Get-Command Feature tests" -Tag Feature {
             $cmds = Get-Command get-hlp -UseFuzzyMatch
             $cmds.Count | Should -BeGreaterThan 0
             $cmds[0].Name | Should -BeExactly 'Get-Help' -Because "This should be closest match so shows up first"
+            $cmds[0].Score | Should -Be 1
         }
 
         It "Should match native commands" {
@@ -19,6 +20,14 @@ Describe "Get-Command Feature tests" -Tag Feature {
             $cmds = Get-Command $input -UseFuzzyMatch
             $cmds.Count | Should -BeGreaterThan 0
             $cmds.Name | Should -Contain $expectedcmd
+        }
+
+        It "Should use minimum distance" {
+            $cmds = Get-Command get-hlp -UseFuzzyMatch -FuzzyMinimumDistance 3
+            $cmds.Count | Should -BeGreaterThan 0
+            foreach ($cmd in $cmds) {
+                $cmd.Score | Should -BeLessOrEqual 3
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a `-FuzzyMinimumDistance` parameter to `Get-Command` so you can get more accurate or less accurate matches.  Also, when using fuzzy matching, a `Score` NoteProperty is added to the CommandInfo to know what the distance was.

The filtering has to be done in the cmdlet as the CommandSearcher currently only has the ability to pass flags and not a value for the distance.

## PR Context

As part of https://github.com/PowerShell/PowerShell/pull/18252, we should limit showing fuzzy matches with distance of 1 or maybe 2 so that the closest matches are displayed.  

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: [9302](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9302)
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
