### PR TITLE
PSModuleAutoLoadingPreference No Longer Accepts Bogus Values

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4320,6 +4320,8 @@ end {
         internal const ActionPreference DefaultWarningPreference = ActionPreference.Continue;
         internal const ActionPreference DefaultInformationPreference = ActionPreference.SilentlyContinue;
 
+        internal const PSModuleAutoLoadingPreference DefaultAutoLoadingPreference = PSModuleAutoLoadingPreference.All;
+
         internal const ErrorView DefaultErrorView = ErrorView.ConciseView;
         internal const bool DefaultWhatIfPreference = false;
         internal const ConfirmImpact DefaultConfirmPreference = ConfirmImpact.High;
@@ -4420,6 +4422,14 @@ end {
                     FormatEnumerationLimit,
                     DefaultFormatEnumerationLimit,
                     RunspaceInit.FormatEnumerationLimitDescription),
+
+                // variable for PSModuleAutoLoadingPreference
+                new SessionStateVariableEntry(
+                   SpecialVariables.PSModuleAutoLoading,
+                   DefaultAutoLoadingPreference, 
+                   RunspaceInit.PSModuleAutoLoadingPreferenceDescription,
+                   ScopedItemOptions.None,
+                   new ArgumentTypeConverterAttribute(typeof(PSModuleAutoLoadingPreference))),
 
                 // variable for PSEmailServer
                 new SessionStateVariableEntry(

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -159,6 +159,9 @@
   <data name="PSEmailServerDescription" xml:space="preserve">
     <value>Variable to contain the name of the email server. This can be used instead of the HostName parameter in the Send-MailMessage cmdlet.</value>
   </data>
+  <data name="PSModuleAutoLoadingPreferenceDescription" xml:space="preserve">
+    <value>Enables and disables automatic importing of modules in the session.</value>
+  </data>
   <data name="ConfirmPreferenceDescription" xml:space="preserve">
     <value>Dictates when confirmation should be requested. Confirmation is requested when the ConfirmImpact of the operation is equal to or greater than $ConfirmPreference. If $ConfirmPreference is None, actions will only be confirmed when Confirm is specified.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -262,6 +262,28 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
     }
 }
 
+Describe "PSModuleAutoloadingPreference has correct default value and rejects bogus values" -Tags 'CI' {
+
+    It "Default value should be all" {
+        $Global:PSModuleAutoloadingPreference | Should -Be "All"
+    }
+
+    It "Assign bogus value fails" {
+        {$Global:PSModuleAutoloadingPreference = "bogus" } | Should -Throw -ErrorId "RuntimeException"
+    }
+
+    It "Assign valid value succeeds" {
+        $Global:PSModuleAutoloadingPreference = "None"
+        $Global:PSModuleAutoloadingPreference | Should -Be "None"
+
+        $Global:PSModuleAutoloadingPreference = "ModuleQualified"
+        $Global:PSModuleAutoloadingPreference | Should -Be "ModuleQualified"
+
+        $Global:PSModuleAutoloadingPreference = "All"
+        $Global:PSModuleAutoloadingPreference | Should -Be "All"
+    }
+}
+
 Describe "Import-Module should be case insensitive" -Tags 'CI' {
     BeforeAll {
         $defaultPSModuleAutoloadingPreference = $PSModuleAutoLoadingPreference


### PR DESCRIPTION
## Changes Summary
Added PSModuleAutoLoadingPreference to initial session state vars, added description for the variable to the runspaceinit.resx file, added tests which cover expected functionality. 

The PSModuleAutoLoadingPreference variable now only accepts values All, ModuleQualified, None. All other variable assignments will error out as shown through the tests. Intended to resolve https://github.com/PowerShell/PowerShell/issues/12037

## Slight User Experience Change

I've marked this pull request as WIP as there is a bit of a hidden behavior change that will occur as a result of the change:


<img width="1020" alt="Screen Shot 2022-11-05 at 12 54 59 PM" src="https://user-images.githubusercontent.com/66397912/200131938-4f7c70ab-efd8-48d1-8e8e-af716ca3dbfa.png">

Shown above is the GetCommandDiscoveryPreference which is used for all accesses to the PSModuleAutoloadingPreference variable in the codebase. With my new change, the PSModuleAutoloadingPreference variable will be set by default. So the result variable in the code above will never be null and we will always enter the first if block and return the preference. The dilemma here is that, with this new change, we would now longer be checking the user’s environment variables to see if they already had the preference set before setting the default value to “All” when the pwsh terminal starts up. This is a behavior change that could potentially break things for some users.

I see two paths forward: 
- Continue with the change as is, setting the initial value for PSModuleAutoloadingPreference to “All” regardless of the user’s current environment variable when the shell starts up. This is ultimately what the documentation here https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-7.2#psmoduleautoloadingpreference suggests the behavior should be and that is the change I recommend. 
- When setting the initial value for the PSModuleAutoloadingPreference variable, first check the environment variable and, if the user doesn’t have it set, set it to “All” otherwise defer to what they've already set. This will keep the current behavior exactly identical to what it is now and potentially prevent breaking changes in case some users are still depending on their autoloadingpreference being set via their current environment variables. However, this behavior would not be consistent with what is stated in the documentation above. 

