### PR TITLE
Remove unused console strings

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleControlStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleControlStrings.resx
@@ -123,12 +123,6 @@
   <data name="RemoveBreakHandlerExceptionTemplate" xml:space="preserve">
     <value>The Win32 internal error "{0}" 0x{1:X} occurred while trying to remove a break handler. Contact Microsoft Customer Support Services.</value>
   </data>
-  <data name="AttachToParentConsoleExceptionTemplate" xml:space="preserve">
-    <value>The Win32 internal error "{0}" 0x{1:X} occurred while attaching to parent console. Contact Microsoft Customer Support Services.</value>
-  </data>
-  <data name="DetachFromConsoleExceptionTemplate" xml:space="preserve">
-    <value>The Win32 internal error "{0}" 0x{1:X} occurred while detaching from the console. Contact Microsoft Customer Support Services.</value>
-  </data>
   <data name="GetInputModeExceptionTemplate" xml:space="preserve">
     <value>The Win32 internal error "{0}" 0x{1:X} occurred while getting input about the console handle. Contact Microsoft Customer Support Services.</value>
   </data>
@@ -192,9 +186,6 @@
   <data name="SetConsoleTextAttributeExceptionTemplate" xml:space="preserve">
     <value>The Win32 internal error "{0}" 0x{1:X} occurred while setting character attributes for the console output buffer. Contact Microsoft Customer Support Services.</value>
   </data>
-  <data name="SetConsoleCursorPositionExceptionTemplate" xml:space="preserve">
-    <value>The Win32 internal error "{0}" 0x{1:X} occurred while trying to set the cursor position. Contact Microsoft Customer Support Services.</value>
-  </data>
   <data name="GetConsoleCursorInfoExceptionTemplate" xml:space="preserve">
     <value>The Win32 internal error "{0}" 0x{1:X} occurred while getting cursor information. Contact Microsoft Customer Support Services.</value>
   </data>
@@ -206,8 +197,5 @@
   </data>
   <data name="SendKeyPressInputExceptionTemplate" xml:space="preserve">
     <value>The Win32 internal error "{0}" 0x{1:X} occurred while sending keyboard input. Contact Microsoft Customer Support Services.</value>
-  </data>
-  <data name="SetConsoleFontInfoExceptionTemplate" xml:space="preserve">
-    <value>The Win32 internal error "{0}" 0x{1:X} occurred while setting console font information. Contact Microsoft Customer Support Services.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -123,14 +123,8 @@
   <data name="InputExitCurrentLoopOutOfSyncError" xml:space="preserve">
     <value>Cannot process input loop. ExitCurrentLoop was called when no InputLoops were running.</value>
   </data>
-  <data name="NestedPromptEntryError" xml:space="preserve">
-    <value>A nested prompt cannot be entered until the host is running at least one prompt loop.</value>
-  </data>
   <data name="DefaultPrompt" xml:space="preserve">
     <value>PS&gt;</value>
-  </data>
-  <data name="InitScriptFailed" xml:space="preserve">
-    <value>Execution of initialization script has failed. The shell cannot be started.</value>
   </data>
   <data name="ShellCannotBeStarted" xml:space="preserve">
     <value>The shell cannot be started. A failure occurred during initialization:</value>
@@ -154,9 +148,6 @@ Machine   : {3} ({4})
 PowerShell transcript end
 End time: {0:yyyyMMddHHmmss}
 **********************</value>
-  </data>
-  <data name="ConsoleHostIsSingleton" xml:space="preserve">
-    <value>An instance of the ConsoleHost class has already been created for this process.</value>
   </data>
   <data name="InitialCommandNotExecuted" xml:space="preserve">
     <value>Command '{0}' could not be run because some PowerShell Snap-Ins did not load.</value>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

These strings are not being used in the source code

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
