### PR TITLE
Preserve content with Get-AuthenticodeSignature

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/SignatureCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SignatureCommands.cs
@@ -294,7 +294,7 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         protected override Signature PerformAction(string sourcePathOrExtension, byte[] content)
         {
-            return SignatureHelper.GetSignature(sourcePathOrExtension, System.Text.Encoding.Unicode.GetString(content));
+            return SignatureHelper.GetSignature(sourcePathOrExtension, content);
         }
     }
 

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -534,22 +534,33 @@ namespace Microsoft.PowerShell
 
             // try harder to validate the signature by being explicit about encoding
             // and providing the script contents
-            string verificationContents = Encoding.Unicode.GetString(script.OriginalEncoding.GetPreamble()) + script.ScriptContents;
-            signature = SignatureHelper.GetSignature(path, Encoding.Unicode.GetBytes(verificationContents));
+            byte[] bytesWithBom = GetContentBytesWithBom(script.OriginalEncoding, script.ScriptContents);
+            signature = SignatureHelper.GetSignature(path, bytesWithBom);
 
             // A last ditch effort -
             // If the file was originally ASCII or UTF8, the SIP may have added the Unicode BOM
             if (signature.Status != SignatureStatus.Valid
                 && script.OriginalEncoding != Encoding.Unicode)
             {
-                verificationContents = Encoding.Unicode.GetString(Encoding.Unicode.GetPreamble()) + script.ScriptContents;
-                Signature fallbackSignature = SignatureHelper.GetSignature(path, Encoding.Unicode.GetBytes(verificationContents));
+                bytesWithBom = GetContentBytesWithBom(Encoding.Unicode, script.ScriptContents);
+                Signature fallbackSignature = SignatureHelper.GetSignature(path, bytesWithBom);
 
                 if (fallbackSignature.Status == SignatureStatus.Valid)
                     signature = fallbackSignature;
             }
 
             return signature;
+        }
+
+        private static byte[] GetContentBytesWithBom(Encoding encoding, string scriptContent)
+        {
+            ReadOnlySpan<byte> bomBytes = encoding.Preamble;
+            byte[] contentBytes = encoding.GetBytes(scriptContent);
+            byte[] bytesWithBom = new byte[bomBytes.Length + contentBytes.Length];
+
+            bomBytes.CopyTo(bytesWithBom);
+            contentBytes.CopyTo(bytesWithBom, index: bomBytes.Length);
+            return bytesWithBom;
         }
 
         #endregion signing check

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -535,7 +535,7 @@ namespace Microsoft.PowerShell
             // try harder to validate the signature by being explicit about encoding
             // and providing the script contents
             string verificationContents = Encoding.Unicode.GetString(script.OriginalEncoding.GetPreamble()) + script.ScriptContents;
-            signature = SignatureHelper.GetSignature(path, verificationContents);
+            signature = SignatureHelper.GetSignature(path, Encoding.Unicode.GetBytes(verificationContents));
 
             // A last ditch effort -
             // If the file was originally ASCII or UTF8, the SIP may have added the Unicode BOM
@@ -543,7 +543,7 @@ namespace Microsoft.PowerShell
                 && script.OriginalEncoding != Encoding.Unicode)
             {
                 verificationContents = Encoding.Unicode.GetString(Encoding.Unicode.GetPreamble()) + script.ScriptContents;
-                Signature fallbackSignature = SignatureHelper.GetSignature(path, verificationContents);
+                Signature fallbackSignature = SignatureHelper.GetSignature(path, Encoding.Unicode.GetBytes(verificationContents));
 
                 if (fallbackSignature.Status == SignatureStatus.Valid)
                     signature = fallbackSignature;

--- a/test/powershell/engine/Security/FileSignature.Tests.ps1
+++ b/test/powershell/engine/Security/FileSignature.Tests.ps1
@@ -20,3 +20,151 @@ Describe "Windows platform file signatures" -Tags 'Feature' {
         $signature.SignatureType | Should -BeExactly 'Catalog'
     }
 }
