### PR TITLE
Make hexidecimal named scripts execute without requiring .\ prefix

### DIFF
--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -3937,6 +3937,7 @@ namespace System.Management.Automation.Language
             multiplier = 1;
 
             bool notNumber = false;
+            bool hasSign = false;
             int signIndex = -1;
             char c;
             var sb = GetStringBuilder();
@@ -3945,6 +3946,7 @@ namespace System.Management.Automation.Language
             {
                 sb.Append(firstChar);
                 firstChar = GetChar();
+                hasSign = true;
             }
 
             if (firstChar == '.')
@@ -3968,7 +3970,7 @@ namespace System.Management.Automation.Language
                         case 'X':
                             sb.Append('0'); // Prepend a 0 to the number before any numeric digits are added
                             ScanHexDigits(sb);
-                            if (sb.Length == 1) // 1 instead of 0 to account for append ↑↑
+                            if (sb.Length == 1 || sb.Length == 2 && hasSign) // 1 instead of 0 to account for append ↑↑
                             {
                                 notNumber = true;
                             }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -3968,7 +3968,7 @@ namespace System.Management.Automation.Language
                         case 'X':
                             sb.Append('0'); // Prepend a 0 to the number before any numeric digits are added
                             ScanHexDigits(sb);
-                            if (sb.Length == 0)
+                            if (sb.Length == 1) // 1 instead of 0 to account for append ↑↑
                             {
                                 notNumber = true;
                             }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -98,11 +98,11 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         if (-not(Test-Path $testfolder2)) {
             New-Item $testfolder2 -Type Directory
         }
-        $BackupEnvPATH = $env:PATH
-        $env:PATH += '{0}{1}' -f @(
-            [System.IO.Path]::PathSeparator
-            $testfolder1
-        )
+#        $BackupEnvPATH = $env:PATH
+#        $env:PATH += '{0}{1}' -f @(
+#            [System.IO.Path]::PathSeparator
+#            $testfolder1
+#        )
         $testdirfile1 = Join-Path -Path $testfolder2 -ChildPath "testdirfile1.txt"
         $testdirfile2 = Join-Path -Path $testfolder2 -ChildPath "testdirfile2.txt"
         Set-Content -Path $testdirfile1 -Value ""
@@ -132,8 +132,8 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         if (Test-Path $testfolder1) {
             Remove-Item $testfolder1 -Recurse -Force -ErrorAction SilentlyContinue
         }
-        
-        $env:PATH = $BackupEnvPATH
+
+#        $env:PATH = $BackupEnvPATH
     }
 
     AfterAll {
@@ -190,16 +190,16 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
     }
 
 
-    It "Test that a hex named script executed without prefix will run case: <case>" -TestCases @(
-            @{ case = "0x.ps1" }
-            @{ case = "-0x.ps1" }
-            @{ case = "+0x.ps1" }
-    ){
-        param ($case)
-        Set-Location $TestDrive
-        New-Item -ItemType File -Name $case -Path $testfolder1 -Value {Write-Output "Hello"}
-        & $case | Should -BeExactly "Hello"
-    }
+#    It "Test that a hex named script executed without prefix will run case: <case>" -TestCases @(
+#            @{ case = "0x.ps1" }
+#            @{ case = "-0x.ps1" }
+#            @{ case = "+0x.ps1" }
+#    ){
+#        param ($case)
+#        Set-Location $TestDrive
+#        New-Item -ItemType File -Name $case -Path $testfolder1 -Value {Write-Output "Hello"}
+#        & $case | Should -BeExactly "Hello"
+#    }
 
     It "This test will check that a path is correctly interpreted when using '..' and '.'  (line 364)" {
         $result = ExecuteCommand "Set-Location $TestDrive; Get-ChildItem dir1\.\.\.\..\dir1\.\dir2\..\..\dir1\.\dir2"

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -130,7 +130,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         }
 
         if (Test-Path $testfolder1) {
-            Remove-Item $testfolder1 -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item $testfolder1 -Recurse -Force -ErrorAction Ignore
         }
 
         $env:PATH = $BackupEnvPATH

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -190,16 +190,18 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
     }
 
 
-#    It "Test that a hex named script executed without prefix will run case: <case>" -TestCases @(
-#            @{ case = "0x.ps1" }
-#            @{ case = "-0x.ps1" }
-#            @{ case = "+0x.ps1" }
-#    ){
-#        param ($case)
-#        Set-Location $TestDrive
-#        New-Item -ItemType File -Name $case -Path $testfolder1 -Value {Write-Output "Hello"}
-#        & $case | Should -BeExactly "Hello"
-#    }
+    It "Test that a hex named script executed without prefix will run case: <case>" -TestCases @(
+            @{ case = "0x.ps1" }
+            @{ case = "-0x.ps1" }
+            @{ case = "+0x.ps1" }
+    ){
+        param ($case)
+        Set-Location $TestDrive
+        New-Item -ItemType File -Name $case -Path $testfolder1 -Value {Write-Output "Hello"}
+        & $case | Should -BeExactly "Hello"
+        $pathtodelete = Join-Path -Path $testfolder1 -ChildPath $case
+        Remove-Item $Pathtodelete -Force
+    }
 
     It "This test will check that a path is correctly interpreted when using '..' and '.'  (line 364)" {
         $result = ExecuteCommand "Set-Location $TestDrive; Get-ChildItem dir1\.\.\.\..\dir1\.\dir2\..\..\dir1\.\dir2"

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -194,7 +194,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
         New-Item -ItemType File -Name $case -Path $ScriptFolder -Value {Write-Output "Hello"}
         $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
-        $result = $case
+        $result = Powershell $case
         $result | Should -BeExactly "Hello"
     }
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -98,11 +98,11 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         if (-not(Test-Path $testfolder2)) {
             New-Item $testfolder2 -Type Directory
         }
