### PR TITLE
WebCmdlets get Retry-After from headers if StatusCode is 429

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1439,18 +1439,18 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // Only set retry interval if MaximumRetryCount is specified, if
                     // the status code is 429 get the retry interval from the Headers.
-                    WebSession.RetryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out IEnumerable<string> retryAfter)) ? Convert.ToInt32(retryAfter.FirstOrDefault(RetryIntervalSec.ToString())) : RetryIntervalSec;
+                    int RetryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out IEnumerable<string> retryAfter)) ? Convert.ToInt32(retryAfter.FirstOrDefault(RetryIntervalSec.ToString())) : RetryIntervalSec;
 
                     string retryMessage = string.Format(
                         CultureInfo.CurrentCulture,
                         WebCmdletStrings.RetryVerboseMsg,
-                        WebSession.RetryIntervalInSeconds,
+                        RetryIntervalInSeconds,
                         response.StatusCode);
 
                     WriteVerbose(retryMessage);
 
                     _cancelToken = new CancellationTokenSource();
-                    Task.Delay(WebSession.RetryIntervalInSeconds * 1000, _cancelToken.Token).GetAwaiter().GetResult();
+                    Task.Delay(RetryIntervalInSeconds * 1000, _cancelToken.Token).GetAwaiter().GetResult();
                     _cancelToken.Cancel();
                     _cancelToken = null;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -689,6 +689,9 @@ namespace Microsoft.PowerShell.Commands
             if (MaximumRetryCount > 0)
             {
                 WebSession.MaximumRetryCount = MaximumRetryCount;
+
+                // Only set retry interval if retry count is set.
+                WebSession.RetryIntervalInSeconds = RetryIntervalSec;
             }
         }
 
@@ -1436,8 +1439,7 @@ namespace Microsoft.PowerShell.Commands
                 // When MaximumRetryCount is not specified, the totalRequests == 1.
                 if (totalRequests > 1 && ShouldRetry(response.StatusCode))
                 {
-                    // Only set retry interval if MaximumRetryCount is specified, if
-                    // the status code is 429 get the retry interval from the Headers.
+                    // If the status code is 429 get the retry interval from the Headers.
                     int retryIntervalInSeconds;
                     if ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out IEnumerable<string> retryAfter)) 
                     {
@@ -1449,12 +1451,12 @@ namespace Microsoft.PowerShell.Commands
                         }
                         catch
                         {
-                            retryIntervalInSeconds = RetryIntervalSec;
+                            retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
                         }
                     }
                     else
                     {
-                        retryIntervalInSeconds = RetryIntervalSec;
+                        retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
                     }
                     
                     string retryMessage = string.Format(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1439,10 +1439,20 @@ namespace Microsoft.PowerShell.Commands
                 // When MaximumRetryCount is not specified, the totalRequests == 1.
                 if (totalRequests > 1 && ShouldRetry(response.StatusCode))
                 {
+                    // If the status code is 429 get the retry interval from the Headers.
+                    if ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out var retryAfter)) 
+                    {
+                        WebSession.RetryIntervalInSeconds = Convert.ToInt32(retryAfter);
+                    }
+                    else
+                    {
+                        WebSession.RetryIntervalInSeconds = RetryIntervalSec;
+                    }
+
                     string retryMessage = string.Format(
                         CultureInfo.CurrentCulture,
                         WebCmdletStrings.RetryVerboseMsg,
-                        RetryIntervalSec,
+                        WebSession.RetryIntervalInSeconds,
                         response.StatusCode);
 
                     WriteVerbose(retryMessage);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1440,14 +1440,7 @@ namespace Microsoft.PowerShell.Commands
                 if (totalRequests > 1 && ShouldRetry(response.StatusCode))
                 {
                     // If the status code is 429 get the retry interval from the Headers.
-                    if ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out var retryAfter)) 
-                    {
-                        WebSession.RetryIntervalInSeconds = Convert.ToInt32(retryAfter);
-                    }
-                    else
-                    {
-                        WebSession.RetryIntervalInSeconds = RetryIntervalSec;
-                    }
+                    WebSession.RetryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out var retryAfter)) ? Convert.ToInt32(retryAfter) : RetryIntervalSec;
 
                     string retryMessage = string.Format(
                         CultureInfo.CurrentCulture,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1439,18 +1439,18 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // Only set retry interval if MaximumRetryCount is specified, if
                     // the status code is 429 get the retry interval from the Headers.
-                    int RetryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out IEnumerable<string> retryAfter)) ? Convert.ToInt32(retryAfter.FirstOrDefault(RetryIntervalSec.ToString())) : RetryIntervalSec;
+                    int retryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out IEnumerable<string> retryAfter)) ? Convert.ToInt32(retryAfter.FirstOrDefault(RetryIntervalSec.ToString())) : RetryIntervalSec;
 
                     string retryMessage = string.Format(
                         CultureInfo.CurrentCulture,
                         WebCmdletStrings.RetryVerboseMsg,
-                        RetryIntervalInSeconds,
+                        retryIntervalInSeconds,
                         response.StatusCode);
 
                     WriteVerbose(retryMessage);
 
                     _cancelToken = new CancellationTokenSource();
