### PR TITLE
Set default native arg passing to Legacy on Windows.

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -28,6 +28,7 @@ namespace System.Management.Automation
         internal const string PSFeedbackProvider = "PSFeedbackProvider";
         internal const string PSCommandWithArgs = "PSCommandWithArgs";
         internal const string PSConstrainedAuditLogging = "PSConstrainedAuditLogging";
+        internal const string PSWindowsNativeCommandArgPassing = "PSWindowsNativeCommandArgPassing";
 
         #endregion
 
@@ -140,6 +141,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSConstrainedAuditLogging,
                     description: "PowerShell restriction logging when WDAC (Windows Defender Application Control) Code Integrity policy is set to Audit mode.")
+                new ExperimentalFeature(
+                    name: "PSWindowsNativeCommandArgPassing",
+                    description: "Enable 'Windows' as the native command argument passing mode"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -140,7 +140,7 @@ namespace System.Management.Automation
                     description: "Enable `-CommandWithArgs` parameter for pwsh"),
                 new ExperimentalFeature(
                     name: PSConstrainedAuditLogging,
-                    description: "PowerShell restriction logging when WDAC (Windows Defender Application Control) Code Integrity policy is set to Audit mode.")
+                    description: "PowerShell restriction logging when WDAC (Windows Defender Application Control) Code Integrity policy is set to Audit mode."),
                 new ExperimentalFeature(
                     name: "PSWindowsNativeCommandArgPassing",
                     description: "Enable 'Windows' as the native command argument passing mode"),

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4545,9 +4545,8 @@ end {
         /// <summary>
         /// Assigns the default behavior for native argument passing.
         /// If the system is non-Windows, we will return Standard.
-        /// If the PreReleaseLabel is not set, we will return Legacy.
-        /// This is because our preview and daily builds have a PSVersion which
-        /// includes a value for PreReleaseLabel, but our official releases do not.
+        /// If the experimental feature is enabled, we will return Windows.
+        /// Otherwise, we will return Legacy.
         /// </summary>
         private static NativeArgumentPassingStyle GetPassingStyle()
         {
@@ -4557,12 +4556,13 @@ end {
                 return NativeArgumentPassingStyle.Standard;
             }
 
-            if (PSVersionInfo.PSCurrentVersion.PreReleaseLabel is null)
+            // If the experimental feature is enabled return Windows..
+            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSWindowsNativeCommandArgPassing))
             {
-                return NativeArgumentPassingStyle.Legacy;
+                return NativeArgumentPassingStyle.Windows;
             }
 
-            return NativeArgumentPassingStyle.Windows;
+            return NativeArgumentPassingStyle.Legacy;
         }
 
         internal static readonly SessionStateVariableEntry[] BuiltInVariables;

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4557,8 +4557,7 @@ end {
                 return NativeArgumentPassingStyle.Standard;
             }
 
