### PR TITLE
Use File.OpenHandle() instead CreateFileW pinvoke. Part 2

### DIFF
--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -190,26 +190,6 @@ namespace System.Management.Automation.Remoting
         internal const uint ERROR_IO_INCOMPLETE = 996;
         internal const uint ERROR_IO_PENDING = 997;
 
-        // File function constants
-        internal const uint GENERIC_READ = 0x80000000;
-        internal const uint GENERIC_WRITE = 0x40000000;
-        internal const uint GENERIC_EXECUTE = 0x20000000;
-        internal const uint GENERIC_ALL = 0x10000000;
-
-        internal const uint CREATE_NEW = 1;
-        internal const uint CREATE_ALWAYS = 2;
-        internal const uint OPEN_EXISTING = 3;
-        internal const uint OPEN_ALWAYS = 4;
-        internal const uint TRUNCATE_EXISTING = 5;
-
-        internal const uint SECURITY_IMPERSONATIONLEVEL_ANONYMOUS = 0;
-        internal const uint SECURITY_IMPERSONATIONLEVEL_IDENTIFICATION = 1;
-        internal const uint SECURITY_IMPERSONATIONLEVEL_IMPERSONATION = 2;
-        internal const uint SECURITY_IMPERSONATIONLEVEL_DELEGATION = 3;
-
-        // Infinite timeout
-        internal const uint INFINITE = 0xFFFFFFFF;
-
         #endregion
 
         #region Data structures

--- a/src/System.Management.Automation/utils/PlatformInvokes.cs
+++ b/src/System.Management.Automation/utils/PlatformInvokes.cs
@@ -677,17 +677,6 @@ namespace System.Management.Automation
         public static extern uint ResumeThread(IntPtr threadHandle);
 
         internal static readonly uint RESUME_THREAD_FAILED = System.UInt32.MaxValue; // (DWORD)-1
-
-        [DllImport(PinvokeDllNames.CreateFileDllName, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern System.IntPtr CreateFileW(
-            [In, MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
-            UInt32 dwDesiredAccess,
-            UInt32 dwShareMode,
-            SECURITY_ATTRIBUTES lpSecurityAttributes,
-            UInt32 dwCreationDisposition,
-            UInt32 dwFlagsAndAttributes,
-            System.IntPtr hTemplateFile);
-
 #endif
 
         #endregion


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Contributes to #18553.

1. Use File.OpenHandle() in RemoteSessionNamedPipe
2. Use File.OpenHandle() in RunspaceConnectionInfo

I cannot test the change.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
