### PR TITLE
Change detection of home directory to fallback to host if SMA.dll location is not found

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6993,7 +6993,7 @@ namespace System.Management.Automation
         {
             var results = new List<CompletionResult>();
             string userHelpDir = HelpUtils.GetUserHomeHelpSearchPath();
-            string appHelpDir = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            string appHelpDir = Utils.GetApplicationBase();
             string currentCulture = CultureInfo.CurrentCulture.Name;
 
             //search for help files for the current culture + en-US as fallback

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -58,7 +58,6 @@ namespace System.Management.Automation.Configuration
 
         // The json file containing system-wide configuration settings.
         // When passed as a pwsh command-line option, overrides the system wide configuration file.
-        private readonly bool systemWideConfigFileExists = false;
         private string systemWideConfigFile;
         private string systemWideConfigDirectory;
 
@@ -84,11 +83,7 @@ namespace System.Management.Automation.Configuration
         {
             // Sets the system-wide configuration file.
             systemWideConfigDirectory = Utils.DefaultPowerShellAppBase;
-            if (!string.IsNullOrEmpty(systemWideConfigDirectory))
-            {
-                systemWideConfigFileExists = true;
-                systemWideConfigFile = Path.Combine(systemWideConfigDirectory, ConfigFileName);
-            }
+            systemWideConfigFile = Path.Combine(systemWideConfigDirectory, ConfigFileName);
 
             // Sets the per-user configuration directory
             // Note: This directory may or may not exist depending upon the execution scenario.
@@ -391,11 +386,6 @@ namespace System.Management.Automation.Configuration
         /// <param name="defaultValue">The default value to return if the key is not present.</param>
         private T ReadValueFromFile<T>(ConfigScope scope, string key, T defaultValue = default)
         {
-            if (scope == ConfigScope.AllUsers && !systemWideConfigFileExists)
-            {
-                return defaultValue;
-            }
-
             string fileName = GetConfigFilePath(scope);
             JObject configData = configRoots[(int)scope];
 
@@ -476,11 +466,6 @@ namespace System.Management.Automation.Configuration
         /// <param name="addValue">Whether the key-value pair should be added to or removed from the file.</param>
         private void UpdateValueInFile<T>(ConfigScope scope, string key, T value, bool addValue)
         {
-            if (scope == ConfigScope.AllUsers && !systemWideConfigFileExists)
-            {
-                return;
-            }
-
             try
             {
                 string fileName = GetConfigFilePath(scope);
@@ -598,11 +583,6 @@ namespace System.Management.Automation.Configuration
         /// <param name="key">The string key of the value.</param>
         private void RemoveValueFromFile<T>(ConfigScope scope, string key)
         {
-            if (scope == ConfigScope.AllUsers && !systemWideConfigFileExists)
-            {
-                return;
-            }
-
             string fileName = GetConfigFilePath(scope);
             // Optimization: If the file doesn't exist, there is nothing to remove
             if (File.Exists(fileName))

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -58,9 +58,9 @@ namespace System.Management.Automation.Configuration
 
         // The json file containing system-wide configuration settings.
         // When passed as a pwsh command-line option, overrides the system wide configuration file.
+        private readonly bool systemWideConfigFileExists = false;
         private string systemWideConfigFile;
         private string systemWideConfigDirectory;
-        private readonly bool systemWideConfigFileExists = false;
 
         // The json file containing the per-user configuration settings.
         private readonly string perUserConfigFile;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,7 +482,7 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase()
         {
-            return AppContext.BaseDirectory ?? Path.GetDirectoryName(Environment.ProcessPath);
+            return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory) ?? Path.GetDirectoryName(Environment.ProcessPath);
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -478,13 +478,11 @@ namespace System.Management.Automation
         }
 #endif
 
-        internal static string DefaultPowerShellAppBase => GetApplicationBase(DefaultPowerShellShellID);
+        internal static string DefaultPowerShellAppBase => GetApplicationBase();
 
-        internal static string GetApplicationBase(string shellId)
+        internal static string GetApplicationBase()
         {
-            // Use the location of SMA.dll as the application base.
-            Assembly assembly = typeof(PSObject).Assembly;
-            return Path.GetDirectoryName(assembly.Location);
+            return AppContext.BaseDirectory;
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -484,7 +484,7 @@ namespace System.Management.Automation
         {
             // Use the location of SMA.dll as the application base or fallback to process home.
             Assembly assembly = typeof(PSObject).Assembly;
-            return Path.GetDirectoryName(assembly.Location) ?? AppContext.BaseDirectory;
+            return Path.GetDirectoryName(assembly.Location ?? Environment.ProcessPath);
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -484,7 +484,7 @@ namespace System.Management.Automation
         {
             // Use the location of SMA.dll as the application base or fallback to process home.
             Assembly assembly = typeof(PSObject).Assembly;
-            return Path.GetDirectoryName(assembly.Location ?? Environment.ProcessPath);
+            return Path.GetDirectoryName(assembly.Location ?? AppContext.BaseDirectory ?? Environment.ProcessPath);
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -483,9 +483,13 @@ namespace System.Management.Automation
         internal static string GetApplicationBase()
         {
             // AppContext is needed where PS7 may be compiled as a single exe
-            // Environment.ProcessPath covers the pwsh exe case
-            // Assembly.Location is needed for hosted scenarios
-            return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory ?? Path.GetDirectoryName(Environment.ProcessPath) ?? Path.GetDirectoryName(typeof(PSObject).Assembly.Location));
+            // Environment.ProcessPath covers the general case
+            if (!string.IsNullOrEmpty(AppContext.BaseDirectory))
+            {
+                return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory);
+            }
+
+            return Path.GetDirectoryName(Environment.ProcessPath);
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,17 +482,9 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase()
         {
-            // Use the location of SMA.dll as the application base.
+            // Use the location of SMA.dll as the application base or fallback to process home.
             Assembly assembly = typeof(PSObject).Assembly;
-            string applicationBase = Path.GetDirectoryName(assembly.Location);
-            if (string.IsNullOrEmpty(applicationBase))
-            {
-                // This can happen if PowerShell is hosted in a native host
-                // so we fallback to using location of the host.
-                applicationBase = AppContext.BaseDirectory;
-            }
-
-            return applicationBase;
+            return Path.GetDirectoryName(assembly.Location) ?? AppContext.BaseDirectory;
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -488,6 +488,10 @@ namespace System.Management.Automation
             {
                 return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory);
             }
+            else if (!string.IsNullOrEmpty(Path.GetDirectoryName(typeof(PSObject).Assembly.Location)))
+            {
+                return Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
+            }
 
             return Path.GetDirectoryName(Environment.ProcessPath);
         }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,7 +482,10 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase()
         {
-            return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory ?? Path.GetDirectoryName(Environment.ProcessPath));
+            // AppContext is needed where PS7 may be compiled as a single exe
+            // Environment.ProcessPath covers the pwsh exe case
+            // Assembly.Location is needed for hosted scenarios
+            return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory ?? Path.GetDirectoryName(Environment.ProcessPath) ?? Path.GetDirectoryName(typeof(PSObject).Assembly.Location));
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,9 +482,7 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase()
         {
-            // Use the location of SMA.dll as the application base or fallback to process home.
-            Assembly assembly = typeof(PSObject).Assembly;
-            return Path.GetDirectoryName(assembly.Location ?? AppContext.BaseDirectory ?? Environment.ProcessPath);
+            return AppContext.BaseDirectory ?? Path.GetDirectoryName(Environment.ProcessPath);
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,7 +482,7 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase()
         {
-            return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory) ?? Path.GetDirectoryName(Environment.ProcessPath);
+            return Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory ?? Path.GetDirectoryName(Environment.ProcessPath));
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,7 +482,17 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase()
         {
-            return AppContext.BaseDirectory;
+            // Use the location of SMA.dll as the application base.
+            Assembly assembly = typeof(PSObject).Assembly;
+            string applicationBase = Path.GetDirectoryName(assembly.Location);
+            if (string.IsNullOrEmpty(applicationBase))
+            {
+                // This can happen if PowerShell is hosted in a native host
+                // so we fallback to using location of the host.
+                applicationBase = AppContext.BaseDirectory;
+            }
+
+            return applicationBase;
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -258,7 +258,7 @@ namespace System.Management.Automation
             string folderPath = string.Empty;
             try
             {
-                folderPath = Utils.GetApplicationBase(shellId);
+                folderPath = Utils.GetApplicationBase();
             }
             catch (System.Security.SecurityException)
             {

--- a/src/System.Management.Automation/help/HelpProvider.cs
+++ b/src/System.Management.Automation/help/HelpProvider.cs
@@ -223,10 +223,7 @@ namespace System.Management.Automation
         /// <returns>String representing base directory of the executing shell.</returns>
         internal string GetDefaultShellSearchPath()
         {
-            string shellID = this.HelpSystem.ExecutionContext.ShellID;
-            // Beginning in PowerShell 6.0.0.12, the $pshome is no longer registry specified, we search the application base instead.
-            // We use executing assemblies location in case registry entry not found
-            return Utils.GetApplicationBase() ?? Path.GetDirectoryName(Environment.ProcessPath);
+            return Utils.GetApplicationBase();
         }
 
         /// <summary>

--- a/src/System.Management.Automation/help/HelpProvider.cs
+++ b/src/System.Management.Automation/help/HelpProvider.cs
@@ -226,7 +226,7 @@ namespace System.Management.Automation
             string shellID = this.HelpSystem.ExecutionContext.ShellID;
             // Beginning in PowerShell 6.0.0.12, the $pshome is no longer registry specified, we search the application base instead.
             // We use executing assemblies location in case registry entry not found
-            return Utils.GetApplicationBase(shellID) ?? Path.GetDirectoryName(Environment.ProcessPath);
+            return Utils.GetApplicationBase() ?? Path.GetDirectoryName(Environment.ProcessPath);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/help/MUIFileSearcher.cs
+++ b/src/System.Management.Automation/help/MUIFileSearcher.cs
@@ -287,7 +287,7 @@ namespace System.Management.Automation
             }
 
             // step 3: locate the file in the default PowerShell installation directory.
-            string defaultPSPath = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            string defaultPSPath = Utils.GetApplicationBase();
             if (defaultPSPath != null &&
                 !result.Contains(defaultPSPath) &&
                 Directory.Exists(defaultPSPath))

--- a/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
@@ -229,7 +229,7 @@ namespace Microsoft.PowerShell.Commands
                 if (!helpModules.ContainsKey(keyTuple))
                 {
                     helpModules.Add(keyTuple, new UpdatableHelpModuleInfo(module.Name, module.Guid,
-                        Utils.GetApplicationBase(context.ShellID), s_metadataCache[module.Name]));
+                        Utils.GetApplicationBase(), s_metadataCache[module.Name]));
                 }
 
                 return;
@@ -328,7 +328,7 @@ namespace Microsoft.PowerShell.Commands
                                         WriteDebug(StringUtil.Format("Found engine module: {0}, {1}.", module.Name, module.Guid));
 
                                         helpModules.Add(keyTuple, new UpdatableHelpModuleInfo(module.Name,
-                                            module.Guid, Utils.GetApplicationBase(context.ShellID), s_metadataCache[module.Name]));
+                                            module.Guid, Utils.GetApplicationBase(), s_metadataCache[module.Name]));
                                     }
                                 }
                             }
