### PR TITLE
Make New-Item -Force overwrite on Junction

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2504,6 +2504,7 @@ namespace Microsoft.PowerShell.Commands
                                     throw;
                                 }
                             }
+
                             CreateDirectory(path, false);
                             pathDirInfo = new DirectoryInfo(path);
                         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2484,14 +2484,6 @@ namespace Microsoft.PowerShell.Commands
                             return;
                         }
 
-                        // Junctions cannot have files
-                        if (DirectoryInfoHasChildItems((DirectoryInfo)pathDirInfo))
-                        {
-                            string message = StringUtil.Format(FileSystemProviderStrings.DirectoryNotEmpty, path);
-                            WriteError(new ErrorRecord(new IOException(message), "DirectoryNotEmpty", ErrorCategory.WriteError, path));
-                            return;
-                        }
-
                         if (Force)
                         {
                             try
@@ -2515,7 +2507,15 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                     else
-                    {
+                    {                        
+                        // Junctions cannot have files
+                        if (DirectoryInfoHasChildItems((DirectoryInfo)pathDirInfo))
+                        {
+                            string message = StringUtil.Format(FileSystemProviderStrings.DirectoryNotEmpty, path);
+                            WriteError(new ErrorRecord(new IOException(message), "DirectoryNotEmpty", ErrorCategory.WriteError, path));
+                            return;
+                        }
+
                         CreateDirectory(path, false);
                         pathDirInfo = new DirectoryInfo(path);
                     }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2505,17 +2505,19 @@ namespace Microsoft.PowerShell.Commands
                                 }
                             }
                         }
+                        else
+                        {
+                            // Junctions cannot have files
+                            if (DirectoryInfoHasChildItems((DirectoryInfo)pathDirInfo))
+                            {
+                                string message = StringUtil.Format(FileSystemProviderStrings.DirectoryNotEmpty, path);
+                                WriteError(new ErrorRecord(new IOException(message), "DirectoryNotEmpty", ErrorCategory.WriteError, path));
+                                return;
+                            }
+                        }
                     }
                     else
                     {                        
-                        // Junctions cannot have files
-                        if (DirectoryInfoHasChildItems((DirectoryInfo)pathDirInfo))
-                        {
-                            string message = StringUtil.Format(FileSystemProviderStrings.DirectoryNotEmpty, path);
-                            WriteError(new ErrorRecord(new IOException(message), "DirectoryNotEmpty", ErrorCategory.WriteError, path));
-                            return;
-                        }
-
                         CreateDirectory(path, false);
                         pathDirInfo = new DirectoryInfo(path);
                     }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2489,8 +2489,6 @@ namespace Microsoft.PowerShell.Commands
                             try
                             {
                                 pathDirInfo.Delete();
-                                CreateDirectory(path, false);
-                                pathDirInfo = new DirectoryInfo(path);
                             }
                             catch (Exception exception)
                             {
@@ -2506,7 +2504,9 @@ namespace Microsoft.PowerShell.Commands
                                     throw;
                                 }
                             }
-                        }
+                            CreateDirectory(path, false);
+                            pathDirInfo = new DirectoryInfo(path);
+                    }
                         else
                         {
                             // Junctions cannot have files

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2484,46 +2484,36 @@ namespace Microsoft.PowerShell.Commands
                             return;
                         }
 
-                        if (Force)
+                        // Junctions cannot have files
+                        if (!Force && DirectoryInfoHasChildItems((DirectoryInfo)pathDirInfo))
                         {
-                            try
-                            {
-                                pathDirInfo.Delete();
-                            }
-                            catch (Exception exception)
-                            {
-                                if ((exception is DirectoryNotFoundException) ||
-                                    (exception is UnauthorizedAccessException) ||
-                                    (exception is System.Security.SecurityException) ||
-                                    (exception is IOException))
-                                {
-                                    WriteError(new ErrorRecord(exception, "NewItemDeleteIOError", ErrorCategory.WriteError, path));
-                                }
-                                else
-                                {
-                                    throw;
-                                }
-                            }
+                            string message = StringUtil.Format(FileSystemProviderStrings.DirectoryNotEmpty, path);
+                            WriteError(new ErrorRecord(new IOException(message), "DirectoryNotEmpty", ErrorCategory.WriteError, path));
+                            return;
+                        }
 
-                            CreateDirectory(path, false);
-                            pathDirInfo = new DirectoryInfo(path);
-                        }
-                        else
+                        try
                         {
-                            // Junctions cannot have files
-                            if (DirectoryInfoHasChildItems((DirectoryInfo)pathDirInfo))
+                            pathDirInfo.Delete();
+                        }
+                        catch (Exception exception)
+                        {
+                            if ((exception is DirectoryNotFoundException) ||
+                                (exception is UnauthorizedAccessException) ||
+                                (exception is System.Security.SecurityException) ||
+                                (exception is IOException))
                             {
-                                string message = StringUtil.Format(FileSystemProviderStrings.DirectoryNotEmpty, path);
-                                WriteError(new ErrorRecord(new IOException(message), "DirectoryNotEmpty", ErrorCategory.WriteError, path));
-                                return;
+                                WriteError(new ErrorRecord(exception, "NewItemDeleteIOError", ErrorCategory.WriteError, path));
+                            }
+                            else
+                            {
+                                throw;
                             }
                         }
                     }
