### PR TITLE
For `NormalView`, the command should also be in the error color

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1051,7 +1051,10 @@ namespace System.Management.Automation.Runspaces
                                         }
                                     }
 
-                                    $errorColor + $commandPrefix
+                                    if ($commandPrefix)
+                                    {
+                                        $errorColor + $commandPrefix
+                                    }
                                 ")
                         .AddScriptBlockExpressionBinding(@"
                                     Set-StrictMode -Off

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1005,15 +1005,14 @@ namespace System.Management.Automation.Runspaces
                                             $errorColor = $PSStyle.Formatting.Error
                                         }
 
-                                        if ($myinv -and $myinv.MyCommand)
-                                        {
+                                        $commandPrefix = if ($myinv -and $myinv.MyCommand) {
                                             switch -regex ( $myinv.MyCommand.CommandType )
                                             {
                                                 ([System.Management.Automation.CommandTypes]::ExternalScript)
                                                 {
                                                     if ($myinv.MyCommand.Path)
                                                     {
-                                                        $errorColor + $myinv.MyCommand.Path + ' : '
+                                                        $myinv.MyCommand.Path + ' : '
                                                     }
 
                                                     break
@@ -1023,7 +1022,7 @@ namespace System.Management.Automation.Runspaces
                                                 {
                                                     if ($myinv.MyCommand.ScriptBlock)
                                                     {
-                                                        $errorColor + $myinv.MyCommand.ScriptBlock.ToString() + ' : '
+                                                        $myinv.MyCommand.ScriptBlock.ToString() + ' : '
                                                     }
 
                                                     break
@@ -1034,12 +1033,12 @@ namespace System.Management.Automation.Runspaces
                                                     {
                                                         if ($myinv.MyCommand.Name)
                                                         {
-                                                            $errorColor + $myinv.MyCommand.Name + ' : '
+                                                            $myinv.MyCommand.Name + ' : '
                                                         }
                                                     }
                                                     else
                                                     {
-                                                        $errorColor + $myinv.InvocationName + ' : '
+                                                        $myinv.InvocationName + ' : '
                                                     }
 
                                                     break
@@ -1048,9 +1047,11 @@ namespace System.Management.Automation.Runspaces
                                         }
                                         elseif ($myinv -and $myinv.InvocationName)
                                         {
-                                            $errorColor + $myinv.InvocationName + ' : '
+                                            $myinv.InvocationName + ' : '
                                         }
                                     }
+
+                                    $errorColor + $commandPrefix
                                 ")
                         .AddScriptBlockExpressionBinding(@"
                                     Set-StrictMode -Off

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1000,6 +1000,11 @@ namespace System.Management.Automation.Runspaces
                                     if (@('NativeCommandErrorMessage','NativeCommandError') -notcontains $_.FullyQualifiedErrorId -and @('CategoryView','ConciseView','DetailedView') -notcontains $ErrorView)
                                     {
                                         $myinv = $_.InvocationInfo
+                                        $errorColor = ''
+                                        if ($Host.UI.SupportsVirtualTerminal) {
+                                            $errorColor = $PSStyle.Formatting.Error
+                                        }
+
                                         if ($myinv -and $myinv.MyCommand)
                                         {
                                             switch -regex ( $myinv.MyCommand.CommandType )
@@ -1008,7 +1013,7 @@ namespace System.Management.Automation.Runspaces
                                                 {
                                                     if ($myinv.MyCommand.Path)
                                                     {
-                                                        $myinv.MyCommand.Path + ' : '
+                                                        $errorColor + $myinv.MyCommand.Path + ' : '
                                                     }
 
                                                     break
@@ -1018,7 +1023,7 @@ namespace System.Management.Automation.Runspaces
                                                 {
                                                     if ($myinv.MyCommand.ScriptBlock)
                                                     {
-                                                        $myinv.MyCommand.ScriptBlock.ToString() + ' : '
+                                                        $errorColor + $myinv.MyCommand.ScriptBlock.ToString() + ' : '
                                                     }
 
                                                     break
@@ -1029,12 +1034,12 @@ namespace System.Management.Automation.Runspaces
                                                     {
                                                         if ($myinv.MyCommand.Name)
                                                         {
-                                                            $myinv.MyCommand.Name + ' : '
+                                                            $errorColor + $myinv.MyCommand.Name + ' : '
                                                         }
                                                     }
                                                     else
                                                     {
-                                                        $myinv.InvocationName + ' : '
+                                                        $errorColor + $myinv.InvocationName + ' : '
                                                     }
 
                                                     break
@@ -1043,7 +1048,7 @@ namespace System.Management.Automation.Runspaces
                                         }
                                         elseif ($myinv -and $myinv.InvocationName)
                                         {
-                                            $myinv.InvocationName + ' : '
+                                            $errorColor + $myinv.InvocationName + ' : '
                                         }
                                     }
                                 ")


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The formatting of errors is split between two script blocks and only the latter applied color correctly so when using `NormalView`, the command has the default writing color instead of the error color.  This was a regression on another change which moved from using the old PrivateData based colors to the $PSStyle based ones.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/18549

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