-#        $BackupEnvPATH = $env:PATH
-#        $env:PATH += '{0}{1}' -f @(
-#            [System.IO.Path]::PathSeparator
-#            $testfolder1
-#        )
+        $BackupEnvPATH = $env:PATH
+        $env:PATH += '{0}{1}' -f @(
+            [System.IO.Path]::PathSeparator
+            $testfolder1
+        )
         $testdirfile1 = Join-Path -Path $testfolder2 -ChildPath "testdirfile1.txt"
         $testdirfile2 = Join-Path -Path $testfolder2 -ChildPath "testdirfile2.txt"
         Set-Content -Path $testdirfile1 -Value ""
@@ -133,7 +133,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             Remove-Item $testfolder1 -Recurse -Force -ErrorAction SilentlyContinue
         }
 
-#        $env:PATH = $BackupEnvPATH
+        $env:PATH = $BackupEnvPATH
     }
 
     AfterAll {

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -132,13 +132,14 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         if (Test-Path $testfolder1) {
             Remove-Item $testfolder1 -Recurse -Force -ErrorAction SilentlyContinue
         }
+        
+        $env:PATH = $BackupEnvPATH
     }
 
     AfterAll {
         if (Test-Path $functionDefinitionFile) {
             Remove-Item $functionDefinitionFile
         }
-        $env:PATH = $BackupEnvPATH
     }
 
     It "Throws a syntax error when parsing a string without a closing quote. (line 164)" {

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -98,6 +98,11 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         if (-not(Test-Path $testfolder2)) {
             New-Item $testfolder2 -Type Directory
         }
+        $BackupEnvPATH = $env:PATH
+        $env:PATH += '{0}{1}' -f @(
+            [System.IO.Path]::PathSeparator
+            $ScriptFolder
+        )
         $testdirfile1 = Join-Path -Path $testfolder2 -ChildPath "testdirfile1.txt"
         $testdirfile2 = Join-Path -Path $testfolder2 -ChildPath "testdirfile2.txt"
         Set-Content -Path $testdirfile1 -Value ""
@@ -133,6 +138,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         if (Test-Path $functionDefinitionFile) {
             Remove-Item $functionDefinitionFile
         }
+        $env:PATH = $BackupEnvPATH
     }
 
     It "Throws a syntax error when parsing a string without a closing quote. (line 164)" {
@@ -190,12 +196,9 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
     ){
         param ($case)
         Set-Location $TestDrive
-        New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
-        $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
-        New-Item -ItemType File -Name $case -Path $ScriptFolder -Value {Write-Output "Hello"}
+        New-Item -ItemType File -Name $case -Path $testfolder1 -Value {Write-Output "Hello"}
         $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
-        $result = Powershell $case
-        $result | Should -BeExactly "Hello"
+        & $case | Should -BeExactly "Hello"
     }
 
     It "This test will check that a path is correctly interpreted when using '..' and '.'  (line 364)" {

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -182,6 +182,16 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         $result | Should -Be 1
     }
 
+    It "Test that hex named command executed without tabcompleted prefix will run" {
+        Set-Location $TestDrive
+        New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
+        $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
+        New-Item -ItemType File -Name 0x.ps1 -Path ".\testfolder\" -Value {Write-Output "Hello"}
+        $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
+        $result = 0x.ps1
+        $result | Should -BeExactly "Hello"
+    }
+
     It "This test will check that a path is correctly interpreted when using '..' and '.'  (line 364)" {
         $result = ExecuteCommand "Set-Location $TestDrive; Get-ChildItem dir1\.\.\.\..\dir1\.\dir2\..\..\dir1\.\dir2"
         $result.Count | Should -Be 2

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -182,23 +182,19 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         $result | Should -Be 1
     }
 
-    It "Test that hex named script executed without tabcompleted prefix will run" {
-        Set-Location $TestDrive
-        New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
-        $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
-        New-Item -ItemType File -Name 0x.ps1 -Path $ScriptFolder -Value {Write-Output "Hello"}
-        $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
-        $result = 0x.ps1
-        $result | Should -BeExactly "Hello"
-    }
 
