### PR TITLE
Telemetry improvements for tracking experimental feature optout

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -214,8 +214,9 @@ namespace System.Management.Automation
                 }
             }
 
-            SendTelemetryForDeactivatedFeatures(list);
-            return new ReadOnlyBag<string>(new HashSet<string>(list, StringComparer.OrdinalIgnoreCase));
+            ReadOnlyBag<string> features = new(new HashSet<string>(list, StringComparer.OrdinalIgnoreCase));
+            SendTelemetryForDeactivatedFeatures(features);
+            return features;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -205,14 +205,14 @@ namespace System.Management.Automation
                     {
                         string message = StringUtil.Format(Logging.EngineExperimentalFeatureNotFound, name);
                         LogError(PSEventId.ExperimentalFeature_InvalidName, name, message);
-                        ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalFeatureInvalid, name);
+                        ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalFeatureInvalid, "InvalidName");
                     }
                 }
                 else
                 {
                     string message = StringUtil.Format(Logging.InvalidExperimentalFeatureName, name);
                     LogError(PSEventId.ExperimentalFeature_InvalidName, name, message);
-                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalFeatureInvalid, name);
+                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalFeatureInvalid, "InvalidName");
                 }
             }
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -157,20 +157,15 @@ namespace System.Management.Automation
             EnabledExperimentalFeatureNames = ProcessEnabledFeatures(enabledFeatures);
         }
 
-        /// <summary>temp variable for debugging/summary>
-        public static int deactivationCount { get; set; } = 0;
-
         /// <summary>
         /// We need to notify which features were not enabled.
         /// </summary>
-        private static void SendTelemetryForDeactivatedFeatures(List<string> enabledFeatures)
+        private static void SendTelemetryForDeactivatedFeatures(ReadOnlyBag<string> enabledFeatures)
         {
-            var features = new HashSet<string>(enabledFeatures, StringComparer.OrdinalIgnoreCase);
             foreach (var feature in EngineExperimentalFeatures)
             {
-                if (!features.Contains(feature.Name))
+                if (!enabledFeatures.Contains(feature.Name))
                 {
-                    deactivationCount++;
                     ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalEngineFeatureDeactivation, feature.Name);
                 }
             }

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -205,14 +205,12 @@ namespace System.Management.Automation
                     {
                         string message = StringUtil.Format(Logging.EngineExperimentalFeatureNotFound, name);
                         LogError(PSEventId.ExperimentalFeature_InvalidName, name, message);
-                        ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalFeatureInvalid, "InvalidName");
                     }
                 }
                 else
                 {
                     string message = StringUtil.Format(Logging.InvalidExperimentalFeatureName, name);
                     LogError(PSEventId.ExperimentalFeature_InvalidName, name, message);
-                    ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalFeatureInvalid, "InvalidName");
                 }
             }
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -18,8 +18,8 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Xml;
-using Dbg = System.Management.Automation.Diagnostics;
 using Microsoft.PowerShell.Telemetry;
