### PR TITLE
Increase timeout to make subsystem tests more reliable

### DIFF
--- a/test/xUnit/csharp/test_Feedback.cs
+++ b/test/xUnit/csharp/test_Feedback.cs
@@ -89,7 +89,7 @@ namespace PSTests.Sequential
                 // Expect the result from 'General' only because the 'slow' one cannot finish before the specified timeout.
                 // The specified timeout is exaggerated to make the test reliable.
                 // xUnit must spin up a lot tasks, which makes the test unreliable when the time difference between 'delay' and 'timeout' is small.
-                var feedbacks = FeedbackHub.GetFeedback(pwsh.Runspace, millisecondsTimeout: 2000);
+                var feedbacks = FeedbackHub.GetFeedback(pwsh.Runspace, millisecondsTimeout: 1500);
                 string expectedCmd = Path.Combine(".", "feedbacktest");
 
                 // Test the result from the 'General' feedback provider.

--- a/test/xUnit/csharp/test_Feedback.cs
+++ b/test/xUnit/csharp/test_Feedback.cs
@@ -89,7 +89,7 @@ namespace PSTests.Sequential
                 // Expect the result from 'General' only because the 'slow' one cannot finish before the specified timeout.
                 // The specified timeout is exaggerated to make the test reliable.
                 // xUnit must spin up a lot tasks, which makes the test unreliable when the time difference between 'delay' and 'timeout' is small.
-                var feedbacks = FeedbackHub.GetFeedback(pwsh.Runspace, millisecondsTimeout: 1000);
+                var feedbacks = FeedbackHub.GetFeedback(pwsh.Runspace, millisecondsTimeout: 2000);
                 string expectedCmd = Path.Combine(".", "feedbacktest");
 
                 // Test the result from the 'General' feedback provider.

--- a/test/xUnit/csharp/test_Prediction.cs
+++ b/test/xUnit/csharp/test_Prediction.cs
@@ -147,7 +147,7 @@ namespace PSTests.Sequential
                 // cannot finish before the specified timeout.
                 // The specified timeout is exaggerated to make the test reliable.
                 // xUnit must spin up a lot tasks, which makes the test unreliable when the time difference between 'delay' and 'timeout' is small.
-                results = CommandPrediction.PredictInputAsync(predClient, ast, tokens, millisecondsTimeout: 1000).Result;
+                results = CommandPrediction.PredictInputAsync(predClient, ast, tokens, millisecondsTimeout: 2000).Result;
                 Assert.Single(results);
 
                 PredictionResult res = results[0];
@@ -214,7 +214,7 @@ namespace PSTests.Sequential
                        slow.DisplayedSuggestions.Count == 0 || fast.DisplayedSuggestions.Count == 0 ||
                        slow.AcceptedSuggestions.Count == 0)
                 {
-                    Thread.Sleep(100);
+                    Thread.Sleep(300);
                 }
 
                 Assert.Equal(2, slow.History.Count);

--- a/test/xUnit/csharp/test_Prediction.cs
+++ b/test/xUnit/csharp/test_Prediction.cs
@@ -147,7 +147,7 @@ namespace PSTests.Sequential
                 // cannot finish before the specified timeout.
                 // The specified timeout is exaggerated to make the test reliable.
                 // xUnit must spin up a lot tasks, which makes the test unreliable when the time difference between 'delay' and 'timeout' is small.
-                results = CommandPrediction.PredictInputAsync(predClient, ast, tokens, millisecondsTimeout: 2000).Result;
+                results = CommandPrediction.PredictInputAsync(predClient, ast, tokens, millisecondsTimeout: 1500).Result;
                 Assert.Single(results);
 
                 PredictionResult res = results[0];


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Increase timeout to make subsystem tests more reliable.

## PR Context

The `CommandPrediction` xUnit tests have been failing for the last 2 days because the expected operation cannot finish before the timeout. The expected operation is done via tasks using the thread pool. xUnit itself generates a lot of tasks backed by thread pool, which makes the task run unpredictable comparing with the real scenario. 

The old timeout has been working well until very recently (2 days ago), and it may be caused by changes in the CI agent or activities involved in the CI pipeline.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
