### PR TITLE
Add `-CommandWithArgs` parameter to pwsh

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -174,6 +174,7 @@ namespace Microsoft.PowerShell
             "sta",
             "mta",
             "command",
+            "commandwithargs",
             "configurationname",
             "custompipename",
             "encodedcommand",
@@ -230,6 +231,7 @@ namespace Microsoft.PowerShell
             WorkingDirectory    = 0x02000000, // -WorkingDirectory | -wd
             ConfigurationFile   = 0x04000000, // -ConfigurationFile
             NoProfileLoadTime   = 0x08000000, // -NoProfileLoadTime
+            CommandWithArgs     = 0x10000000, // -CommandWithArgs | -cwa
             // Enum values for specified ExecutionPolicy
             EPUnrestricted      = 0x0000000100000000, // ExecutionPolicy unrestricted
             EPRemoteSigned      = 0x0000000200000000, // ExecutionPolicy remote signed
@@ -998,6 +1000,19 @@ namespace Microsoft.PowerShell
                     _customPipeName = args[i];
                     ParametersUsed |= ParameterBitmap.CustomPipeName;
                 }
+                else if (MatchSwitch(switchKey, "commandwithargs", "commandwithargs") || MatchSwitch(switchKey, "cwa", "cwa"))
+                {
+                    _commandHasArgs = true;
+
+                    if (!ParseCommand(args, ref i, noexitSeen, false))
+                    {
+                        break;
+                    }
+
+                    i++;
+                    CollectPSArgs(args, ref i);
+                    ParametersUsed |= ParameterBitmap.CommandWithArgs;
+                }
                 else if (MatchSwitch(switchKey, "command", "c"))
                 {
                     if (!ParseCommand(args, ref i, noexitSeen, false))
@@ -1250,15 +1265,6 @@ namespace Microsoft.PowerShell
         // treat -command as an argument to the script...
         private bool ParseFile(string[] args, ref int i, bool noexitSeen)
         {
-            // Try parse '$true', 'true', '$false' and 'false' values.
-            static object ConvertToBoolIfPossible(string arg)
-            {
-                // Before parsing we skip '$' if present.
-                return arg.Length > 0 && bool.TryParse(arg.AsSpan(arg[0] == '$' ? 1 : 0), out bool boolValue)
-                    ? (object)boolValue
-                    : (object)arg;
-            }
-
             ++i;
             if (i >= args.Length)
             {
@@ -1346,51 +1352,64 @@ namespace Microsoft.PowerShell
 
                 i++;
 
-                string? pendingParameter = null;
+                CollectPSArgs(args, ref i);
+            }
 
-                // Accumulate the arguments to this script...
-                while (i < args.Length)
+            return true;
+        }
+
+        private void CollectPSArgs(string[] args, ref int i)
+        {
+            // Try parse '$true', 'true', '$false' and 'false' values.
+            static object ConvertToBoolIfPossible(string arg)
+            {
+                // Before parsing we skip '$' if present.
+                return arg.Length > 0 && bool.TryParse(arg.AsSpan(arg[0] == '$' ? 1 : 0), out bool boolValue)
+                    ? (object)boolValue
+                    : (object)arg;
+            }
+
+            string? pendingParameter = null;
+
+            while (i < args.Length)
+            {
+                string arg = args[i];
+
+                // If there was a pending parameter, add a named parameter
+                // using the pending parameter and current argument
+                if (pendingParameter != null)
                 {
-                    string arg = args[i];
-
-                    // If there was a pending parameter, add a named parameter
-                    // using the pending parameter and current argument
-                    if (pendingParameter != null)
+                    _collectedArgs.Add(new CommandParameter(pendingParameter, arg));
+                    pendingParameter = null;
+                }
+                else if (!string.IsNullOrEmpty(arg) && CharExtensions.IsDash(arg[0]) && arg.Length > 1)
+                {
+                    int offset = arg.IndexOf(':');
+                    if (offset >= 0)
                     {
-                        _collectedArgs.Add(new CommandParameter(pendingParameter, arg));
-                        pendingParameter = null;
-                    }
-                    else if (!string.IsNullOrEmpty(arg) && CharExtensions.IsDash(arg[0]) && arg.Length > 1)
-                    {
-                        int offset = arg.IndexOf(':');
-                        if (offset >= 0)
+                        if (offset == arg.Length - 1)
                         {
-                            if (offset == arg.Length - 1)
-                            {
-                                pendingParameter = arg.TrimEnd(':');
-                            }
-                            else
-                            {
-                                string argValue = arg.Substring(offset + 1);
-                                string argName = arg.Substring(0, offset);
-                                _collectedArgs.Add(new CommandParameter(argName, ConvertToBoolIfPossible(argValue)));
-                            }
+                            pendingParameter = arg.TrimEnd(':');
                         }
                         else
                         {
-                            _collectedArgs.Add(new CommandParameter(arg));
+                            string argValue = arg.Substring(offset + 1);
+                            string argName = arg.Substring(0, offset);
+                            _collectedArgs.Add(new CommandParameter(argName, ConvertToBoolIfPossible(argValue)));
                         }
                     }
                     else
                     {
-                        _collectedArgs.Add(new CommandParameter(null, arg));
+                        _collectedArgs.Add(new CommandParameter(arg));
                     }
-
-                    ++i;
                 }
-            }
+                else
+                {
+                    _collectedArgs.Add(new CommandParameter(null, arg));
+                }
 
-            return true;
+                ++i;
+            }
         }
 
         private bool ParseCommand(string[] args, ref int i, bool noexitSeen, bool isEncoded)