-            // If we can parse the version to an actual version, it's not a preview, so return Legacy
-            if (Version.TryParse(PSVersionInfo.PSCurrentVersion.ToString(), out var version))
+            if (PSVersionInfo.PSCurrentVersion.PreReleaseLabel is null)
             {
                 return NativeArgumentPassingStyle.Legacy;
             }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4545,9 +4545,9 @@ end {
         /// <summary>
         /// Assigns the default behavior for native argument passing.
         /// If the system is non-Windows, we will return Standard.
-        /// If the PSVersion takes the shape of a Version Type, we will return Legacy.
+        /// If the PreReleaseLabel is not set, we will return Legacy.
         /// This is because our preview and daily builds have a PSVersion which
-        /// looks like 7.3.0-preview.3 which can't be parsed into a Version.
+        /// includes a value for PreReleaseLabel, but our official releases do not.
         /// </summary>
         private static NativeArgumentPassingStyle GetPassingStyle()
         {

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4552,7 +4552,7 @@ end {
         private static NativeArgumentPassingStyle GetPassingStyle()
         {
             // If non-Windows, use the standard passing style
-            if (! Platform.IsWindows)
+            if (!Platform.IsWindows)
             {
                 return NativeArgumentPassingStyle.Standard;
             }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4534,7 +4534,7 @@ end {
             builtinVariables.Add(
                 new SessionStateVariableEntry(
                     SpecialVariables.NativeArgumentPassing,
-                    GetPassingStyle(), // Platform.IsWindows ? NativeArgumentPassingStyle.Windows : NativeArgumentPassingStyle.Standard,
+                    GetPassingStyle(),
                     RunspaceInit.NativeCommandArgumentPassingDescription,
                     ScopedItemOptions.None,
                     new ArgumentTypeConverterAttribute(typeof(NativeArgumentPassingStyle))));

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4550,19 +4550,16 @@ end {
         /// </summary>
         private static NativeArgumentPassingStyle GetPassingStyle()
         {
-            // If non-Windows, use the standard passing style
-            if (!Platform.IsWindows)
-            {
-                return NativeArgumentPassingStyle.Standard;
-            }
-
-            // If the experimental feature is enabled return Windows..
+#if UNIX
+            return NativeArgumentPassingStyle.Standard;
+#else
             if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSWindowsNativeCommandArgPassing))
             {
                 return NativeArgumentPassingStyle.Windows;
             }
 
             return NativeArgumentPassingStyle.Legacy;
+#endif
         }
 
         internal static readonly SessionStateVariableEntry[] BuiltInVariables;

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -586,8 +586,7 @@ namespace System.Management.Automation
             // Send Telemetry indicating what argument passing mode we are in.
             ApplicationInsightsTelemetry.SendExperimentalUseData(
                 ExperimentalFeature.PSWindowsNativeCommandArgPassing,
-                NativeParameterBinderController.ArgumentPassingStyle.ToString()
-                );
+                NativeParameterBinderController.ArgumentPassingStyle.ToString());
 
 #if !UNIX
             string commandPath = this.Path.ToLowerInvariant();

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -583,6 +583,12 @@ namespace System.Management.Automation
             // Get the start info for the process.
             ProcessStartInfo startInfo = GetProcessStartInfo(redirectOutput, redirectError, redirectInput, soloCommand);
 
+            // Send Telemetry indicating what argument passing mode we are in.
+            ApplicationInsightsTelemetry.SendExperimentalUseData(
+                ExperimentalFeature.PSWindowsNativeCommandArgPassing,
+                NativeParameterBinderController.ArgumentPassingStyle.ToString()
+                );
+
 #if !UNIX
             string commandPath = this.Path.ToLowerInvariant();
             if (commandPath.EndsWith("powershell.exe") || commandPath.EndsWith("powershell_ise.exe"))

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -5,7 +5,12 @@ param()
 
 Describe "Behavior is specific for each platform" -tags "CI" {
     It "PSNativeCommandArgumentPassing is set to 'Windows' on Windows systems" -skip:(-not $IsWindows) {
-        $PSNativeCommandArgumentPassing | Should -Be "Windows"
+        if ([Version]::TryParse($PSVersiontable.PSVersion.ToString(), [ref]$null)) {
+            $PSNativeCommandArgumentPassing | Should -BeExactly "Legacy"
+        }
+        else {
+            $PSNativeCommandArgumentPassing | Should -BeExactly "Windows"
+        }
     }
     It "PSNativeCommandArgumentPassing is set to 'Standard' on non-Windows systems" -skip:($IsWindows) {
         $PSNativeCommandArgumentPassing | Should -Be "Standard"


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The committee agreed to a new `PSWindowsNativeCommandArgPassing` experimental feature.  When this feature is enabled:

- On Windows
  - `$PSNativeCommandArgumentPassing` = `Windows`
- Non-Windows
  - `$PSNativeCommandArgumentPassing` = `Standard`
 
When this feature is disabled:

- On Windows
  - `$PSNativeCommandArgumentPassing` = `Legacy`
- Non-Windows
  - `$PSNativeCommandArgumentPassing` = `Standard`

Additionally, new telemetry metric will be added for native command execution to inform the mode being used.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9739
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
