### PR TITLE
[release/v7.2.7] Backport of "Fix error formatting to use color defined in `$PSStyle.Formatting`"

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -811,33 +811,18 @@ namespace System.Management.Automation.Runspaces
                             $ellipsis = ""`u{2026}""
                             $resetColor = ''
                             $errorColor = ''
+                            $accentColor = ''
+
                             if ($Host.UI.SupportsVirtualTerminal -and ([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
-                                if ($null -ne $psstyle) {
-                                    $errorColor = $psstyle.Formatting.Error
-                                }
-
-                                $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
-                                    [System.Management.Automation.VTUtility+VT]::Reset
-                                )
-                            }
-
-                            function Get-VT100Color([ConsoleColor] $color) {
-                                if (!$Host.UI.SupportsVirtualTerminal -or !([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
-                                    return ''
-                                }
-
-                                return [System.Management.Automation.VTUtility]::GetEscapeSequence($color)
+                                $resetColor = $PSStyle.Reset
+                                $errorColor = $psstyle.Formatting.Error
+                                $accentColor = $PSStyle.Formatting.FormatAccent
                             }
 
                             function Show-ErrorRecord($obj, [int]$indent = 0, [int]$depth = 1) {
                                 $newline = [Environment]::Newline
                                 $output = [System.Text.StringBuilder]::new()
                                 $prefix = ' ' * $indent
-                                $accentColor = ''
-
-                                if ($null -ne $Host.PrivateData) {
-                                    $accentColor = Get-VT100Color ($Host.PrivateData.FormatAccentColor ?? $Host.PrivateData.ErrorForegroundColor)
-                                }
 
                                 $expandTypes = @(
                                     'Microsoft.Rest.HttpRequestMessageWrapper'
@@ -1066,36 +1051,17 @@ namespace System.Management.Automation.Runspaces
                                     Set-StrictMode -Off
                                     $newline = [Environment]::Newline
 
+                                    $resetColor = ''
+                                    $errorColor = ''
+                                    $accentColor = ''
+
+                                    if ($Host.UI.SupportsVirtualTerminal -and ([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
+                                        $resetColor = $PSStyle.Reset
+                                        $errorColor = $PSStyle.Formatting.Error
+                                        $accentColor = $PSStyle.Formatting.ErrorAccent
+                                    }
+
                                     function Get-ConciseViewPositionMessage {
-
-                                        $resetColor = ''
-                                        if ($Host.UI.SupportsVirtualTerminal -and ([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
-                                            $resetColor = [System.Management.Automation.VTUtility]::GetEscapeSequence(
-                                                [System.Management.Automation.VTUtility+VT]::Reset
-                                            )
-                                        }
-
-                                        function Get-VT100Color([ConsoleColor] $color) {
-                                            if (!$Host.UI.SupportsVirtualTerminal -or !([string]::IsNullOrEmpty($env:__SuppressAnsiEscapeSequences))) {
-                                                return ''
-                                            }
-
-                                            return [System.Management.Automation.VTUtility]::GetEscapeSequence($color)
-                                        }
-
-                                        # return length of string sans VT100 codes
-                                        function Get-RawStringLength($string) {
-                                            $vtCodes = ""`e[0m"", ""`e[2;30m"", ""`e[2;31m"", ""`e[2;32m"", ""`e[2;33m"", ""`e[2;34m"",
-                                                ""`e[2;35m"", ""`e[2;36m"", ""`e[2;37m"", ""`e[1;30m"", ""`e[1;31m"", ""`e[1;32m"",
-                                                ""`e[1;33m"", ""`e[1;34m"", ""`e[1;35m"", ""`e[1;36m"", ""`e[1;37m""
-
-                                            $newString = $string
-                                            foreach ($vtCode in $vtCodes) {
-                                                $newString = $newString.Replace($vtCode, '')
-                                            }
-
-                                            return $newString.Length
-                                        }
 
                                         # returns a string cut to last whitespace
                                         function Get-TruncatedString($string, [int]$length) {
@@ -1105,14 +1071,6 @@ namespace System.Management.Automation.Runspaces
                                             }
 
                                             return ($string.Substring(0,$length) -split '\s',-2)[0]
-                                        }
-
-                                        $errorColor = ''
-                                        $accentColor = ''
-
-                                        if ($null -ne $Host.PrivateData) {
-                                            $errorColor = Get-VT100Color $Host.PrivateData.ErrorForegroundColor
-                                            $accentColor = Get-VT100Color ($Host.PrivateData.ErrorAccentColor ?? $errorColor)
                                         }
 
                                         $posmsg = ''
@@ -1217,7 +1175,7 @@ namespace System.Management.Automation.Runspaces
 
                                         # if rendering line information, break up the message if it's wider than the console
                                         if ($myinv -and $myinv.ScriptName -or $err.CategoryInfo.Category -eq 'ParserError') {
-                                            $prefixLength = Get-RawStringLength -string $prefix
+                                            $prefixLength = [System.Management.Automation.Internal.StringDecorated]::new($prefix).ContentLength
                                             $prefixVtLength = $prefix.Length - $prefixLength
 
                                             # replace newlines in message so it lines up correct
@@ -1296,82 +1254,77 @@ namespace System.Management.Automation.Runspaces
                                         $myinv = $err.InvocationInfo
                                     }
 
-                                    if ($ErrorView -ne 'ConciseView' -and $null -ne $host.PrivateData) {
-                                        if ($null -ne $host.PrivateData.ErrorForegroundColor) {
-                                            [Console]::ForegroundColor = $host.PrivateData.ErrorForegroundColor
-                                        }
-
-                                        if ($null -ne $host.PrivateData.ErrorBackgroundColor) {
-                                            [Console]::BackgroundColor = $host.PrivateData.ErrorBackgroundColor
-                                        }
+                                    if ($err.FullyQualifiedErrorId -eq 'NativeCommandErrorMessage' -or $err.FullyQualifiedErrorId -eq 'NativeCommandError') {
+                                        return ""${errorColor}$($err.Exception.Message)${resetcolor}""
                                     }
 
-                                    if ($err.FullyQualifiedErrorId -eq 'NativeCommandErrorMessage' -or $err.FullyQualifiedErrorId -eq 'NativeCommandError') {
-                                        $err.Exception.Message
+                                    $myinv = $err.InvocationInfo
+                                    if ($ErrorView -eq 'DetailedView') {
+                                        $message = Get-Error | Out-String
+                                        return ""${errorColor}${message}${resetcolor}""
+                                    }
+
+                                    if ($ErrorView -eq 'CategoryView') {
+                                        $message = $err.CategoryInfo.GetMessage()
+                                        return ""${errorColor}${message}${resetcolor}""
+                                    }
+
+                                    $posmsg = ''
+                                    if ($ErrorView -eq 'ConciseView') {
+                                        $posmsg = Get-ConciseViewPositionMessage
+                                    }
+                                    elseif ($myinv -and ($myinv.MyCommand -or ($err.CategoryInfo.Category -ne 'ParserError'))) {
+                                        $posmsg = $myinv.PositionMessage
+                                    }
+
+                                    if ($posmsg -ne '') {
+                                        $posmsg = $newline + $posmsg
+                                    }
+
+                                    if ($err.PSMessageDetails) {
+                                        $posmsg = ' : ' +  $err.PSMessageDetails + $posmsg
+                                    }
+
+                                    if ($ErrorView -eq 'ConciseView') {
+                                        if ($err.PSMessageDetails) {
+                                            $posmsg = ""${errorColor}${posmsg}""
+                                        }
+                                        return $posmsg
+                                    }
+
+                                    $indent = 4
+
+                                    $errorCategoryMsg = $err.ErrorCategory_Message
+
+                                    if ($null -ne $errorCategoryMsg)
+                                    {
+                                        $indentString = '+ CategoryInfo          : ' + $err.ErrorCategory_Message
                                     }
                                     else
                                     {
-                                        $myinv = $err.InvocationInfo
-                                        if ($ErrorView -eq 'DetailedView') {
-                                            return (Get-Error | Out-String)
-                                        }
-                                        elseif ($ErrorView -eq 'ConciseView') {
-                                            $posmsg = Get-ConciseViewPositionMessage
-                                        }
-                                        elseif ($myinv -and ($myinv.MyCommand -or ($err.CategoryInfo.Category -ne 'ParserError'))) {
-                                            $posmsg = $myinv.PositionMessage
-                                        } else {
-                                            $posmsg = ''
-                                        }
-
-                                        if ($posmsg -ne '')
-                                        {
-                                            $posmsg = $newline + $posmsg
-                                        }
-
-                                        if ($err.PSMessageDetails) {
-                                            $posmsg = ' : ' +  $err.PSMessageDetails + $posmsg
-                                        }
-
-                                        if ($ErrorView -eq 'ConciseView') {
-                                            return $posmsg
-                                        }
-
-                                        $indent = 4
-
-                                        $errorCategoryMsg = $err.ErrorCategory_Message
-
-                                        if ($null -ne $errorCategoryMsg)
-                                        {
-                                            $indentString = '+ CategoryInfo          : ' + $err.ErrorCategory_Message
-                                        }
-                                        else
-                                        {
-                                            $indentString = '+ CategoryInfo          : ' + $err.CategoryInfo
-                                        }
-
-                                        $posmsg += $newline + $indentString
-
-                                        $indentString = ""+ FullyQualifiedErrorId : "" + $err.FullyQualifiedErrorId
-                                        $posmsg += $newline + $indentString
-
-                                        $originInfo = $err.OriginInfo
-
-                                        if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
-                                        {
-                                            $indentString = ""+ PSComputerName        : "" + $originInfo.PSComputerName
-                                            $posmsg += $newline + $indentString
-                                        }
-
-                                        if ($ErrorView -eq 'CategoryView') {
-                                            $err.CategoryInfo.GetMessage()
-                                        }
-                                        elseif (! $err.ErrorDetails -or ! $err.ErrorDetails.Message) {
-                                            $err.Exception.Message + $posmsg
-                                        } else {
-                                            $err.ErrorDetails.Message + $posmsg
-                                        }
+                                        $indentString = '+ CategoryInfo          : ' + $err.CategoryInfo
                                     }
+
+                                    $posmsg += $newline + $indentString
+
+                                    $indentString = ""+ FullyQualifiedErrorId : "" + $err.FullyQualifiedErrorId
+                                    $posmsg += $newline + $indentString
+
+                                    $originInfo = $err.OriginInfo
+
+                                    if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
+                                    {
+                                        $indentString = ""+ PSComputerName        : "" + $originInfo.PSComputerName
+                                        $posmsg += $newline + $indentString
+                                    }
+
+                                    $finalMsg = if ($err.ErrorDetails.Message) {
+                                        $err.ErrorDetails.Message + $posmsg
+                                    } else {
+                                        $err.Exception.Message + $posmsg
+                                    }
+
+                                    ""${errorColor}${finalMsg}${resetcolor}""
                                 ")
                     .EndEntry()
                 .EndControl());

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4489,7 +4489,7 @@ end {
                 SpecialVariables.PSStyle,
                 PSStyle.Instance,
                 RunspaceInit.PSStyleDescription,
-                ScopedItemOptions.None),
+                ScopedItemOptions.Constant),
 
             // Variable which controls the encoding for piping data to a NativeCommand
             new SessionStateVariableEntry(

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -420,14 +420,15 @@ export $envVarName='$guid'
         It "errors are in text if error is redirected, encoded command, non-interactive, and outputformat specified" {
             $p = [Diagnostics.Process]::new()
             $p.StartInfo.FileName = "pwsh"
-            $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes('$ErrorView="NormalView";throw "boom"'))
+            $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes('throw "boom"'))
             $p.StartInfo.Arguments = "-EncodedCommand $encoded -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -OutputFormat text"
             $p.StartInfo.UseShellExecute = $false
             $p.StartInfo.RedirectStandardError = $true
             $p.Start() | Out-Null
             $out = $p.StandardError.ReadToEnd()
             $out | Should -Not -BeNullOrEmpty
-            $out.Split([Environment]::NewLine)[0] | Should -BeExactly "boom"
+            $out = $out.Split([Environment]::NewLine)[0]
+            [System.Management.Automation.Internal.StringDecorated]::new($out).ToString("PlainText") | Should -BeExactly "Exception: boom"
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Backport of "Fix error formatting to use color defined in `$PSStyle.Formatting`".
Reference PR: #18086

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
