### PR TITLE
Replace `UTF8Encoding(false)` with `Encoding.Default` part 2

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -229,7 +229,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         /// <summary>
         /// Gets or sets property that sets append parameter.
@@ -615,7 +615,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         /// <summary>
         /// Avoid writing out duplicate warning messages when there are one or more unspecified names.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         /// <summary>
         /// Gets or sets count of bytes to read from the input stream.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         /// <summary>
         /// Property that sets append parameter.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         #endregion Parameters
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1363,7 +1363,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         /// <summary>
         /// Gets or sets the number of context lines to collect. If set to a

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.Commands
         [ArgumentToEncodingTransformationAttribute]
         [ArgumentEncodingCompletionsAttribute]
         [ValidateNotNullOrEmpty]
-        public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
+        public Encoding Encoding { get; set; } = Encoding.Default;
 
         /// <summary>
         /// Variable parameter.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         #endregion Command Line Parameters
 

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -515,7 +515,7 @@ namespace System.Management.Automation
                 {
                     using (FileStream readerStream = new FileStream(_path, FileMode.Open, FileAccess.Read))
                     {
-                        Encoding defaultEncoding = ClrFacade.GetDefaultEncoding();
+                        Encoding defaultEncoding = Encoding.Default;
 
                         using (StreamReader scriptReader = new StreamReader(readerStream, defaultEncoding))
                         {

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -515,9 +515,7 @@ namespace System.Management.Automation
                 {
                     using (FileStream readerStream = new FileStream(_path, FileMode.Open, FileAccess.Read))
                     {
-                        Encoding defaultEncoding = Encoding.Default;
-
-                        using (StreamReader scriptReader = new StreamReader(readerStream, defaultEncoding))
+                        using (StreamReader scriptReader = new StreamReader(readerStream, Encoding.Default))
                         {
                             _scriptContents = scriptReader.ReadToEnd();
                             _originalEncoding = scriptReader.CurrentEncoding;

--- a/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
+++ b/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
@@ -94,7 +94,7 @@ namespace System.Management.Automation
         {
             using (FileStream readerStream = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
-                Encoding defaultEncoding = ClrFacade.GetDefaultEncoding();
+                Encoding defaultEncoding = Encoding.Default;
                 Microsoft.Win32.SafeHandles.SafeFileHandle safeFileHandle = readerStream.SafeFileHandle;
 
                 using (StreamReader scriptReader = new StreamReader(readerStream, defaultEncoding))

--- a/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
+++ b/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
@@ -94,10 +94,9 @@ namespace System.Management.Automation
         {
             using (FileStream readerStream = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
-                Encoding defaultEncoding = Encoding.Default;
                 Microsoft.Win32.SafeHandles.SafeFileHandle safeFileHandle = readerStream.SafeFileHandle;
 
-                using (StreamReader scriptReader = new StreamReader(readerStream, defaultEncoding))
+                using (StreamReader scriptReader = new StreamReader(readerStream, Encoding.Default))
                 {
                     return scriptReader.ReadToEnd();
                 }

--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -794,7 +794,7 @@ namespace Microsoft.PowerShell.Commands
                 // the changes
                 if (waitChanges)
                 {
-                    WaitForChanges(_path, _mode, _access, _share, ClrFacade.GetDefaultEncoding());
+                    WaitForChanges(_path, _mode, _access, _share, Encoding.Default);
                     byteRead = _stream.ReadByte();
                 }
             }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6610,7 +6610,7 @@ namespace Microsoft.PowerShell.Commands
 
             // Defaults for the file read operation
             string delimiter = "\n";
-            Encoding encoding = ClrFacade.GetDefaultEncoding();
+            Encoding encoding = Encoding.Default;
             bool waitForChanges = false;
 
             bool streamTypeSpecified = false;
@@ -6792,7 +6792,7 @@ namespace Microsoft.PowerShell.Commands
             // If this is true, then the content will be read as bytes
             bool usingByteEncoding = false;
             bool streamTypeSpecified = false;
-            Encoding encoding = ClrFacade.GetDefaultEncoding();
+            Encoding encoding = Encoding.Default;
             const FileMode filemode = FileMode.OpenOrCreate;
             string streamName = null;
             bool suppressNewline = false;
@@ -7668,7 +7668,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private Encoding _encoding = ClrFacade.GetDefaultEncoding();
+        private Encoding _encoding = Encoding.Default;
 
         /// <summary>
         /// Return file contents as a byte stream or create file from a series of bytes.

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -101,23 +101,6 @@ namespace System.Management.Automation
         #region Encoding
 
         /// <summary>
-        /// Facade for getting default encoding.
-        /// </summary>
-        internal static Encoding GetDefaultEncoding()
-        {
-            if (s_defaultEncoding == null)
-            {
-                // load all available encodings
-                EncodingRegisterProvider();
-                s_defaultEncoding = new UTF8Encoding(false);
-            }
-
-            return s_defaultEncoding;
-        }
-
-        private static volatile Encoding s_defaultEncoding;
-
-        /// <summary>
         /// Facade for getting OEM encoding
         /// OEM encodings work on all platforms, or rather codepage 437 is available on both Windows and Non-Windows.
         /// </summary>
@@ -142,7 +125,7 @@ namespace System.Management.Automation
 
         private static void EncodingRegisterProvider()
         {
-            if (s_defaultEncoding == null && s_oemEncoding == null)
+            if (s_oemEncoding == null)
             {
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             }
@@ -263,7 +246,7 @@ namespace System.Management.Automation
             }
 
             // If we successfully get the zone data stream, try to read the ZoneId information
-            using (StreamReader zoneDataReader = new StreamReader(zoneDataStream, GetDefaultEncoding()))
+            using (StreamReader zoneDataReader = new StreamReader(zoneDataStream, Encoding.Default))
             {
                 string line = null;
                 bool zoneTransferMatched = false;

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -33,15 +33,15 @@ namespace System.Management.Automation
             { Ascii, System.Text.Encoding.ASCII },
             { BigEndianUnicode, System.Text.Encoding.BigEndianUnicode },
             { BigEndianUtf32, new UTF32Encoding(bigEndian: true, byteOrderMark: true) },
-            { Default, ClrFacade.GetDefaultEncoding() },
+            { Default, Encoding.Default },
             { OEM, ClrFacade.GetOEMEncoding() },
             { Unicode, System.Text.Encoding.Unicode },
 #pragma warning disable SYSLIB0001
             { Utf7, System.Text.Encoding.UTF7 },
 #pragma warning restore SYSLIB0001
-            { Utf8, ClrFacade.GetDefaultEncoding() },
+            { Utf8, Encoding.Default },
             { Utf8Bom, System.Text.Encoding.UTF8 },
-            { Utf8NoBom, ClrFacade.GetDefaultEncoding() },
+            { Utf8NoBom, Encoding.Default },
             { Utf32, System.Text.Encoding.UTF32 },
             { String, System.Text.Encoding.Unicode },
             { Unknown, System.Text.Encoding.Unicode },
@@ -57,7 +57,7 @@ namespace System.Management.Automation
             if (string.IsNullOrEmpty(encoding))
             {
                 // no parameter passed, default to UTF8
-                return ClrFacade.GetDefaultEncoding();
+                return Encoding.Default;
             }
 
             Encoding foundEncoding;


### PR DESCRIPTION
Follow-up: #18144.

cc: @iSazonov, @daxian-dbw, @JamesWTruher

Context: dotnet/runtime#45541, #5080