### PR TITLE
Change `exec` from alias to function to handle arbitrary args

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4078,6 +4078,13 @@ $RawUI.SetBufferContents(
             }
         }
 
+        internal static string GetExecFunctionText()
+        {
+            return @"
+Switch-Process -WithCommand $args                
+";
+        }
+
         /// <summary>
         /// This is the default function to use for man/help. It uses
         /// splatting to pass in the parameters.
@@ -4683,10 +4690,6 @@ end {
                     new SessionStateAliasEntry("sls", "Select-String"),
                 };
 
-#if UNIX
-                builtInAliases.Add(new SessionStateAliasEntry("exec", "Switch-Process"));
-#endif
-
                 return builtInAliases.ToArray();
             }
         }
@@ -4715,6 +4718,10 @@ end {
                 string.Concat("$null = Read-Host '", CodeGeneration.EscapeSingleQuotedStringContent(RunspaceInit.PauseDefinitionString), "'"), isProductCode: true, languageMode: systemLanguageMode),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("help", GetHelpPagingFunctionText(), isProductCode: true, languageMode: systemLanguageMode),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("prompt", DefaultPromptFunctionText, isProductCode: true, languageMode: systemLanguageMode),
+
+#if UNIX
+            SessionStateFunctionEntry.GetDelayParsedFunctionEntry("exec", GetExecFunctionText(), isProductCode: true, languageMode: systemLanguageMode),
+#endif
 
             // Functions that require full language mode and are trusted
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("Clear-Host", GetClearHostFunctionText(), isProductCode: true, languageMode: PSLanguageMode.FullLanguage),

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4078,12 +4078,14 @@ $RawUI.SetBufferContents(
             }
         }
 
+#if UNIX
         internal static string GetExecFunctionText()
         {
             return @"
 Switch-Process -WithCommand $args
 ";
         }
+#endif
 
         /// <summary>
         /// This is the default function to use for man/help. It uses

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4081,7 +4081,7 @@ $RawUI.SetBufferContents(
         internal static string GetExecFunctionText()
         {
             return @"
-Switch-Process -WithCommand $args                
+Switch-Process -WithCommand $args
 ";
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -15,10 +15,10 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
-    It 'Exec alias should map to Switch-Process' {
+    It 'Exec function should map to Switch-Process' {
         $alias = Get-Command exec
-        $alias | Should -BeOfType [System.Management.Automation.AliasInfo]
-        $alias.Definition | Should -BeExactly 'Switch-Process'
+        $alias | Should -BeOfType [System.Management.Automation.CommandInfo]
+        $alias.Definition | Should -Not -BeNullOrEmpty
     }
 
     It 'Exec by itself does nothing' {
@@ -59,6 +59,11 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
     It 'The environment will be copied to the child process' {
         $env = pwsh -noprofile -outputformat text -command { $env:TEST_FOO='my test = value'; Switch-Process bash -c 'echo $TEST_FOO' }
         $env | Should -BeExactly 'my test = value'
+    }
+
+    It 'The command can include a -w paramter' {
+        $out = pwsh -noprofile -outputformat text -command { exec /bin/echo 1 -w 2 }
+        $out | Should -BeExactly '1 -w 2'
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -61,7 +61,7 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
         $env | Should -BeExactly 'my test = value'
     }
 
-    It 'The command can include a -w paramter' {
+    It 'The command can include a -w parameter' {
         $out = pwsh -noprofile -outputformat text -command { exec /bin/echo 1 -w 2 }
         $out | Should -BeExactly '1 -w 2'
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Exec.Tests.ps1
@@ -16,9 +16,9 @@ Describe 'Switch-Process tests for Unix' -Tags 'CI' {
     }
 
     It 'Exec function should map to Switch-Process' {
-        $alias = Get-Command exec
-        $alias | Should -BeOfType [System.Management.Automation.CommandInfo]
-        $alias.Definition | Should -Not -BeNullOrEmpty
+        $func = Get-Command exec
+        $func | Should -BeOfType [System.Management.Automation.CommandInfo]
+        $func.Definition | Should -Not -BeNullOrEmpty
     }
 
     It 'Exec by itself does nothing' {

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -58,7 +58,6 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Alias",        "epsn",                             "Export-PSSession",                 $($FullCLR                               ),     "",                     "",                     ""
 "Alias",        "erase",                            "Remove-Item",                      $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     ""
 "Alias",        "etsn",                             "Enter-PSSession",                  $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     ""
-"Alias",        "exec",                             "Switch-Process",                   $(                              $CoreUnix),     "",                     "",                     ""
 "Alias",        "exsn",                             "Exit-PSSession",                   $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     ""
 "Alias",        "fc",                               "Format-Custom",                    $($FullCLR -or $CoreWindows -or $CoreUnix),     "ReadOnly",             "",                     ""
 "Alias",        "fhx",                              "Format-Hex",                       $($FullCLR -or $CoreWindows -or $CoreUnix),     "",                     "",                     ""


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Previously `exec` was an alias to `switch-process`.  The problem is if you use `exec` with args that contain something like `-w` which PowerShell tries to bind to `-WithCommand` (parameter for `Switch-Process`) then the other args try to get bound to positional parameters which do not exist.  So something like `exec /bin/echo 1 -w 2` fails whereas it should simply replace the current `pwsh` with `echo` and emit "1 -w 2".

The fix is to change from an alias to a function so that all the args get passed to `Switch-Parameter` by using `-WithCommand` explicitly so the remaining args get handled correctly.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/18561

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9444
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
