### PR TITLE
Remove unsupported versions from `PSCompatibleVersions`

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -64,6 +64,8 @@ namespace System.Management.Automation
         /// For each later release of PowerShell, this constant needs to
         /// be updated to reflect the right version.
         /// </remarks>
+        private static readonly Version s_psV1Version = new(1, 0);
+        private static readonly Version s_psV2Version = new(2, 0);
         private static readonly Version s_psV3Version = new(3, 0);
         private static readonly Version s_psV4Version = new(4, 0);
         private static readonly Version s_psV5Version = new(5, 0);
@@ -95,7 +97,7 @@ namespace System.Management.Automation
             s_psVersionTable[PSVersionName] = s_psSemVersion;
             s_psVersionTable[PSEditionName] = PSEditionValue;
             s_psVersionTable[PSGitCommitIdName] = GitCommitId;
-            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV61Version, s_psV62Version, s_psV7Version, s_psV71Version, s_psV72Version, s_psVersion };
+            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV61Version, s_psV62Version, s_psV7Version, s_psV71Version, s_psV72Version, s_psVersion };
             s_psVersionTable[SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
             s_psVersionTable[PSRemotingProtocolVersionName] = RemotingConstants.ProtocolVersion;
             s_psVersionTable[WSManStackVersionName] = GetWSManStackVersion();

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -64,8 +64,6 @@ namespace System.Management.Automation
         /// For each later release of PowerShell, this constant needs to
         /// be updated to reflect the right version.
         /// </remarks>
-        private static readonly Version s_psV1Version = new(1, 0);
-        private static readonly Version s_psV2Version = new(2, 0);
         private static readonly Version s_psV3Version = new(3, 0);
         private static readonly Version s_psV4Version = new(4, 0);
         private static readonly Version s_psV5Version = new(5, 0);
@@ -97,7 +95,7 @@ namespace System.Management.Automation
             s_psVersionTable[PSVersionName] = s_psSemVersion;
             s_psVersionTable[PSEditionName] = PSEditionValue;
             s_psVersionTable[PSGitCommitIdName] = GitCommitId;
-            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV61Version, s_psV62Version, s_psV7Version, s_psV71Version, s_psV72Version, s_psVersion };
+            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV61Version, s_psV62Version, s_psV7Version, s_psV71Version, s_psV72Version, s_psVersion };
             s_psVersionTable[SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
             s_psVersionTable[PSRemotingProtocolVersionName] = RemotingConstants.ProtocolVersion;
             s_psVersionTable[WSManStackVersionName] = GetWSManStackVersion();

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -68,13 +68,8 @@ namespace System.Management.Automation
         private static readonly Version s_psV2Version = new(2, 0);
         private static readonly Version s_psV3Version = new(3, 0);
         private static readonly Version s_psV4Version = new(4, 0);
-        private static readonly Version s_psV5Version = new(5, 0);
         private static readonly Version s_psV51Version = new(5, 1);
-        private static readonly Version s_psV6Version = new(6, 0, 0);
-        private static readonly Version s_psV61Version = new(6, 1, 0);
-        private static readonly Version s_psV62Version = new(6, 2, 0);
         private static readonly Version s_psV7Version = new(7, 0, 0);
-        private static readonly Version s_psV71Version = new(7, 1, 0);
         private static readonly Version s_psV72Version = new(7, 2, 0);
         private static readonly Version s_psVersion;
         private static readonly SemanticVersion s_psSemVersion;
@@ -97,7 +92,7 @@ namespace System.Management.Automation
             s_psVersionTable[PSVersionName] = s_psSemVersion;
             s_psVersionTable[PSEditionName] = PSEditionValue;
             s_psVersionTable[PSGitCommitIdName] = GitCommitId;
-            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version, s_psV61Version, s_psV62Version, s_psV7Version, s_psV71Version, s_psV72Version, s_psVersion };
+            s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV51Version, s_psV7Version, s_psV72Version, s_psVersion };
             s_psVersionTable[SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
             s_psVersionTable[PSRemotingProtocolVersionName] = RemotingConstants.ProtocolVersion;
             s_psVersionTable[WSManStackVersionName] = GetWSManStackVersion();

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -23,7 +23,7 @@ Describe "PSVersionTable" -Tags "CI" {
             $unexpectectGitCommitIdPattern = $fullVersionPattern
         }
 
-        $powerShellVersions = "1.0", "2.0", "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0", "7.1", "7.2", "7.3"
+        $powerShellVersions = "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0", "7.1", "7.2", "7.3"
         $powerShellCompatibleVersions = $PSVersionTable.PSCompatibleVersions |
             ForEach-Object {$_.ToString(2).SubString(0,3)}
     }

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -23,7 +23,7 @@ Describe "PSVersionTable" -Tags "CI" {
             $unexpectectGitCommitIdPattern = $fullVersionPattern
         }
 
-        $powerShellVersions = "1.0", "2.0", "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0", "7.1", "7.2", "7.3"
+        $powerShellVersions = "1.0", "2.0", "3.0", "4.0", "5.1", "7.0", "7.2", "7.3"
         $powerShellCompatibleVersions = $PSVersionTable.PSCompatibleVersions |
             ForEach-Object {$_.ToString(2).SubString(0,3)}
     }

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -23,7 +23,7 @@ Describe "PSVersionTable" -Tags "CI" {
             $unexpectectGitCommitIdPattern = $fullVersionPattern
         }
 
-        $powerShellVersions = "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0", "7.1", "7.2", "7.3"
+        $powerShellVersions = "1.0", "2.0", "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0", "7.1", "7.2", "7.3"
         $powerShellCompatibleVersions = $PSVersionTable.PSCompatibleVersions |
             ForEach-Object {$_.ToString(2).SubString(0,3)}
     }


### PR DESCRIPTION
Remove the following unsupported versions from `$PSVersionTable.PSCompatibleVersions`:

| Version | End-of-support
| -- | -- |
| 5.0 | October 10, 2017* |
| 6.0 | February 13, 2019 |
| 6.1 | September 28, 2019 |
| 6.2 | September 4, 2020 |
| 7.1 | May 8, 2022 |

The following versions were **not** removed as they are apparently still supported by Microsoft:

| Version | |
| -- | -- |
| 1.0  | Optional component of Windows Server 2008, which is supported under Extended Security Updates on Azure until January 9, 2024. |
| 2.0 | Integrated in Windows Server 2008 R2, which is supported under Extended Security Updates on Azure until January 9, 2024. |

*Installed by default on Windows 10 version 1511, which is out-of-support since October 10, 2017. See [Windows PowerShell System Requirements](https://learn.microsoft.com/en-us/powershell/scripting/windows-powershell/install/windows-powershell-system-requirements#windows-powershell-50). 