### PR TITLE
Set PSScriptRoot to PWD when it's null

### DIFF
--- a/src/System.Management.Automation/engine/InvocationInfo.cs
+++ b/src/System.Management.Automation/engine/InvocationInfo.cs
@@ -294,7 +294,7 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    return string.Empty;
+                    return MyCommand.Context.SessionState.Path.CurrentFileSystemLocation.ProviderPath;
                 }
             }
         }

--- a/src/System.Management.Automation/engine/InvocationInfo.cs
+++ b/src/System.Management.Automation/engine/InvocationInfo.cs
@@ -294,7 +294,7 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    return MyCommand.Context.SessionState.Path.CurrentFileSystemLocation.ProviderPath;
+                    return string.Empty;
                 }
             }
         }

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -1075,7 +1075,22 @@ namespace System.Management.Automation
             string psCommandPath;
             if (string.IsNullOrEmpty(File))
             {
-                psScriptRoot = context.SessionState.Path.CurrentFileSystemLocation.ProviderPath;
+                if (context.SessionState.Provider.Count == 0)
+                {
+                    psScriptRoot = string.Empty;
+                }
+                else
+                {
+                    try
+                    {
+                        psScriptRoot = context.SessionState.Path.CurrentFileSystemLocation.ProviderPath;
+                    }
+                    catch
+                    {
+                        psScriptRoot = string.Empty;
+                    }
+                }
+                
                 psCommandPath = string.Empty;
             }
             else

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -1071,9 +1071,14 @@ namespace System.Management.Automation
 
         internal void SetPSScriptRootAndPSCommandPath(MutableTuple locals, ExecutionContext context)
         {
-            var psScriptRoot = string.Empty;
-            var psCommandPath = string.Empty;
-            if (!string.IsNullOrEmpty(File))
+            string psScriptRoot;
+            string psCommandPath;
+            if (string.IsNullOrEmpty(File))
+            {
+                psScriptRoot = context.SessionState.Path.CurrentFileSystemLocation.ProviderPath;
+                psCommandPath = string.Empty;
+            }
+            else
             {
                 psScriptRoot = Path.GetDirectoryName(File);
                 psCommandPath = File;

--- a/test/powershell/Language/Parser/AutomaticVariables.Tests.ps1
+++ b/test/powershell/Language/Parser/AutomaticVariables.Tests.ps1
@@ -20,7 +20,9 @@ Describe 'Automatic variable $input' -Tags "CI" {
         & { [cmdletbinding()]param() process { @($input).Count } } | Should -Be 0
         & { [cmdletbinding()]param() end { @($input).Count } } | Should -Be 0
     }
+}
 
+Describe 'Automatic variable $PSScriptRoot' -Tags "CI" {
     It '$PSScriptRoot is the same as $PWD when not running from a script file' {
         [powershell]::Create().AddScript("Set-Location -LiteralPath $($PWD.ProviderPath); `$PSScriptRoot").Invoke()[0] | Should -Be $PWD.ProviderPath
     }

--- a/test/powershell/Language/Parser/AutomaticVariables.Tests.ps1
+++ b/test/powershell/Language/Parser/AutomaticVariables.Tests.ps1
@@ -20,4 +20,8 @@ Describe 'Automatic variable $input' -Tags "CI" {
         & { [cmdletbinding()]param() process { @($input).Count } } | Should -Be 0
         & { [cmdletbinding()]param() end { @($input).Count } } | Should -Be 0
     }
+
+    It '$PSScriptRoot is the same as $PWD when not running from a script file' {
+        [powershell]::Create().AddScript("Set-Location -LiteralPath $($PWD.ProviderPath); `$PSScriptRoot").Invoke()[0] | Should -Be $PWD.ProviderPath
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes https://github.com/PowerShell/PowerShell/issues/9089
This hasn't been discussed since 2019, hopefully this PR can make it easier to test and come to a conclusion.
Personally I'm very much in favor of this because I always select sections of my code and press F8 to run them but that doesn't work with `$PSScriptRoot`.
Now that PS 7.3 has been released it could be a good idea to get this merged ASAP and listen for feedback for the 7.4 previews.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