+using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation
 {
@@ -964,6 +964,7 @@ namespace System.Management.Automation
         /// <summary>
         /// We need to send the telemetry as to whether the user has set the variable, and if so, what the value is.
         /// </summary>
+        /// <param name="detail">The details of the ErrorActionPreference setting.</param>
         private static void TelemetrySendUseData(string detail)
         {
             ApplicationInsightsTelemetry.SendTelemetryMetric(

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -894,12 +894,12 @@ namespace System.Management.Automation
                     // The variable is unset
                     if (useDefaultSetting)
                     {
-                        TelemetrySendUseData("unset");
+                        ApplicationInsightsTelemetry.SendExperimentalUseData(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName, "unset");
                         return;
                     }
 
                     // Send the value that was set.
-                    TelemetrySendUseData(nativeErrorActionPreferenceSetting.ToString());
+                    ApplicationInsightsTelemetry.SendExperimentalUseData(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName, nativeErrorActionPreferenceSetting.ToString());
 
                     // if it was explicitly set to false, return
                     if (!nativeErrorActionPreferenceSetting)
@@ -959,17 +959,6 @@ namespace System.Management.Automation
 
                 throw appFailedException;
             }
-        }
-
-        /// <summary>
-        /// We need to send the telemetry as to whether the user has set the variable, and if so, what the value is.
-        /// </summary>
-        /// <param name="detail">The details of the ErrorActionPreference setting.</param>
-        private static void TelemetrySendUseData(string detail)
-        {
-            ApplicationInsightsTelemetry.SendTelemetryMetric(
-                TelemetryType.ExperimentalFeatureUse,
-                ApplicationInsightsTelemetry.GetExperimentalFeatureUseData(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName, detail));
         }
 
         #region Process cleanup with Child Process cleanup

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -3,7 +3,6 @@
 
 #pragma warning disable 1634, 1691
 
-using Microsoft.PowerShell.Telemetry;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -20,6 +19,7 @@ using System.Text;
 using System.Threading;
 using System.Xml;
 using Dbg = System.Management.Automation.Diagnostics;
+using Microsoft.PowerShell.Telemetry;
 
 namespace System.Management.Automation
 {
@@ -885,22 +885,24 @@ namespace System.Management.Automation
                     // - The variable is not present
                     // - The value is not set (variable is null)
                     // - The value is set to true or false
-                    bool UseDefaultSetting;
-                    bool NativeErrorActionPreferenceSetting = Command.Context.GetBooleanPreference(
+                    bool useDefaultSetting;
+                    bool nativeErrorActionPreferenceSetting = Command.Context.GetBooleanPreference(
                         SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
                         defaultPref: false,
-                        out UseDefaultSetting);
+                        out useDefaultSetting);
+
                     // The variable is unset
-                    if (UseDefaultSetting)
+                    if (useDefaultSetting)
                     {
                         TelemetrySendUseData("unset");
                         return;
                     }
 
                     // Send the value that was set.
-                    TelemetrySendUseData(NativeErrorActionPreferenceSetting.ToString());
-                    // if false, return
-                    if (!NativeErrorActionPreferenceSetting)
+                    TelemetrySendUseData(nativeErrorActionPreferenceSetting.ToString());
+
+                    // if it was explicitly set to false, return
+                    if (!nativeErrorActionPreferenceSetting)
                     {
                         return;
                     }
@@ -961,13 +963,12 @@ namespace System.Management.Automation
 
         /// <summary>
         /// We need to send the telemetry as to whether the user has set the variable, and if so, what the value is.
-        /// <summary>
+        /// </summary>
         private static void TelemetrySendUseData(string detail)
         {
             ApplicationInsightsTelemetry.SendTelemetryMetric(
                 TelemetryType.ExperimentalFeatureUse,
-                ApplicationInsightsTelemetry.GetExperimentalFeatureUseData(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName, detail)
-                );
+                ApplicationInsightsTelemetry.GetExperimentalFeatureUseData(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName, detail));
         }
 
         #region Process cleanup with Child Process cleanup

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -743,8 +743,8 @@ namespace Microsoft.PowerShell.Telemetry
         /// <summary>
         /// Send additional information about an experimental feature as it is used.
         /// </summary>
-        /// <param name="detail">The name of the experimental feature.</param>
-        /// <param name="featureName">The details of the experimental feature.</param>
+        /// <param name="featureName">The name of the experimental feature.</param>
+        /// <param name="detail">The details about the experimental feature use.</param>
         internal static void SendExperimentalUseData(string featureName, string detail)
         {
             if (!CanSendTelemetry)
@@ -971,6 +971,5 @@ namespace Microsoft.PowerShell.Telemetry
             CanSendTelemetry = false;
             return id;
         }
-
     }
 }

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.Telemetry
                 configuration.ConnectionString = "InstrumentationKey=" + _psCoreTelemetryKey;
 
                 // Set this to true to reduce latency during development
-                configuration.TelemetryChannel.DeveloperMode = true;
+                configuration.TelemetryChannel.DeveloperMode = false;
 
                 // Be sure to obscure any information about the client node name.
                 configuration.TelemetryInitializers.Add(new NameObscurerTelemetryInitializer());

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -807,6 +807,7 @@ namespace Microsoft.PowerShell.Telemetry
             properties.Add("UUID", s_uniqueUserIdentifier);
             properties.Add("GitCommitID", PSVersionInfo.GitCommitId);
             properties.Add("OSDescription", RuntimeInformation.OSDescription);
