### PR TITLE
Webcmdlets Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1682,6 +1682,8 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         internal long SetRequestContent(HttpRequestMessage request, string content)
         {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
@@ -1731,6 +1733,8 @@ namespace Microsoft.PowerShell.Commands
 
         internal long SetRequestContent(HttpRequestMessage request, XmlNode xmlNode)
         {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -414,6 +414,8 @@ namespace Microsoft.PowerShell.Commands
 
         internal static string DecodeStream(Stream stream, string characterSet, out Encoding encoding)
         {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
             try
             {
                 encoding = Encoding.GetEncoding(characterSet);
@@ -428,6 +430,8 @@ namespace Microsoft.PowerShell.Commands
 
         internal static bool TryGetEncoding(string characterSet, out Encoding encoding)
         {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            
             bool result = false;
             try
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fix support for exotic text encodings in Webcmdlets

(I need some advice on the best place to add  `Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)`)

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Anytime we use `Encoding.GetEncoding()` we have to use `Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)` to account for all the exotic charsets (at the moment we consider only: ASCII, ISO-8859-1, UTF-7, UTF-8, UTF-16, UTF-32)

Fixes #18677

Test: `Invoke-WebRequest "https://www.ukrlib.com.ua/"`
(This website uses the windows-1251 encoding, it was not supported even if it was correctly identified by the `s_metaexp` Regex in `StreamHelper.cs`)

[https://learn.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?source=recommendations&view=net-7.0](url)
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->


