### PR TITLE
Make use of StringSplitOptions.TrimEntries when possible

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
@@ -55,35 +55,34 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            string[] lines = _stringData.Split('\n');
+            string[] lines = _stringData.Split('\n', StringSplitOptions.TrimEntries);
 
             foreach (string line in lines)
             {
-                string s = line.Trim();
 
-                if (string.IsNullOrEmpty(s) || s[0] == '#')
+                if (string.IsNullOrEmpty(line) || line[0] == '#')
                     continue;
 
-                int index = s.IndexOf(Delimiter);
+                int index = line.IndexOf(Delimiter);
                 if (index <= 0)
                 {
                     throw PSTraceSource.NewInvalidOperationException(
                         ConvertFromStringData.InvalidDataLine,
-                        s);
+                        line);
                 }
 
-                string name = s.Substring(0, index);
+                string name = line.Substring(0, index);
                 name = name.Trim();
 
                 if (result.ContainsKey(name))
                 {
                     throw PSTraceSource.NewInvalidOperationException(
                         ConvertFromStringData.DataItemAlreadyDefined,
-                        s,
+                        line,
                         name);
                 }
 
-                string value = s.Substring(index + 1);
+                string value = line.Substring(index + 1);
                 value = value.Trim();
 
                 value = Regex.Unescape(value);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1273,24 +1273,23 @@ namespace System.Management.Automation
             };
 
             var modulePathList = new List<string>();
-            foreach (var path in currentModulePath.Split(';'))
+            foreach (var path in currentModulePath.Split(';', StringSplitOptions.TrimEntries))
             {
-                var trimmedPath = path.Trim();
-                if (!excludeModulePaths.Contains(trimmedPath))
+                if (!excludeModulePaths.Contains(path))
                 {
                     // make sure this module path is Not part of other PS Core installation
-                    var possiblePwshDir = Path.GetDirectoryName(trimmedPath);
+                    var possiblePwshDir = Path.GetDirectoryName(path);
 
                     if (string.IsNullOrEmpty(possiblePwshDir))
                     {
                         // i.e. module dir is in the drive root
-                        modulePathList.Add(trimmedPath);
+                        modulePathList.Add(path);
                     }
                     else
                     {
                         if (!File.Exists(Path.Combine(possiblePwshDir, "pwsh.dll")))
                         {
-                            modulePathList.Add(trimmedPath);
+                            modulePathList.Add(path);
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

[StringSplitOptions](https://learn.microsoft.com/de-de/dotnet/api/system.stringsplitoptions?view=net-7.0).TrimEntries is available since .NET 5 and reduces string allocations compared to calling Trim() on each string.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
