### PR TITLE
Apply expected file permissions to linux files after authenticode signing

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4640,12 +4640,13 @@ function Export-LinuxFilePermission {
     )
 
     begin {
-        if ((Test-Path $FilePath) -and (-not $Force)) {
+        if (Test-Path $FilePath) {
+          if (-not $Force) {
             throw "File '$FilePath' already exists."
-        }
-
-        if ($Force) {
+          }
+          else {
             Remove-Item $FilePath -Force
+          }
         }
 
         $fileData = @{}

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -669,7 +669,7 @@ function New-TarballPackage {
 
             try {
                 Push-Location -Path $Staging
-                tar $options $packagePath .
+                tar $options $packagePath *
             } finally {
                 Pop-Location
             }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4480,15 +4480,21 @@ function Invoke-AzDevOpsLinuxPackageCreation {
 
         switch ($BuildType) {
             'fxdependent' {
+                $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}-meta\linuxFilePermission.json"
+                Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}"
                 Start-PSPackage -Type 'fxdependent' @releaseTagParam -LTS:$LTS
             }
             'alpine' {
+                $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}-meta\linuxFilePermission.json"
+                Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}"
                 Start-PSPackage -Type 'tar-alpine' @releaseTagParam -LTS:$LTS
             }
             'rpm' {
                 Start-PSPackage -Type 'rpm' @releaseTagParam -LTS:$LTS
             }
             default {
+                $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}-meta\linuxFilePermission.json"
+                Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}"
                 Start-PSPackage @releaseTagParam -LTS:$LTS -Type 'deb', 'tar'
             }
         }
@@ -4497,6 +4503,9 @@ function Invoke-AzDevOpsLinuxPackageCreation {
             Start-PSPackage -Type tar @releaseTagParam -LTS:$LTS
 
             Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${minSizeLinuxBuildFolder}-meta\psoptions.json"
+
+            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${minSizeLinuxBuildFolder}-meta\linuxFilePermission.json"
+            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${minSizeLinuxBuildFolder}"
 
             Write-Verbose -Verbose "---- Min-Size ----"
             Write-Verbose -Verbose "options.Output: $($options.Output)"
@@ -4507,14 +4516,20 @@ function Invoke-AzDevOpsLinuxPackageCreation {
             ## Create 'linux-arm' 'tar.gz' package.
             ## Note that 'linux-arm' can only be built on Ubuntu environment.
             Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm32LinuxBuildFolder}-meta\psoptions.json"
+            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm32LinuxBuildFolder}-meta\linuxFilePermission.json"
+            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm32LinuxBuildFolder}"
             Start-PSPackage -Type tar-arm @releaseTagParam -LTS:$LTS
 
             ## Create 'linux-arm64' 'tar.gz' package.
             ## Note that 'linux-arm64' can only be built on Ubuntu environment.
             Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64LinuxBuildFolder}-meta\psoptions.json"
+            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64LinuxBuildFolder}-meta\linuxFilePermission.json"
+            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64LinuxBuildFolder}"
             Start-PSPackage -Type tar-arm64 @releaseTagParam -LTS:$LTS
         } elseif ($BuildType -eq 'rpm') {
             Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64MarinerBuildFolder}-meta\psoptions.json"
+            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64MarinerBuildFolder}-meta\linuxFilePermission.json"
+            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64MarinerBuildFolder}"
 
             Write-Verbose -Verbose "---- rpm-fxdependent ----"
             Write-Verbose -Verbose "options.Output: $($options.Output)"
@@ -4627,6 +4642,38 @@ function Invoke-AzDevOpsLinuxPackageBuild {
     catch {
         Get-Error -InputObject $_
         throw
+    }
+}
+
+function Set-LinuxFilePermission {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)] [string] $FilePath,
+        [Parameter(Mandatory)] [string] $RootPath
+    )
+
+    if (-not (Test-Path $FilePath)) {
+        throw "File does not exist: $FilePath"
+    }
+
+    if (-not (Test-Path $RootPath)) {
+        throw "File does not exist: $RootPath"
+    }
+
+    try {
+        Push-Location $RootPath
+        $filePermission = Get-Content $FilePath -Raw | ConvertFrom-Json -AsHashtable
+
+        foreach ($file in $filePermission) {
+            $file = $file.Key
+            $permission = $filePermission[$file]
+            $fileFullName = Join-Path -Path $RootPath -ChildPath $file
+            Write-Verbose "Set permission $permission to $fileFullName" -Verbose
+            chmod $permission $fileFullName
+        }
+    }
+    finally {
+        Pop-Location
     }
 }
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4645,6 +4645,21 @@ function Invoke-AzDevOpsLinuxPackageBuild {
     }
 }
 