-    It "Test that a dash hex named script executed without tabcompleted prefix will run" {
+    It "Test that a hex named script executed without prefix will run case: <case>" -TestCases @(
+            @{ case = "0x.ps1" }
+            @{ case = "-0x.ps1" }
+            @{ case = "+0x.ps1" }
+    ){
+        param ($case)
         Set-Location $TestDrive
         New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
         $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
-        New-Item -ItemType File -Name `-0x.ps1 -Path $ScriptFolder -Value {Write-Output "Hello"}
+        New-Item -ItemType File -Name $case -Path $ScriptFolder -Value {Write-Output "Hello"}
         $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
-        $result = -0x.ps1
+        $result = $case
         $result | Should -BeExactly "Hello"
     }
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -184,10 +184,8 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 
     It "Test that hex named command executed without tabcompleted prefix will run" {
         Set-Location $TestDrive
-        New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
-        $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
-        New-Item -ItemType File -Name 0x.ps1 -Path ".\testfolder\" -Value {Write-Output "Hello"}
-        $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
+        New-Item -ItemType File -Name 0x.ps1 -Value {Write-Output "Hello"}
+        $env:PATH += ";$TestDrive" #To execute without .\<script>\ we must add the script location to PATH.
         $result = 0x.ps1
         $result | Should -BeExactly "Hello"
     }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -196,7 +196,6 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             @{ case = "+0x.ps1" }
     ){
         param ($case)
-        Set-Location $TestDrive
         New-Item -ItemType File -Name $case -Path $testfolder1 -Value {Write-Output "Hello"}
         & $case | Should -BeExactly "Hello"
         $pathtodelete = Join-Path -Path $testfolder1 -ChildPath $case

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -198,7 +198,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
         New-Item -ItemType File -Name `-0x.ps1 -Path $ScriptFolder -Value {Write-Output "Hello"}
         $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
-        $result -0x.ps1
+        $result = -0x.ps1
         $result | Should -BeExactly "Hello"
     }
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -130,7 +130,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         }
 
         if (Test-Path $testfolder1) {
-            Remove-Item $testfolder1
+            Remove-Item $testfolder1 -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -182,11 +182,23 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         $result | Should -Be 1
     }
 
-    It "Test that hex named command executed without tabcompleted prefix will run" {
+    It "Test that hex named script executed without tabcompleted prefix will run" {
         Set-Location $TestDrive
-        New-Item -ItemType File -Name 0x.ps1 -Value {Write-Output "Hello"}
-        $env:PATH += ";$TestDrive" #To execute without .\<script>\ we must add the script location to PATH.
+        New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
+        $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
+        New-Item -ItemType File -Name 0x.ps1 -Path $Scriptfolder -Value {Write-Output "Hello"}
+        $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
         $result = 0x.ps1
+        $result | Should -BeExactly "Hello"
+    }
+
+    It "Test that a dash hex named script executed without tabcompleted prefix will run" {
+        Set-Location $TestDrive
+        New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
+        $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
+        New-Item -ItemType File -Name `-0x.ps1 -Path $Scriptfolder -Value {Write-Output "Hello"}
+        $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
+        $result -0x.ps1
         $result | Should -BeExactly "Hello"
     }
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -101,7 +101,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         $BackupEnvPATH = $env:PATH
         $env:PATH += '{0}{1}' -f @(
             [System.IO.Path]::PathSeparator
-            $ScriptFolder
+            $testfolder1
         )
         $testdirfile1 = Join-Path -Path $testfolder2 -ChildPath "testdirfile1.txt"
         $testdirfile2 = Join-Path -Path $testfolder2 -ChildPath "testdirfile2.txt"
@@ -197,7 +197,6 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         param ($case)
         Set-Location $TestDrive
         New-Item -ItemType File -Name $case -Path $testfolder1 -Value {Write-Output "Hello"}
-        $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
         & $case | Should -BeExactly "Hello"
     }
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -186,7 +186,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         Set-Location $TestDrive
         New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
         $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
-        New-Item -ItemType File -Name 0x.ps1 -Path $Scriptfolder -Value {Write-Output "Hello"}
+        New-Item -ItemType File -Name 0x.ps1 -Path $ScriptFolder -Value {Write-Output "Hello"}
         $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
         $result = 0x.ps1
         $result | Should -BeExactly "Hello"
@@ -196,7 +196,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         Set-Location $TestDrive
         New-Item -ItemType Directory -Path $TestDrive -Name "testfolder"
         $ScriptFolder = Join-Path $TestDrive -ChildPath "testfolder"
-        New-Item -ItemType File -Name `-0x.ps1 -Path $Scriptfolder -Value {Write-Output "Hello"}
+        New-Item -ItemType File -Name `-0x.ps1 -Path $ScriptFolder -Value {Write-Output "Hello"}
         $env:PATH += ";$ScriptFolder" #To execute without .\<script>\ we must add the script location to PATH.
         $result -0x.ps1
         $result | Should -BeExactly "Hello"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
In #15543 it was discovered that if you have a case where a script is named in a way that can be interpreted as hexadecimal (such as `0x.ps1` and you execute it without the dot backslash convention (`.\0x.ps1` the script will always return null.
@vexx32 identified the problem as being an oversight in an `if` statement that doesn't account for a number appended a few lines above.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
This aims to solve #15543.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
