### PR TITLE
Allow non-default encodings to be used in user's script/code

### DIFF
--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Linq;
 using System.Management.Automation.Host;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
+using System.Text;
 
 namespace System.Management.Automation
 {
@@ -14,8 +14,15 @@ namespace System.Management.Automation
     /// </summary>
     internal class AutomationEngine
     {
+        static AutomationEngine()
+        {
+            // Register the encoding provider to load encodings that are not supported by default,
+            // so as to allow them to be used in user's script/code.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         // Holds the parser to use for this instance of the engine...
-        internal Language.Parser EngineParser;
+        internal Parser EngineParser;
 
         /// <summary>
         /// Returns the handle to the execution context

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -108,10 +108,8 @@ namespace System.Management.Automation
         {
             if (s_oemEncoding == null)
             {
-                // load all available encodings
-                EncodingRegisterProvider();
 #if UNIX
-                s_oemEncoding = new UTF8Encoding(false);
+                s_oemEncoding = Encoding.Default;
 #else
                 uint oemCp = NativeMethods.GetOEMCP();
                 s_oemEncoding = Encoding.GetEncoding((int)oemCp);
@@ -122,14 +120,6 @@ namespace System.Management.Automation
         }
 
         private static volatile Encoding s_oemEncoding;
-
-        private static void EncodingRegisterProvider()
-        {
-            if (s_oemEncoding == null)
-            {
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            }
-        }
 
         #endregion Encoding
 

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -30,21 +30,21 @@ namespace System.Management.Automation
 
         internal static readonly Dictionary<string, Encoding> encodingMap = new Dictionary<string, Encoding>(StringComparer.OrdinalIgnoreCase)
         {
-            { Ascii, System.Text.Encoding.ASCII },
-            { BigEndianUnicode, System.Text.Encoding.BigEndianUnicode },
+            { Ascii, Encoding.ASCII },
+            { BigEndianUnicode, Encoding.BigEndianUnicode },
             { BigEndianUtf32, new UTF32Encoding(bigEndian: true, byteOrderMark: true) },
             { Default, Encoding.Default },
             { OEM, ClrFacade.GetOEMEncoding() },
-            { Unicode, System.Text.Encoding.Unicode },
+            { Unicode, Encoding.Unicode },
 #pragma warning disable SYSLIB0001
-            { Utf7, System.Text.Encoding.UTF7 },
+            { Utf7, Encoding.UTF7 },
 #pragma warning restore SYSLIB0001
             { Utf8, Encoding.Default },
-            { Utf8Bom, System.Text.Encoding.UTF8 },
+            { Utf8Bom, Encoding.UTF8 },
             { Utf8NoBom, Encoding.Default },
-            { Utf32, System.Text.Encoding.UTF32 },
-            { String, System.Text.Encoding.Unicode },
-            { Unknown, System.Text.Encoding.Unicode },
+            { Utf32, Encoding.UTF32 },
+            { String, Encoding.Unicode },
+            { Unknown, Encoding.Unicode },
         };
 
         /// <summary>

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -49,6 +49,7 @@ Describe "Validate start of console host" -Tag CI {
             'System.Security.AccessControl.dll'
             'System.Security.Cryptography.dll'
             'System.Security.Principal.Windows.dll'
+            'System.Text.Encoding.CodePages.dll'
             'System.Text.Encoding.Extensions.dll'
             'System.Text.RegularExpressions.dll'
             'System.Threading.dll'

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -128,4 +128,10 @@ public class NullStringTest {
         [NullStringTest]::Get([NullString]::Value) | Should -BeExactly 'System.String'
         [NullStringTest]::Get(@('foo', [NullString]::Value, 'bar')) | Should -BeExactly 'System.String[]; 2nd element is NULL'
     }
+
+    It 'Non-default encoding should work in PowerShell' {
+        $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
+        $result = & $powershell -noprofile -c '[System.Text.Encoding]::GetEncoding("IBM437").WebName'
+        $result | Should -BeExactly "ibm437"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #18537

Fix the regression to allow non-default encodings to be used in user's script/code.

Move the registration of `CodePagesEncodingProvider` to the static constructor of `AutomationEngine`, which is before the `AutomationEngine` constructor is called, which calls into `iss.Bind(...)` that may run user code.

Also, almost right after creating an `AutomationEngine` instance in `LocalRunspace.DoOpenHelper()`, `InitialSessionState.BindRunspace` will be called, which will try loading modules (could be custom modules) that are specified in the `InitialSessionState` instance.

In fact, `Encoding.GetEncoding('IBM437')` doesn't really work consistently as of today (7.2 or 7.3), here is a simple repro:
```
## Running this from 7.2.x or 7.3.0 fails because no module loading gets triggered, and thus, the call
## to `GetDefaultEncoding()` doesn't happen as early as when `PSReadLine` is auto-loaded at startup.
pwsh -noprofile -c "[System.Text.Encoding]::GetEncoding('IBM437').WebName"
```
You will get this failure:

![image](https://user-images.githubusercontent.com/127450/202539295-0837a45f-3221-478b-b761-d0e82e66dc31.png)

So, this PR is to make it a consistent, predictable behavior.

## PR Context

The root cause of the regression is:
- before the change of #18356, `Encoding.RegisterProvider` will be called on the first time retrieving the default encoding by `GetDefaultEncoding()`, which happens when loading the `PSReadLine` module on startup. So, the encoding provider gets registered early enough for `GetEncoding("IBM437")` to work in user script/code. 
- after #18356, `Encoding.RegisterProvider` won't be called until `GetOEMEncoding()` is called, which happens pretty late -- until you run a cmdlet that accesses `EncodingConversion`. So, the encoding provider is not registered when `GetEncoding("IBM437")` is used in user script/code.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