@@ -341,7 +341,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             helpModules.Add(keyTuple2,
                                             new UpdatableHelpModuleInfo(name.Key, Guid.Empty,
-                                                                        Utils.GetApplicationBase(context.ShellID),
+                                                                        Utils.GetApplicationBase(),
                                                                         name.Value));
                         }
                     }

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -388,7 +388,7 @@ namespace Microsoft.PowerShell.Commands
                         Debug.Assert(helpInfoUri != null, "If we are here, helpInfoUri must not be null");
 
                         string helpContentUri = contentUri.ResolvedUri;
-                        string xsdPath = SessionState.Path.Combine(Utils.GetApplicationBase(Context.ShellID), "Schemas\\PSMaml\\maml.xsd"); // TODO: Edit the maml XSDs and change this
+                        string xsdPath = SessionState.Path.Combine(Utils.GetApplicationBase(), "Schemas\\PSMaml\\maml.xsd"); // TODO: Edit the maml XSDs and change this
 
                         // Gather destination paths
                         Collection<string> destPaths = new Collection<string>();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The path to the system wide `powershell.config.json` file depends on the location of SMA.dll.  However, for some uses like hosting in a Windows Service, the .NET call to get the path to SMA.dll returns null which then subsequently fails a `Path.Join()` call.  The change is to use AppContext.BaseDirectory instead of location of SMA.dll.  In addition, the internal method takes a parameter that hasn't been used and has been removed.

I originally tried making the members nullable, however, this brought in a cascade of other changes needed to make it work across multiple files and also adds more regression risk since the behavior changes being nullable.  Instead, I opened for this current approach which is more straight forward.

Also, this change is needed to experiment with building a single exe pwsh where SMA.dll won't be found.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/18109

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
