### PR TITLE
Avoid using regex when unnecessary in `ScriptWriter`

### DIFF
--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -524,7 +524,7 @@ function __cmdletization_BindCommonParameters
                 string psType = typeMetadata.PSType;
                 foreach (EnumMetadataEnum e in _cmdletizationMetadata.Enums)
                 {
-                    int index = psType.IndexOf(e.EnumName, StringComparison.InvariantCulture);
+                    int index = psType.IndexOf(e.EnumName, StringComparison.Ordinal);
                     if (index == -1)
                     {
                         // Fast return if 'PSType' doesn't contain the enum name at all.
@@ -546,10 +546,7 @@ function __cmdletization_BindCommonParameters
                         // Now we have to fall back to the expensive regular expression matching, because 'PSType'
                         // could be a composite type like 'Nullable<enum_name>' or 'Dictionary<enum_name, object>',
                         // but we don't want the case where the enum name is part of another type's name.
-                        matchFound = Regex.IsMatch(
-                            psType,
-                            string.Format(CultureInfo.InvariantCulture, @"\b{0}\b", Regex.Escape(e.EnumName)),
-                            RegexOptions.CultureInvariant);
+                        matchFound = Regex.IsMatch(psType, $@"\b{Regex.Escape(e.EnumName)}\b");
                     }
 
                     if (matchFound)

--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -543,8 +543,9 @@ function __cmdletization_BindCommonParameters
 
                     if (!matchFound)
                     {
-                        // Now we have to fall back to the expensive regular expression matching, because the 'PSType'
-                        // could be a composite type like 'Nullable<enum_name>' or 'Dictionary<enum_name, object>'.
+                        // Now we have to fall back to the expensive regular expression matching, because 'PSType'
+                        // could be a composite type like 'Nullable<enum_name>' or 'Dictionary<enum_name, object>',
+                        // but we don't want the case where the enum name is part of another type's name.
                         matchFound = Regex.IsMatch(
                             psType,
                             string.Format(CultureInfo.InvariantCulture, @"\b{0}\b", Regex.Escape(e.EnumName)),

--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -527,14 +527,14 @@ function __cmdletization_BindCommonParameters
                     int index = psType.IndexOf(e.EnumName, StringComparison.InvariantCulture);
                     if (index == -1)
                     {
-                        // Fast return if 'PSType' doesn't contains the enum name at all.
+                        // Fast return if 'PSType' doesn't contain the enum name at all.
                         continue;
                     }
 
                     bool matchFound = false;
                     if (index == 0)
                     {
-                        // Handle 2 common cases here (cover 99% of how enum name is used in 'PSType'):
+                        // Handle 2 common cases here (cover over 99% of how enum name is used in 'PSType'):
                         //  - 'PSType' is exactly the enum name.
                         //  - 'PSType' is the array format of the enum.
                         ReadOnlySpan<char> remains = psType.AsSpan(e.EnumName.Length);

--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -517,13 +517,17 @@ function __cmdletization_BindCommonParameters
             Dbg.Assert(typeMetadata != null, "Caller should verify typeMetadata != null");
 
             string psTypeText;
-            List<EnumMetadataEnum> matchingEnums = (_cmdletizationMetadata.Enums ?? Enumerable.Empty<EnumMetadataEnum>())
-                .Where(e => Regex.IsMatch(
-                    typeMetadata.PSType,
-                    string.Format(CultureInfo.InvariantCulture, @"\b{0}\b", Regex.Escape(e.EnumName)),
-                    RegexOptions.CultureInvariant))
-                .ToList();
-            EnumMetadataEnum matchingEnum = matchingEnums.Count == 1 ? matchingEnums[0] : null;
+            EnumMetadataEnum matchingEnum = null;
+
+            if (_cmdletizationMetadata.Enums is not null)
+            {
+                List<EnumMetadataEnum> matchingEnums = _cmdletizationMetadata.Enums
+                    .Where(e => string.Equals(typeMetadata.PSType, e.EnumName, StringComparison.InvariantCulture))
+                    .ToList();
+
+                matchingEnum = matchingEnums.Count == 1 ? matchingEnums[0] : null;
+            }
+
             if (matchingEnum != null)
             {
                 psTypeText = typeMetadata.PSType.Replace(matchingEnum.EnumName, EnumWriter.GetEnumFullName(matchingEnum));


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

The `Regex.IsMatch` in `GetDotNetType` is pretty expensive. Actually, in most cases, we can use simpler checks to get what we need. Handle those common cases so as to avoid regular expression checks when possible.

## PR Context

It's reported from MS internal team the `GetDotNetType` method call results in tons of regular expression creations, taking up a lot of CPU usage.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
