### PR TITLE
Fix `Switch-Process` to set termios appropriate for child process

### DIFF
--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -69,6 +69,7 @@ namespace Microsoft.PowerShell.Commands
             // need null terminator at end
             execArgs[execArgs.Length - 1] = null;
 
+            // setup termios for a child process as .NET modifies termios dynamically for use with ReadKey()
             ConfigureTerminalForChildProcess(true);
             int exitCode = Exec(command.Source, execArgs);
             if (exitCode < 0)
@@ -110,6 +111,7 @@ namespace Microsoft.PowerShell.Commands
             SetLastError = true)]
         private static extern int Exec(string path, string?[] args);
 
+        // leverage .NET runtime's native library which abstracts the need to handle different OS and architectures for termios api
         [DllImport("libSystem.Native", EntryPoint = "SystemNative_ConfigureTerminalForChildProcess")]
         private static extern void ConfigureTerminalForChildProcess([MarshalAs(UnmanagedType.Bool)] bool childUsesTerminal);
     }

--- a/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/SwitchProcessCommand.cs
@@ -69,7 +69,31 @@ namespace Microsoft.PowerShell.Commands
             // need null terminator at end
             execArgs[execArgs.Length - 1] = null;
 
-            int exitCode = Exec(command.Source, execArgs);
+            // set termios to reasonble default before execv since .NET modifies it during ReadKey
+            Termios t;
+            int exitCode = TcGetAttr(STDIN_FILENO, out t);
+            bool resetTerminal = false;
+            Termios old_t = t;
+            if (exitCode == 0)
+            {
+                t.c_lflag = ECHOE | ECHOK | ECHOCTL | ECHOKE | PENDIN;
+                t.c_iflag = IUTF8;
+                t.c_cflag = CS8 | ~PARENB;
+                t.c_oflag = ~OXTABS;
+                exitCode = TcSetAttr(STDIN_FILENO, TCSANOW, ref t);
+                if (exitCode == 0)
+                {
+                    Termios t2;
+                    exitCode = TcGetAttr(STDIN_FILENO, out t2);
+                    resetTerminal = true;
+                }
+            }
+
+            exitCode = Exec(command.Source, execArgs);
+            if (resetTerminal)
+            {
+                TcSetAttr(STDIN_FILENO, TCSANOW, ref old_t);
+            }
 
             if (exitCode < 0)
             {
@@ -108,6 +132,45 @@ namespace Microsoft.PowerShell.Commands
             CharSet = CharSet.Ansi,
             SetLastError = true)]
         private static extern int Exec(string path, string?[] args);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct Termios
+        {
+            public int c_iflag; /* input flags */
+            public int c_oflag; /* output flags */
+            public int c_cflag; /* control flags */
+            public int c_lflag; /* local flags */
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+            public byte[] c_cc; /* control chars */
+            public int c_ispeed; /* input speed */
+            public int c_ospeed; /* output speed */
+        }
+
+        [DllImport("libc",
+            EntryPoint = "tcgetattr",
+            CallingConvention = CallingConvention.Cdecl,
+            CharSet = CharSet.Ansi,
+            SetLastError = true)]
+        private static extern int TcGetAttr(int fd, out Termios termios);
+
+        [DllImport("libc",
+            EntryPoint = "tcsetattr",
+            CallingConvention = CallingConvention.Cdecl,
+            CharSet = CharSet.Ansi,
+            SetLastError = true)]
+        private static extern int TcSetAttr(int fd, int optional_actions, ref Termios termios);
+
+        private const int STDIN_FILENO = 0;
+        private const int TCSANOW = 0;          // change immediately
+        private const int ECHOE = (1 << 1); //0x00000010;   // visual erase for ERASE
+        private const int ECHOK = (1 << 2); //0x00000020;   // echo newline after kill
+        private const int ECHOCTL = (1 << 6); //0x00000200; // echo control characters as ^X
+        private const int ECHOKE = (1 << 0); //0x00000800;  // visual erase for KILL
+        private const int PENDIN = (1 << 29); //0x00004000;  // retype pending input
+        private const int IUTF8 = 0x20000; // 0x00004000;   // UTF8
+        private const int OXTABS = (1 << 2);
+        private const int PARENB = (1 << 12);
+        private const int CS8 = (1 << 8) | (1 << 9);
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

.NET makes changes to termios for the purpose of `ReadKey()` (and maybe other uses).  So when `execv()` is called, the terminal is set not to echo.  Unless the child process (like `bash`) sets up termios appropriately, echo is now disabled and needs to manually be reenabled.  The fix is to leverage an exported function from .NET that sets up termios correctly for a child process.

Manually validated on macOS with bash since using `pwsh` non-interactively doesn't have a problem (as there isn't a TTY).

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/18433

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
