### PR TITLE
Add `testexe.exe -echocmdline` to output raw command line received by the process on Windows

### DIFF
--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -12,6 +12,7 @@ namespace TestExe
     {
         private static int Main(string[] args)
         {
+            int exitCode = 0;
             if (args.Length > 0)
             {
                 switch (args[0].ToLowerInvariant())
@@ -20,7 +21,7 @@ namespace TestExe
                         EchoArgs(args);
                         break;
                     case "-echocmdline":
-                        EchoCmdLine(args);
+                        EchoCmdLine();
                         break;
                     case "-createchildprocess":
                         CreateChildProcess(args);
@@ -37,16 +38,18 @@ namespace TestExe
                         PrintHelp();
                         break;
                     default:
-                        Console.WriteLine("Unknown test {0}. Run with '-h' for help.", args[0]);
+                        exitCode = 1;
+                        Console.Error.WriteLine("Unknown test {0}. Run with '-h' for help.", args[0]);
                         break;
                 }
             }
             else
             {
-                Console.WriteLine("Test not specified");
+                exitCode = 1;
+                Console.Error.WriteLine("Test not specified");
             }
 
-            return 0;
+            return exitCode;
         }
 
         // <Summary>
@@ -63,7 +66,7 @@ namespace TestExe
         // <Summary>
         // Echos the raw command line received by the process plus the arguments passed in.
         // </Summary>
-        private static void EchoCmdLine(string[] args)
+        private static void EchoCmdLine()
         {
             string rawCmdLine = "N/A";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -80,14 +80,14 @@ namespace TestExe
         // </Summary>
         private static void PrintHelp()
         {
-            const string content = @"
+            const string Content = @"
 Options for echoing args are:
    -echoargs     Echos back to stdout the arguments passed in.
    -echocmdline  Echos the raw command line received by the process.
 
 Other options are for specific tests only. Read source code for details.
 ";
-            Console.WriteLine(content);
+            Console.WriteLine(Content);
         }
 
         // <Summary>

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -19,6 +19,9 @@ namespace TestExe
                     case "-echoargs":
                         EchoArgs(args);
                         break;
+                    case "-echoraw":
+                        EchoRaw(args);
+                        break;
                     case "-createchildprocess":
                         CreateChildProcess(args);
                         break;
@@ -28,6 +31,10 @@ namespace TestExe
                         return int.Parse(args[1]);
                     case "-stderr":
                         Console.Error.WriteLine(args[1]);
+                        break;
+                    case "--help":
+                    case "-h":
+                        PrintHelp();
                         break;
                     default:
                         Console.WriteLine("Unknown test {0}", args[0]);
@@ -47,13 +54,6 @@ namespace TestExe
         // </Summary>
         private static void EchoArgs(string[] args)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                IntPtr cmdLinePtr = GetCommandLineW();
-                string rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr);
-                Console.WriteLine("Raw Command Line:\n{0}\n", rawCmdLine);
-            }
-
             for (int i = 1; i < args.Length; i++)
             {
                 Console.WriteLine("Arg {0} is <{1}>", i - 1, args[i]);
@@ -62,6 +62,38 @@ namespace TestExe
 
         [DllImport("Kernel32.dll")]
         private static extern IntPtr GetCommandLineW();
+
+        // <Summary>
+        // Echos the raw command line received by the process plus the arguments passed in.
+        // </Summary>
+        private static void EchoRaw(string[] args)
+        {
+            string rawCmdLine = Environment.CommandLine;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                IntPtr cmdLinePtr = GetCommandLineW();
+                rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr);
+            }
+
+            Console.WriteLine("Raw Command Line:\n{0}\n", rawCmdLine);
+            EchoArgs(args);
+        }
+
+        // <Summary>
+        // Print help content.
+        // </Summary>
+        private static void PrintHelp()
+        {
+            const string content = @"
+Options for echoing args are:
+   -echoargs     Echos back to stdout the arguments passed in.
+   -echoraw      Echos the raw command line received by the process plus the arguments passed in.
+
+Other options are for specific tests only. Read source code for details.
+";
+            Console.WriteLine(content);
+        }
 
         // <Summary>
         // First argument is the number of child processes to create which are instances of itself

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -19,8 +19,8 @@ namespace TestExe
                     case "-echoargs":
                         EchoArgs(args);
                         break;
-                    case "-echoraw":
-                        EchoRaw(args);
+                    case "-echocmdline":
+                        EchoCmdLine(args);
                         break;
                     case "-createchildprocess":
                         CreateChildProcess(args);
@@ -37,7 +37,7 @@ namespace TestExe
                         PrintHelp();
                         break;
                     default:
-                        Console.WriteLine("Unknown test {0}", args[0]);
+                        Console.WriteLine("Unknown test {0}. Run with '-h' for help.", args[0]);
                         break;
                 }
             }
@@ -60,24 +60,19 @@ namespace TestExe
             }
         }
 
-        [DllImport("Kernel32.dll")]
-        private static extern IntPtr GetCommandLineW();
-
         // <Summary>
         // Echos the raw command line received by the process plus the arguments passed in.
         // </Summary>
-        private static void EchoRaw(string[] args)
+        private static void EchoCmdLine(string[] args)
         {
-            string rawCmdLine = Environment.CommandLine;
-
+            string rawCmdLine = "N/A";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                IntPtr cmdLinePtr = GetCommandLineW();
+                nint cmdLinePtr = Interop.GetCommandLineW();
                 rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr);
             }
 
-            Console.WriteLine("Raw Command Line:\n{0}\n", rawCmdLine);
-            EchoArgs(args);
+            Console.WriteLine(rawCmdLine);
         }
 
         // <Summary>
@@ -88,7 +83,7 @@ namespace TestExe
             const string content = @"
 Options for echoing args are:
    -echoargs     Echos back to stdout the arguments passed in.
-   -echoraw      Echos the raw command line received by the process plus the arguments passed in.
+   -echocmdline  Echos the raw command line received by the process.
 
 Other options are for specific tests only. Read source code for details.
 ";
@@ -115,5 +110,11 @@ Other options are for specific tests only. Read source code for details.
             // sleep is needed so the process doesn't exit before the test case kill it
             Thread.Sleep(100000);
         }
+    }
+
+    internal static partial class Interop
+    {
+        [LibraryImport("Kernel32.dll")]
+        internal static partial nint GetCommandLineW();
     }
 }

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace TestExe
 {
@@ -46,11 +47,21 @@ namespace TestExe
         // </Summary>
         private static void EchoArgs(string[] args)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                IntPtr cmdLinePtr = GetCommandLineW();
+                string rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr);
+                Console.WriteLine("Raw Command Line:\n{0}\n", rawCmdLine);
+            }
+
             for (int i = 1; i < args.Length; i++)
             {
                 Console.WriteLine("Arg {0} is <{1}>", i - 1, args[i]);
             }
         }
+
+        [DllImport("Kernel32.dll")]
+        private static extern IntPtr GetCommandLineW();
 
         // <Summary>
         // First argument is the number of child processes to create which are instances of itself


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Add `testexe.exe -echocmdline` to output raw command line received by the process on Windows

It could be useful to print out the raw command line received by the testing process on Windows because it will show what is actually passed in by PowerShell when starting a native command.

![image](https://user-images.githubusercontent.com/127450/202548248-0a062fd9-e790-425f-82c7-b3b00627f72f.png)

![image](https://user-images.githubusercontent.com/127450/202548510-f0e4ff3d-d3e2-4cfd-bb75-b334ce9dac91.png)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