+
+Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWindows') {
+    $PSDefaultParameterValues = @{ "It:Skip" = (-not $IsWindows) }
+
+    BeforeAll {
+        $session = New-PSSession -UseWindowsPowerShell
+        try {
+            # New-SelfSignedCertificate runs in implicit remoting so do all the
+            # setup work over there
+            $caRootThumbprint, $signingThumbprint = Invoke-Command -Session $session -ScriptBlock {
+                $testPrefix = 'SelfSignedTest'
+
+                $enhancedKeyUsage = [Security.Cryptography.OidCollection]::new()
+                $null = $enhancedKeyUsage.Add('1.3.6.1.5.5.7.3.3')  # Code Signing
+
+                $caParams = @{
+                    Extension         = @(
+                        [Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new($true, $false, 0, $true),
+                        [Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new('KeyCertSign', $false),
+                        [Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension ]::new($enhancedKeyUsage, $false)
+                    )
+                    CertStoreLocation = 'Cert:\CurrentUser\My'
+                    NotAfter          = (Get-Date).AddDays(1)
+                    Type              = 'Custom'
+                }
+                $caRoot = PKI\New-SelfSignedCertificate @caParams -Subject "CN=$testPrefix-CA"
+
+                $rootStore = Get-Item -Path Cert:\LocalMachine\Root
+                $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+                try {
+                    $rootStore.Add([System.Security.Cryptography.X509Certificates.X509Certificate2]::new($caRoot.RawData))
+                } finally {
+                    $rootStore.Close()
+                }
+
+                $certParams = @{
+                    CertStoreLocation = 'Cert:\CurrentUser\My'
+                    KeyUsage          = 'DigitalSignature'
+                    TextExtension     = @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+                    Type              = 'Custom'
+                }
+                $certificate = PKI\New-SelfSignedCertificate @certParams -Subject "CN=$testPrefix-Signed" -Signer $caRoot
+
+                $publisherStore = Get-Item -Path Cert:\LocalMachine\TrustedPublisher
+                $publisherStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+                try {
+                    $publisherStore.Add([System.Security.Cryptography.X509Certificates.X509Certificate2]::new($certificate.RawData))
+                } finally {
+                    $publisherStore.Close()
+                }
+
+                $caRoot | Remove-Item
+
+                $caRoot.Thumbprint, $certificate.Thumbprint
+            }
+        } finally {
+            $session | Remove-PSSession
+        }
+
+        $certificate = Get-Item -Path Cert:\CurrentUser\My\$signingThumbprint
+    }
+
+    AfterAll {
+        Remove-Item -Path Cert:\LocalMachine\Root\$caRootThumbprint -Force
+        Remove-Item -Path Cert:\LocalMachine\TrustedPublisher\$signingThumbprint -Force
+        Remove-Item -Path Cert:\CurrentUser\My\$signingThumbprint -Force
+    }
+
+    It "Validates signature using path on even char count with Encoding <Encoding>" -TestCases @(
+        @{ Encoding = 'ASCII' }
+        @{ Encoding = 'Unicode' }
+        @{ Encoding = 'UTF8BOM' }
+        @{ Encoding = 'UTF8NoBOM' }
+    ) {
+        param ($Encoding)
+
+        Set-Content -Path testdrive:\test.ps1 -Value 'Write-Output "Hello World"' -Encoding $Encoding
+
+        $scriptPath = Join-Path $TestDrive test.ps1
+        $status = Set-AuthenticodeSignature -FilePath $scriptPath -Certificate $certificate
+        $status.Status | Should -Be 'Valid'
+
+        $actual = Get-AuthenticodeSignature -FilePath $scriptPath
+        $actual.SignerCertificate.Thumbprint | Should -Be $certificate.Thumbprint
+        $actual.Status | Should -Be 'Valid'
+    }
+
+    It "Validates signature using path on odd char count with Encoding <Encoding>" -TestCases @(
+        @{ Encoding = 'ASCII' }
+        @{ Encoding = 'Unicode' }
+        @{ Encoding = 'UTF8BOM' }
+        @{ Encoding = 'UTF8NoBOM' }
+    ) {
+        param ($Encoding)
+
+        Set-Content -Path testdrive:\test.ps1 -Value 'Write-Output "Hello World!"' -Encoding $Encoding
+
+        $scriptPath = Join-Path $TestDrive test.ps1
+        $status = Set-AuthenticodeSignature -FilePath $scriptPath -Certificate $certificate
+        $status.Status | Should -Be 'Valid'
+
+        $actual = Get-AuthenticodeSignature -FilePath $scriptPath
+        $actual.SignerCertificate.Thumbprint | Should -Be $certificate.Thumbprint
+        $actual.Status | Should -Be 'Valid'
+    }
+
+    It "Validates signature using content on even char count with Encoding <Encoding>" -TestCases @(
+        @{ Encoding = 'ASCII' }
+        @{ Encoding = 'Unicode' }
+        @{ Encoding = 'UTF8BOM' }
+        @{ Encoding = 'UTF8NoBOM' }
+    ) {
+        param ($Encoding)
+
+        Set-Content -Path testdrive:\test.ps1 -Value 'Write-Output "Hello World"' -Encoding $Encoding
+
+        $scriptPath = Join-Path $TestDrive test.ps1
+        $status = Set-AuthenticodeSignature -FilePath $scriptPath -Certificate $certificate
+        $status.Status | Should -Be 'Valid'
+
+        $fileBytes = Get-Content -Path testdrive:\test.ps1 -AsByteStream
+
+        $actual = Get-AuthenticodeSignature -Content $fileBytes -SourcePathOrExtension .ps1
+        $actual.SignerCertificate.Thumbprint | Should -Be $certificate.Thumbprint
+        $actual.Status | Should -Be 'Valid'
+    }
+
+    It "Validates signature using content on odd char count with Encoding <Encoding>" -TestCases @(
+        @{ Encoding = 'ASCII' }
+        @{ Encoding = 'Unicode' }
+        @{ Encoding = 'UTF8BOM' }
+        @{ Encoding = 'UTF8NoBOM' }
+    ) {
+        param ($Encoding)
+
+        Set-Content -Path testdrive:\test.ps1 -Value 'Write-Output "Hello World!"' -Encoding $Encoding
+
+        $scriptPath = Join-Path $TestDrive test.ps1
+        $status = Set-AuthenticodeSignature -FilePath $scriptPath -Certificate $certificate
+        $status.Status | Should -Be 'Valid'
+
+        $fileBytes = Get-Content -Path testdrive:\test.ps1 -AsByteStream
+
+        $actual = Get-AuthenticodeSignature -Content $fileBytes -SourcePathOrExtension .ps1
+        $actual.SignerCertificate.Thumbprint | Should -Be $certificate.Thumbprint
+        $actual.Status | Should -Be 'Valid'
+    }
+}


### PR DESCRIPTION
# PR Summary

Do not try and roundtrip the `-Content` bytes to a Unicode encoded string and then back to bytes. Instead just use the raw input bytes when validating the content signature.

## PR Context

Fixes https://github.com/PowerShell/PowerShell/issues/18773

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
