### PR TITLE
Refactor UTF-7 encoding detection

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }
@@ -610,7 +610,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1358,7 +1358,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                EncodingConversion.WarnIfObsolete(this, value);
+                EncodingConversion.WarnIfUtf7Encoding(this, value);
                 _encoding = value;
             }
         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7665,7 +7665,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     const int CodePageUtf7 = 65000;
 
-                    // Compare against the the well-known UTF-7 code page, see:
+                    // Use the recommended pattern to check for UTF-7.
                     // https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
                     if (value is { CodePage: CodePageUtf7 })
                     {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7656,15 +7656,22 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                // Check for UTF-7 by checking for code page 65000
-                // See: https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
-                if (value != null && value.CodePage == 65000)
-                {
-                    _provider.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
-                }
+                WarnIfObsolete(value);
                 _encoding = value;
                 // If an encoding was explicitly set, be sure to capture that.
                 WasStreamTypeSpecified = true;
+
+                void WarnIfObsolete(Encoding value)
+                {
+                    const int CodePageUtf7 = 65000;
+
+                    // Compare against the the well-known UTF-7 code page, see:
+                    // https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
+                    if (value is { CodePage: CodePageUtf7 })
+                    {
+                        _provider.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
+                    }
+                }
             }
         }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7657,7 +7657,7 @@ namespace Microsoft.PowerShell.Commands
             set
             {
                 // Check for UTF-7 by checking for code page 65000
-                // See: https://docs.microsoft.com/en-us/dotnet/core/compatibility/corefx#utf-7-code-paths-are-obsolete
+                // See: https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
                 if (value != null && value.CodePage == 65000)
                 {
                     _provider.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7656,12 +7656,12 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                WarnIfObsolete(value);
+                WarnIfUtf7Encoding(value);
                 _encoding = value;
                 // If an encoding was explicitly set, be sure to capture that.
                 WasStreamTypeSpecified = true;
 
-                void WarnIfObsolete(Encoding value)
+                void WarnIfUtf7Encoding(Encoding value)
                 {
                     const int CodePageUtf7 = 65000;
 

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -63,7 +63,7 @@ namespace System.Management.Automation
             Encoding foundEncoding;
             if (encodingMap.TryGetValue(encoding, out foundEncoding))
             {
-                WarnIfObsolete(cmdlet, foundEncoding);
+                WarnIfUtf7Encoding(cmdlet, foundEncoding);
 
                 return foundEncoding;
             }
@@ -85,11 +85,11 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Warn if the encoding has been designated as obsolete.
+        /// Warn if the encoding is obsolete UTF-7 encoding.
         /// </summary>
         /// <param name="cmdlet">A cmdlet instance which is used to emit the warning.</param>
         /// <param name="encoding">The encoding to check for obsolescence.</param>
-        internal static void WarnIfObsolete(Cmdlet cmdlet, Encoding encoding)
+        internal static void WarnIfUtf7Encoding(Cmdlet cmdlet, Encoding encoding)
         {
             const int CodePageUtf7 = 65000;
 

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -92,7 +92,7 @@ namespace System.Management.Automation
         internal static void WarnIfObsolete(Cmdlet cmdlet, Encoding encoding)
         {
             // Check for UTF-7 by checking for code page 65000
-            // See: https://docs.microsoft.com/en-us/dotnet/core/compatibility/corefx#utf-7-code-paths-are-obsolete
+            // See: https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
             if (encoding != null && encoding.CodePage == 65000)
             {
                 cmdlet.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -63,11 +63,7 @@ namespace System.Management.Automation
             Encoding foundEncoding;
             if (encodingMap.TryGetValue(encoding, out foundEncoding))
             {
-                // Write a warning if using utf7 as it is obsolete in .NET5
-                if (string.Equals(encoding, Utf7, StringComparison.OrdinalIgnoreCase))
-                {
-                    cmdlet.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
-                }
+                WarnIfObsolete(cmdlet, foundEncoding);
 
                 return foundEncoding;
             }

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -91,9 +91,11 @@ namespace System.Management.Automation
         /// <param name="encoding">The encoding to check for obsolescence.</param>
         internal static void WarnIfObsolete(Cmdlet cmdlet, Encoding encoding)
         {
-            // Check for UTF-7 by checking for code page 65000
-            // See: https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
-            if (encoding != null && encoding.CodePage == 65000)
+            const int CodePageUtf7 = 65000;
+
+            // Compare against the the well-known UTF-7 code page, see:
+            // https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
+            if (encoding is { CodePage: CodePageUtf7 })
             {
                 cmdlet.WriteWarning(PathUtilsStrings.Utf7EncodingObsolete);
             }

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -93,7 +93,7 @@ namespace System.Management.Automation
         {
             const int CodePageUtf7 = 65000;
 
-            // Compare against the the well-known UTF-7 code page, see:
+            // Use the recommended pattern to check for UTF-7.
             // https://docs.microsoft.com/dotnet/core/compatibility/core-libraries/5.0/utf-7-code-paths-obsolete
             if (encoding is { CodePage: CodePageUtf7 })
             {


### PR DESCRIPTION
## Motivation

Remove the unnecessary string comparison in `EncodingConversion.Convert`.

https://github.com/PowerShell/PowerShell/blob/f3f56d4d1d27081312e7cd52b04195a8400bfbf2/src/System.Management.Automation/utils/EncodingUtils.cs#L67

## Context

* #13358
* #13430

cc: @JamesWTruher