@@ -1446,23 +1465,30 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                // Collect the remaining parameters and combine them into a single command to be run.
-
-                StringBuilder cmdLineCmdSB = new StringBuilder();
-
-                while (i < args.Length)
+                if (_commandHasArgs)
                 {
-                    cmdLineCmdSB.Append(args[i] + " ");
-                    ++i;
+                    _commandLineCommand = args[i];
                 }
-
-                if (cmdLineCmdSB.Length > 0)
+                else
                 {
-                    // remove the last blank
-                    cmdLineCmdSB.Remove(cmdLineCmdSB.Length - 1, 1);
-                }
+                    // Collect the remaining parameters and combine them into a single command to be run.
 
-                _commandLineCommand = cmdLineCmdSB.ToString();
+                    StringBuilder cmdLineCmdSB = new StringBuilder();
+
+                    while (i < args.Length)
+                    {
+                        cmdLineCmdSB.Append(args[i] + " ");
+                        ++i;
+                    }
+
+                    if (cmdLineCmdSB.Length > 0)
+                    {
+                        // remove the last blank
+                        cmdLineCmdSB.Remove(cmdLineCmdSB.Length - 1, 1);
+                    }
+
+                    _commandLineCommand = cmdLineCmdSB.ToString();
+                }
             }
 
             if (!noexitSeen && !_explicitReadCommandsFromStdin)
@@ -1534,6 +1560,7 @@ namespace Microsoft.PowerShell
         private bool _noPrompt;
         private string? _commandLineCommand;
         private bool _wasCommandEncoded;
+        private bool _commandHasArgs = false;
         private uint _exitCode = ConsoleHost.ExitCodeSuccess;
         private bool _dirty;
         private Serialization.DataFormat _outFormat = Serialization.DataFormat.Text;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1471,7 +1471,8 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    _commandLineCommand = string.Join(' ', args, i, args.Length - i);                
+                    _commandLineCommand = string.Join(' ', args, i, args.Length - i);
+                    i = args.Length;
                 }
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1560,7 +1560,7 @@ namespace Microsoft.PowerShell
         private bool _noPrompt;
         private string? _commandLineCommand;
         private bool _wasCommandEncoded;
-        private bool _commandHasArgs = false;
+        private bool _commandHasArgs;
         private uint _exitCode = ConsoleHost.ExitCodeSuccess;
         private bool _dirty;
         private Serialization.DataFormat _outFormat = Serialization.DataFormat.Text;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1471,23 +1471,7 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    // Collect the remaining parameters and combine them into a single command to be run.
-
-                    StringBuilder cmdLineCmdSB = new StringBuilder();
-
-                    while (i < args.Length)
-                    {
-                        cmdLineCmdSB.Append(args[i] + " ");
-                        ++i;
-                    }
-
-                    if (cmdLineCmdSB.Length > 0)
-                    {
-                        // remove the last blank
-                        cmdLineCmdSB.Remove(cmdLineCmdSB.Length - 1, 1);
-                    }
-
-                    _commandLineCommand = cmdLineCmdSB.ToString();
+                    _commandLineCommand = string.Join(' ', args, i, args.Length - i);                
                 }
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandAlreadySpecified" xml:space="preserve">
-    <value>Cannot process command because a command is already specified with -Command or -EncodedCommand.</value>
+    <value>Cannot process command because a command is already specified with -Command, -CommandWithArgs, or -EncodedCommand.</value>
   </data>
   <data name="MissingCommandParameter" xml:space="preserve">
     <value>Cannot process the command because of a missing parameter. A command must follow -Command.</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -284,6 +284,7 @@ All parameters are case-insensitive.</value>
 
 -CommandWithArgs | -cwa
 
