### PR TITLE
Fix `Switch-Process` error to include the command that is not found

### DIFF
--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -46,12 +46,12 @@ namespace Microsoft.PowerShell.Commands
                             string.Format(
                                 System.Globalization.CultureInfo.InvariantCulture,
                                 CommandBaseStrings.NativeCommandNotFound,
-                                command
+                                WithCommand[0]
                             )
                         ),
                         "CommandNotFound",
                         ErrorCategory.InvalidArgument,
-                        WithCommand
+                        WithCommand[0]
                     )
                 );
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -48,6 +48,13 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
             ($p | Get-Process).Name -eq 'sleep'
         } -timeout 60000 -interval 100 | Should -BeTrue
     }
+
+    It 'Error is returned if target command is not found' {
+        $invalidCommand = 'doesNotExist'
+        $e = { Switch-Process $invalidCommand } | Should -Throw -ErrorId 'CommandNotFound,Microsoft.PowerShell.Commands.SwitchProcessCommand' -PassThru
+        $e.Exception.Message | Should -BeLike "*'$invalidCommand'*"
+        $e.TargetObject | Should -BeExactly $invalidCommand
+    }
 }
 
 Describe 'Switch-Process for Windows' -Tag 'CI' {

--- a/test/xUnit/csharp/test_Feedback.cs
+++ b/test/xUnit/csharp/test_Feedback.cs
@@ -48,7 +48,7 @@ namespace PSTests.Sequential
             {
                 // The delay is exaggerated to make the test reliable.
                 // xUnit must spin up a lot tasks, which makes the test unreliable when the time difference between 'delay' and 'timeout' is small.
-                Thread.Sleep(2000);
+                Thread.Sleep(2500);
             }
 
             return $"{commandLine}+{errorRecord.FullyQualifiedErrorId}";


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The formatting of the error was incorrectly using the wrong variable which would be null.  Fix is to use the first item in the input which is the command name.

Had to increase timeout in a test that kept failing with multiple reruns.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/18436

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
