### PR TITLE
Fix `SuspiciousContentChecker.Match` to detect a pre-defined string when the text starts with it

### DIFF
--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2033,7 +2033,7 @@ namespace System.Management.Automation
                         continue;
                     }
 
-                    for (int j = Math.Min(i, runningHash.Length) - 1; j > 0; j--)
+                    for (int j = Math.Min(i, runningHash.Length - 1); j > 0; j--)
                     {
                         // Say our input is: `Emit` (our shortest pattern, len 4).
                         // Towards the end just before matching, we will:

--- a/test/powershell/engine/Api/SuspiciousContentChecker.Tests.ps1
+++ b/test/powershell/engine/Api/SuspiciousContentChecker.Tests.ps1
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'SuspiciousContentChecker verification' -Tags "CI" {
+    BeforeAll {
+        $type = [psobject].Assembly.GetType('System.Management.Automation.ScriptBlock+SuspiciousContentChecker')
+
+        $testCases = @(
+            @{ number = 1; text = "add-TyPe"; expected = "Add-Type" }
+            @{ number = 2; text = "GetDelegateForFunctionPointer"; expected = "GetDelegateForFunctionPointer" }
+            @{ number = 3; text = "ZeroFreeGlobalAllocUnicode"; expected = "ZeroFreeGlobalAllocUnicode" }
+            @{ number = 4; text = "Hello world emit new"; expected = "Emit" }
+            @{ number = 5; text = "xxxx yyyyMakeByRefTypecccc Type 'help' to get help"; expected = "MakeByRefType" }
+            @{ number = 9; text = "emjt TypeHandlebegood"; expected = "TypeHandle" }
+
+            @{ number = 6; text = "PowerShell Preview Extension v2022.11.2"; expected = $null }
+            @{ number = 7; text = "add-typu"; expected = $null }
+            @{ number = 8; text = "GetDelegateForFunctionPointfr"; expected = $null }
+            @{ number = 9; text = "emjt TypeHandlfe"; expected = $null }
+        )
+    }
+
+    It "Smoke testing the suspicious content detection - <number>" -TestCases $testCases {
+        param($text, $expected)
+
+        $type::Match($text) | Should -BeExactly $expected
+    }
+}

--- a/test/powershell/engine/Api/SuspiciousContentChecker.Tests.ps1
+++ b/test/powershell/engine/Api/SuspiciousContentChecker.Tests.ps1
@@ -16,7 +16,8 @@ Describe 'SuspiciousContentChecker verification' -Tags "CI" {
             @{ id = 'Should Detect (8)'; text = "*&)(@~>-typeemit"; expected = "Emit" }
             @{ id = 'Should Detect (9)'; text = "Type`u{48}andle`u{2122}"; expected = "TypeHandle" }
             @{ id = 'Should Detect (10)'; text = "`u{2122}Type`u{48}andle`u{2122}"; expected = "TypeHandle" }
-            @{ id = 'Should Detect (11)'; text = "`u{D83D}`u{DE00}Type`u{48}andle`u{D83D}`u{DE00}"; expected = "TypeHandle" } ## Use surrogate pairs in the string.
+            @{ id = 'Should Detect (11)'; text = "`u{D83D}`u{DE00}Type`u{48}andle`u{D83D}`u{DE00}"; expected = "TypeHandle" } ## use surrogate pairs in the string.
+            @{ id = 'Should Detect (12)'; text = "xx`u{48}`u{48}xx()xxx--xx[]xx;'xpox?/xxemit"; expected = "Emit" } ## suspicious string starts at the index 29.
 
             @{ id = 'Should NOT Detect (1)'; text = "PowerShell Preview Extension v2022.11.2"; expected = $null }
             @{ id = 'Should NOT Detect (2)'; text = "add-typu"; expected = $null }

--- a/test/powershell/engine/Api/SuspiciousContentChecker.Tests.ps1
+++ b/test/powershell/engine/Api/SuspiciousContentChecker.Tests.ps1
@@ -6,21 +6,27 @@ Describe 'SuspiciousContentChecker verification' -Tags "CI" {
         $type = [psobject].Assembly.GetType('System.Management.Automation.ScriptBlock+SuspiciousContentChecker')
 
         $testCases = @(
-            @{ number = 1; text = "add-TyPe"; expected = "Add-Type" }
-            @{ number = 2; text = "GetDelegateForFunctionPointer"; expected = "GetDelegateForFunctionPointer" }
-            @{ number = 3; text = "ZeroFreeGlobalAllocUnicode"; expected = "ZeroFreeGlobalAllocUnicode" }
-            @{ number = 4; text = "Hello world emit new"; expected = "Emit" }
-            @{ number = 5; text = "xxxx yyyyMakeByRefTypecccc Type 'help' to get help"; expected = "MakeByRefType" }
-            @{ number = 9; text = "emjt TypeHandlebegood"; expected = "TypeHandle" }
+            @{ id = 'Should Detect (1)'; text = "add-TyPe"; expected = "Add-Type" }
+            @{ id = 'Should Detect (2)'; text = "GetDelegateForFunctionPointer"; expected = "GetDelegateForFunctionPointer" }
+            @{ id = 'Should Detect (3)'; text = "ZeroFreeGlobalAllocUnicode"; expected = "ZeroFreeGlobalAllocUnicode" }
+            @{ id = 'Should Detect (4)'; text = "Hello world emit new"; expected = "Emit" }
+            @{ id = 'Should Detect (5)'; text = "xxxx yyyyMakeByRefTypecccc Type 'help' to get help"; expected = "MakeByRefType" }
+            @{ id = 'Should Detect (6)'; text = "emjt TypeHandlebegood"; expected = "TypeHandle" }
+            @{ id = 'Should Detect (7)'; text = "emit*&)(@~>-type"; expected = "Emit" }
+            @{ id = 'Should Detect (8)'; text = "*&)(@~>-typeemit"; expected = "Emit" }
+            @{ id = 'Should Detect (9)'; text = "Type`u{48}andle`u{2122}"; expected = "TypeHandle" }
+            @{ id = 'Should Detect (10)'; text = "`u{2122}Type`u{48}andle`u{2122}"; expected = "TypeHandle" }
+            @{ id = 'Should Detect (11)'; text = "`u{D83D}`u{DE00}Type`u{48}andle`u{D83D}`u{DE00}"; expected = "TypeHandle" } ## Use surrogate pairs in the string.
 
-            @{ number = 6; text = "PowerShell Preview Extension v2022.11.2"; expected = $null }
-            @{ number = 7; text = "add-typu"; expected = $null }
-            @{ number = 8; text = "GetDelegateForFunctionPointfr"; expected = $null }
-            @{ number = 9; text = "emjt TypeHandlfe"; expected = $null }
+            @{ id = 'Should NOT Detect (1)'; text = "PowerShell Preview Extension v2022.11.2"; expected = $null }
+            @{ id = 'Should NOT Detect (2)'; text = "add-typu"; expected = $null }
+            @{ id = 'Should NOT Detect (3)'; text = "GetDelegateForFunctionPointfr"; expected = $null }
+            @{ id = 'Should NOT Detect (4)'; text = "emjt TypeHandlfe"; expected = $null }
+            @{ id = 'Should NOT Detect (5)'; text = "Get*&)(@~>-Types"; expected = $null }
         )
     }
 
-    It "Smoke testing the suspicious content detection - <number>" -TestCases $testCases {
+    It "Smoke testing the suspicious content detection - <id>" -TestCases $testCases {
         param($text, $expected)
 
         $type::Match($text) | Should -BeExactly $expected


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix `SuspiciousContentChecker.Match` to detect a pre-defined string when the text starts with it.

## PR Context

The method `SuspiciousContentChecker.Match` has a flaw: when the text starts with a string that is defined in `LookupHash(uint h)`, it cannot detect the string.

```
PS:1> $t = [psobject].Assembly.GetType('System.Management.Automation.ScriptBlock+SuspiciousContentChecker')
PS:2> $t::Match("Add-Type") -eq $null
True
PS:3> $t::Match(" Add-Type")      ## it can detect the string when text doesn't start with it.
Add-Type
```
**NOTE:** The `SuspiciousContentChecker.Match` check is a defense-and-depth thing, so this bug is **NOT** a security vulnerability.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
