### PR TITLE
Fix `Switch-Process` to copy the current env to the new process

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -57,8 +57,8 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
     }
 
     It 'The environment will be copied to the child process' {
-        $env = pwsh -noprofile -outputformat text -command { $env:TEST_FOO='my_test_value'; Switch-Process bash -c 'echo $TEST_FOO' }
-        $env | Should -BeExactly 'my_test_value'
+        $env = pwsh -noprofile -outputformat text -command { $env:TEST_FOO='my test = value'; Switch-Process bash -c 'echo $TEST_FOO' }
+        $env | Should -BeExactly 'my test = value'
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -55,6 +55,11 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
         $e.Exception.Message | Should -BeLike "*'$invalidCommand'*"
         $e.TargetObject | Should -BeExactly $invalidCommand
     }
+
+    It 'The environment will be copied to the child process' {
+        $env = pwsh -noprofile -outputformat text -command { $env:TEST_FOO='my_test_value'; Switch-Process bash -c 'echo $TEST_FOO' }
+        $env | Should -BeExactly 'my_test_value'
+    }
 }
 
 Describe 'Switch-Process for Windows' -Tag 'CI' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The `execv()` API is documented to copy the env to the new process, but doesn't do that.  Apparently it requires use of a global variable in C.  Switch to `execve()` and manually copy the current env to the new process.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/18432

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9396
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