+            properties.Add("RuntimeIdentifier", RuntimeInformation.RuntimeIdentifier);
             properties.Add("OSChannel", string.IsNullOrEmpty(channel) ? "unknown" : channel);
             properties.Add("StartMode", string.IsNullOrEmpty(mode) ? "unknown" : mode);
 

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -150,7 +150,7 @@ namespace Microsoft.PowerShell.Telemetry
         private static readonly HashSet<string> s_knownModules;
 
         /// <summary>Gets a value indicating whether telemetry can be sent.</summary>
-        public static bool CanSendTelemetry { get; private set; }
+        public static bool CanSendTelemetry { get; private set; } = false;
 
         /// <summary>
         /// Initializes static members of the <see cref="ApplicationInsightsTelemetry"/> class.
@@ -746,6 +746,21 @@ namespace Microsoft.PowerShell.Telemetry
             }
         }
 
+        /// <summary>
+        /// Send additional information about an experimental feature as it is used.
+        /// </summary>
+        /// <param name="detail">The name of the experimental feature.</param>
+        /// <param name="featureName">The details of the experimental feature.</param>
+        internal static void SendExperimentalUseData(string featureName, string detail)
+        {
+            if (!CanSendTelemetry)
+            {
+                return;
+            }
+
+            ApplicationInsightsTelemetry.SendTelemetryMetric(TelemetryType.ExperimentalFeatureUse, string.Join(":", featureName, detail));
+        }
+
         // Get the experimental feature name. If we can report it, we'll return the name of the feature, otherwise, we'll return "anonymous"
         private static string GetExperimentalFeatureName(string featureNameToValidate)
         {
@@ -963,17 +978,5 @@ namespace Microsoft.PowerShell.Telemetry
             return id;
         }
 
-        /// <summary>
-        /// Construct a string which represents the experimental feature use.
-        /// This takes the feature name and the detail and joins them with a colon
-        /// so they can be deconstructed in the telemetry queries.
-        /// </summary>
-        /// <param name="feature">The name of the experimental feature.</param>
-        /// <param name="detail">The detail of the experimental feature.</param>
-        /// <returns>A string which represents the experimental feature use.</returns>
-        public static string GetExperimentalFeatureUseData(string feature, string detail)
-        {
-            return string.Join(":", feature, detail);
-        }
     }
 }

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -51,11 +51,6 @@ namespace Microsoft.PowerShell.Telemetry
         ExperimentalEngineFeatureActivation,
 
         /// <summary>
-        /// Send telemetry for an invalid experimental name.
-        /// </summary>
-        ExperimentalFeatureInvalid,
-
-        /// <summary>
         /// Send telemetry for an experimental feature when use.
         /// </summary>
         ExperimentalFeatureUse,
@@ -728,7 +723,6 @@ namespace Microsoft.PowerShell.Telemetry
                     case TelemetryType.RemoteSessionOpen:
                     case TelemetryType.ExperimentalEngineFeatureActivation:
                     case TelemetryType.ExperimentalEngineFeatureDeactivation:
-                    case TelemetryType.ExperimentalFeatureInvalid:
                     case TelemetryType.ExperimentalFeatureUse:
                         s_telemetryClient.GetMetric(metricName, "uuid", "SessionId", "Detail").TrackValue(metricValue: 1.0, s_uniqueUserIdentifier, s_sessionId, data);
                         break;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add new telemetry types to track experimental feature optout better.
Add a GetExperimentalFeatureUseData to provide a consistent way to track feature and details. Add telemetry to PSNativeCommandUseErrorActionPreference so we can track the actual values in use.
This also provides better tracking for experimental features and now tracks 2 states:
- Enabled
- Disabled

Also, we will now collect `RuntimeInformation.RuntimeIdentifier` which allows better clarity on our Docker use since OSDescription is information about the Host OS rather than the guest.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

We don't currently have an easy way of determining which experimental features are not enabled.
We also don't have _any_ way of determining whether a feature is actually being used. This PR
provides actual setting of PSNativeCommandUseErrorActionPreference (true/false/unset) to help us determine how much this feature is being used.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
