### PR TITLE
Remove some unused strings in System.Management.Automation

### DIFF
--- a/src/System.Management.Automation/resources/PowerShellStrings.resx
+++ b/src/System.Management.Automation/resources/PowerShellStrings.resx
@@ -132,12 +132,6 @@
   <data name="InvalidRunspaceState" xml:space="preserve">
     <value>Cannot perform operation because the runspace is not in the '{0}' state. Current state of runspace is '{1}'.</value>
   </data>
-  <data name="RemoteRunspacePoolNotOpened" xml:space="preserve">
-    <value>The runspace pool specified is not in an opened state.</value>
-  </data>
-  <data name="OperationNotSupportedForRemoting" xml:space="preserve">
-    <value>This operation is currently not supported in the remoting scenario.</value>
-  </data>
   <data name="NestedPowerShellInvokeAsync" xml:space="preserve">
     <value>Nested PowerShell instances cannot be invoked asynchronously. Use the Invoke method.</value>
   </data>
@@ -159,24 +153,6 @@
   <data name="CommandInvokedFromWrongThreadWithCommand" xml:space="preserve">
     <value>There is no Runspace available to run commands in this thread. You can provide one in the DefaultRunspace property of the System.Management.Automation.Runspaces.Runspace type. The command you attempted to invoke was: {0}</value>
   </data>
-  <data name="GetJobForCommandNotSupported" xml:space="preserve">
-    <value>GetJobForCommand is not supported when there is more than one command in the PowerShell instance.</value>
-  </data>
-  <data name="GetJobForCommandRequiresACommand" xml:space="preserve">
-    <value>The Command property of a PowerShell object cannot be empty.</value>
-  </data>
-  <data name="JobCannotBeStartedWhenRunning" xml:space="preserve">
-    <value>A job cannot be started when it is already running.</value>
-  </data>
-  <data name="UnblockNotSupported" xml:space="preserve">
-    <value>Support for interactive jobs is not available</value>
-  </data>
-  <data name="JobObjectCanBeUsedOnce" xml:space="preserve">
-    <value>A job object can be used only once.</value>
-  </data>
-  <data name="JobCanBeStartedOnce" xml:space="preserve">
-    <value>A job object cannot be reused.</value>
-  </data>
   <data name="CannotConnect" xml:space="preserve">
     <value>This PowerShell object cannot be connected because it is not associated with a remote runspace or runspace pool.</value>
   </data>
@@ -191,10 +167,6 @@
   </data>
   <data name="ConnectFailed" xml:space="preserve">
     <value>The connection attempt to the remote command failed.</value>
-  </data>
-  <data name="ProxyChildJobControlNotSupported" xml:space="preserve">
-    <value>PSChildJobProxy does not support control methods.</value>
-    <comment>PSChildJobProxy is the name of a class and should not be localized</comment>
   </data>
   <data name="ExecutionStopping" xml:space="preserve">
     <value>The operation cannot be performed because a command is currently stopping. Wait for the command to complete stopping, and then try the operation again.</value>

--- a/src/System.Management.Automation/resources/RunspaceStrings.resx
+++ b/src/System.Management.Automation/resources/RunspaceStrings.resx
@@ -162,9 +162,6 @@
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
     <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
   </data>
-  <data name="ParameterNameOrValueNeeded" xml:space="preserve">
-    <value>Parameter name or value must be specified.</value>
-  </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
     <value>This property cannot be changed after the runspace has been opened.</value>
   </data>
@@ -206,9 +203,6 @@
   </data>
   <data name="CannotConnect" xml:space="preserve">
     <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
-  </data>
-  <data name="CmdletNotFoundWhileLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred while processing the module '{0}' that is specified in the InitialSessionState object used to create this runspace. For a complete list of errors, see the ErrorRecords property.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
     <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>

--- a/src/System.Management.Automation/resources/TypesXmlStrings.resx
+++ b/src/System.Management.Automation/resources/TypesXmlStrings.resx
@@ -126,9 +126,6 @@
   <data name="NotMoreThanOnceOne" xml:space="preserve">
     <value>Node "{0}" must occur only once under "{1}". The parent node, "{1}", will be ignored.</value>
   </data>
-  <data name="NotMoreThanOnceZeroOrOne" xml:space="preserve">
-    <value>Node "{0}" must have a maximum of one occurrence under "{1}". The parent node, "{1}", will be ignored.</value>
-  </data>
   <data name="UnknownNode" xml:space="preserve">
     <value>The node {0} is not allowed. The following nodes are allowed: {1}.</value>
   </data>
@@ -140,18 +137,6 @@
   </data>
   <data name="NodeNotFoundOnce" xml:space="preserve">
     <value>Node "{0}" was not found. It should occur only once under "{1}". The parent node, "{1}", will be ignored.</value>
-  </data>
-  <data name="NodeNotFoundAtLeastOnce" xml:space="preserve">
-    <value>Node "{0}" was not found. It should occur at least once under "{1}". The parent node, "{1}", will be ignored.</value>
-  </data>
-  <data name="ExpectedNodeTypeInstead" xml:space="preserve">
-    <value>Expected XML tag "{0}" instead of node of type "{1}".</value>
-  </data>
-  <data name="UnexpectedNodeType" xml:space="preserve">
-    <value>Node of type "{0}" was not expected.</value>
-  </data>
-  <data name="ExpectedNodeNameInstead" xml:space="preserve">
-    <value>Expected XML tag "{0}" instead of "{1}".</value>
   </data>
   <data name="TypeNodeShouldHaveMembersOrTypeConverters" xml:space="preserve">
     <value>The "Type" node must have "Members", "TypeConverters", or "TypeAdapters".</value>
@@ -200,9 +185,6 @@
   </data>
   <data name="IsHiddenNotSupported" xml:space="preserve">
     <value>Node "{0}" should not have "{1}" attribute.</value>
-  </data>
-  <data name="IsHiddenValueShouldBeTrueOrFalse" xml:space="preserve">
-    <value>Value should be "true" or "false" instead of "{0}" for "{1}" attribute.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>{0}, {1}: The file was not found.</value>
@@ -260,12 +242,6 @@
   </data>
   <data name="TypeDataShouldNotBeNullOrEmpty" xml:space="preserve">
     <value>"{0}" should not have null or an empty string in its property "{1}".</value>
-  </data>
-  <data name="DuplicateMembersDefinedInType" xml:space="preserve">
-    <value>More than one member with the name "{0}" is defined in the type file.</value>
-  </data>
-  <data name="DuplicateFileInInitialSessionState" xml:space="preserve">
-    <value>{0}: The file was skipped because it already occurred.</value>
   </data>
   <data name="TypeNotFound" xml:space="preserve">
     <value>The type "{0}" was not found. The type name value must be the full name of the type. Verify the type name and run the command again.</value>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Unused strings from 3 resx files associated with SMA

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
