### PR TITLE
Rewrite Get-FileHash to use static HashData methods

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -140,6 +140,7 @@ namespace Microsoft.PowerShell.Commands
                 case HashAlgorithmNames.MD5:
                     return MD5.HashData(stream);
             }
+
             Debug.Assert(false, "invalid hash algorithm");
             return SHA256.HashData(stream);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -69,15 +69,6 @@ namespace Microsoft.PowerShell.Commands
         public Stream InputStream { get; set; }
 
         /// <summary>
-        /// BeginProcessing() override.
-        /// This is for hash function init.
-        /// </summary>
-        protected override void BeginProcessing()
-        {
-            InitHasher(Algorithm);
-        }
-
-        /// <summary>
         /// ProcessRecord() override.
         /// This is for paths collecting from pipe.
         /// </summary>
@@ -134,6 +125,29 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Calculate the hash data from the Stream with the specified hash algorithm
+        /// </summary>
+        /// <returns>The computed hash data</returns>
+        private byte[] ComputeHash(Stream stream)
+        {
+            switch (Algorithm)
+            {
+                case HashAlgorithmNames.SHA1:
+                    return SHA1.HashData(stream);
+                case HashAlgorithmNames.SHA256:
+                    return SHA256.HashData(stream);
+                case HashAlgorithmNames.SHA384:
+                    return SHA384.HashData(stream);
+                case HashAlgorithmNames.SHA512:
+                    return SHA512.HashData(stream);
+                case HashAlgorithmNames.MD5:
+                    return MD5.HashData(stream);
+                default:
+                    return SHA256.HashData(stream);
+            }
+        }
+
+        /// <summary>
         /// Perform common error checks.
         /// Populate source code.
         /// </summary>
@@ -141,12 +155,9 @@ namespace Microsoft.PowerShell.Commands
         {
             if (ParameterSetName == StreamParameterSet)
             {
-                byte[] bytehash = null;
-                string hash = null;
+                byte[] bytehash = ComputeHash(InputStream);
 
-                bytehash = hasher.ComputeHash(InputStream);
-
-                hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
+                string hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
                 WriteHashResult(Algorithm, hash, string.Empty);
             }
         }
@@ -159,7 +170,6 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Boolean value indicating whether the hash calculation succeeded or failed.</returns>
         private bool ComputeFileHash(string path, out string hash)
         {
-            byte[] bytehash = null;
             Stream openfilestream = null;
 
             hash = null;
@@ -167,8 +177,8 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 openfilestream = File.OpenRead(path);
+                byte[] bytehash = ComputeHash(openfilestream);
 
-                bytehash = hasher.ComputeHash(openfilestream);
                 hash = BitConverter.ToString(bytehash).Replace("-", string.Empty);
             }
             catch (FileNotFoundException ex)
@@ -274,40 +284,6 @@ namespace Microsoft.PowerShell.Commands
             public const string SHA256 = "SHA256";
             public const string SHA384 = "SHA384";
             public const string SHA512 = "SHA512";
-        }
-
-        /// <summary>
-        /// Init a hash algorithm.
-        /// </summary>
-        protected void InitHasher(string Algorithm)
-        {
-            try
-            {
-                switch (Algorithm)
-                {
-                    case HashAlgorithmNames.SHA1:
-                        hasher = SHA1.Create();
-                        break;
-                    case HashAlgorithmNames.SHA256:
-                        hasher = SHA256.Create();
-                        break;
-                    case HashAlgorithmNames.SHA384:
-                        hasher = SHA384.Create();
-                        break;
-                    case HashAlgorithmNames.SHA512:
-                        hasher = SHA512.Create();
-                        break;
-                    case HashAlgorithmNames.MD5:
-                        hasher = MD5.Create();
-                        break;
-                }
-            }
-            catch
-            {
-                // Seems it will never throw! Remove?
-                Exception exc = new NotSupportedException(UtilityCommonStrings.AlgorithmTypeNotSupported);
-                ThrowTerminatingError(new ErrorRecord(exc, "AlgorithmTypeNotSupported", ErrorCategory.NotImplemented, null));
-            }
         }
     }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Management.Automation;
 using System.Security.Cryptography;
@@ -124,10 +125,6 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        /// <summary>
-        /// Calculate the hash data from the Stream with the specified hash algorithm
-        /// </summary>
-        /// <returns>The computed hash data</returns>
         private byte[] ComputeHash(Stream stream)
         {
             switch (Algorithm)
@@ -142,9 +139,9 @@ namespace Microsoft.PowerShell.Commands
                     return SHA512.HashData(stream);
                 case HashAlgorithmNames.MD5:
                     return MD5.HashData(stream);
-                default:
-                    return SHA256.HashData(stream);
             }
+            Debug.Assert(false, "invalid hash algorithm");
+            return SHA256.HashData(stream);
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -267,11 +267,6 @@ namespace Microsoft.PowerShell.Commands
         private string _Algorithm = HashAlgorithmNames.SHA256;
 
         /// <summary>
-        /// Hash algorithm is used.
-        /// </summary>
-        protected HashAlgorithm hasher;
-
-        /// <summary>
         /// Hash algorithm names.
         /// </summary>
         internal static class HashAlgorithmNames

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
@@ -83,11 +83,6 @@ namespace Microsoft.PowerShell.Commands
         public static string FormatHexPathPrefix { get { return UtilityCommonStrings.FormatHexPathPrefix; } }
 
         /// <summary>
-        /// Error message to indicate that requested algorithm is not supported on the target platform.
-        /// </summary>
-        public static string AlgorithmTypeNotSupported { get { return UtilityCommonStrings.AlgorithmTypeNotSupported; } }
-
-        /// <summary>
         /// The file '{0}' could not be parsed as a PowerShell Data File.
         /// </summary>
         public static string CouldNotParseAsPowerShellDataFile { get { return UtilityCommonStrings.CouldNotParseAsPowerShellDataFile; } }

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityCommonStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityCommonStrings.resx
@@ -162,9 +162,6 @@
   <data name="PSPrefixReservedInInformationTag" xml:space="preserve">
     <value>Cannot use tag '{0}'. The 'PS' prefix is reserved.</value>
   </data>
-  <data name="AlgorithmTypeNotSupported" xml:space="preserve">
-    <value>Algorithm '{0}' is not supported in this system.</value>
-  </data>
   <data name="CouldNotParseAsPowerShellDataFile" xml:space="preserve">
     <value>The file '{0}' could not be parsed as a PowerShell Data File.</value>
   </data>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
The [HashData(Stream s)](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha256.hashdata?view=net-7.0) methods have been added in .NET 7
The static HashData methods are more optimized and [preferred over the ComputeHash methods](https://github.com/dotnet/runtime/issues/40579).
~~Still need to test if anything broke, therefore WIP~~

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