+    [Experimental]
     Executes a PowerShell command with arguments.  Unlike `-Command`, this
     parameter populates the `$args built-in variable which can be used by the
     command.

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -145,6 +145,7 @@
     <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
                   [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]
                                 | &lt;string&gt; [&lt;CommandParameters&gt;] } ]
+                  [-CommandWithArgs &lt;string&gt; [&lt;CommandParameters&gt;]
                   [-ConfigurationName &lt;string&gt;] [-ConfigurationFile &lt;filePath&gt;]
                   [-CustomPipeName &lt;string&gt;] [-EncodedCommand &lt;Base64EncodedCommand&gt;]
                   [-ExecutionPolicy &lt;ExecutionPolicy&gt;] [-InputFormat {Text | XML}]
@@ -280,6 +281,24 @@ All parameters are case-insensitive.</value>
     Similarly, the value 1 is returned when a script-terminating
     (runspace-terminating) error, such as a throw or -ErrorAction Stop, occurs
     or when execution is interrupted with Ctrl-C.
+
+-CommandWithArgs | -cwa
+
+    Executes a PowerShell command with arguments.  Unlike `-Command`, this
+    parameter populates the `$args built-in variable which can be used by the
+    command.
+
+    The first string is the command and subsequent strings delimited by whitespace
+    are the arguments.
+
+    For example:
+
+        pwsh -CommandWithArgs '$args | % { "arg: $_" }' arg1 arg2
+
+    This example produces the following output:
+
+        arg: arg1
+        arg: arg2
 
 -ConfigurationName | -config
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -25,6 +25,7 @@ namespace System.Management.Automation
         internal const string PSModuleAutoLoadSkipOfflineFilesFeatureName = "PSModuleAutoLoadSkipOfflineFiles";
         internal const string PSCustomTableHeaderLabelDecoration = "PSCustomTableHeaderLabelDecoration";
         internal const string PSFeedbackProvider = "PSFeedbackProvider";
+        internal const string PSCommandWithArgs = "PSCommandWithArgs";
 
         #endregion
 
@@ -128,6 +129,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSFeedbackProvider,
                     description: "Replace the hard-coded suggestion framework with the extensible feedback provider"),
+                new ExperimentalFeature(
+                    name: PSCommandWithArgs,
+                    description: "Enable `-CommandWithArgs` parameter for pwsh"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -917,6 +917,28 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
             $out[0] | Should -MatchExactly $expectedPromptPattern
         }
     }
+
+    Context 'CommandWithArgs tests' {
+        It 'Should be able to run a pipeline with arguments using <param>' -TestCases @(
+            @{ param = '-commandwithargs' }
+            @{ param = '-cwa' }
+        ){
+            param($param)
+            $out = pwsh -nologo -noprofile $param '$args | % { "[$_]" }'  '$fun' '@times'
+            $out.Count | Should -Be 2 -Because ($out | Out-String)
+            $out[0] | Should -BeExactly '[$fun]'
+            $out[1] | Should -BeExactly '[@times]'
+        }
+
+        It 'Should be able to handle boolean switch: <param>' -TestCases @(
+            @{ param = '-switch:$true'; expected = 'True'}
+            @{ param = '-switch:$false'; expected = 'False'}
+        ){
+            param($param, $expected)
+            $out = pwsh -nologo -noprofile -cwa 'param([switch]$switch) $switch.IsPresent' $param
+            $out | Should -Be $expected
+        }
+    }
 }
 
 Describe "WindowStyle argument" -Tag Feature {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There are situations where you want to run a PS pipeline from `pwsh -c`, but need to provide arguments.  This adds a new `-CommandWithArgs` parameter where the first string is the command and subsequent space delimited strings are arguments.

This is advertised as an Experimental Feature, but is not code fenced.  It reuses the arg parsing logic as `-File` so that switch parameters can be turned off.  This makes the diff look a bit more complex than it is as the arg parsing code was moved from `ParseFile()` to a separate `CollectPSArgs()` method.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/15417

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): <!-- Experimental feature name(s) here -->`PSCommandWithArgs`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9529
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
