### PR TITLE
Implement `IDisposable` in `NamedPipeClient`

### DIFF
--- a/test/tools/NamedPipeConnection/src/code/NamedPipeConnection.cs
+++ b/test/tools/NamedPipeConnection/src/code/NamedPipeConnection.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.CustomNamedPipeConnection
     /// a client side named pipe object that can connect to a running PowerShell 
     /// process by its process Id.
     /// </summary>
-    internal sealed class NamedPipeClient
+    internal sealed class NamedPipeClient : IDisposable
     {
         #region Members
 


### PR DESCRIPTION
Fix #18338 (CA1816: Call GC.SuppressFinalize correctly).