### PR TITLE
Remove the `ProcessorArchitecture` portion from the full name as it's obsolete

### DIFF
--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -865,7 +865,7 @@ namespace System.Management.Automation
             return v;
         }
 
-        internal static void ReadRegistryInfo(out Version assemblyVersion, out string publicKeyToken, out string culture, out string architecture, out string applicationBase, out Version psVersion)
+        internal static void ReadRegistryInfo(out Version assemblyVersion, out string publicKeyToken, out string culture, out string applicationBase, out Version psVersion)
         {
             applicationBase = Utils.DefaultPowerShellAppBase;
             Dbg.Assert(
@@ -885,8 +885,7 @@ namespace System.Management.Automation
             // culture, publickeytoken...This will break the scenarios where only one of
             // the assemblies is patched. ie., all monad assemblies should have the
             // same version number.
-            Assembly currentAssembly = typeof(PSSnapInReader).Assembly;
-            AssemblyName assemblyName = currentAssembly.GetName();
+            AssemblyName assemblyName = typeof(PSSnapInReader).Assembly.GetName();
             assemblyVersion = assemblyName.Version;
             byte[] publicTokens = assemblyName.GetPublicKeyToken();
             if (publicTokens.Length == 0)
@@ -899,11 +898,6 @@ namespace System.Management.Automation
             // save some cpu cycles by hardcoding the culture to neutral
             // assembly should never be targeted to a particular culture
             culture = "neutral";
-
-            // Hardcoding the architecture MSIL as PowerShell assemblies are architecture neutral, this should
-            // be changed if the assumption is broken. Preferred hardcoded string to using (for perf reasons):
-            // string architecture = currentAssembly.GetName().ProcessorArchitecture.ToString()
-            architecture = "MSIL";
         }
 
         /// <summary>
@@ -931,13 +925,12 @@ namespace System.Management.Automation
         /// </returns>
         internal static PSSnapInInfo ReadCoreEngineSnapIn()
         {
-            Version assemblyVersion, psVersion;
-            string publicKeyToken = null;
-            string culture = null;
-            string architecture = null;
-            string applicationBase = null;
-
-            ReadRegistryInfo(out assemblyVersion, out publicKeyToken, out culture, out architecture, out applicationBase, out psVersion);
+            ReadRegistryInfo(
+                out Version assemblyVersion,
+                out string publicKeyToken,
+                out string culture,
+                out string applicationBase,
+                out Version psVersion);
 
             // System.Management.Automation formats & types files
             Collection<string> types = new Collection<string>(new string[] { "types.ps1xml", "typesv3.ps1xml" });
@@ -946,8 +939,8 @@ namespace System.Management.Automation
                          "Help.format.ps1xml", "HelpV3.format.ps1xml", "PowerShellCore.format.ps1xml", "PowerShellTrace.format.ps1xml",
                          "Registry.format.ps1xml"});
 
-            string strongName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, Culture={2}, PublicKeyToken={3}, ProcessorArchitecture={4}",
-                s_coreSnapin.AssemblyName, assemblyVersion, culture, publicKeyToken, architecture);
+            string strongName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, Culture={2}, PublicKeyToken={3}",
+                s_coreSnapin.AssemblyName, assemblyVersion, culture, publicKeyToken);
 
             string moduleName = Path.Combine(applicationBase, s_coreSnapin.AssemblyName + ".dll");
 
@@ -985,13 +978,12 @@ namespace System.Management.Automation
         /// </returns>
         internal static Collection<PSSnapInInfo> ReadEnginePSSnapIns()
         {
-            Version assemblyVersion, psVersion;
-            string publicKeyToken = null;
-            string culture = null;
-            string architecture = null;
-            string applicationBase = null;
-
-            ReadRegistryInfo(out assemblyVersion, out publicKeyToken, out culture, out architecture, out applicationBase, out psVersion);
+            ReadRegistryInfo(
+                out Version assemblyVersion,
+                out string publicKeyToken,
+                out string culture,
+                out string applicationBase,
+                out Version psVersion);
 
             // System.Management.Automation formats & types files
             Collection<string> smaFormats = new Collection<string>(new string[]
@@ -1010,12 +1002,11 @@ namespace System.Management.Automation
 
                 string strongName = string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0}, Version={1}, Culture={2}, PublicKeyToken={3}, ProcessorArchitecture={4}",
+                    "{0}, Version={1}, Culture={2}, PublicKeyToken={3}",
                     defaultMshSnapinInfo.AssemblyName,
                     assemblyVersionString,
                     culture,
-                    publicKeyToken,
-                    architecture);
+                    publicKeyToken);
 
                 Collection<string> formats = null;
                 Collection<string> types = null;

--- a/test/xUnit/csharp/test_MshSnapinInfo.cs
+++ b/test/xUnit/csharp/test_MshSnapinInfo.cs
@@ -17,7 +17,7 @@ namespace PSTests.Parallel
             Skip.IfNot(Platform.IsWindows);
             Version someVersion = null;
             string someString = null;
-            PSSnapInReader.ReadRegistryInfo(out someVersion, out someString, out someString, out someString, out someString, out someVersion);
+            PSSnapInReader.ReadRegistryInfo(out someVersion, out someString, out someString, out someString, out someVersion);
         }
 
         // PublicKeyToken is null on Linux


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Remove the `ProcessorArchitecture` portion from the full name as it's obsolete in .NET 7.0
https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assemblyname.processorarchitecture?view=net-7.0

This additional field in the assembly full name started to fail `Assembly.Load` in PowerShell remoting scenario, when starting a remote session. See example failures in the following CI run:
https://dev.azure.com/powershell/PowerShell/_build/results?buildId=110951&view=logs&j=8ff999f7-4a61-5f51-a6a7-d94e9758120c&t=b9d6b495-b227-54e1-c647-304a73968aa2&l=396

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
