### PR TITLE
Code Cleanup ContentHelper.Common.cs

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -13,13 +13,6 @@ namespace Microsoft.PowerShell.Commands
 {
     internal static class ContentHelper
     {
-        #region Fields
-
-        // used to split contentType arguments
-        private static readonly char[] s_contentTypeParamSeparator = { ';' };
-
-        #endregion Fields
-
         #region Internal Methods
 
         internal static string GetContentType(HttpResponseMessage response)
@@ -175,7 +168,7 @@ namespace Microsoft.PowerShell.Commands
             if (string.IsNullOrEmpty(contentType))
                 return null;
 
-            string sig = contentType.Split(s_contentTypeParamSeparator, 2)[0].ToUpperInvariant();
+            string sig = contentType.Split(';', 2)[0].ToUpperInvariant();
             return (sig);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -13,13 +13,6 @@ namespace Microsoft.PowerShell.Commands
 {
     internal static class ContentHelper
     {
-        #region Constants
-
-        // default codepage encoding for web content.  See RFC 2616.
-        private const string _defaultCodePage = "ISO-8859-1";
-
-        #endregion Constants
-
         #region Fields
 
         // used to split contentType arguments
@@ -36,8 +29,9 @@ namespace Microsoft.PowerShell.Commands
         }
 
         internal static Encoding GetDefaultEncoding()
-        { 
-            Encoding encoding = Encoding.GetEncoding(_defaultCodePage);
+        {
+            // default codepage encoding for web content.  See RFC 2616.
+            Encoding encoding = Encoding.GetEncoding("ISO-8859-1");
             return encoding;    
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -36,34 +36,9 @@ namespace Microsoft.PowerShell.Commands
         }
 
         internal static Encoding GetDefaultEncoding()
-        {
-            return GetEncodingOrDefault((string)null);
-        }
-
-        internal static Encoding GetEncoding(HttpResponseMessage response)
-        {
-            // ContentType may not exist in response header.
-            string charSet = response.Content.Headers.ContentType?.CharSet;
-            return GetEncodingOrDefault(charSet);
-        }
-
-        internal static Encoding GetEncodingOrDefault(string characterSet)
-        {
-            // get the name of the codepage to use for response content
-            string codepage = (string.IsNullOrEmpty(characterSet) ? _defaultCodePage : characterSet);
-            Encoding encoding = null;
-
-            try
-            {
-                encoding = Encoding.GetEncoding(codepage);
-            }
-            catch (ArgumentException)
-            {
-                // 0, default code page
-                encoding = Encoding.GetEncoding(0);
-            }
-
-            return encoding;
+        { 
+            Encoding encoding = Encoding.GetEncoding(_defaultCodePage);
+            return encoding;    
         }
 
         internal static StringBuilder GetRawContentHeader(HttpResponseMessage response)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -404,8 +404,6 @@ namespace Microsoft.PowerShell.Commands
                     string charSet = response.Content.Headers.ContentType?.CharSet;
                     if (!string.IsNullOrEmpty(charSet))
                     {
-                        // NOTE: Don't use ContentHelper.GetEncoding; it returns a
-                        // default which bypasses checking for a meta charset value.
                         StreamHelper.TryGetEncoding(charSet, out encoding);
                     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Removed `ContentHelper.GetEncoding`, it was never used.
Without `ContentHelper.GetEncoding`, `ContentHelper.GetDefaultEncoding` always passes a null string to `ContentHelper.GetEncodingOrDefault`, so it always returns the default encoding.
Simplified `ContentHelper.GetDefaultEncoding`.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
