### PR TITLE
Fix `Start-Job` to check the existence of working directory using the PowerShell way

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -484,7 +484,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets an initial working directory for the powershell background job.
         /// </summary>
         [Parameter]
-        [ValidateNotNullOrEmpty]
+        [ValidateNotNullOrWhiteSpace]
         public string WorkingDirectory { get; set; }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -601,23 +601,16 @@ namespace Microsoft.PowerShell.Commands
                 ThrowTerminatingError(errorRecord);
             }
 
-            if (WorkingDirectory != null && !Directory.Exists(WorkingDirectory))
+            if (WorkingDirectory != null && !InvokeProvider.Item.IsContainer(WorkingDirectory))
             {
-                try
-                {
-                    _ = SessionState.Path.GetResolvedPSPathFromPSPath(WorkingDirectory);
-                }
-                catch
-                {
-                    string message = StringUtil.Format(RemotingErrorIdStrings.StartJobWorkingDirectoryNotFound, WorkingDirectory);
-                    var errorRecord = new ErrorRecord(
-                        new DirectoryNotFoundException(message),
-                        "DirectoryNotFoundException",
-                        ErrorCategory.InvalidOperation,
-                        targetObject: null);
+                string message = StringUtil.Format(RemotingErrorIdStrings.StartJobWorkingDirectoryNotFound, WorkingDirectory);
+                var errorRecord = new ErrorRecord(
+                    new DirectoryNotFoundException(message),
+                    "DirectoryNotFoundException",
+                    ErrorCategory.InvalidOperation,
+                    targetObject: null);
 
-                    ThrowTerminatingError(errorRecord);
-                }
+                ThrowTerminatingError(errorRecord);
             }
 
             if (WorkingDirectory == null)

--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -603,14 +603,21 @@ namespace Microsoft.PowerShell.Commands
 
             if (WorkingDirectory != null && !Directory.Exists(WorkingDirectory))
             {
-                string message = StringUtil.Format(RemotingErrorIdStrings.StartJobWorkingDirectoryNotFound, WorkingDirectory);
-                var errorRecord = new ErrorRecord(
-                    new DirectoryNotFoundException(message),
-                    "DirectoryNotFoundException",
-                    ErrorCategory.InvalidOperation,
-                    targetObject: null);
+                try
+                {
+                    _ = SessionState.Path.GetResolvedPSPathFromPSPath(WorkingDirectory);
+                }
+                catch
+                {
+                    string message = StringUtil.Format(RemotingErrorIdStrings.StartJobWorkingDirectoryNotFound, WorkingDirectory);
+                    var errorRecord = new ErrorRecord(
+                        new DirectoryNotFoundException(message),
+                        "DirectoryNotFoundException",
+                        ErrorCategory.InvalidOperation,
+                        targetObject: null);
 
-                ThrowTerminatingError(errorRecord);
+                    ThrowTerminatingError(errorRecord);
+                }
             }
 
             if (WorkingDirectory == null)

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -86,6 +86,17 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
             $jobOutput | Should -BeExactly $path.ToString()
         }
 
+        It 'Can specify the working directory with a PSPath' {
+            try {
+                Push-Location 'Temp:\'
+                $job = Start-Job -ScriptBlock { $PWD } -WorkingDirectory $pwd.Path | Wait-Job
+                $jobOutput = Receive-Job $job
+                $jobOutput | Should -BeExactly $pwd.Path
+            } finally {
+                Pop-Location
+            }
+        }
+
         It 'Can use the user specified working directory parameter with quote' -Skip:($IsWindows) {
             $path = Join-Path -Path $TestDrive -ChildPath "My ""Dir"
             $null = New-Item -ItemType Directory -Path "$path"

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -111,9 +111,9 @@ Describe 'Basic Job Tests' -Tags 'Feature' {
         }
 
         It 'Throws an error when the working directory parameter is <case>' -TestCases $invalidPathTestCases {
-            param($path, $case, $expectedErrorId)
+            param($path, $case, $errorId)
 
-            {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $path} | Should -Throw -ErrorId $expectedErrorId
+            {Start-Job -ScriptBlock { 1 + 1 } -WorkingDirectory $path} | Should -Throw -ErrorId $errorId
         }
 
         It 'Verifies that the current working directory is preserved' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #18618

Fix `Start-Job` to check the existence of working directory using the PowerShell way.
Use `InvokeProvider.Item.IsContainer` instead of `Directory.Exists` to verify if the specified working directory path exists.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] NoneMake sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/Po
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
