### PR TITLE
Use generic `GetValues`, `GetNames` enum methods

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -1890,7 +1890,7 @@ namespace Microsoft.PowerShell.Commands
             var mask = suiteMask.Value;
             var list = new List<OSProductSuite>();
 
-            foreach (OSProductSuite suite in Enum.GetValues(typeof(OSProductSuite)))
+            foreach (OSProductSuite suite in Enum.GetValues<OSProductSuite>())
                 if ((mask & (uint)suite) != 0)
                     list.Add(suite);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-SddlString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-SddlString.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                foreach (AccessRightTypeNames member in Enum.GetValues(typeof(AccessRightTypeNames)))
+                foreach (AccessRightTypeNames member in Enum.GetValues<AccessRightTypeNames>())
                 {
                     typesToExamine.Add(GetRealAccessRightType(member));
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1200,7 +1200,7 @@ namespace Microsoft.PowerShell
         private void ParseFormat(string[] args, ref int i, ref Serialization.DataFormat format, string resourceStr)
         {
             StringBuilder sb = new StringBuilder();
-            foreach (string s in Enum.GetNames(typeof(Serialization.DataFormat)))
+            foreach (string s in Enum.GetNames<Serialization.DataFormat>())
             {
                 sb.Append(s);
                 sb.Append(Environment.NewLine);

--- a/src/System.Management.Automation/engine/CommandMetadata.cs
+++ b/src/System.Management.Automation/engine/CommandMetadata.cs
@@ -1249,7 +1249,7 @@ clean
 
             // This should only be called with 1 valid category
             ParameterMetadata categoryParameter = new ParameterMetadata("Category", typeof(string[]));
-            categoryParameter.Attributes.Add(new ValidateSetAttribute(Enum.GetNames(typeof(HelpCategory))));
+            categoryParameter.Attributes.Add(new ValidateSetAttribute(Enum.GetNames<HelpCategory>()));
             categoryParameter.Attributes.Add(new ValidateCountAttribute(0, 1));
 
             return GetRestrictedCmdlet("Get-Help", null, "https://go.microsoft.com/fwlink/?LinkID=113316", nameParameter, categoryParameter);

--- a/src/System.Management.Automation/engine/TypeMetadata.cs
+++ b/src/System.Management.Automation/engine/TypeMetadata.cs
@@ -983,7 +983,7 @@ namespace System.Management.Automation
                 /* TODO: Validate Pattern dont support Options in ScriptCmdletText.
                 StringBuilder regexOps = new System.Text.StringBuilder();
                 string or = string.Empty;
-                string[] regexOptionEnumValues = Enum.GetNames(typeof(System.Text.RegularExpressions.RegexOptions));
+                string[] regexOptionEnumValues = Enum.GetNames<System.Text.RegularExpressions.RegexOptions>();
 
                 foreach (string regexOption in regexOptionEnumValues)
                 {

--- a/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
@@ -98,7 +98,7 @@ namespace System.Management.Automation.Remoting
                 Dbg.Assert(value != null, "Fragmentor cannot be null.");
                 _fragmentor = value;
                 // create serialized streams using fragment size.
-                string[] names = Enum.GetNames(typeof(DataPriorityType));
+                string[] names = Enum.GetNames<DataPriorityType>();
                 _dataToBeSent = new SerializedDataStream[names.Length];
                 _dataSyncObjects = new object[names.Length];
                 for (int i = 0; i < names.Length; i++)
@@ -765,7 +765,7 @@ namespace System.Management.Automation.Remoting
         internal PriorityReceiveDataCollection(Fragmentor defragmentor, bool createdByClientTM)
         {
             _defragmentor = defragmentor;
-            string[] names = Enum.GetNames(typeof(DataPriorityType));
+            string[] names = Enum.GetNames<DataPriorityType>();
             _recvdData = new ReceiveDataCollection[names.Length];
             for (int index = 0; index < names.Length; index++)
             {


### PR DESCRIPTION
Since .NET 5.0, we can use these generic methods:

* `Enum.GetValues<TEnum>()`
* `Enum.GetNames<TEnum>()`