### PR TITLE
Makes Format-Custom treat DateTime as a scalar unless Expaned

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -38,11 +38,9 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [ValidateRangeAttribute(1, int.MaxValue)]
         [Parameter]
-        public int Depth {get; set; } = ComplexSpecificParameters.maxDepthAllowable;
+        public int Depth { get; set; } = ComplexSpecificParameters.maxDepthAllowable;
 
-        /// <summary>
-        /// Types that by default are rendered as scalars (such as System.DateTime), but should be expanded.
-        /// </summary>
+        /// <inheritdoc <see cref="ComplexSpecificParameters.scalarTypesToExpand" />
         [Parameter]
         public string[] ExpandType { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -42,6 +42,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <inheritdoc cref="ComplexSpecificParameters.ScalarTypesToExpand" />
         [Parameter]
+        [ValidateSet("System.DateTime", "System.DateTimeOffset")] // if we get more types here, consider moving to IValidateSetValuesGenerator
         public string[] ExpandType { get; set; }
 
         #endregion
@@ -79,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
 
             ComplexSpecificParameters csp = new();
             csp.maxDepth = Depth;
-            csp.scalarTypesToExpand = ExpandType;
+            csp.ScalarTypesToExpand = ExpandType;
             parameters.shapeParameters = csp;
 
             return parameters;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public int Depth { get; set; } = ComplexSpecificParameters.maxDepthAllowable;
 
-        /// <inheritdoc <see cref="ComplexSpecificParameters.scalarTypesToExpand" />
+        /// <inheritdoc cref="ComplexSpecificParameters.ScalarTypesToExpand" />
         [Parameter]
         public string[] ExpandType { get; set; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -31,28 +31,20 @@ namespace Microsoft.PowerShell.Commands
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]
-        public object[] Property
-        {
-            get { return _props; }
-
-            set { _props = value; }
-        }
-
-        private object[] _props;
+        public object[] Property { get; set; }
 
         /// <summary>
+        /// Specifies the number of levels to recurse complex properties
         /// </summary>
-        /// <value></value>
         [ValidateRangeAttribute(1, int.MaxValue)]
         [Parameter]
-        public int Depth
-        {
-            get { return _depth; }
+        public int Depth {get; set; } = ComplexSpecificParameters.maxDepthAllowable;
 
-            set { _depth = value; }
-        }
-
-        private int _depth = ComplexSpecificParameters.maxDepthAllowable;
+        /// <summary>
+        /// Types that by default are rendered as scalars (such as System.DateTime), but should be expanded.
+        /// </summary>
+        [Parameter]
+        public string[] ExpandType { get; set; }
 
         #endregion
 
@@ -60,11 +52,11 @@ namespace Microsoft.PowerShell.Commands
         {
             FormattingCommandLineParameters parameters = new();
 
-            if (_props != null)
+            if (Property != null)
             {
                 ParameterProcessor processor = new(new FormatObjectParameterDefinition());
                 TerminatingErrorContext invocationContext = new(this);
-                parameters.mshParameterList = processor.ProcessParameters(_props, invocationContext);
+                parameters.mshParameterList = processor.ProcessParameters(Property, invocationContext);
             }
 
             if (!string.IsNullOrEmpty(this.View))
@@ -88,7 +80,8 @@ namespace Microsoft.PowerShell.Commands
             parameters.expansion = ProcessExpandParameter();
 
             ComplexSpecificParameters csp = new();
-            csp.maxDepth = _depth;
+            csp.maxDepth = Depth;
+            csp.scalarTypesToExpand = ExpandType;
             parameters.shapeParameters = csp;
 
             return parameters;

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -107,11 +107,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal int maxDepth = maxDepthAllowable;
 
         /// <summary>
-        /// list of types that are by default rendered as scalar, but should be expanded
+        /// Gets or sets an array of type names that are by default rendered as scalar, but should be expanded.
         /// </summary>
-        internal string[] scalarTypesToExpand {
+        internal string[] scalarTypesToExpand
+        {
             get => _scalarTypesToExpand ?? Array.Empty<string>();
-            set => _scalarTypesToExpand = value; }
+            set => _scalarTypesToExpand = value;
+        }
 
         private string[] _scalarTypesToExpand;
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -105,6 +105,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// Max depth of recursion on sub objects.
         /// </summary>
         internal int maxDepth = maxDepthAllowable;
+
+        /// <summary>
+        /// list of types that are by default rendered as scalar, but should be expanded
+        /// </summary>
+        internal string[] scalarTypesToExpand {
+            get => _scalarTypesToExpand ?? Array.Empty<string>();
+            set => _scalarTypesToExpand = value; }
+
+        private string[] _scalarTypesToExpand;
     }
 
     #endregion

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Gets or sets an array of type names that are by default rendered as scalar, but should be expanded.
         /// </summary>
-        internal string[] scalarTypesToExpand
+        internal string[] ScalarTypesToExpand
         {
             get => _scalarTypesToExpand ?? Array.Empty<string>();
             set => _scalarTypesToExpand = value;

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -447,7 +447,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // create a top level entry as root of the tree
             ComplexViewEntry cve = new ComplexViewEntry();
             var typeNames = so.InternalTypeNames;
-            if (TreatAsScalarType(typeNames, _complexSpecificParameters.scalarTypesToExpand))
+            if (TreatAsScalarType(typeNames, _complexSpecificParameters.ScalarTypesToExpand))
             {
                 FormatEntry fe = new FormatEntry();
 
@@ -591,7 +591,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     formatValueList.Add(new FormatNewLine());
                     DisplayEnumeration(e, level.NextLevel, AddIndentationLevel(formatValueList));
                 }
-                else if (val == null || TreatAsLeafNode(val, level, _complexSpecificParameters.scalarTypesToExpand))
+                else if (val == null || TreatAsLeafNode(val, level, _complexSpecificParameters.ScalarTypesToExpand))
                 {
                     DisplayLeaf(val, formatValueList);
                 }
@@ -642,7 +642,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     enumCount++;
                 }
 
-                if (TreatAsLeafNode(x, level, _complexSpecificParameters.scalarTypesToExpand))
+                if (TreatAsLeafNode(x, level, _complexSpecificParameters.ScalarTypesToExpand))
                 {
                     DisplayLeaf(x, formatValueList);
                 }
@@ -684,11 +684,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="val">Object to verify.</param>
         /// <param name="level">Current level of recursion.</param>
         /// <param name="scalarTypesToExpand">Array of names of types that should not be rendered as scalars.</param>
-        /// <returns></returns>
+        /// <returns>True if it has to be treated as leaf node.</returns>
         private static bool TreatAsLeafNode(object val, TraversalInfo level, string[] scalarTypesToExpand)
         {
             if (level.Level >= level.MaxDepth || val == null)
+            {
                 return true;
+            }
 
             return TreatAsScalarType(PSObject.GetTypeNames(val), scalarTypesToExpand);
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -418,7 +418,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal sealed class ComplexViewObjectBrowser
     {
-        private static readonly HashSet<string> s_defaultLeafTypes = new() { "System.DateTime" };
+        private static readonly HashSet<string> s_defaultLeafTypes = new(System.StringComparer.OrdinalIgnoreCase) 
+        { 
+            "System.DateTime", 
+            "System.DateTimeOffset" 
+        };
 
         internal ComplexViewObjectBrowser(FormatErrorManager resultErrorManager, PSPropertyExpressionFactory mshExpressionFactory, int enumerationLimit)
         {
@@ -703,7 +707,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <returns>True if it has to be treated as a scalar.</returns>
         private static bool TreatAsScalarType(Collection<string> typeNames, string[] scalarTypesToExpand)
         {
-            return TypeIsScalarForComplexView(typeNames, scalarTypesToExpand) || DefaultScalarTypes.IsTypeInList(typeNames);
+            return DefaultScalarTypes.IsTypeInList(typeNames) || TypeIsScalarForComplexView(typeNames, scalarTypesToExpand);
         }
 
         private static bool TypeIsScalarForComplexView(Collection<string> typeNames, string[] scalarTypesToExpand)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -711,7 +711,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // if the type is in the scalarTypesToExpand, we should not treat it as a scalar
                 if (s_defaultLeafTypes.Contains(type))
                 {
-                    if (System.Array.Find(scalarTypesToExpand, t => t == type) is not null){
+                    if (System.Array.Find(scalarTypesToExpand, t => t == type) is not null)
+                    {
                         return false;
                     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -33,7 +33,9 @@ Describe "Format-Custom" -Tags "CI" {
             }
             # locale aware formatting
             $dateStr = $date.ToString()
+            $shortDate = $date.Date.ToString()
             $longDate = $date.ToString("F")
+
         }
 
         It "Should treat datetime as scalar by default" {
@@ -54,7 +56,7 @@ class DateTimeTest
   Date =
     class DateTime
     {
-      Date = 2000-01-02 00:00:00
+      Date = $shortDate
       Day = 2
       DayOfWeek = Sunday
       DayOfYear = 2

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -48,7 +48,7 @@ class DateTimeTest
         }
 
         It "Treats datetime as non-scalar when Expanded" {
-            $res = ($obj | Format-Custom -ExpandType:System.DateTime -Depth:1 | Out-String).Trim()
+            $res = $obj | Format-Custom -ExpandType:System.DateTime -Depth:1 | Out-String
 
             $expected = @"
 class DateTimeTest
@@ -74,8 +74,9 @@ class DateTimeTest
       DateTime = $longDate
     }
 }
-"@ -replace '=\r\n', "= `r`n"
-
+"@ -replace '=\r?\n', "=`n"
+            $res = ($res -replace '\r?\n', "`n").Trim()
+            $expected = ($expected -replace '\r?\n', "`n").Trim()
             $res | Should -BeExactly $expected
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -32,9 +32,8 @@ Describe "Format-Custom" -Tags "CI" {
                 PSTypeName="DateTimeTest"
             }
             # locale aware formatting
-            [string] $dateStr = $date.ToString()
-            [string] $longDate = $date.ToString("F")
-
+            $dateStr = $date.ToString()
+            $longDate = $date.ToString("F")
         }
 
         It "Should treat datetime as scalar by default" {
@@ -48,9 +47,8 @@ class DateTimeTest
         }
 
         It "Treats datetime as non-scalar when Expanded" {
-            $res = $obj | Format-Custom -ExpandType:System.DateTime -Depth:1 | Out-String
 
-            $expected = @"
+          $expected = @"
 class DateTimeTest
 {
   Date =
@@ -74,12 +72,11 @@ class DateTimeTest
       DateTime = $longDate
     }
 }
-"@ -replace '=\r?\n', "=`n"
-            $res = ($res -replace '\r?\n', "`n").Trim()
-            $expected = ($expected -replace '\r?\n', "`n").Trim()
-            $res | Should -BeExactly $expected
-        }
+"@ -replace 'Date =\r?\n', "Date = `n" -replace '\r\n', "`n" # the 'Date = ' replacement is needed as editors trim whitespace at the end of lines.
 
+            $actual = ($obj | Format-Custom -ExpandType:System.DateTime -Depth:1 | Out-String).Trim() -replace '\r?\n', "`n"
+            $actual | Should -BeExactly $expected
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The default behavior of Format-Custom with datetime Properties becomes very spammy. This PR makes the formatting system treat  System.DateTime as a scalar, unless included in the new `ExpandType` parameter.

## PR Context

As discussed in issue #18142, and easily verified by typing
```powershell
[pscustomobject]@{Time = [datetime]::now} | format-custom
```
the default handling of datetime is spammy.

This PR changes the default treatment of DateTime in Format-Custom, but adds a parameter `-ExpandType` that allows the user to opt-in to the old behavior.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: #18142
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
