### PR TITLE
WebSession.MaximumRetryCount and WebSession.MaximumRedirection to local variable

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -685,14 +685,9 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-
-            if (MaximumRetryCount > 0)
-            {
-                WebSession.MaximumRetryCount = MaximumRetryCount;
-
-                // only set retry interval if retry count is set.
-                WebSession.RetryIntervalInSeconds = RetryIntervalSec;
-            }
+            //will be removed after merging #18717
+            // only set retry interval if retry count is set.
+            WebSession.RetryIntervalInSeconds = RetryIntervalSec;
         }
 
         #endregion Virtual Methods
@@ -1346,7 +1341,7 @@ namespace Microsoft.PowerShell.Commands
             int intCode = (int)code;
             return
             (
-                (intCode == 304 || (intCode >= 400 && intCode <= 599)) && WebSession.MaximumRetryCount > 0
+                (intCode == 304 || (intCode >= 400 && intCode <= 599)) && MaximumRetryCount > 0
             );
         }
 
@@ -1357,7 +1352,7 @@ namespace Microsoft.PowerShell.Commands
             if (request == null) { throw new ArgumentNullException(nameof(request)); }
 
             // Add 1 to account for the first request.
-            int totalRequests = WebSession.MaximumRetryCount + 1;
+            int totalRequests = MaximumRetryCount + 1;
             HttpRequestMessage req = request;
             HttpResponseMessage response = null;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -685,7 +685,8 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-            //will be removed after merging #18717
+            
+            // will be removed after merging #18717
             // only set retry interval if retry count is set.
             WebSession.RetryIntervalInSeconds = RetryIntervalSec;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -657,11 +657,6 @@ namespace Microsoft.PowerShell.Commands
                 WebSession.Proxy = webProxy;
             }
 
-            if (MaximumRedirection > -1)
-            {
-                WebSession.MaximumRedirection = MaximumRedirection;
-            }
-
             // store the other supplied headers
             if (Headers != null)
             {
@@ -1021,15 +1016,15 @@ namespace Microsoft.PowerShell.Commands
             {
                 handler.AllowAutoRedirect = false;
             }
-            else if (WebSession.MaximumRedirection > -1)
+            else if (MaximumRedirection > -1)
             {
-                if (WebSession.MaximumRedirection == 0)
+                if (MaximumRedirection == 0)
                 {
                     handler.AllowAutoRedirect = false;
                 }
                 else
                 {
-                    handler.MaxAutomaticRedirections = WebSession.MaximumRedirection;
+                    handler.MaxAutomaticRedirections = MaximumRedirection;
                 }
             }
 
@@ -1364,9 +1359,9 @@ namespace Microsoft.PowerShell.Commands
                     _cancelToken = null;
 
                     // if explicit count was provided, reduce it for this redirection.
-                    if (WebSession.MaximumRedirection > 0)
+                    if (MaximumRedirection > 0)
                     {
-                        WebSession.MaximumRedirection--;
+                        MaximumRedirection--;
                     }
                     // For selected redirects that used POST, GET must be used with the
                     // redirected Location.
@@ -1582,7 +1577,7 @@ namespace Microsoft.PowerShell.Commands
                                 // Errors with redirection counts of greater than 0 are handled automatically by .NET, but are
                                 // impossible to detect programmatically when we hit this limit. By handling this ourselves
                                 // (and still writing out the result), users can debug actual HTTP redirect problems.
-                                if (WebSession.MaximumRedirection == 0 && IsRedirectCode(response.StatusCode)) // Indicate "HttpClientHandler.AllowAutoRedirect == false"
+                                if (MaximumRedirection == 0 && IsRedirectCode(response.StatusCode)) // Indicate "HttpClientHandler.AllowAutoRedirect == false"
                                 {
                                     ErrorRecord er = new(new InvalidOperationException(), "MaximumRedirectExceeded", ErrorCategory.InvalidOperation, request);
                                     er.ErrorDetails = new ErrorDetails(WebCmdletStrings.MaximumRedirectionCountExceeded);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -237,14 +237,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateRange(0, int.MaxValue)]
-        public virtual int MaximumRedirection
-        {
-            get { return _maximumRedirection; }
-
-            set { _maximumRedirection = value; }
-        }
-
-        private int _maximumRedirection = -1;
+        public virtual int MaximumRedirection { get; set; } = -1;
 
         /// <summary>
         /// Gets or sets the MaximumRetryCount property, which determines the number of retries of a failed web request.
@@ -685,7 +678,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-            
+
             // will be removed after merging #18717
             // only set retry interval if retry count is set.
             WebSession.RetryIntervalInSeconds = RetryIntervalSec;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
`WebSession.MaximumRedirection` and `WebSession.MaximumRetryCount` are now replaced by a local variable in Webcmdlets as briefly discussed in #18717.
Must be merged after #18717

*The name of the first commit should have been `WebSession.MaximumRetryCount to local variable`