-                    else
-                    {
-                        CreateDirectory(path, false);
-                        pathDirInfo = new DirectoryInfo(path);
-                    }
+
+                    CreateDirectory(path, streamOutput: false);
+                    pathDirInfo = new DirectoryInfo(path);
 
                     try
                     {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2489,6 +2489,8 @@ namespace Microsoft.PowerShell.Commands
                             try
                             {
                                 pathDirInfo.Delete();
+                                CreateDirectory(path, false);
+                                pathDirInfo = new DirectoryInfo(path);
                             }
                             catch (Exception exception)
                             {
@@ -2517,7 +2519,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                     else
-                    {                        
+                    {
                         CreateDirectory(path, false);
                         pathDirInfo = new DirectoryInfo(path);
                     }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2506,7 +2506,7 @@ namespace Microsoft.PowerShell.Commands
                             }
                             CreateDirectory(path, false);
                             pathDirInfo = new DirectoryInfo(path);
-                    }
+                        }
                         else
                         {
                             // Junctions cannot have files

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -550,6 +550,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
         $nonFile = Join-Path $TestPath "not-a-file"
         $fileContent = "some text"
         $realDir = Join-Path $TestPath "subdir"
+        $realDir2 = Join-Path $TestPath "second-subdir"
         $nonDir = Join-Path $TestPath "not-a-dir"
         $hardLinkToFile = Join-Path $TestPath "hard-to-file.txt"
         $symLinkToFile = Join-Path $TestPath "sym-link-to-file.txt"
@@ -560,6 +561,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
 
         New-Item -ItemType File -Path $realFile -Value $fileContent > $null
         New-Item -ItemType Directory -Path $realDir > $null
+        New-Item -ItemType Directory -Path $realDir2 > $null
     }
 
     Context "New-Item and hard/symbolic links" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -636,8 +636,8 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             New-Item -Name testfile.txt -ItemType file -Path $realDir
             New-Item -ItemType Junction -Path $junctionToDir -Value $realDir > $null
             Test-Path $junctionToDir | Should -BeTrue
-            { New-Item -ItemType Junction -Path $junctionToDir -Value $realDir > $null -ErrorAction Stop } | Should -Throw -ErrorId "DirectoryNotEmpty,Microsoft.PowerShell.Commands.NewItemCommand"
-            New-Item -ItemType Junction -Path $junctionToDir -Value $realDir2 > $null -Force
+            { New-Item -ItemType Junction -Path $junctionToDir -Value $realDir -ErrorAction Stop > $null } | Should -Throw -ErrorId "DirectoryNotEmpty,Microsoft.PowerShell.Commands.NewItemCommand"
+            New-Item -ItemType Junction -Path $junctionToDir -Value $realDir2 -Force > $null
             $Junction = Get-Item -Path $junctionToDir
             $Junction.Target | Should -BeExactly $rd2.ToString()
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -630,6 +630,17 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $i = New-Item -ItemType File -Path "$TestDrive\file.txt" -Force -ErrorAction Ignore
             { New-Item -ItemType HardLink -Path $i -Target $i -Force -ErrorAction Stop } | Should -Throw -ErrorId "TargetIsSameAsLink,Microsoft.PowerShell.Commands.NewItemCommand"
         }
+
+        It "New-Item -Force can overwrite a junction" -Skip:(-Not $IsWindows){
+            $rd2 = Get-Item -Path $realDir2
+            New-Item -Name testfile.txt -ItemType file -Path $realDir
+            New-Item -ItemType Junction -Path $junctionToDir -Value $realDir > $null
+            Test-Path $junctionToDir | Should -BeTrue
+            { New-Item -ItemType Junction -Path $junctionToDir -Value $realDir > $null -ErrorAction Stop } | Should -Throw -ErrorId "DirectoryNotEmpty,Microsoft.PowerShell.Commands.NewItemCommand"
+            New-Item -ItemType Junction -Path $junctionToDir -Value $realDir2 > $null -Force
+            $Junction = Get-Item -Path $junctionToDir
+            $Junction.Target | Should -BeExactly $rd2.ToString()
+        }
     }
 
     Context "Get-ChildItem and symbolic links" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
When performing `New-Item <itemname> -Type Junction -Value <path> -Force`, it will fail with `"<path> cannot be removed because it is not empty."`. 

This has been resolved by moving the Child Item check from before force is checked, to the else condition of the force check.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
This PR aims to fix #17656.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
