### PR TITLE
Avoid depending on the pre-generated experimental feature list in private and CI builds

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -637,11 +637,9 @@ Fix steps:
     $config = [ordered]@{}
 
     if ($Options.Runtime -like "*win*") {
-        # Execution Policy is only supported on Windows
-        $config = [ordered]@{
-            "Microsoft.PowerShell:ExecutionPolicy" = "RemoteSigned";
-            "WindowsPowerShellCompatibilityModuleDenyList"  = @("PSScheduledJob", "BestPractices", "UpdateServices")
-        }
+        # Execution Policy and WinCompat feature are only supported on Windows.
+        $config.Add("Microsoft.PowerShell:ExecutionPolicy", "RemoteSigned")
+        $config.Add("WindowsPowerShellCompatibilityModuleDenyList", @("PSScheduledJob", "BestPractices", "UpdateServices"))
     }
 
     if (-not $SkipExperimentalFeatureGeneration -and

--- a/tools/releaseBuild/azureDevOps/releaseBuild.yml
+++ b/tools/releaseBuild/azureDevOps/releaseBuild.yml
@@ -28,6 +28,8 @@ resources:
     ref: master
 
 variables:
+  - name: PS_RELEASE_BUILD
+    value: 1
   - name: DOTNET_CLI_TELEMETRY_OPTOUT
     value: 1
   - name: POWERSHELL_TELEMETRY_OPTOUT


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

The pre-generated files `experimental-feature-windows.json` and `experimental-feature-linux.json` exist only for building purpose -- so that the `powershell.config.json` file can include all experimental features for the pre-release builds to enable all experimental features by default. (A little background context -- you cannot start the newly built pwsh when doing cross-compilation for ARM architectures)

However, it turns out this becomes a burden to the developer who is working on an experimental feature -- they have to update those 2 files to make the new experimental feature enabled in CI builds and private builds. This makes declaring an experimental feature harder and more confusing, as there is no documentation saying that those 2 files need to be updated as part of creating an experimental feature.

This PR update `Start-PSBuild` to avoid depending on those 2 files for private builds and CI builds. For release builds, since we have a [GitHub Action workflow](https://github.com/PowerShell/PowerShell/actions/workflows/exp-json.yml) to update those 2 files daily, we should be good.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