-                    Task.Delay(RetryIntervalInSeconds * 1000, _cancelToken.Token).GetAwaiter().GetResult();
+                    Task.Delay(retryIntervalInSeconds * 1000, _cancelToken.Token).GetAwaiter().GetResult();
                     _cancelToken.Cancel();
                     _cancelToken = null;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
 using System.Net;
 using System.Net.Http;
@@ -1440,7 +1441,7 @@ namespace Microsoft.PowerShell.Commands
                 if (totalRequests > 1 && ShouldRetry(response.StatusCode))
                 {
                     // If the status code is 429 get the retry interval from the Headers.
-                    WebSession.RetryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out var retryAfter)) ? Convert.ToInt32(retryAfter) : RetryIntervalSec;
+                    WebSession.RetryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out IEnumerable<string> retryAfter)) ? Convert.ToInt32(retryAfter.FirstOrDefault(RetryIntervalSec.ToString())) : RetryIntervalSec;
 
                     string retryMessage = string.Format(
                         CultureInfo.CurrentCulture,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -690,9 +690,6 @@ namespace Microsoft.PowerShell.Commands
             if (MaximumRetryCount > 0)
             {
                 WebSession.MaximumRetryCount = MaximumRetryCount;
-
-                // only set retry interval if retry count is set.
-                WebSession.RetryIntervalInSeconds = RetryIntervalSec;
             }
         }
 
@@ -1440,7 +1437,8 @@ namespace Microsoft.PowerShell.Commands
                 // When MaximumRetryCount is not specified, the totalRequests == 1.
                 if (totalRequests > 1 && ShouldRetry(response.StatusCode))
                 {
-                    // If the status code is 429 get the retry interval from the Headers.
+                    // Only set retry interval if MaximumRetryCount is specified, if
+                    // the status code is 429 get the retry interval from the Headers.
                     WebSession.RetryIntervalInSeconds = ((int)response.StatusCode == 429 && response.Headers.TryGetValues("Retry-After", out IEnumerable<string> retryAfter)) ? Convert.ToInt32(retryAfter.FirstOrDefault(RetryIntervalSec.ToString())) : RetryIntervalSec;
 
                     string retryMessage = string.Format(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1443,7 +1443,7 @@ namespace Microsoft.PowerShell.Commands
 
                     // If the status code is 429 get the retry interval from the Headers.
                     // Ignore broken header and its value.
-                    if ((int)response.StatusCode == HttpStatusCode.Conflict && response.Headers.TryGetValues(HttpKnownHeaderNames.RetryAfter, out IEnumerable<string> retryAfter)) 
+                    if (response.StatusCode is HttpStatusCode.Conflict && response.Headers.TryGetValues(HttpKnownHeaderNames.RetryAfter, out IEnumerable<string> retryAfter)) 
                     {
                         try 
                         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
If the Status Code is 429 it tries to get the `Retry-After` property from the headers and use it as `WebSession.RetryIntervalInSeconds`

(I decided to use an if-else instead of a ternary operator for better code readability)
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes #13188
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
