### PR TITLE
PSCustomObject does not work with Select-Object -Unique and Sort-Object -Unique

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands
@@ -238,6 +239,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
+
+            // #17953: PSCustomObject contains only NoteProperties ignored by -Unique by default
+            // If first object is PSCustomObject, then default to "*" instead
+            if (Unique && Property?.Any() != true && InputObjects.FirstOrDefault()?.BaseObject is PSCustomObject)
+            {
+                Property = new[] { "*" };
+            }
+
             OrderByProperty orderByProperty = new(
                 this, InputObjects, Property, !Descending, ConvertedCulture, CaseSensitive);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Sort-Object.cs
@@ -239,7 +239,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-
             // #17953: PSCustomObject contains only NoteProperties ignored by -Unique by default
             // If first object is PSCustomObject, then default to "*" instead
             if (Unique && Property?.Any() != true && InputObjects.FirstOrDefault()?.BaseObject is PSCustomObject)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -196,6 +196,16 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
     }
 
+    # Special case because by default, NoteProperties are ignored and PSCustomObjects are nothing but
+    It "Select-Object with Unique should work work for PSCustomObject and <name>" -TestCases @(
+        @{ name = '-Property *'; splat = @{ Property = '*' } }
+        @{ name = 'no -Property'; splat = @{} }
+    ) {
+        param ($name, $splat)
+        $results = ($employees + $employees) | Select-Object -Unique @splat
+        $results.Count | Should -Be $employees.Count
+    }
+
     It "Select-Object with Simple should work" {
         $employee1 = [pscustomobject]@{"FirstName" = "joesph"; "LastName" = "smith"; "YearsInMS" = 15 }
         $employee2 = [pscustomobject]@{"FirstName" = "paul"; "LastName" = "smith"; "YearsInMS" = 15 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -196,13 +196,8 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results[2].YearsInMS | Should -Be $employees[3].YearsInMS
     }
 
-    # Special case because by default, NoteProperties are ignored and PSCustomObjects are nothing but
-    It "Select-Object with Unique should work work for PSCustomObject and <name>" -TestCases @(
-        @{ name = '-Property *'; splat = @{ Property = '*' } }
-        @{ name = 'no -Property'; splat = @{} }
-    ) {
-        param ($name, $splat)
-        $results = ($employees + $employees) | Select-Object -Unique @splat
+    It "Select-Object with Unique should work work for PSCustomObject and no -Property" {
+        $results = ($employees + $employees) | Select-Object -Unique
         $results.Count | Should -Be $employees.Count
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
@@ -160,6 +160,19 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 		$results[2] | Should -Be $employees[1]
 	}
 
+	It 'SortObject with Unique should work with PSCustomObject and no -Property' {
+		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
+		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
+		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=12}
+		$employees = @($employee1,$employee2,$employee3)
+		$results = ($employees + $employees) | Sort-Object -Unique
+
+		$results.Count | Should -Be 3
+		$results[0] | Should -Be $employees[1]
+		$results[1] | Should -Be $employees[0]
+		$results[2] | Should -Be $employees[2]
+	}
+
 	It "Sort-Object with Two Order Entry Keys should work"{
 		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
 		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
@@ -23,6 +23,13 @@ Describe "Sort-Object" -Tags "CI" {
 }
 
 Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
+	BeforeEach {
+		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
+		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
+		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=2}
+		$employees = @($employee1,$employee2,$employee3)
+	}
+
 	It "Sort-Object with object array should work"{
 		$employee1 = [pscustomobject]@{"FirstName"="Eight"; "LastName"="Eight"; "YearsInMS"=8}
 		$employee2 = [pscustomobject]@{"FirstName"="Eight"; "YearsInMS"=$null}
@@ -48,10 +55,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Non Conflicting Order Entry Keys should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=2}
-		$employees = @($employee1,$employee2,$employee3)
 		$ht = @{"e"="YearsInMS"; "descending"=$false; "ascending"=$true}
 		$results = $employees | Sort-Object -Property $ht -Descending
 
@@ -61,10 +64,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Conflicting Order Entry Keys should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=2}
-		$employees = @($employee1,$employee2,$employee3)
 		$ht = @{"e"="YearsInMS"; "descending"=$false; "ascending"=$false}
 		$results = $employees | Sort-Object -Property $ht -Descending
 
@@ -74,10 +73,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with One Order Entry Key should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=2}
-		$employees = @($employee1,$employee2,$employee3)
 		$ht = @{"e"="YearsInMS"; "descending"=$false}
 		$results = $employees | Sort-Object -Property $ht -Descending
 
@@ -137,10 +132,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Non Case-Sensitive Unique should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=12}
-		$employees = @($employee1,$employee2,$employee3)
 		$results = $employees | Sort-Object -Property "LastName" -Descending -Unique
 
 		$results[0] | Should -Be $employees[2]
@@ -149,10 +140,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Case-Sensitive Unique should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=12}
-		$employees = @($employee1,$employee2,$employee3)
 		$results = $employees | Sort-Object -Property "LastName","FirstName" -Descending -Unique -CaseSensitive
 
 		$results[0] | Should -Be $employees[2]
@@ -161,10 +148,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It 'SortObject with Unique should work with PSCustomObject and no -Property' {
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=12}
-		$employees = @($employee1,$employee2,$employee3)
 		$results = ($employees + $employees) | Sort-Object -Unique
 
 		$results.Count | Should -Be 3
@@ -174,10 +157,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Two Order Entry Keys should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=2}
-		$employees = @($employee1,$employee2,$employee3)
 		$ht1 = @{"expression"="LastName"; "ascending"=$false}
 		$ht2 = @{"expression"="FirstName"; "ascending"=$true}
 		$results = $employees | Sort-Object -Property @($ht1,$ht2) -Descending
@@ -188,10 +167,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with -Descending:$false and Two Order Entry Keys should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=12}
-		$employees = @($employee1,$employee2,$employee3)
 		$results = $employees | Sort-Object -Property "LastName","FirstName" -Descending:$false
 
 		$results[0] | Should -Be $employees[1]
@@ -200,10 +175,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with -Descending and Two Order Entry Keys should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=12}
-		$employees = @($employee1,$employee2,$employee3)
 		$results = $employees | Sort-Object -Property "LastName","FirstName" -Descending
 
 		$results[0] | Should -Be $employees[2]
@@ -212,10 +183,6 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	}
 
 	It "Sort-Object with Two Order Entry Keys with asc=true should work"{
-		$employee1 = [pscustomobject]@{"FirstName"="john"; "LastName"="smith"; "YearsInMS"=5}
-		$employee2 = [pscustomobject]@{"FirstName"="joesph"; "LastName"="smith"; "YearsInMS"=15}
-		$employee3 = [pscustomobject]@{"FirstName"="john"; "LastName"="smyth"; "YearsInMS"=12}
-		$employees = @($employee1,$employee2,$employee3)
 		$ht1 = @{"e"="FirstName"; "asc"=$true}
 		$ht2 = @{"e"="LastName";}
 		$results = $employees | Sort-Object -Property @($ht1,$ht2) -Descending


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fix #17953 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

By default, `Select-Object -Unique` and `Sort-Object -Unique` ignore `NoteProperties` when comparing objects. This is a problem for `PSCustomObject`, as it contains nothing but `NoteProperties`. The fix is that if the first object processed is `PSCustomObject`, the default is equivalent to `-Property *` which does include `NoteProperties`.

## PR Checklist

- [*] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [*] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [*] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [*] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [*] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [*] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [*] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [*] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