+<#
+    Apply the file permissions specified in the json file $FilePath to the files under $RootPath.
+    The format of the json file is like:
+
+    {
+        "System.Net.WebClient.dll": "744",
+        "Schemas/PSMaml/developer.xsd": "644",
+        "ref/System.Security.AccessControl.dll": "744",
+        "ref/System.IO.dll": "744",
+        "cs/Microsoft.CodeAnalysis.resources.dll": "744",
+        "Schemas/PSMaml/base.xsd": "644",
+        "Schemas/PSMaml/structureProcedure.xsd": "644",
+        "ref/System.Net.Security.dll": "744"
+    }
+#>
 function Set-LinuxFilePermission {
     [CmdletBinding()]
     param (
@@ -4679,6 +4694,24 @@ function Set-LinuxFilePermission {
     }
 }
 
+<#
+    Store the linux file permissions for all the files under root path $RootPath to the json file $FilePath.
+    The json file stores them as relative paths to the root.
+
+    The format of the json file is like:
+
+    {
+        "System.Net.WebClient.dll": "744",
+        "Schemas/PSMaml/developer.xsd": "644",
+        "ref/System.Security.AccessControl.dll": "744",
+        "ref/System.IO.dll": "744",
+        "cs/Microsoft.CodeAnalysis.resources.dll": "744",
+        "Schemas/PSMaml/base.xsd": "644",
+        "Schemas/PSMaml/structureProcedure.xsd": "644",
+        "ref/System.Net.Security.dll": "744"
+    }
+
+#>
 function Export-LinuxFilePermission {
     [CmdletBinding()]
     param (
@@ -4704,6 +4737,7 @@ function Export-LinuxFilePermission {
     process {
         foreach ($object in $InputObject) {
             Write-Verbose "Processing $($object.FullName)"
+            # This gets the unix stat information for the file in the format that chmod expects, like '644'.
             $filePerms = [convert]::ToString($object.unixstat.mode, 8).substring(3)
             $relativePath = [System.IO.Path]::GetRelativePath($RootPath, $_.FullName)
             $fileData.Add($relativePath, $filePerms)

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4664,11 +4664,11 @@ function Set-LinuxFilePermission {
         Push-Location $RootPath
         $filePermission = Get-Content $FilePath -Raw | ConvertFrom-Json -AsHashtable
 
-        Write-Verbose -Verbose -Message "Got file permission: $filePermission.Count for $FilePath"
+        Write-Verbose -Verbose -Message "Got file permission: $($filePermission.Count) for $FilePath"
 
-        foreach ($file in $filePermission) {
-            $file = $file.Key
-            $permission = $file.Value
+        $filePermission.GetEnumerator() | ForEach-Object {
+            $file = $_.Name
+            $permission = $_.Value
             $fileFullName = Join-Path -Path $RootPath -ChildPath $file
             Write-Verbose "Set permission $permission to $fileFullName" -Verbose
             chmod $permission $fileFullName

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4664,9 +4664,11 @@ function Set-LinuxFilePermission {
         Push-Location $RootPath
         $filePermission = Get-Content $FilePath -Raw | ConvertFrom-Json -AsHashtable
 
+        Write-Verbose -Verbose -Message "Got file permission: $filePermission.Count for $FilePath"
+
         foreach ($file in $filePermission) {
             $file = $file.Key
-            $permission = $filePermission[$file]
+            $permission = $file.Value
             $fileFullName = Join-Path -Path $RootPath -ChildPath $file
             Write-Verbose "Set permission $permission to $fileFullName" -Verbose
             chmod $permission $fileFullName

--- a/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
@@ -20,45 +20,68 @@ jobs:
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: pwshLinuxBuild
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+      artifact: pwshLinuxBuild.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuild.tar.gz
     displayName: Download deb build
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: pwshLinuxBuildMinSize
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize
+      artifact: pwshLinuxBuildMinSize.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize.tar.gz
     displayName: Download min-size build
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: pwshLinuxBuildArm32
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32
+      artifact: pwshLinuxBuildArm32.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32.tar.gz
     displayName: Download arm32 build
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: pwshLinuxBuildArm64
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64
+      artifact: pwshLinuxBuildArm64.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64.tar.gz
     displayName: Download arm64 build
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: pwshMarinerBuildAmd64
-      path: $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
+      artifact: pwshMarinerBuildAmd64.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64.tar.gz
     displayName: Download mariner build
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: pwshLinuxBuildAlpine
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine
+      artifact: pwshLinuxBuildAlpine.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine.tar.gz
     displayName: Download alpine build
 
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: pwshLinuxBuildFxdependent
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent
+      artifact: pwshLinuxBuildFxdependent.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent.tar.gz
     displayName: Download fxdependent build
+
+  - pwsh: |
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize"
+      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize
+
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32"
+      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32
+
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64"
+      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64
+
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64"
+      tar -xf $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
+
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine"
+      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine
+
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent"
+      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent
+    displayName: Expand builds
 
   - template: SetVersionVariables.yml
     parameters:
@@ -116,12 +139,3 @@ jobs:
     parameters:
       binLocation: pwshLinuxBuildFxdependent
       buildPrefixName: 'PowerShell Linux Framework Dependent'
-
-  #- template: Sbom.yml@ComplianceRepo
-  #  parameters:
-  #    BuildDropPath: '$(System.ArtifactsDirectory)/$(BIN_LOCATION)'
-  #    Build_Repository_Uri: $(Github_Build_Repository_Uri)
-  #    displayName: ${{ parameters.buildName }} SBOM
-  #    PackageName: $(PACKAGE_NAME)
-  #    PackageVersion: $(Version)
-  #    sourceScanPath: '$(PowerShellRoot)/tools'

--- a/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
@@ -51,13 +51,13 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuildAlpine.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/linuxTars
+      path: $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildAlpine.tar.gz
     displayName: Download alpine build
 
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuildFxdependent.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/linuxTars
+      path: $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildFxdependent.tar.gz
     displayName: Download fxdependent build
 
   - pwsh: |

--- a/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
@@ -85,13 +85,13 @@ jobs:
       New-Item -Path $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64 -ItemType Directory
       tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshMarinerBuildAmd64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildAlpine.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine"
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildAlpine.tar.gz/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine"
       New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine -ItemType Directory
-      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildAlpine.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildAlpine.tar.gz/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildFxdependent.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent"
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildFxdependent.tar.gz/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent"
       New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent -ItemType Directory
-      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildFxdependent.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildFxdependent.tar.gz/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent
     displayName: Expand builds
 
   - template: SetVersionVariables.yml

--- a/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
@@ -21,66 +21,77 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuild.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuild.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/linuxTars
     displayName: Download deb build
 
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuildMinSize.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/linuxTars
     displayName: Download min-size build
 
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuildArm32.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/linuxTars
     displayName: Download arm32 build
 
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuildArm64.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/linuxTars
     displayName: Download arm64 build
 
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshMarinerBuildAmd64.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/linuxTars
     displayName: Download mariner build
 
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuildAlpine.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/linuxTars
     displayName: Download alpine build
 
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: pwshLinuxBuildFxdependent.tar.gz
-      path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent.tar.gz
+      path: $(Build.ArtifactStagingDirectory)/linuxTars
     displayName: Download fxdependent build
 
   - pwsh: |
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
-      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+      Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/linuxTars
+    displayName: Capture downloaded tars
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize"
-      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize
+  - pwsh: |
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+      New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild -ItemType Directory
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32"
-      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildMinSize.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize"
+      New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize -ItemType Directory
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildMinSize.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64"
-      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildArm32.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32"
+      New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32 -ItemType Directory
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildArm32.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64"
-      tar -xf $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildArm64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64"
+      New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64 -ItemType Directory
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildArm64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine"
-      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshMarinerBuildAmd64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64"
+      New-Item -Path $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64 -ItemType Directory
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshMarinerBuildAmd64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
 
-      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent"
-      tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildAlpine.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine"
+      New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine -ItemType Directory
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildAlpine.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine
+
+      Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildFxdependent.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent"
+      New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent -ItemType Directory
+      tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildFxdependent.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent
     displayName: Expand builds
 
   - template: SetVersionVariables.yml

--- a/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-authenticode-sign.yml
@@ -68,6 +68,8 @@ jobs:
       Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
       New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild -ItemType Directory
       tar -xf $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+      Write-Verbose -Verbose "File permisions after expanding"
+      Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild/pwsh | Select-Object -Property 'unixmode', 'size', 'name'
 
       Write-Verbose -Verbose -Message "Expanding $(Build.ArtifactStagingDirectory)/linuxTars/pwshLinuxBuildMinSize.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize"
       New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize -ItemType Directory

--- a/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
@@ -26,50 +26,57 @@ jobs:
   - ${{ if or(eq(variables.build,'deb'), eq(variables.build,'rpm')) }} :
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifact: pwshLinuxBuild-signed
-        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+        artifact: authenticode-signed
+        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuild-signed
+        pattern: '**/pwshLinuxBuild.tar.gz'
       displayName: Download deb build
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifact: pwshLinuxBuildMinSize-signed
-        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize
+        artifact: authenticode-signed
+        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize-signed
+        pattern: '**/pwshLinuxBuildMinSize.tar.gz'
       displayName: Download min-size build
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifact: pwshLinuxBuildArm32-signed
-        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32
+        artifact: authenticode-signed
+        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32-signed
+        pattern: '**/pwshLinuxBuildArm32.tar.gz'
       displayName: Download arm32 build
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifact: pwshLinuxBuildArm64-signed
-        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64
+        artifact: authenticode-signed
+        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64-signed
+        pattern: '**/pwshLinuxBuildArm64.tar.gz'
       displayName: Download arm64 build
 
   - ${{ if eq(variables.build,'rpm') }} :
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifact: pwshMarinerBuildAmd64-signed
-        path: $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
+        artifact: authenticode-signed
+        path: $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64-signed
+        pattern: '**/pwshMarinerBuildAmd64.tar.gz'
       displayName: Download mariner build
 
   - ${{ if eq(variables.build,'alpine') }} :
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifact: pwshLinuxBuildAlpine-signed
-        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+        artifact: authenticode-signed
+        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine-signed
+        pattern: '**/pwshLinuxBuildAlpine.tar.gz'
       displayName: Download alpine build
 
   - ${{ if eq(variables.build,'fxdependent') }} :
     - task: DownloadPipelineArtifact@2
       inputs:
-        artifact: pwshLinuxBuildFxdependent-signed
-        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+        artifact: authenticode-signed
+        path: $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent-signed
+        pattern: '**/pwshLinuxBuildFxdependent.tar.gz'
       displayName: Download fxdependent build
 
   - ${{ if or(eq(variables.build,'deb'), eq(variables.build,'rpm')) }} :
@@ -124,6 +131,43 @@ jobs:
   - pwsh: |
       Get-ChildItem '$(Build.ArtifactStagingDirectory)' | Select-Object -Property 'unixmode', 'size', 'name'
     displayName: Capture downloads
+
+  - pwsh: |
+      if ('$(build)' -eq 'deb' -or '$(build)' -eq 'deb') {
+        Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuild-signed/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+        tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuild-signed/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+      }
+
+      if ('$(build)' -eq 'deb') {
+        Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize-signed/pwshLinuxBuildMinSize.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize"
+        tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize-signed/pwshLinuxBuildMinSize.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize
+
+        Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32-signed/pwshLinuxBuildArm32.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32"
+        tar -xf  $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32-signed/pwshLinuxBuildArm32.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32
+
+        Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64-signed/pwshLinuxBuildArm64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64"
+        tar -xf  $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64-signed/pwshLinuxBuildArm64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64
+      }
+
+      if ('$(build)' -eq 'rpm') {
+        Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64-signed/pwshMarinerBuildAmd64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64"
+        tar -xf $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64-signed/pwshMarinerBuildAmd64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
+      }
+
+      if ('$(build)' -eq 'alpine') {
+        Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine-signed/pwshLinuxBuildAlpine.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+        tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine-signed/pwshLinuxBuildAlpine.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+      }
+
+      if ('$(build)' -eq 'fxdependent') {
+        Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent-signed/pwshLinuxBuildFxdependent.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+        tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent-signed/pwshLinuxBuildFxdependent.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
+      }
+    displayName: Expand all signed tar.gz
+
+  - pwsh: |
+      Get-ChildItem '$(Build.ArtifactStagingDirectory)' | Select-Object -Property 'unixmode', 'size', 'name'
+    displayName: Capture expanded
 
   - checkout: self
     clean: true

--- a/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
@@ -133,7 +133,7 @@ jobs:
     displayName: Capture downloads
 
   - pwsh: |
-      if ('$(build)' -eq 'deb' -or '$(build)' -eq 'deb') {
+      if ('$(build)' -eq 'deb' -or '$(build)' -eq 'rpm') {
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuild-signed/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
         New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild -ItemType Directory
         tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuild-signed/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
@@ -167,6 +167,7 @@ jobs:
 
       if ('$(build)' -eq 'fxdependent') {
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent-signed/pwshLinuxBuildFxdependent.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+        New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild -ItemType Directory
         tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildFxdependent-signed/pwshLinuxBuildFxdependent.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
       }
     displayName: Expand all signed tar.gz

--- a/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
@@ -161,6 +161,7 @@ jobs:
 
       if ('$(build)' -eq 'alpine') {
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine-signed/pwshLinuxBuildAlpine.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+        New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild -ItemType Directory
         tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildAlpine-signed/pwshLinuxBuildAlpine.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
       }
 

--- a/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux-packaging.yml
@@ -135,22 +135,27 @@ jobs:
   - pwsh: |
       if ('$(build)' -eq 'deb' -or '$(build)' -eq 'deb') {
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuild-signed/pwshLinuxBuild.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuild"
+        New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild -ItemType Directory
         tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuild-signed/pwshLinuxBuild.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuild
       }
 
       if ('$(build)' -eq 'deb') {
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize-signed/pwshLinuxBuildMinSize.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize"
+        New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize -ItemType Directory
         tar -xf $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize-signed/pwshLinuxBuildMinSize.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildMinSize
 
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32-signed/pwshLinuxBuildArm32.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32"
+        New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32 -ItemType Directory
         tar -xf  $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32-signed/pwshLinuxBuildArm32.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm32
 
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64-signed/pwshLinuxBuildArm64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64"
+        New-Item -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64 -ItemType Directory
         tar -xf  $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64-signed/pwshLinuxBuildArm64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshLinuxBuildArm64
       }
 
       if ('$(build)' -eq 'rpm') {
         Write-Verbose -Verbose "Expanding $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64-signed/pwshMarinerBuildAmd64.tar.gz to $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64"
+        New-Item -Path $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64 -ItemType Directory
         tar -xf $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64-signed/pwshMarinerBuildAmd64.tar.gz -C $(Build.ArtifactStagingDirectory)/pwshMarinerBuildAmd64
       }
 

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -134,10 +134,10 @@ jobs:
 
   - ${{ if eq(variables.build,'deb') }} :
     - pwsh: |
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64'
-    displayName: Compress deb
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64'
+      displayName: Compress deb
 
   - ${{ if eq(variables.build,'rpm') }} :
     - pwsh: |

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -129,19 +129,19 @@ jobs:
         sourceScanPath: '$(PowerShellRoot)/tools'
 
   - pwsh: |
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuild'
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuild' *
     displayName: Compress pwshLinuxBuild
 
   - ${{ if eq(variables.build,'deb') }} :
     - pwsh: |
-        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
-        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
-        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64'
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize' *
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32' *
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64' *
       displayName: Compress deb
 
   - ${{ if eq(variables.build,'rpm') }} :
     - pwsh: |
-        tar -czvf $(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64'
+        tar -czvf $(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz -C '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64' *
       displayName: Compress pwshMarinerBuildAmd64
 
   - ${{ if eq(variables.build,'deb') }} :

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -88,6 +88,10 @@ jobs:
       PackageVersion: $(Version)
       sourceScanPath: '$(PowerShellRoot)/tools'
 
+  - pwsh: |
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuild'
+    displayName: Compress pwshLinuxBuild
+
   - ${{ if eq(variables.build,'rpm') }} :
     - template: Sbom.yml@ComplianceRepo
       parameters:
@@ -97,6 +101,10 @@ jobs:
         PackageName: PowerShell Linux Framework Dependent
         PackageVersion: $(Version)
         sourceScanPath: '$(PowerShellRoot)/tools'
+
+  - pwsh: |
+      tar -czvf $(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64'
+    displayName: Compress pwshMarinerBuildAmd64
 
   - ${{ if eq(variables.build,'deb') }} :
     - template: Sbom.yml@ComplianceRepo
@@ -108,6 +116,10 @@ jobs:
         PackageVersion: $(Version)
         sourceScanPath: '$(PowerShellRoot)/tools'
 
+  - pwsh: |
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
+    displayName: Compress pwshLinuxBuildMinSize
+
   - ${{ if eq(variables.build,'deb') }} :
     - template: Sbom.yml@ComplianceRepo
       parameters:
@@ -117,6 +129,10 @@ jobs:
         PackageName: PowerShell Linux Arm32
         PackageVersion: $(Version)
         sourceScanPath: '$(PowerShellRoot)/tools'
+
+  - pwsh: |
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
+    displayName: Compress pwshLinuxBuildArm32
 
   - ${{ if eq(variables.build,'deb') }} :
     - template: Sbom.yml@ComplianceRepo
@@ -128,11 +144,15 @@ jobs:
         PackageVersion: $(Version)
         sourceScanPath: '$(PowerShellRoot)/tools'
 
+  - pwsh: |
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64'
+    displayName: Compress pwshLinuxBuildArm64
+
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(System.ArtifactsDirectory)/pwshLinuxBuild'
-        artifactName: pwshLinuxBuild
+        path: '$(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz'
+        artifactName: pwshLinuxBuild.tar.gz
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
@@ -143,8 +163,8 @@ jobs:
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
-        artifactName: pwshLinuxBuildMinSize
+        path: '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz'
+        artifactName: pwshLinuxBuildMinSize.tar.gz
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
@@ -155,8 +175,8 @@ jobs:
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
-        artifactName: pwshLinuxBuildArm32
+        path: '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz'
+        artifactName: pwshLinuxBuildArm32.tar.gz
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
@@ -167,8 +187,8 @@ jobs:
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64'
-        artifactName: pwshLinuxBuildArm64
+        path: '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz'
+        artifactName: pwshLinuxBuildArm64.tar.gz
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1
@@ -179,8 +199,8 @@ jobs:
   - ${{ if eq(variables.build,'rpm') }} :
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64'
-        artifactName: pwshMarinerBuildAmd64
+        path: '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz'
+        artifactName: pwshMarinerBuildAmd64.tar.gz
 
   - ${{ if eq(variables.build,'rpm') }} :
     - task: PublishPipelineArtifact@1
@@ -191,8 +211,8 @@ jobs:
   - ${{ if eq(variables.build,'alpine') }} :
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(System.ArtifactsDirectory)/pwshLinuxBuild'
-        artifactName: pwshLinuxBuildAlpine
+        path: '$(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz'
+        artifactName: pwshLinuxBuildAlpine.tar.gz
 
   - ${{ if eq(variables.build,'alpine') }} :
     - task: PublishPipelineArtifact@1
@@ -203,8 +223,8 @@ jobs:
   - ${{ if eq(variables.build,'fxdependent') }} :
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(System.ArtifactsDirectory)/pwshLinuxBuild'
-        artifactName: pwshLinuxBuildFxdependent
+        path: '$(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz'
+        artifactName: pwshLinuxBuildFxdependent.tar.gz
 
   - ${{ if eq(variables.build,'fxdependent') }} :
     - task: PublishPipelineArtifact@1

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -88,10 +88,6 @@ jobs:
       PackageVersion: $(Version)
       sourceScanPath: '$(PowerShellRoot)/tools'
 
-  - pwsh: |
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuild'
-    displayName: Compress pwshLinuxBuild
-
   - ${{ if eq(variables.build,'rpm') }} :
     - template: Sbom.yml@ComplianceRepo
       parameters:
@@ -101,10 +97,6 @@ jobs:
         PackageName: PowerShell Linux Framework Dependent
         PackageVersion: $(Version)
         sourceScanPath: '$(PowerShellRoot)/tools'
-
-  - pwsh: |
-      tar -czvf $(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64'
-    displayName: Compress pwshMarinerBuildAmd64
 
   - ${{ if eq(variables.build,'deb') }} :
     - template: Sbom.yml@ComplianceRepo
@@ -116,10 +108,6 @@ jobs:
         PackageVersion: $(Version)
         sourceScanPath: '$(PowerShellRoot)/tools'
 
-  - pwsh: |
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
-    displayName: Compress pwshLinuxBuildMinSize
-
   - ${{ if eq(variables.build,'deb') }} :
     - template: Sbom.yml@ComplianceRepo
       parameters:
@@ -129,10 +117,6 @@ jobs:
         PackageName: PowerShell Linux Arm32
         PackageVersion: $(Version)
         sourceScanPath: '$(PowerShellRoot)/tools'
-
-  - pwsh: |
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
-    displayName: Compress pwshLinuxBuildArm32
 
   - ${{ if eq(variables.build,'deb') }} :
     - template: Sbom.yml@ComplianceRepo
@@ -145,8 +129,20 @@ jobs:
         sourceScanPath: '$(PowerShellRoot)/tools'
 
   - pwsh: |
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuild'
+    displayName: Compress pwshLinuxBuild
+
+  - ${{ if eq(variables.build,'deb') }} :
+    - pwsh: |
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
       tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64'
-    displayName: Compress pwshLinuxBuildArm64
+    displayName: Compress deb
+
+  - ${{ if eq(variables.build,'rpm') }} :
+    - pwsh: |
+        tar -czvf $(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64'
+      displayName: Compress pwshMarinerBuildAmd64
 
   - ${{ if eq(variables.build,'deb') }} :
     - task: PublishPipelineArtifact@1

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -129,19 +129,24 @@ jobs:
         sourceScanPath: '$(PowerShellRoot)/tools'
 
   - pwsh: |
-      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuild' *
+      Set-Location '$(System.ArtifactsDirectory)/pwshLinuxBuild'
+      tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz *
     displayName: Compress pwshLinuxBuild
 
   - ${{ if eq(variables.build,'deb') }} :
     - pwsh: |
-        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize' *
-        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32' *
-        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz -C '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64' *
+        Set-Location '$(System.ArtifactsDirectory)/pwshLinuxBuildMinSize'
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildMinSize.tar.gz *
+        Set-Location '$(System.ArtifactsDirectory)/pwshLinuxBuildArm32'
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm32.tar.gz *
+        Set-Location '$(System.ArtifactsDirectory)/pwshLinuxBuildArm64'
+        tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuildArm64.tar.gz *
       displayName: Compress deb
 
   - ${{ if eq(variables.build,'rpm') }} :
     - pwsh: |
-        tar -czvf $(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz -C '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64' *
+        Set-Location '$(System.ArtifactsDirectory)/pwshMarinerBuildAmd64'
+        tar -czvf $(System.ArtifactsDirectory)/pwshMarinerBuildAmd64.tar.gz *
       displayName: Compress pwshMarinerBuildAmd64
 
   - ${{ if eq(variables.build,'deb') }} :

--- a/tools/releaseBuild/azureDevOps/templates/linux.yml
+++ b/tools/releaseBuild/azureDevOps/templates/linux.yml
@@ -71,6 +71,10 @@ jobs:
         Import-Module "$env:POWERSHELLROOT/tools/packaging"
 
         Invoke-AzDevOpsLinuxPackageBuild -ReleaseTag '$(ReleaseTagVar)' -BuildType '$(build)'
+
+        Write-Verbose -Verbose "File permisions after building"
+        Get-ChildItem -Path $(System.ArtifactsDirectory)/pwshLinuxBuild/pwsh | Select-Object -Property 'unixmode', 'size', 'name'
+
       } catch {
         Get-Error
         throw
@@ -130,6 +134,8 @@ jobs:
 
   - pwsh: |
       Set-Location '$(System.ArtifactsDirectory)/pwshLinuxBuild'
+      Write-Verbose -Verbose "File permisions before compressing"
+      Get-ChildItem -Path $(Build.ArtifactStagingDirectory)/pwshLinuxBuild/pwsh | Select-Object -Property 'unixmode', 'size', 'name'
       tar -czvf $(System.ArtifactsDirectory)/pwshLinuxBuild.tar.gz *
     displayName: Compress pwshLinuxBuild
 

--- a/tools/releaseBuild/azureDevOps/templates/signBuildFiles.yml
+++ b/tools/releaseBuild/azureDevOps/templates/signBuildFiles.yml
@@ -174,6 +174,11 @@ steps:
 
 - pwsh: |
       $uploadFolder = '$(System.ArtifactsDirectory)/${{ parameters.binLocation }}'
-      $containerName = '${{ parameters.binLocation }}-signed'
-      Write-Host "##vso[artifact.upload containerfolder=$containerName;artifactname=$containerName]$uploadFolder"
+      $containerName = 'authenticode-signed'
+
+      $uploadTarFilePath = '$(System.ArtifactsDirectory)/${{ parameters.binLocation }}.tar.gz'
+      Write-Verbose -Verbose -Message "Creating tar.gz - $uploadTarFilePath"
+      tar -czvf $uploadTarFilePath $uploadFolder
+
+      Write-Host "##vso[artifact.upload containerfolder=$containerName;artifactname=$containerName]$uploadTarFilePath"
   displayName: ${{ parameters.buildPrefixName }} - Upload signed files to artifacts

--- a/tools/releaseBuild/azureDevOps/templates/signBuildFiles.yml
+++ b/tools/releaseBuild/azureDevOps/templates/signBuildFiles.yml
@@ -178,7 +178,7 @@ steps:
 
       $uploadTarFilePath = '$(System.ArtifactsDirectory)/${{ parameters.binLocation }}.tar.gz'
       Write-Verbose -Verbose -Message "Creating tar.gz - $uploadTarFilePath"
-      tar -czvf $uploadTarFilePath $uploadFolder
+      tar -czvf $uploadTarFilePath -C $uploadFolder *
 
       Write-Host "##vso[artifact.upload containerfolder=$containerName;artifactname=$containerName]$uploadTarFilePath"
   displayName: ${{ parameters.buildPrefixName }} - Upload signed files to artifacts

--- a/tools/releaseBuild/azureDevOps/templates/signBuildFiles.yml
+++ b/tools/releaseBuild/azureDevOps/templates/signBuildFiles.yml
@@ -176,6 +176,9 @@ steps:
       $uploadFolder = '$(System.ArtifactsDirectory)/${{ parameters.binLocation }}'
       $containerName = 'authenticode-signed'
 
+      Write-Verbose -Verbose "File permissions after signing"
+      Get-ChildItem $uploadFolder\pwsh | Select-Object -Property 'unixmode', 'size', 'name'
+
       $uploadTarFilePath = '$(System.ArtifactsDirectory)/${{ parameters.binLocation }}.tar.gz'
       Write-Verbose -Verbose -Message "Creating tar.gz - $uploadTarFilePath"
       tar -czvf $uploadTarFilePath -C $uploadFolder *


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When trying to authenticode sign files on Windows the linux file permissions are lost. We store them in a json file and then re-apply them.

Fixes https://github.com/PowerShell/PowerShell/issues/18495

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
