### PR TITLE
Replace ArgumentNullException(nameof()) -> ArgumentNullException.ThrowIfNull()

### DIFF
--- a/src/Microsoft.Management.UI.Internal/HelpWindow/ParagraphBuilder.cs
+++ b/src/Microsoft.Management.UI.Internal/HelpWindow/ParagraphBuilder.cs
@@ -43,10 +43,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="paragraph">Paragraph we will be adding lines to in BuildParagraph.</param>
         internal ParagraphBuilder(Paragraph paragraph)
         {
-            if (paragraph == null)
-            {
-                throw new ArgumentNullException("paragraph");
-            }
+            ArgumentNullException.ThrowIfNull(paragraph);
 
             this.paragraph = paragraph;
             this.boldSpans = new List<TextSpan>();
@@ -185,10 +182,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="bold">True if the text should be bold.</param>
         internal void AddText(string str, bool bold)
         {
-            if (str == null)
-            {
-                throw new ArgumentNullException("str");
-            }
+            ArgumentNullException.ThrowIfNull(str);
 
             if (str.Length == 0)
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/IntegralConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/IntegralConverter.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Management.UI.Internal
         /// </returns>
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
+            ArgumentNullException.ThrowIfNull(values);
 
             if (values.Length != 2)
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/InverseBooleanConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/InverseBooleanConverter.cs
@@ -22,10 +22,7 @@ namespace Microsoft.Management.UI.Internal
         /// <returns>The inverted boolean value.</returns>
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
             var boolValue = (bool)value;
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/IsEqualConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/IsEqualConverter.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Management.UI.Internal
         /// </returns>
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
+            ArgumentNullException.ThrowIfNull(values);
 
             if (values.Length != 2)
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/StringFormatConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/StringFormatConverter.cs
@@ -23,10 +23,7 @@ namespace Microsoft.Management.UI.Internal
         /// <returns>The formatted string.</returns>
         public object Convert(object value, Type targetType, Object parameter, CultureInfo culture)
         {
-            if (parameter == null)
-            {
-                throw new ArgumentNullException("parameter");
-            }
+            ArgumentNullException.ThrowIfNull(parameter);
 
             string str = (string)value;
             string formatString = (string)parameter;

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/Utilities.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/Utilities.cs
@@ -83,10 +83,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public static bool AreAllItemsOfType<T>(IEnumerable items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
+            ArgumentNullException.ThrowIfNull(items);
 
             foreach (object item in items)
             {
@@ -108,10 +105,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public static T Find<T>(this IEnumerable items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
+            ArgumentNullException.ThrowIfNull(items);
 
             foreach (object item in items)
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/VisualToAncestorDataConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/VisualToAncestorDataConverter.cs
@@ -27,15 +27,9 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
-            if (parameter == null)
-            {
-                throw new ArgumentNullException("parameter");
-            }
+            ArgumentNullException.ThrowIfNull(parameter);
 
             Type dataType = (Type)parameter;
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/WeakEventListener.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/WeakEventListener.cs
@@ -20,10 +20,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="handler">The handler for the event.</param>
         public WeakEventListener(EventHandler<TEventArgs> handler)
         {
-            if (handler == null)
-            {
-                throw new ArgumentNullException("handler");
-            }
+            ArgumentNullException.ThrowIfNull(handler);
 
             this.realHander = handler;
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/WpfHelp.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/WpfHelp.cs
@@ -153,10 +153,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="NotSupportedException">The specified value does not have a parent that supports removal.</exception>
         public static void RemoveFromParent(FrameworkElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
 
             // If the element has already been detached, do nothing \\
             if (element.Parent == null)
@@ -215,10 +212,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="NotSupportedException">The specified value does not have a parent that supports removal.</exception>
         public static void AddChild(FrameworkElement parent, FrameworkElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
 
             if (parent == null)
             {
@@ -310,10 +304,8 @@ namespace Microsoft.Management.UI.Internal
             where T : DependencyObject
         {
             Debug.Assert(obj != null, "obj is null");
-            if (obj == null)
-            {
-                throw new ArgumentNullException("obj");
-            }
+
+            ArgumentNullException.ThrowIfNull(obj);
 
             List<T> childrenOfType = new List<T>();
 
@@ -348,10 +340,7 @@ namespace Microsoft.Management.UI.Internal
         public static T FindVisualAncestorData<T>(this DependencyObject obj)
             where T : class
         {
-            if (obj == null)
-            {
-                throw new ArgumentNullException("obj");
-            }
+            ArgumentNullException.ThrowIfNull(obj);
 
             FrameworkElement parent = obj.FindVisualAncestor<FrameworkElement>();
 
@@ -413,10 +402,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public static bool TryExecute(this RoutedCommand command, object parameter, IInputElement target)
         {
-            if (command == null)
-            {
-                throw new ArgumentNullException("command");
-            }
+            ArgumentNullException.ThrowIfNull(command);
 
             if (command.CanExecute(parameter, target))
             {
@@ -437,10 +423,7 @@ namespace Microsoft.Management.UI.Internal
         /// <returns>The reference to the child, or null if the template part wasn't found.</returns>
         public static T GetOptionalTemplateChild<T>(Control templateParent, string childName) where T : FrameworkElement
         {
-            if (templateParent == null)
-            {
-                throw new ArgumentNullException("templateParent");
-            }
+            ArgumentNullException.ThrowIfNull(templateParent);
 
             if (string.IsNullOrEmpty(childName))
             {
@@ -566,10 +549,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentOutOfRangeException">The specified index is not valid for the specified collection.</exception>
         public static void ChangeIndex(ItemCollection items, object item, int newIndex)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
+            ArgumentNullException.ThrowIfNull(items);
 
             if (!items.Contains(item))
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/CommonControls/ResizerGripThicknessConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/CommonControls/ResizerGripThicknessConverter.cs
@@ -38,10 +38,7 @@ namespace Microsoft.Management.UI.Internal
         /// <returns>A converted value. If the method returns nullNothingnullptra null reference (Nothing in Visual Basic), the valid null value is used.</returns>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
+            ArgumentNullException.ThrowIfNull(values);
 
             if (object.ReferenceEquals(values[0], DependencyProperty.UnsetValue) ||
                 object.ReferenceEquals(values[1], DependencyProperty.UnsetValue))

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/DefaultFilterRuleCustomizationFactory.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/DefaultFilterRuleCustomizationFactory.cs
@@ -36,10 +36,7 @@ namespace Microsoft.Management.UI.Internal
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 this.propertyValueGetter = value;
             }
@@ -106,15 +103,9 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public override void TransferValues(FilterRule oldRule, FilterRule newRule)
         {
-            if (oldRule == null)
-            {
-                throw new ArgumentNullException("oldRule");
-            }
+            ArgumentNullException.ThrowIfNull(oldRule);
 
-            if (newRule == null)
-            {
-                throw new ArgumentNullException("newRule");
-            }
+            ArgumentNullException.ThrowIfNull(newRule);
 
             if (this.TryTransferValuesAsSingleValueComparableValueFilterRule(oldRule, newRule))
             {
@@ -130,10 +121,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public override void ClearValues(FilterRule rule)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             if (this.TryClearValueFromSingleValueComparableValueFilterRule(rule))
             {
@@ -163,10 +151,7 @@ namespace Microsoft.Management.UI.Internal
         /// </returns>
         public override string GetErrorMessageForInvalidValue(string value, Type typeToParseTo)
         {
-            if (typeToParseTo == null)
-            {
-                throw new ArgumentNullException("typeToParseTo");
-            }
+            ArgumentNullException.ThrowIfNull(typeToParseTo);
 
             bool isNumericType = typeToParseTo == typeof(byte)
                 || typeToParseTo == typeof(sbyte)
@@ -222,10 +207,7 @@ namespace Microsoft.Management.UI.Internal
             Debug.Assert(rule != null && !string.IsNullOrEmpty(propertyName), "rule and propertyname are not null");
 
             // NOTE: This isn't needed but OACR is complaining
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             Type ruleType = rule.GetType();
 
@@ -241,10 +223,7 @@ namespace Microsoft.Management.UI.Internal
             Debug.Assert(rule != null && !string.IsNullOrEmpty(propertyName), "rule and propertyname are not null");
 
             // NOTE: This isn't needed but OACR is complaining
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             Type ruleType = rule.GetType();
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterEvaluator.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterEvaluator.cs
@@ -145,10 +145,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public void AddFilterExpressionProvider(IFilterExpressionProvider provider)
         {
-            if (provider == null)
-            {
-                throw new ArgumentNullException("provider");
-            }
+            ArgumentNullException.ThrowIfNull(provider);
 
             this.filterExpressionProviders.Add(provider);
             provider.FilterExpressionChanged += this.FilterProvider_FilterExpressionChanged;
@@ -162,10 +159,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public void RemoveFilterExpressionProvider(IFilterExpressionProvider provider)
         {
-            if (provider == null)
-            {
-                throw new ArgumentNullException("provider");
-            }
+            ArgumentNullException.ThrowIfNull(provider);
 
             this.filterExpressionProviders.Remove(provider);
             provider.FilterExpressionChanged -= this.FilterProvider_FilterExpressionChanged;

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExceptionEventArgs.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExceptionEventArgs.cs
@@ -32,10 +32,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public FilterExceptionEventArgs(Exception exception)
         {
-            if (exception == null)
-            {
-                throw new ArgumentNullException("exception");
-            }
+            ArgumentNullException.ThrowIfNull(exception);
 
             this.Exception = exception;
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExpressionNodes/FilterExpressionAndOperatorNode.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExpressionNodes/FilterExpressionAndOperatorNode.cs
@@ -52,10 +52,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public FilterExpressionAndOperatorNode(IEnumerable<FilterExpressionNode> children)
         {
-            if (children == null)
-            {
-                throw new ArgumentNullException("children");
-            }
+            ArgumentNullException.ThrowIfNull(children);
 
             this.children.AddRange(children);
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExpressionNodes/FilterExpressionOperandNode.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExpressionNodes/FilterExpressionOperandNode.cs
@@ -38,10 +38,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public FilterExpressionOperandNode(FilterRule rule)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             this.Rule = rule;
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExpressionNodes/FilterExpressionOrOperatorNode.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterExpressionNodes/FilterExpressionOrOperatorNode.cs
@@ -52,10 +52,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public FilterExpressionOrOperatorNode(IEnumerable<FilterExpressionNode> children)
         {
-            if (children == null)
-            {
-                throw new ArgumentNullException("children");
-            }
+            ArgumentNullException.ThrowIfNull(children);
 
             this.children.AddRange(children);
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRuleCustomizationFactory.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRuleCustomizationFactory.cs
@@ -32,10 +32,7 @@ namespace Microsoft.Management.UI.Internal
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 factoryInstance = value;
             }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRuleExtensions.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRuleExtensions.cs
@@ -27,10 +27,7 @@ namespace Microsoft.Management.UI.Internal
         /// </returns>
         public static FilterRule DeepCopy(this FilterRule rule)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             Debug.Assert(rule.GetType().IsSerializable, "rule is serializable");
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertyValueSelectorFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertyValueSelectorFilterRule.cs
@@ -76,10 +76,7 @@ namespace Microsoft.Management.UI.Internal
                 throw new ArgumentNullException("propertyDisplayName");
             }
 
-            if (rules == null)
-            {
-                throw new ArgumentNullException("rules");
-            }
+            ArgumentNullException.ThrowIfNull(rules);
 
             this.PropertyName = propertyName;
             this.DisplayName = propertyDisplayName;

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextFilterRule.cs
@@ -101,15 +101,9 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         protected internal string GetRegexPattern(string pattern, string exactMatchPattern)
         {
-            if (pattern == null)
-            {
-                throw new ArgumentNullException("pattern");
-            }
+            ArgumentNullException.ThrowIfNull(pattern);
 
-            if (exactMatchPattern == null)
-            {
-                throw new ArgumentNullException("exactMatchPattern");
-            }
+            ArgumentNullException.ThrowIfNull(exactMatchPattern);
 
             Debug.Assert(this.IsValid, "is valid");
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValue.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValue.cs
@@ -165,10 +165,7 @@ namespace Microsoft.Management.UI.Internal
         {
             castValue = default(T);
 
-            if (rawValue == null)
-            {
-                throw new ArgumentNullException("rawValue");
-            }
+            ArgumentNullException.ThrowIfNull(rawValue);
 
             if (typeof(T).IsEnum)
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValueBase.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValueBase.cs
@@ -141,10 +141,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="rule">The validation rule to add.</param>
         public void AddValidationRule(DataErrorInfoValidationRule rule)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             this.validationRules.Add(rule);
 
@@ -162,10 +159,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="rule">The rule to remove.</param>
         public void RemoveValidationRule(DataErrorInfoValidationRule rule)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             this.validationRules.Remove(rule);
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanel.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanel.cs
@@ -154,15 +154,9 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public void AddFilterRulePanelItemContentTemplate(Type type, DataTemplate dataTemplate)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException("type");
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
-            if (dataTemplate == null)
-            {
-                throw new ArgumentNullException("dataTemplate");
-            }
+            ArgumentNullException.ThrowIfNull(dataTemplate);
 
             this.filterRuleTemplateSelector.TemplateDictionary.Add(new KeyValuePair<Type, DataTemplate>(type, dataTemplate));
         }
@@ -176,10 +170,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public void RemoveFilterRulePanelItemContentTemplate(Type type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException("type");
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
             this.filterRuleTemplateSelector.TemplateDictionary.Remove(type);
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelController.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelController.cs
@@ -88,10 +88,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public void AddFilterRulePanelItem(FilterRulePanelItem item)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException("item");
-            }
+            ArgumentNullException.ThrowIfNull(item);
 
             int insertionIndex = this.GetInsertionIndex(item);
             this.filterRulePanelItems.Insert(insertionIndex, item);
@@ -116,10 +113,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public void RemoveFilterRulePanelItem(FilterRulePanelItem item)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException("item");
-            }
+            ArgumentNullException.ThrowIfNull(item);
 
             item.Rule.EvaluationResultInvalidated -= this.Rule_EvaluationResultInvalidated;
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelItem.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelItem.cs
@@ -79,10 +79,7 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public FilterRulePanelItem(FilterRule rule, string groupId)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             if (string.IsNullOrEmpty(groupId))
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/InputFieldBackgroundTextConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/InputFieldBackgroundTextConverter.cs
@@ -40,10 +40,7 @@ namespace Microsoft.Management.UI.Internal
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
             Type inputType = null;
             if (this.IsOfTypeValidatingValue(value))

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchBox.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchBox.cs
@@ -88,10 +88,7 @@ namespace Microsoft.Management.UI.Internal
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 this.parser = value;
             }
@@ -120,10 +117,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         protected static FilterExpressionNode ConvertToFilterExpression(ICollection<SearchTextParseResult> searchBoxItems)
         {
-            if (searchBoxItems == null)
-            {
-                throw new ArgumentNullException("searchBoxItems");
-            }
+            ArgumentNullException.ThrowIfNull(searchBoxItems);
 
             if (searchBoxItems.Count == 0)
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchTextParseResult.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchTextParseResult.cs
@@ -18,10 +18,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public SearchTextParseResult(FilterRule rule)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             this.FilterRule = rule;
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchTextParser.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchTextParser.cs
@@ -45,10 +45,7 @@ namespace Microsoft.Management.UI.Internal
         public bool TryAddSearchableRule<T>(SelectorFilterRule selectorRule)
             where T : TextFilterRule
         {
-            if (selectorRule == null)
-            {
-                throw new ArgumentNullException("selectorRule");
-            }
+            ArgumentNullException.ThrowIfNull(selectorRule);
 
             T textRule = selectorRule.AvailableRules.AvailableValues.Find<T>();
 
@@ -193,20 +190,11 @@ namespace Microsoft.Management.UI.Internal
             /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
             public SearchableRule(string uniqueId, SelectorFilterRule selectorFilterRule, TextFilterRule childRule)
             {
-                if (uniqueId == null)
-                {
-                    throw new ArgumentNullException("uniqueId");
-                }
+                ArgumentNullException.ThrowIfNull(uniqueId);
 
-                if (selectorFilterRule == null)
-                {
-                    throw new ArgumentNullException("selectorFilterRule");
-                }
+                ArgumentNullException.ThrowIfNull(selectorFilterRule);
 
-                if (childRule == null)
-                {
-                    throw new ArgumentNullException("childRule");
-                }
+                ArgumentNullException.ThrowIfNull(childRule);
 
                 this.UniqueId = uniqueId;
                 this.selectorFilterRule = selectorFilterRule;
@@ -240,10 +228,7 @@ namespace Microsoft.Management.UI.Internal
             /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
             public SelectorFilterRule GetRuleWithValueSet(string value)
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 SelectorFilterRule selectorRule = (SelectorFilterRule)this.selectorFilterRule.DeepCopy();
                 selectorRule.AvailableRules.SelectedIndex = this.selectorFilterRule.AvailableRules.AvailableValues.IndexOf(this.childRule);

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/ValidatingSelectorValueToDisplayNameConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/ValidatingSelectorValueToDisplayNameConverter.cs
@@ -38,10 +38,7 @@ namespace Microsoft.Management.UI.Internal
         /// </returns>
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (values == null)
-            {
-                throw new ArgumentNullException("values");
-            }
+            ArgumentNullException.ThrowIfNull(values);
 
             if (values.Length != 2)
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/ColumnPicker.xaml.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/ColumnPicker.xaml.cs
@@ -59,15 +59,9 @@ namespace Microsoft.Management.UI.Internal
             ICollection<InnerListColumn> availableColumns)
             : this()
         {
-            if (columns == null)
-            {
-                throw new ArgumentNullException("columns");
-            }
-
-            if (availableColumns == null)
-            {
-                throw new ArgumentNullException("availableColumns");
-            }
+            ArgumentNullException.ThrowIfNull(columns);
+            
+            ArgumentNullException.ThrowIfNull(availableColumns);
 
             // Add visible columns to Selected list, preserving order
             // Note that availableColumns is not necessarily in the order

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/InnerListGridView.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/InnerListGridView.cs
@@ -45,10 +45,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         internal InnerListGridView(ObservableCollection<InnerListColumn> availableColumns)
         {
-            if (availableColumns == null)
-            {
-                throw new ArgumentNullException("availableColumns");
-            }
+            ArgumentNullException.ThrowIfNull(availableColumns);
 
             // Setting the AvailableColumns property won't trigger CollectionChanged, so we have to do it manually \\
             this.AvailableColumns = availableColumns;

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
@@ -191,10 +191,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public void ApplySort(InnerListColumn column, bool shouldScrollIntoView)
         {
-            if (column == null)
-            {
-                throw new ArgumentNullException("column");
-            }
+            ArgumentNullException.ThrowIfNull(column);
 
             // NOTE : By setting the column here, it will be used
             // later to set the sorted column when the UI state

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/ManagementListStateDescriptor.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/ManagementListStateDescriptor.cs
@@ -63,10 +63,7 @@ namespace Microsoft.Management.UI.Internal
         /// </exception>
         public override void SaveState(ManagementList subject)
         {
-            if (subject == null)
-            {
-                throw new ArgumentNullException("subject");
-            }
+            ArgumentNullException.ThrowIfNull(subject);
 
             this.SaveColumns(subject);
             this.SaveSortOrder(subject);
@@ -100,10 +97,7 @@ namespace Microsoft.Management.UI.Internal
         /// </exception>
         public void RestoreState(ManagementList subject, bool applyRestoredFilter)
         {
-            if (subject == null)
-            {
-                throw new ArgumentNullException("subject");
-            }
+            ArgumentNullException.ThrowIfNull(subject);
 
             // Clear the sort, otherwise restoring columns and filters may trigger extra sorting \\
             subject.List.ClearSort();

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueGetter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueGetter.cs
@@ -48,10 +48,7 @@ namespace Microsoft.Management.UI.Internal
                 throw new ArgumentException("propertyName is empty", "propertyName");
             }
 
-            if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
             PropertyDescriptor descriptor = this.GetPropertyDescriptor(propertyName, value);
             if (descriptor == null)

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/innerlistcolumn.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/innerlistcolumn.cs
@@ -68,10 +68,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="createDefaultBinding">Whether the column should create a default binding using the specified data's property.</param>
         public InnerListColumn(UIPropertyGroupDescription dataDescription, bool isVisible, bool createDefaultBinding)
         {
-            if (dataDescription == null)
-            {
-                throw new ArgumentNullException("dataDescription");
-            }
+            ArgumentNullException.ThrowIfNull(dataDescription);
 
             GridViewColumnHeader header = new GridViewColumnHeader();
             header.Content = dataDescription.DisplayContent;

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/managementlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/managementlist.cs
@@ -50,10 +50,7 @@ namespace Microsoft.Management.UI.Internal
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 this.savedViewFactory = value;
             }
@@ -177,10 +174,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public void AddColumn(InnerListColumn column)
         {
-            if (column == null)
-            {
-                throw new ArgumentNullException("column");
-            }
+            ArgumentNullException.ThrowIfNull(column);
 
             this.AddColumn(column, this.IsFilterShown);
         }
@@ -193,10 +187,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public void AddColumn(InnerListColumn column, bool addDefaultFilterRules)
         {
-            if (column == null)
-            {
-                throw new ArgumentNullException("column");
-            }
+            ArgumentNullException.ThrowIfNull(column);
 
             this.List.Columns.Add(column);
 
@@ -229,10 +220,7 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public void AddRule(FilterRule rule)
         {
-            if (rule == null)
-            {
-                throw new ArgumentNullException("rule");
-            }
+            ArgumentNullException.ThrowIfNull(rule);
 
             this.AddFilterRulePicker.ShortcutFilterRules.Add(new AddFilterRulePickerItem(new FilterRulePanelItem(rule, rule.DisplayName)));
         }

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/AllModulesViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/AllModulesViewModel.cs
@@ -95,10 +95,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="noCommonParameter">True not to show common parameters.</param>
         public AllModulesViewModel(Dictionary<string, ShowCommandModuleInfo> importedModules, IEnumerable<ShowCommandCommandInfo> commands, bool noCommonParameter)
         {
-            if (commands == null)
-            {
-                throw new ArgumentNullException("commands");
-            }
+            ArgumentNullException.ThrowIfNull(commands);
 
             this.Initialization(importedModules, commands, noCommonParameter);
         }

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/CommandViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/CommandViewModel.cs
@@ -490,10 +490,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <returns>The CommandViewModel corresponding to commandInfo.</returns>
         internal static CommandViewModel GetCommandViewModel(ModuleViewModel module, ShowCommandCommandInfo commandInfo, bool noCommonParameters)
         {
-            if (commandInfo == null)
-            {
-                throw new ArgumentNullException("commandInfo");
-            }
+            ArgumentNullException.ThrowIfNull(commandInfo);
 
             CommandViewModel returnValue = new CommandViewModel();
             returnValue.commandInfo = commandInfo;

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ModuleViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ModuleViewModel.cs
@@ -67,10 +67,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="importedModules">All loaded modules.</param>
         public ModuleViewModel(string name, Dictionary<string, ShowCommandModuleInfo> importedModules)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             this.name = name;
             this.commands = new List<CommandViewModel>();

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterSetViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterSetViewModel.cs
@@ -45,15 +45,9 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
             string name,
             List<ParameterViewModel> parameters)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
-            if (parameters == null)
-            {
-                throw new ArgumentNullException("parameters");
-            }
+            ArgumentNullException.ThrowIfNull(parameters);
 
             parameters.Sort(Compare);
 

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterViewModel.cs
@@ -48,15 +48,9 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="parameterSetName">The name of the parameter set this parameter is in.</param>
         public ParameterViewModel(ShowCommandParameterInfo parameter, string parameterSetName)
         {
-            if (parameter == null)
-            {
-                throw new ArgumentNullException("parameter");
-            }
+            ArgumentNullException.ThrowIfNull(parameter);
 
-            if (parameterSetName == null)
-            {
-                throw new ArgumentNullException("parameterSetName");
-            }
+            ArgumentNullException.ThrowIfNull(parameterSetName);
 
             this.parameter = parameter;
             this.parameterSetName = parameterSetName;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
@@ -577,8 +577,9 @@ namespace Microsoft.PowerShell.Cmdletization
         /// <param name="passThru"><see langword="true"/> if successful method invocations should emit downstream the <paramref name="objectInstance"/> being operated on.</param>
         public override void ProcessRecord(TObjectInstance objectInstance, MethodInvocationInfo methodInvocationInfo, bool passThru)
         {
-            if (objectInstance == null) throw new ArgumentNullException(nameof(objectInstance));
-            if (methodInvocationInfo == null) throw new ArgumentNullException(nameof(methodInvocationInfo));
+            ArgumentNullException.ThrowIfNull(objectInstance);
+
+            ArgumentNullException.ThrowIfNull(methodInvocationInfo);
 
             foreach (TSession sessionForJob in this.GetSessionsToActAgainst(objectInstance))
             {
@@ -603,7 +604,7 @@ namespace Microsoft.PowerShell.Cmdletization
         /// <param name="methodInvocationInfo">Method invocation details.</param>
         public override void ProcessRecord(MethodInvocationInfo methodInvocationInfo)
         {
-            if (methodInvocationInfo == null) throw new ArgumentNullException(nameof(methodInvocationInfo));
+            ArgumentNullException.ThrowIfNull(methodInvocationInfo);
 
             foreach (TSession sessionForJob in this.GetSessionsToActAgainst(methodInvocationInfo))
             {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/CimJobException.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/CimJobException.cs
@@ -54,10 +54,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             SerializationInfo info,
             StreamingContext context) : base(info, context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
 
             _errorRecord = (ErrorRecord)info.GetValue("errorRecord", typeof(ErrorRecord));
         }
@@ -69,10 +66,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info); 
 
             base.GetObjectData(info, context);
             info.AddValue("errorRecord", _errorRecord);

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell.Cim
         /// <exception cref="PSInvalidCastException">The only kind of exception this method can throw.</exception>
         internal static object ConvertFromCimToDotNet(object cimObject, Type expectedDotNetType)
         {
-            if (expectedDotNetType == null) { throw new ArgumentNullException(nameof(expectedDotNetType)); }
+            ArgumentNullException.ThrowIfNull(expectedDotNetType);
 
             if (cimObject == null)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
@@ -314,15 +314,9 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         /// <param name="optionValue"></param>
         public override void AddQueryOption(string optionName, object optionValue)
         {
-            if (string.IsNullOrEmpty(optionName))
-            {
-                throw new ArgumentNullException(nameof(optionName));
-            }
+            ArgumentNullException.ThrowIfNull(optionName);
 
-            if (optionValue == null)
-            {
-                throw new ArgumentNullException(nameof(optionValue));
-            }
+            ArgumentNullException.ThrowIfNull(optionValue); 
 
             this.queryOptions[optionName] = optionValue;
         }

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
@@ -314,7 +314,10 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         /// <param name="optionValue"></param>
         public override void AddQueryOption(string optionName, object optionValue)
         {
-            ArgumentNullException.ThrowIfNull(optionName);
+            if (string.IsNullOrEmpty(optionName))
+            {
+                throw new ArgumentNullException(nameof(optionName));
+            }
 
             ArgumentNullException.ThrowIfNull(optionValue); 
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2962,9 +2962,8 @@ namespace Microsoft.PowerShell.Commands
         {
             base.GetObjectData(info, context);
 
-            if (info == null)
-                throw new ArgumentNullException(nameof(info));
-
+            ArgumentNullException.ThrowIfNull(info);
+            
             info.AddValue("ProcessName", _processName);
         }
         #endregion Serialization

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -2569,10 +2569,7 @@ namespace Microsoft.PowerShell.Commands
         protected ServiceCommandException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
 
             _serviceName = info.GetString("ServiceName");
         }
@@ -2583,10 +2580,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="context">Streaming context.</param>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
 
             base.GetObjectData(info, context);
             info.AddValue("ServiceName", _serviceName);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -951,10 +951,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Converted string.</returns>
         internal string ConvertPropertyNamesCSV(IList<string> propertyNames)
         {
-            if (propertyNames == null)
-            {
-                throw new ArgumentNullException(nameof(propertyNames));
-            }
+            ArgumentNullException.ThrowIfNull(propertyNames); 
 
             _outputString.Clear();
             bool first = true;
@@ -1018,10 +1015,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         internal string ConvertPSObjectToCSV(PSObject mshObject, IList<string> propertyNames)
         {
-            if (propertyNames == null)
-            {
-                throw new ArgumentNullException(nameof(propertyNames));
-            }
+            ArgumentNullException.ThrowIfNull(propertyNames); 
 
             _outputString.Clear();
             bool first = true;
@@ -1107,10 +1101,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>ToString() value.</returns>
         internal static string GetToStringValueForProperty(PSPropertyInfo property)
         {
-            if (property == null)
-            {
-                throw new ArgumentNullException(nameof(property));
-            }
+            ArgumentNullException.ThrowIfNull(property); 
 
             string value = null;
             try
@@ -1272,15 +1263,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal ImportCsvHelper(PSCmdlet cmdlet, char delimiter, IList<string> header, string typeName, StreamReader streamReader)
         {
-            if (cmdlet == null)
-            {
-                throw new ArgumentNullException(nameof(cmdlet));
-            }
+            ArgumentNullException.ThrowIfNull(cmdlet); 
 
-            if (streamReader == null)
-            {
-                throw new ArgumentNullException(nameof(streamReader));
-            }
+            ArgumentNullException.ThrowIfNull(streamReader);
 
             _cmdlet = cmdlet;
             _delimiter = delimiter;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
@@ -58,20 +58,11 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="types">An array of types to add.</param>
         internal void AddColumns(string[] propertyNames, string[] displayNames, Type[] types)
         {
-            if (propertyNames == null)
-            {
-                throw new ArgumentNullException(nameof(propertyNames));
-            }
+            ArgumentNullException.ThrowIfNull(propertyNames);
 
-            if (displayNames == null)
-            {
-                throw new ArgumentNullException(nameof(displayNames));
-            }
+            ArgumentNullException.ThrowIfNull(displayNames);
 
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
+            ArgumentNullException.ThrowIfNull(types);
 
             try
             {
@@ -177,10 +168,7 @@ namespace Microsoft.PowerShell.Commands
         /// </param>
         internal void AddItem(PSObject livePSObject)
         {
-            if (livePSObject == null)
-            {
-                throw new ArgumentNullException(nameof(livePSObject));
-            }
+            ArgumentNullException.ThrowIfNull(livePSObject);
 
             if (_headerInfo == null)
             {
@@ -203,10 +191,7 @@ namespace Microsoft.PowerShell.Commands
         /// </param>
         internal void AddHeteroViewItem(PSObject livePSObject)
         {
-            if (livePSObject == null)
-            {
-                throw new ArgumentNullException(nameof(livePSObject));
-            }
+            ArgumentNullException.ThrowIfNull(livePSObject);
 
             if (_headerInfo == null)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -532,10 +532,7 @@ namespace Microsoft.PowerShell.Commands
 
             public void CopyTo(T[] array, int arrayIndex)
             {
-                if (array == null)
-                {
-                    throw new ArgumentNullException(nameof(array));
-                }
+                ArgumentNullException.ThrowIfNull(array); 
 
                 if (arrayIndex < 0)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -24,10 +24,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="wildcardPatternsStrings">Array of pattern strings to use.</param>
         internal PSPropertyExpressionFilter(string[] wildcardPatternsStrings)
         {
-            if (wildcardPatternsStrings == null)
-            {
-                throw new ArgumentNullException(nameof(wildcardPatternsStrings));
-            }
+            ArgumentNullException.ThrowIfNull(wildcardPatternsStrings);
 
             _wildcardPatterns = new WildcardPattern[wildcardPatternsStrings.Length];
             for (int k = 0; k < wildcardPatternsStrings.Length; k++)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandCommandInfo.cs
@@ -22,10 +22,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandCommandInfo(CommandInfo other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Name;
             this.ModuleName = other.ModuleName;
@@ -71,10 +68,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandCommandInfo(PSObject other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Members["Name"].Value as string;
             this.ModuleName = other.Members["ModuleName"].Value as string;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandModuleInfo.cs
@@ -20,10 +20,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandModuleInfo(PSModuleInfo other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Name;
         }
@@ -37,10 +34,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandModuleInfo(PSObject other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Members["Name"].Value as string;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterInfo.cs
@@ -22,10 +22,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandParameterInfo(CommandParameterInfo other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Name;
             this.IsMandatory = other.IsMandatory;
@@ -50,10 +47,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandParameterInfo(PSObject other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Members["Name"].Value as string;
             this.IsMandatory = (bool)(other.Members["IsMandatory"].Value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterSetInfo.cs
@@ -22,10 +22,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandParameterSetInfo(CommandParameterSetInfo other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Name;
             this.IsDefault = other.IsDefault;
@@ -41,10 +38,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandParameterSetInfo(PSObject other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.Name = other.Members["Name"].Value as string;
             this.IsDefault = (bool)(other.Members["IsDefault"].Value);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandParameterType.cs
@@ -21,10 +21,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandParameterType(Type other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.FullName = other.FullName;
             if (other.IsEnum)
@@ -51,10 +48,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandExtension
         /// </param>
         public ShowCommandParameterType(PSObject other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             this.IsEnum = (bool)(other.Members["IsEnum"].Value);
             this.FullName = other.Members["FullName"].Value as string;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -380,7 +380,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="response"></param>
         internal override void ProcessResponse(HttpResponseMessage response)
         {
-            if (response == null) { throw new ArgumentNullException(nameof(response)); }
+            ArgumentNullException.ThrowIfNull(response);
 
             var baseResponseStream = StreamHelper.GetResponseStream(response);
 
@@ -473,7 +473,7 @@ namespace Microsoft.PowerShell.Commands
 
         private static RestReturnType CheckReturnType(HttpResponseMessage response)
         {
-            if (response == null) { throw new ArgumentNullException(nameof(response)); }
+            ArgumentNullException.ThrowIfNull(response);
 
             RestReturnType rt = RestReturnType.Detect;
             string contentType = ContentHelper.GetContentType(response);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -13,7 +13,15 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.PowerShell.Commands
 {
-    public partial class InvokeRestMethodCommand
+    /// <summary>
+    /// The Invoke-RestMethod command
+    /// This command makes an HTTP or HTTPS request to a web service,
+    /// and returns the response in an appropriate way.
+    /// Intended to work against the wide spectrum of "RESTful" web services
+    /// currently deployed across the web.
+    /// </summary>
+    [Cmdlet(VerbsLifecycle.Invoke, "RestMethod", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096706", DefaultParameterSetName = "StandardMethod")]
+    public class InvokeRestMethodCommand : WebRequestPSCmdlet
     {
         #region Parameters
 
@@ -83,7 +91,123 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion Parameters
 
+        #region Virtual Method Overrides
+
+        /// <summary>
+        /// Process the web response and output corresponding objects.
+        /// </summary>
+        /// <param name="response"></param>
+        internal override void ProcessResponse(HttpResponseMessage response)
+        {
+            ArgumentNullException.ThrowIfNull(response);
+
+            var baseResponseStream = StreamHelper.GetResponseStream(response);
+
+            if (ShouldWriteToPipeline)
+            {
+                using var responseStream = new BufferingStreamReader(baseResponseStream);
+
+                // First see if it is an RSS / ATOM feed, in which case we can
+                // stream it - unless the user has overridden it with a return type of "XML"
+                if (TryProcessFeedStream(responseStream))
+                {
+                    // Do nothing, content has been processed.
+                }
+                else
+                {
+                    // determine the response type
+                    RestReturnType returnType = CheckReturnType(response);
+
+                    // Try to get the response encoding from the ContentType header.
+                    Encoding encoding = null;
+                    string charSet = response.Content.Headers.ContentType?.CharSet;
+                    if (!string.IsNullOrEmpty(charSet))
+                    {
+                        StreamHelper.TryGetEncoding(charSet, out encoding);
+                    }
+
+                    object obj = null;
+                    Exception ex = null;
+
+                    string str = StreamHelper.DecodeStream(responseStream, ref encoding);
+
+                    string encodingVerboseName;
+                    try
+                    {
+                        encodingVerboseName = string.IsNullOrEmpty(encoding.HeaderName) ? encoding.EncodingName : encoding.HeaderName;
+                    }
+                    catch (NotSupportedException)
+                    {
+                        encodingVerboseName = encoding.EncodingName;
+                    }
+
+                    // NOTE: Tests use this verbose output to verify the encoding.
+                    WriteVerbose(string.Format(System.Globalization.CultureInfo.InvariantCulture, "Content encoding: {0}", encodingVerboseName));
+                    
+                    bool convertSuccess = false;
+
+                    if (returnType == RestReturnType.Json)
+                    {
+                        convertSuccess = TryConvertToJson(str, out obj, ref ex) || TryConvertToXml(str, out obj, ref ex);
+                    }
+                    // default to try xml first since it's more common
+                    else
+                    {
+                        convertSuccess = TryConvertToXml(str, out obj, ref ex) || TryConvertToJson(str, out obj, ref ex);
+                    }
+
+                    if (!convertSuccess)
+                    {
+                        // fallback to string
+                        obj = str;
+                    }
+
+                    WriteObject(obj);
+                }
+            }
+            else if (ShouldSaveToOutFile)
+            {
+                StreamHelper.SaveStreamToFile(baseResponseStream, QualifiedOutFile, this, response.Content.Headers.ContentLength.GetValueOrDefault(), _cancelToken.Token);
+            }
+
+            if (!string.IsNullOrEmpty(StatusCodeVariable))
+            {
+                PSVariableIntrinsics vi = SessionState.PSVariable;
+                vi.Set(StatusCodeVariable, (int)response.StatusCode);
+            }
+
+            if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+            {
+                PSVariableIntrinsics vi = SessionState.PSVariable;
+                vi.Set(ResponseHeadersVariable, WebResponseHelper.GetHeadersDictionary(response));
+            }
+        }
+
+        #endregion Virtual Method Overrides
+
         #region Helper Methods
+
+        private static RestReturnType CheckReturnType(HttpResponseMessage response)
+        {
+            if (response == null) { throw new ArgumentNullException(nameof(response)); }
+
+            RestReturnType rt = RestReturnType.Detect;
+            string contentType = ContentHelper.GetContentType(response);
+            if (string.IsNullOrEmpty(contentType))
+            {
+                rt = RestReturnType.Detect;
+            }
+            else if (ContentHelper.IsJson(contentType))
+            {
+                rt = RestReturnType.Json;
+            }
+            else if (ContentHelper.IsXml(contentType))
+            {
+                rt = RestReturnType.Xml;
+            }
+
+            return rt;
+        }
 
         private bool TryProcessFeedStream(Stream responseStream)
         {
@@ -111,7 +235,8 @@ namespace Microsoft.PowerShell.Commands
                 if (isRssOrFeed)
                 {
                     XmlDocument workingDocument = new();
-                    // performing a Read() here to avoid rrechecking
+
+                    // Performing a Read() here to avoid rechecking
                     // "rss" or "feed" items
                     reader.Read();
                     while (!reader.EOF)
@@ -122,7 +247,7 @@ namespace Microsoft.PowerShell.Commands
                              string.Equals("Entry", reader.Name, StringComparison.OrdinalIgnoreCase))
                            )
                         {
-                            // this one will do reader.Read() internally
+                            // This one will do reader.Read() internally
                             XmlNode result = workingDocument.ReadNode(reader);
                             WriteObject(result);
                         }
@@ -178,7 +303,7 @@ namespace Microsoft.PowerShell.Commands
                 doc = null;
             }
 
-            return (doc != null);
+            return doc != null;
         }
 
         private static bool TryConvertToJson(string json, out object obj, ref Exception exRef)
@@ -226,7 +351,7 @@ namespace Microsoft.PowerShell.Commands
             return converted;
         }
 
-        #endregion
+        #endregion Helper Methods
 
         /// <summary>
         /// Enum for rest return type.
@@ -265,20 +390,11 @@ namespace Microsoft.PowerShell.Commands
             private readonly MemoryStream _streamBuffer;
             private readonly byte[] _copyBuffer;
 
-            public override bool CanRead
-            {
-                get { return true; }
-            }
+            public override bool CanRead => true;
 
-            public override bool CanSeek
-            {
-                get { return true; }
-            }
+            public override bool CanSeek => true;
 
-            public override bool CanWrite
-            {
-                get { return false; }
-            }
+            public override bool CanWrite => false;
 
             public override void Flush()
             {
@@ -358,141 +474,5 @@ namespace Microsoft.PowerShell.Commands
                 throw new NotSupportedException();
             }
         }
-    }
-
-    // TODO: Merge Partials
-
-    /// <summary>
-    /// The Invoke-RestMethod command
-    /// This command makes an HTTP or HTTPS request to a web service,
-    /// and returns the response in an appropriate way.
-    /// Intended to work against the wide spectrum of "RESTful" web services
-    /// currently deployed across the web.
-    /// </summary>
-    [Cmdlet(VerbsLifecycle.Invoke, "RestMethod", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096706", DefaultParameterSetName = "StandardMethod")]
-    public partial class InvokeRestMethodCommand : WebRequestPSCmdlet
-    {
-        #region Virtual Method Overrides
-
-        /// <summary>
-        /// Process the web response and output corresponding objects.
-        /// </summary>
-        /// <param name="response"></param>
-        internal override void ProcessResponse(HttpResponseMessage response)
-        {
-            ArgumentNullException.ThrowIfNull(response);
-
-            var baseResponseStream = StreamHelper.GetResponseStream(response);
-
-            if (ShouldWriteToPipeline)
-            {
-                using var responseStream = new BufferingStreamReader(baseResponseStream);
-
-                // First see if it is an RSS / ATOM feed, in which case we can
-                // stream it - unless the user has overridden it with a return type of "XML"
-                if (TryProcessFeedStream(responseStream))
-                {
-                    // Do nothing, content has been processed.
-                }
-                else
-                {
-                    // determine the response type
-                    RestReturnType returnType = CheckReturnType(response);
-
-                    // Try to get the response encoding from the ContentType header.
-                    Encoding encoding = null;
-                    string charSet = response.Content.Headers.ContentType?.CharSet;
-                    if (!string.IsNullOrEmpty(charSet))
-                    {
-                        StreamHelper.TryGetEncoding(charSet, out encoding);
-                    }
-
-                    object obj = null;
-                    Exception ex = null;
-
-                    string str = StreamHelper.DecodeStream(responseStream, ref encoding);
-
-                    string encodingVerboseName;
-                    try
-                    {
-                        encodingVerboseName = string.IsNullOrEmpty(encoding.HeaderName) ? encoding.EncodingName : encoding.HeaderName;
-                    }
-                    catch (NotSupportedException)
-                    {
-                        encodingVerboseName = encoding.EncodingName;
-                    }
-                    // NOTE: Tests use this verbose output to verify the encoding.
-                    WriteVerbose(string.Format
-                    (
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        "Content encoding: {0}",
-                        encodingVerboseName)
-                    );
-                    bool convertSuccess = false;
-
-                    if (returnType == RestReturnType.Json)
-                    {
-                        convertSuccess = TryConvertToJson(str, out obj, ref ex) || TryConvertToXml(str, out obj, ref ex);
-                    }
-                    // default to try xml first since it's more common
-                    else
-                    {
-                        convertSuccess = TryConvertToXml(str, out obj, ref ex) || TryConvertToJson(str, out obj, ref ex);
-                    }
-
-                    if (!convertSuccess)
-                    {
-                        // fallback to string
-                        obj = str;
-                    }
-
-                    WriteObject(obj);
-                }
-            }
-            else if (ShouldSaveToOutFile)
-            {
-                StreamHelper.SaveStreamToFile(baseResponseStream, QualifiedOutFile, this, response.Content.Headers.ContentLength.GetValueOrDefault(), _cancelToken.Token);
-            }
-
-            if (!string.IsNullOrEmpty(StatusCodeVariable))
-            {
-                PSVariableIntrinsics vi = SessionState.PSVariable;
-                vi.Set(StatusCodeVariable, (int)response.StatusCode);
-            }
-
-            if (!string.IsNullOrEmpty(ResponseHeadersVariable))
-            {
-                PSVariableIntrinsics vi = SessionState.PSVariable;
-                vi.Set(ResponseHeadersVariable, WebResponseHelper.GetHeadersDictionary(response));
-            }
-        }
-
-        #endregion Virtual Method Overrides
-
-        #region Helper Methods
-
-        private static RestReturnType CheckReturnType(HttpResponseMessage response)
-        {
-            ArgumentNullException.ThrowIfNull(response);
-
-            RestReturnType rt = RestReturnType.Detect;
-            string contentType = ContentHelper.GetContentType(response);
-            if (string.IsNullOrEmpty(contentType))
-            {
-                rt = RestReturnType.Detect;
-            }
-            else if (ContentHelper.IsJson(contentType))
-            {
-                rt = RestReturnType.Json;
-            }
-            else if (ContentHelper.IsXml(contentType))
-            {
-                rt = RestReturnType.Xml;
-            }
-
-            return (rt);
-        }
-
-        #endregion Helper Methods
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -762,7 +762,7 @@ namespace Microsoft.PowerShell.Commands
 
         private static Uri CheckProtocol(Uri uri)
         {
-            if (uri == null) { throw new ArgumentNullException(nameof(uri)); }
+            ArgumentNullException.ThrowIfNull(uri);
 
             if (!uri.IsAbsoluteUri)
             {
@@ -780,8 +780,7 @@ namespace Microsoft.PowerShell.Commands
 
         private static string FormatDictionary(IDictionary content)
         {
-            if (content == null)
-                throw new ArgumentNullException(nameof(content));
+            ArgumentNullException.ThrowIfNull(content);
 
             StringBuilder bodyBuilder = new();
             foreach (string key in content.Keys)
@@ -1181,7 +1180,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal virtual void FillRequestStream(HttpRequestMessage request)
         {
-            if (request == null) { throw new ArgumentNullException(nameof(request)); }
+            ArgumentNullException.ThrowIfNull(request);
 
             // set the content type
             if (ContentType != null)
@@ -1352,9 +1351,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal virtual HttpResponseMessage GetResponse(HttpClient client, HttpRequestMessage request, bool keepAuthorization)
         {
-            if (client == null) { throw new ArgumentNullException(nameof(client)); }
+            ArgumentNullException.ThrowIfNull(client);
 
-            if (request == null) { throw new ArgumentNullException(nameof(request)); }
+            ArgumentNullException.ThrowIfNull(request);
 
             // Add 1 to account for the first request.
             int totalRequests = WebSession.MaximumRetryCount + 1;
@@ -1466,7 +1465,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal virtual void UpdateSession(HttpResponseMessage response)
         {
-            if (response == null) { throw new ArgumentNullException(nameof(response)); }
+            ArgumentNullException.ThrowIfNull(response);
         }
 
         #endregion Virtual Methods
@@ -1659,8 +1658,8 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         internal long SetRequestContent(HttpRequestMessage request, byte[] content)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            ArgumentNullException.ThrowIfNull(request);
+
             if (content == null)
                 return 0;
 
@@ -1682,8 +1681,7 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         internal long SetRequestContent(HttpRequestMessage request, string content)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            ArgumentNullException.ThrowIfNull(request);
 
             if (content == null)
                 return 0;
@@ -1731,8 +1729,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal long SetRequestContent(HttpRequestMessage request, XmlNode xmlNode)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            ArgumentNullException.ThrowIfNull(request);
 
             if (xmlNode == null)
                 return 0;
@@ -1768,10 +1765,9 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         internal long SetRequestContent(HttpRequestMessage request, Stream contentStream)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-            if (contentStream == null)
-                throw new ArgumentNullException(nameof(contentStream));
+            ArgumentNullException.ThrowIfNull(request);
+
+            ArgumentNullException.ThrowIfNull(contentStream);
 
             var streamContent = new StreamContent(contentStream);
             request.Content = streamContent;
@@ -1791,15 +1787,9 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         internal long SetRequestContent(HttpRequestMessage request, MultipartFormDataContent multipartContent)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
+            ArgumentNullException.ThrowIfNull(request);
 
-            if (multipartContent == null)
-            {
-                throw new ArgumentNullException(nameof(multipartContent));
-            }
+            ArgumentNullException.ThrowIfNull(multipartContent);
 
             request.Content = multipartContent;
 
@@ -1808,10 +1798,9 @@ namespace Microsoft.PowerShell.Commands
 
         internal long SetRequestContent(HttpRequestMessage request, IDictionary content)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-            if (content == null)
-                throw new ArgumentNullException(nameof(content));
+            ArgumentNullException.ThrowIfNull(request);
+
+            ArgumentNullException.ThrowIfNull(content);
 
             string body = FormatDictionary(content);
             return (SetRequestContent(request, body));
@@ -1864,10 +1853,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="enumerate">If true, collection types in <paramref name="fieldValue"/> will be enumerated. If false, collections will be treated as single value.</param>
         private void AddMultipartContent(object fieldName, object fieldValue, MultipartFormDataContent formData, bool enumerate)
         {
-            if (formData == null)
-            {
-                throw new ArgumentNullException(nameof(formData));
-            }
+            ArgumentNullException.ThrowIfNull(formData);
 
             // It is possible that the dictionary keys or values are PSObject wrapped depending on how the dictionary is defined and assigned.
             // Before processing the field name and value we need to ensure we are working with the base objects and not the PSObject wrappers.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void SetResponse(HttpResponseMessage response, Stream contentStream)
         {
-            if (response is null) { throw new ArgumentNullException(nameof(response)); }
+            ArgumentNullException.ThrowIfNull(response);
 
             BaseResponse = response;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="response"></param>
         internal override void ProcessResponse(HttpResponseMessage response)
         {
-            if (response == null) { throw new ArgumentNullException(nameof(response)); }
+            ArgumentNullException.ThrowIfNull(response);
 
             Stream responseStream = StreamHelper.GetResponseStream(response);
             if (ShouldWriteToPipeline)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebProxy.cs
@@ -13,10 +13,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal WebProxy(Uri address)
         {
-            if (address == null)
-            {
-                throw new ArgumentNullException(nameof(address));
-            }
+            ArgumentNullException.ThrowIfNull(address);
 
             _proxyAddress = address;
         }
@@ -48,10 +45,7 @@ namespace Microsoft.PowerShell.Commands
 
         public Uri GetProxy(Uri destination)
         {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
+            ArgumentNullException.ThrowIfNull(destination);
 
             if (destination.IsLoopback)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -152,10 +152,7 @@ namespace Microsoft.PowerShell.Commands
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
         public static object ConvertFromJson(string input, bool returnHashtable, int? maxDepth, out ErrorRecord error)
         {
-            if (input == null)
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
+            ArgumentNullException.ThrowIfNull(input);
 
             error = null;
             try

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -290,10 +290,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal static void WriteToStream(Stream input, Stream output, PSCmdlet cmdlet, long? contentLength, CancellationToken cancellationToken)
         {
-            if (cmdlet == null)
-            {
-                throw new ArgumentNullException(nameof(cmdlet));
-            }
+            ArgumentNullException.ThrowIfNull(cmdlet);
 
             Task copyTask = input.CopyToAsync(output, cancellationToken);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
@@ -330,15 +330,9 @@ namespace Microsoft.PowerShell.Commands
             bool writeError,
             Collection<PSTraceSource> matchingSources)
         {
-            if (cmdlet == null)
-            {
-                throw new ArgumentNullException(nameof(cmdlet));
-            }
-
-            if (matchingSources == null)
-            {
-                throw new ArgumentNullException(nameof(matchingSources));
-            }
+            ArgumentNullException.ThrowIfNull(cmdlet);
+            
+            ArgumentNullException.ThrowIfNull(matchingSources);
 
             _cmdlet = cmdlet;
             _writeError = writeError;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -771,7 +771,7 @@ namespace Microsoft.PowerShell
 
             public ConsoleColorProxy(ConsoleHostUserInterface ui)
             {
-                if (ui == null) throw new ArgumentNullException(nameof(ui));
+                ArgumentNullException.ThrowIfNull(ui);
                 _ui = ui;
             }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -49,10 +49,7 @@ namespace Microsoft.PowerShell
         /// </param>
         public static int Start([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] string[] args, int argc)
         {
-            if (args == null)
-            {
-                throw new ArgumentNullException(nameof(args));
-            }
+            ArgumentNullException.ThrowIfNull(args);
 
 #if DEBUG
             if (args.Length > 0 && !string.IsNullOrEmpty(args[0]) && args[0]!.Equals("-isswait", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell
         internal
         ProgressPane(ConsoleHostUserInterface ui)
         {
-            if (ui == null) throw new ArgumentNullException(nameof(ui));
+            ArgumentNullException.ThrowIfNull(ui);
             _ui = ui;
             _rawui = ui.RawUI;
         }

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
@@ -437,10 +437,7 @@ namespace System.Diagnostics.Eventing
         {
             int status = 0;
 
-            if (eventMessage == null)
-            {
-                throw new ArgumentNullException(nameof(eventMessage));
-            }
+            ArgumentNullException.ThrowIfNull(eventMessage);
 
             if (IsEnabled(eventLevel, eventKeywords))
             {
@@ -508,10 +505,7 @@ namespace System.Diagnostics.Eventing
         {
             uint status = 0;
 
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
+            ArgumentNullException.ThrowIfNull(data);
 
             if (IsEnabled(eventDescriptor.Level, eventDescriptor.Keywords))
             {

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
@@ -72,8 +72,7 @@ namespace System.Diagnostics.Eventing
         public EventProviderTraceListener(string providerId, string name, string delimiter)
             : base(name)
         {
-            if (delimiter == null)
-                throw new ArgumentNullException(nameof(delimiter));
+            ArgumentNullException.ThrowIfNull(delimiter);
 
             if (delimiter.Length == 0)
                 throw new ArgumentException(DotNetEventingStrings.Argument_NeedNonemptyDelimiter);

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
@@ -3145,8 +3145,7 @@ namespace System.Management.Automation.SecurityAccountsManager
 
             internal OperatingSystem(Version version, string servicePack)
             {
-                if (version == null)
-                    throw new ArgumentNullException("version");
+                ArgumentNullException.ThrowIfNull(version);
 
                 _version = version;
                 _servicePack = servicePack;

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobTrigger.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobTrigger.cs
@@ -709,10 +709,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         /// <returns>True if the converter can convert the <paramref name="sourceValue"/> parameter to the <paramref name="destinationType"/> parameter, otherwise false.</returns>
         public override bool CanConvertFrom(object sourceValue, Type destinationType)
         {
-            if (destinationType == null)
-            {
-                throw new ArgumentNullException("destinationType");
-            }
+            ArgumentNullException.ThrowIfNull(destinationType);
 
             return (sourceValue is ScheduledJobTrigger) && (destinationType.Equals(typeof(CimInstance)));
         }
@@ -728,15 +725,9 @@ namespace Microsoft.PowerShell.ScheduledJob
         /// <exception cref="InvalidCastException">If no conversion was possible.</exception>
         public override object ConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
         {
-            if (destinationType == null)
-            {
-                throw new ArgumentNullException("destinationType");
-            }
+            ArgumentNullException.ThrowIfNull(destinationType);
 
-            if (sourceValue == null)
-            {
-                throw new ArgumentNullException("sourceValue");
-            }
+            ArgumentNullException.ThrowIfNull(sourceValue);
 
             ScheduledJobTrigger originalTrigger = (ScheduledJobTrigger) sourceValue;
             using (CimSession cimSession = CimSession.Create(null))

--- a/src/Microsoft.WSMan.Management/CurrentConfigurations.cs
+++ b/src/Microsoft.WSMan.Management/CurrentConfigurations.cs
@@ -61,10 +61,7 @@ namespace Microsoft.WSMan.Management
         /// <param name="serverSession">Current server session.</param>
         public CurrentConfigurations(IWSManSession serverSession)
         {
-            if (serverSession == null)
-            {
-                throw new ArgumentNullException(nameof(serverSession));
-            }
+            ArgumentNullException.ThrowIfNull(serverSession);
 
             this.rootDocument = new XmlDocument();
             this.serverSession = serverSession;
@@ -117,10 +114,7 @@ namespace Microsoft.WSMan.Management
         /// <param name="pathToNodeFromRoot">Path with namespace to the node from Root element. Must not end with '/'.</param>
         public void RemoveOneConfiguration(string pathToNodeFromRoot)
         {
-            if (pathToNodeFromRoot == null)
-            {
-                throw new ArgumentNullException(nameof(pathToNodeFromRoot));
-            }
+            ArgumentNullException.ThrowIfNull(pathToNodeFromRoot);
 
             XmlNode nodeToRemove =
                 this.documentElement.SelectSingleNode(
@@ -150,20 +144,14 @@ namespace Microsoft.WSMan.Management
         /// <param name="configurationValue">Value of the configurations.</param>
         public void UpdateOneConfiguration(string pathToNodeFromRoot, string configurationName, string configurationValue)
         {
-            if (pathToNodeFromRoot == null)
-            {
-                throw new ArgumentNullException(nameof(pathToNodeFromRoot));
-            }
+            ArgumentNullException.ThrowIfNull(pathToNodeFromRoot);
 
             if (string.IsNullOrEmpty(configurationName))
             {
                 throw new ArgumentNullException(nameof(configurationName));
             }
 
-            if (configurationValue == null)
-            {
-                throw new ArgumentNullException(nameof(configurationValue));
-            }
+            ArgumentNullException.ThrowIfNull(configurationValue);
 
             XmlNode nodeToUpdate =
                 this.documentElement.SelectSingleNode(
@@ -195,10 +183,7 @@ namespace Microsoft.WSMan.Management
         /// <returns>Value of the Node, or Null if no node present.</returns>
         public string GetOneConfiguration(string pathFromRoot)
         {
-            if (pathFromRoot == null)
-            {
-                throw new ArgumentNullException(nameof(pathFromRoot));
-            }
+            ArgumentNullException.ThrowIfNull(pathFromRoot);
 
             XmlNode requiredNode =
                 this.documentElement.SelectSingleNode(

--- a/src/Microsoft.WSMan.Management/WsManHelper.cs
+++ b/src/Microsoft.WSMan.Management/WsManHelper.cs
@@ -178,10 +178,7 @@ namespace Microsoft.WSMan.Management
             string resourceName,
             object[] args)
         {
-            if (resourceManager == null)
-            {
-                throw new ArgumentNullException(nameof(resourceManager));
-            }
+            ArgumentNullException.ThrowIfNull(resourceManager);
 
             if (string.IsNullOrEmpty(resourceName))
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -761,10 +761,7 @@ namespace System.Management.Automation
 
         private static string ValidateNoContent(string text)
         {
-            if (text is null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
+            ArgumentNullException.ThrowIfNull(text);
 
             var decorartedString = new ValueStringDecorated(text);
             if (decorartedString.ContentLength > 0)

--- a/src/System.Management.Automation/cimSupport/cmdletization/MethodInvocationInfo.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/MethodInvocationInfo.cs
@@ -21,8 +21,8 @@ namespace Microsoft.PowerShell.Cmdletization
         /// <param name="returnValue">Return value of the method (ok to pass <see langword="null"/> if the method doesn't return anything).</param>
         public MethodInvocationInfo(string name, IEnumerable<MethodParameter> parameters, MethodParameter returnValue)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
-            if (parameters == null) throw new ArgumentNullException(nameof(parameters));
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(parameters);
             // returnValue can be null
 
             MethodName = name;

--- a/src/System.Management.Automation/cimSupport/cmdletization/ObjectModelWrapper.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ObjectModelWrapper.cs
@@ -17,25 +17,17 @@ namespace Microsoft.PowerShell.Cmdletization
     {
         internal void Initialize(PSCmdlet cmdlet, string className, string classVersion, IDictionary<string, string> privateData)
         {
-            if (cmdlet == null)
-            {
-                throw new ArgumentNullException(nameof(cmdlet));
-            }
+            ArgumentNullException.ThrowIfNull(cmdlet);
 
             if (string.IsNullOrEmpty(className))
             {
                 throw new ArgumentNullException(nameof(className));
             }
 
-            if (classVersion == null) // possible and ok to have classVersion==string.Empty
-            {
-                throw new ArgumentNullException(nameof(classVersion));
-            }
+            // possible and ok to have classVersion==string.Empty
+            ArgumentNullException.ThrowIfNull(classVersion);
 
-            if (privateData == null)
-            {
-                throw new ArgumentNullException(nameof(privateData));
-            }
+            ArgumentNullException.ThrowIfNull(privateData);
 
             _cmdlet = cmdlet;
             _className = className;

--- a/src/System.Management.Automation/cimSupport/cmdletization/xml/CoreCLR/cmdlets-over-objects.xmlSerializer.autogen.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/xml/CoreCLR/cmdlets-over-objects.xmlSerializer.autogen.cs
@@ -6678,10 +6678,7 @@ namespace Microsoft.PowerShell.Cmdletization.Xml
     {
         internal object Deserialize(XmlReader reader)
         {
-            if (reader == null)
-            {
-                throw new ArgumentNullException(nameof(reader));
-            }
+            ArgumentNullException.ThrowIfNull(reader);
 
             XmlSerializationReader1 cdxmlSerializationReader = new XmlSerializationReader1(reader);
             return cdxmlSerializationReader.Read50_PowerShellMetadata();

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -195,10 +195,7 @@ namespace Microsoft.PowerShell.Cim
         /// <returns></returns>
         public override string GetPropertyTypeName(PSAdaptedProperty adaptedProperty)
         {
-            if (adaptedProperty == null)
-            {
-                throw new ArgumentNullException(nameof(adaptedProperty));
-            }
+            ArgumentNullException.ThrowIfNull(adaptedProperty);
 
             CimProperty cimProperty = adaptedProperty.Tag as CimProperty;
             if (cimProperty != null)
@@ -220,10 +217,7 @@ namespace Microsoft.PowerShell.Cim
         /// <returns></returns>
         public override object GetPropertyValue(PSAdaptedProperty adaptedProperty)
         {
-            if (adaptedProperty == null)
-            {
-                throw new ArgumentNullException(nameof(adaptedProperty));
-            }
+            ArgumentNullException.ThrowIfNull(adaptedProperty);
 
             CimProperty cimProperty = adaptedProperty.Tag as CimProperty;
             if (cimProperty != null)
@@ -375,10 +369,7 @@ namespace Microsoft.PowerShell.Cim
         /// <param name="value"></param>
         public override void SetPropertyValue(PSAdaptedProperty adaptedProperty, object value)
         {
-            if (adaptedProperty == null)
-            {
-                throw new ArgumentNullException(nameof(adaptedProperty));
-            }
+            ArgumentNullException.ThrowIfNull(adaptedProperty);
 
             if (!IsSettable(adaptedProperty))
             {

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -110,10 +110,7 @@ namespace System.Management.Automation
             // The name can be empty for functions and filters but it
             // can't be null
 
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             Name = name;
             CommandType = type;

--- a/src/System.Management.Automation/engine/EngineIntrinsics.cs
+++ b/src/System.Management.Automation/engine/EngineIntrinsics.cs
@@ -35,10 +35,7 @@ namespace System.Management.Automation
         /// </exception>
         internal EngineIntrinsics(ExecutionContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             _context = context;
             _host = context.EngineHostInterface;

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -193,10 +193,7 @@ namespace System.Management.Automation
         #region ctor
         internal ErrorCategoryInfo(ErrorRecord errorRecord)
         {
-            if (errorRecord == null)
-            {
-                throw new ArgumentNullException(nameof(errorRecord));
-            }
+            ArgumentNullException.ThrowIfNull(errorRecord);
 
             _errorRecord = errorRecord;
         }

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -817,10 +817,7 @@ namespace System.Management.Automation
         /// </summary>
         private void UnsubscribeEvent(PSEventSubscriber subscriber, bool skipDraining)
         {
-            if (subscriber == null)
-            {
-                throw new ArgumentNullException(nameof(subscriber));
-            }
+            ArgumentNullException.ThrowIfNull(subscriber);
 
             Delegate existingSubscriber = null;
             lock (_eventSubscribers)
@@ -2368,10 +2365,7 @@ namespace System.Management.Automation
         /// <remarks>Don't add events to the collection directly; use the EventManager instead</remarks>
         internal void Add(PSEventArgs eventToAdd)
         {
-            if (eventToAdd == null)
-            {
-                throw new ArgumentNullException(nameof(eventToAdd));
-            }
+            ArgumentNullException.ThrowIfNull(eventToAdd);
 
             _eventCollection.Add(eventToAdd);
 
@@ -2486,10 +2480,9 @@ namespace System.Management.Automation
             string name)
             : base(action?.ToString(), name)
         {
-            if (eventManager == null)
-                throw new ArgumentNullException(nameof(eventManager));
-            if (subscriber == null)
-                throw new ArgumentNullException(nameof(subscriber));
+            ArgumentNullException.ThrowIfNull(eventManager);
+
+            ArgumentNullException.ThrowIfNull(subscriber);
 
             UsesResultsCollection = true;
             ScriptBlock = action;

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -303,10 +303,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 // if '...CimInstance#Win32_Process' is specified, then exclude '...CimInstance'
                 List<PSTypeName> filteredParameterTypes = new List<PSTypeName>(value.Length);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -980,10 +980,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="items"></param>
         public InitialSessionStateEntryCollection(IEnumerable<T> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
+            ArgumentNullException.ThrowIfNull(items);
 
             _internalCollection = new Collection<T>();
 
@@ -1154,10 +1151,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="type">The type of object to remove, can be null to remove any type.</param>
         public void Remove(string name, object type)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             lock (_syncObject)
             {
@@ -1192,10 +1186,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="item">The item to add...</param>
         public void Add(T item)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException(nameof(item));
-            }
+            ArgumentNullException.ThrowIfNull(item);
 
             lock (_syncObject)
             {
@@ -1209,10 +1200,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="items"></param>
         public void Add(IEnumerable<T> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
+            ArgumentNullException.ThrowIfNull(items);
 
             lock (_syncObject)
             {
@@ -1870,10 +1858,7 @@ namespace System.Management.Automation.Runspaces
         /// <returns></returns>
         public void ImportPSModule(params string[] name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             foreach (string n in name)
             {
@@ -1898,10 +1883,7 @@ namespace System.Management.Automation.Runspaces
         /// </param>
         public void ImportPSModule(IEnumerable<ModuleSpecification> modules)
         {
-            if (modules == null)
-            {
-                throw new ArgumentNullException(nameof(modules));
-            }
+            ArgumentNullException.ThrowIfNull(modules);
 
             foreach (var moduleSpecification in modules)
             {
@@ -1929,10 +1911,7 @@ namespace System.Management.Automation.Runspaces
         /// <returns></returns>
         internal void ImportPSCoreModule(string[] name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             foreach (string n in name)
             {
@@ -4931,10 +4910,8 @@ end {
             out string helpFile)
         {
             helpFile = null;
-            if (assembly == null)
-            {
-                throw new ArgumentNullException(nameof(assembly));
-            }
+
+            ArgumentNullException.ThrowIfNull(assembly);
 
             cmdlets = null;
             aliases = null;

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -67,10 +67,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="moduleSpecification">The module specification as a hashtable.</param>
         public ModuleSpecification(Hashtable moduleSpecification)
         {
-            if (moduleSpecification == null)
-            {
-                throw new ArgumentNullException(nameof(moduleSpecification));
-            }
+            ArgumentNullException.ThrowIfNull(moduleSpecification);
 
             var exception = ModuleSpecificationInitHelper(this, moduleSpecification);
             if (exception != null)
@@ -172,10 +169,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal ModuleSpecification(PSModuleInfo moduleInfo)
         {
-            if (moduleInfo == null)
-            {
-                throw new ArgumentNullException(nameof(moduleInfo));
-            }
+            ArgumentNullException.ThrowIfNull(moduleInfo);
 
             this.Name = moduleInfo.Name;
             this.Version = moduleInfo.Version;

--- a/src/System.Management.Automation/engine/MshCmdlet.cs
+++ b/src/System.Management.Automation/engine/MshCmdlet.cs
@@ -801,8 +801,7 @@ namespace System.Management.Automation
             IList input,
             params object[] args)
         {
-            if (script == null)
-                throw new ArgumentNullException(nameof(script));
+            ArgumentNullException.ThrowIfNull(script);
 
             // Compile the script text into an executable script block.
             ScriptBlock sb = ScriptBlock.Create(_context, script);

--- a/src/System.Management.Automation/engine/ProxyCommand.cs
+++ b/src/System.Management.Automation/engine/ProxyCommand.cs
@@ -376,10 +376,7 @@ namespace System.Management.Automation
         /// <exception cref="System.InvalidOperationException">When the help argument is not recognized as a HelpInfo object.</exception>
         public static string GetHelpComments(PSObject help)
         {
-            if (help == null)
-            {
-                throw new ArgumentNullException(nameof(help));
-            }
+            ArgumentNullException.ThrowIfNull(help);
 
             bool isHelpObject = false;
             foreach (string typeName in help.InternalTypeNames)

--- a/src/System.Management.Automation/engine/SessionStateUtils.cs
+++ b/src/System.Management.Automation/engine/SessionStateUtils.cs
@@ -151,10 +151,7 @@ namespace System.Management.Automation
         /// </exception>
         internal static bool CollectionContainsValue(IEnumerable collection, object value, IComparer comparer)
         {
-            if (collection == null)
-            {
-                throw new ArgumentNullException(nameof(collection));
-            }
+            ArgumentNullException.ThrowIfNull(collection);
 
             bool result = false;
 

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -296,10 +296,7 @@ namespace System.Management.Automation
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "object")]
         public virtual Collection<string> GetTypeNameHierarchy(object baseObject)
         {
-            if (baseObject == null)
-            {
-                throw new ArgumentNullException(nameof(baseObject));
-            }
+            ArgumentNullException.ThrowIfNull(baseObject);
 
             Collection<string> types = new Collection<string>();
 

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -4732,15 +4732,9 @@ namespace System.Management.Automation.Runspaces
             PSHost host,
             out bool failToLoadFile)
         {
-            if (filePath == null)
-            {
-                throw new ArgumentNullException(nameof(filePath));
-            }
+            ArgumentNullException.ThrowIfNull(filePath);
 
-            if (errors == null)
-            {
-                throw new ArgumentNullException(nameof(errors));
-            }
+            ArgumentNullException.ThrowIfNull(errors);
 
             if (isShared)
             {
@@ -4810,10 +4804,9 @@ namespace System.Management.Automation.Runspaces
             ConcurrentBag<string> errors,
             bool isRemove)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-            if (errors == null)
-                throw new ArgumentNullException(nameof(errors));
+            ArgumentNullException.ThrowIfNull(type);
+
+            ArgumentNullException.ThrowIfNull(errors);
 
             if (isShared)
             {

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1702,10 +1702,7 @@ namespace System.Management.Automation.Internal
         /// </summary>
         internal ReadOnlyBag(HashSet<T> hashset)
         {
-            if (hashset == null)
-            {
-                throw new ArgumentNullException(nameof(hashset));
-            }
+            ArgumentNullException.ThrowIfNull(hashset);
 
             _hashset = hashset;
         }

--- a/src/System.Management.Automation/engine/cmdlet.cs
+++ b/src/System.Management.Automation/engine/cmdlet.cs
@@ -1719,8 +1719,7 @@ namespace System.Management.Automation
         {
             using (PSTransactionManager.GetEngineProtectionScope())
             {
-                if (errorRecord == null)
-                    throw new ArgumentNullException(nameof(errorRecord));
+                ArgumentNullException.ThrowIfNull(errorRecord);
 
                 if (commandRuntime != null)
                 {

--- a/src/System.Management.Automation/engine/hostifaces/ListModifier.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ListModifier.cs
@@ -212,10 +212,7 @@ namespace System.Management.Automation
         /// <param name="collectionToUpdate">The collection to update.</param>
         public void ApplyTo(object collectionToUpdate)
         {
-            if (collectionToUpdate == null)
-            {
-                throw new ArgumentNullException(nameof(collectionToUpdate));
-            }
+            ArgumentNullException.ThrowIfNull(collectionToUpdate);
 
             collectionToUpdate = PSObject.Base(collectionToUpdate);
 

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -6157,15 +6157,9 @@ namespace System.Management.Automation
 
         internal PowerShellStopper(ExecutionContext context, PowerShell powerShell)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
-            if (powerShell == null)
-            {
-                throw new ArgumentNullException(nameof(powerShell));
-            }
+            ArgumentNullException.ThrowIfNull(powerShell);
 
             _powerShell = powerShell;
 

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -1096,15 +1096,9 @@ namespace System.Management.Automation
     {
         internal SteppablePipeline(ExecutionContext context, PipelineProcessor pipeline)
         {
-            if (pipeline == null)
-            {
-                throw new ArgumentNullException(nameof(pipeline));
-            }
+            ArgumentNullException.ThrowIfNull(pipeline);
 
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             _pipeline = pipeline;
             _context = context;
@@ -1128,10 +1122,7 @@ namespace System.Management.Automation
         /// <param name="contextToRedirectTo">Context used to figure out how to route the output and errors.</param>
         public void Begin(bool expectInput, EngineIntrinsics contextToRedirectTo)
         {
-            if (contextToRedirectTo == null)
-            {
-                throw new ArgumentNullException(nameof(contextToRedirectTo));
-            }
+            ArgumentNullException.ThrowIfNull(contextToRedirectTo);
 
             ExecutionContext executionContext = contextToRedirectTo.SessionState.Internal.ExecutionContext;
             CommandProcessorBase commandProcessor = executionContext.CurrentCommandProcessor;

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -142,10 +142,7 @@ namespace System.Management.Automation.Language
         /// <returns>The <see cref="ScriptBlockAst"/> that represents the input script file.</returns>
         public static ScriptBlockAst ParseInput(string input, string fileName, out Token[] tokens, out ParseError[] errors)
         {
-            if (input is null)
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
+            ArgumentNullException.ThrowIfNull(input);
 
             Parser parser = new Parser();
             List<Token> tokenList = new List<Token>();

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -3884,10 +3884,7 @@ namespace System.Management.Automation.Language
         /// <returns></returns>
         public CommentHelpInfo GetHelpContent(Dictionary<Ast, Token[]> scriptBlockTokenCache)
         {
-            if (scriptBlockTokenCache == null)
-            {
-                throw new ArgumentNullException(nameof(scriptBlockTokenCache));
-            }
+            ArgumentNullException.ThrowIfNull(scriptBlockTokenCache);
 
             var commentTokens = HelpCommentsParser.GetHelpCommentTokens(this, scriptBlockTokenCache);
             if (commentTokens != null)
@@ -5577,15 +5574,9 @@ namespace System.Management.Automation.Language
             bool background = false)
             : base(extent)
         {
-            if (lhsChain == null)
-            {
-                throw new ArgumentNullException(nameof(lhsChain));
-            }
+            ArgumentNullException.ThrowIfNull(lhsChain);
 
-            if (rhsPipeline == null)
-            {
-                throw new ArgumentNullException(nameof(rhsPipeline));
-            }
+            ArgumentNullException.ThrowIfNull(rhsPipeline);
 
             if (chainOperator != TokenKind.AndAnd && chainOperator != TokenKind.OrOr)
             {
@@ -10462,10 +10453,7 @@ namespace System.Management.Automation.Language
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "We want to get the underlying variable only for the UsingExpressionAst.")]
         public static VariableExpressionAst ExtractUsingVariable(UsingExpressionAst usingExpressionAst)
         {
-            if (usingExpressionAst == null)
-            {
-                throw new ArgumentNullException(nameof(usingExpressionAst));
-            }
+            ArgumentNullException.ThrowIfNull(usingExpressionAst);
 
             return ExtractUsingVariableImpl(usingExpressionAst);
         }

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -447,10 +447,7 @@ namespace System.Management.Automation
         internal WildcardPatternException(ErrorRecord errorRecord)
             : base(RetrieveMessage(errorRecord))
         {
-            if (errorRecord == null)
-            {
-                throw new ArgumentNullException(nameof(errorRecord));
-            }
+            ArgumentNullException.ThrowIfNull(errorRecord);
 
             _errorRecord = errorRecord;
         }

--- a/src/System.Management.Automation/engine/remoting/client/Job2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job2.cs
@@ -706,10 +706,8 @@ namespace System.Management.Automation
         public void AddChildJob(Job2 childJob)
         {
             AssertNotDisposed();
-            if (childJob == null)
-            {
-                throw new ArgumentNullException(nameof(childJob));
-            }
+
+            ArgumentNullException.ThrowIfNull(childJob);
 
             _tracer.WriteMessage(TraceClassName, "AddChildJob", Guid.Empty, childJob, "Adding Child to Parent with InstanceId : ", InstanceId.ToString());
 
@@ -2181,8 +2179,7 @@ namespace System.Management.Automation
         /// <param name="context">The standard StreaminContext.</param>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
-                throw new ArgumentNullException(nameof(info));
+            ArgumentNullException.ThrowIfNull(info);
 
             base.GetObjectData(info, context);
 

--- a/src/System.Management.Automation/engine/remoting/client/JobManager.cs
+++ b/src/System.Management.Automation/engine/remoting/client/JobManager.cs
@@ -176,10 +176,7 @@ namespace System.Management.Automation
         /// </exception>
         public Job2 NewJob(JobDefinition definition)
         {
-            if (definition == null)
-            {
-                throw new ArgumentNullException(nameof(definition));
-            }
+            ArgumentNullException.ThrowIfNull(definition);
 
             JobSourceAdapter sourceAdapter = GetJobSourceAdapter(definition);
             Job2 newJob;
@@ -216,10 +213,7 @@ namespace System.Management.Automation
         /// </exception>
         public Job2 NewJob(JobInvocationInfo specification)
         {
-            if (specification == null)
-            {
-                throw new ArgumentNullException(nameof(specification));
-            }
+            ArgumentNullException.ThrowIfNull(specification);
 
             if (specification.Definition == null)
             {

--- a/src/System.Management.Automation/engine/remoting/client/RemotingErrorRecord.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingErrorRecord.cs
@@ -149,7 +149,7 @@ namespace System.Management.Automation.Runspaces
 
         private static ProgressRecord Validate(ProgressRecord progressRecord)
         {
-            if (progressRecord == null) throw new ArgumentNullException(nameof(progressRecord));
+            ArgumentNullException.ThrowIfNull(progressRecord);
             return progressRecord;
         }
     }

--- a/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
@@ -294,7 +294,7 @@ namespace System.Management.Automation
         {
             using (var jobGotEnqueued = new ManualResetEventSlim(initialState: false))
             {
-                if (childJob == null) throw new ArgumentNullException(nameof(childJob));
+                ArgumentNullException.ThrowIfNull(childJob);
 
                 this.AddChildJobWithoutBlocking(childJob, flags, jobGotEnqueued.Set);
                 jobGotEnqueued.Wait();
@@ -308,7 +308,7 @@ namespace System.Management.Automation
         {
             using (var forwardingCancellation = new CancellationTokenSource())
             {
-                if (childJob == null) throw new ArgumentNullException(nameof(childJob));
+                ArgumentNullException.ThrowIfNull(childJob);
 
                 this.AddChildJobWithoutBlocking(childJob, flags, forwardingCancellation.Cancel);
                 this.ForwardAllResultsToCmdlet(cmdlet, forwardingCancellation.Token);
@@ -368,7 +368,7 @@ namespace System.Management.Automation
         /// </exception>
         internal void AddChildJobWithoutBlocking(StartableJob childJob, ChildJobFlags flags, Action jobEnqueuedAction = null)
         {
-            if (childJob == null) throw new ArgumentNullException(nameof(childJob));
+            ArgumentNullException.ThrowIfNull(childJob);
             if (childJob.JobStateInfo.State != JobState.NotStarted) throw new ArgumentException(RemotingErrorIdStrings.ThrottlingJobChildAlreadyRunning, nameof(childJob));
             this.AssertNotDisposed();
 

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2460,10 +2460,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>A list of UsingExpressionAsts ordered by the StartOffset.</returns>
         private static List<VariableExpressionAst> GetUsingVariables(ScriptBlock localScriptBlock)
         {
-            if (localScriptBlock == null)
-            {
-                throw new ArgumentNullException(nameof(localScriptBlock), "Caller needs to make sure the parameter value is not null");
-            }
+            ArgumentNullException.ThrowIfNull(localScriptBlock, "Caller needs to make sure the parameter value is not null");
 
             var allUsingExprs = UsingExpressionAstSearcher.FindAllUsingExpressions(localScriptBlock.Ast);
             return allUsingExprs.Select(static usingExpr => UsingExpressionAst.ExtractUsingVariable((UsingExpressionAst)usingExpr)).ToList();

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -284,10 +284,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="options"></param>
         public virtual void SetSessionOptions(PSSessionOption options)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+            ArgumentNullException.ThrowIfNull(options);
 
             if (options.Culture != null)
             {
@@ -1029,10 +1026,7 @@ namespace System.Management.Automation.Runspaces
         /// </exception>
         public override void SetSessionOptions(PSSessionOption options)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+            ArgumentNullException.ThrowIfNull(options);
 
             if ((options.ProxyAccessType == ProxyAccessType.None) && (options.ProxyCredential != null))
             {

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -168,10 +168,7 @@ namespace System.Management.Automation.Runspaces
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 _culture = value;
             }
@@ -191,10 +188,7 @@ namespace System.Management.Automation.Runspaces
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 _uiCulture = value;
             }

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -820,14 +820,11 @@ namespace System.Management.Automation.Remoting
 
         public override InitialSessionState GetInitialSessionState(PSSessionConfigurationData sessionConfigurationData, PSSenderInfo senderInfo, string configProviderId)
         {
-            if (sessionConfigurationData == null)
-                throw new ArgumentNullException(nameof(sessionConfigurationData));
+            ArgumentNullException.ThrowIfNull(sessionConfigurationData);
 
-            if (senderInfo == null)
-                throw new ArgumentNullException(nameof(senderInfo));
+            ArgumentNullException.ThrowIfNull(senderInfo);
 
-            if (configProviderId == null)
-                throw new ArgumentNullException(nameof(configProviderId));
+            ArgumentNullException.ThrowIfNull(configProviderId);
 
             InitialSessionState sessionState = InitialSessionState.CreateDefault2();
             // now get all the modules in the specified path and import the same

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostRawUserInterface.cs
@@ -343,10 +343,7 @@ namespace System.Management.Automation.Remoting
         // to keep the other overload in sync: LengthInBufferCells(string, int)
         public override int LengthInBufferCells(string source)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ArgumentNullException.ThrowIfNull(source);
 
             return source.Length;
         }
@@ -354,10 +351,7 @@ namespace System.Management.Automation.Remoting
         // more performant than the default implementation provided by PSHostRawUserInterface
         public override int LengthInBufferCells(string source, int offset)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ArgumentNullException.ThrowIfNull(source);
 
             Dbg.Assert(offset >= 0, "offset >= 0");
             Dbg.Assert(string.IsNullOrEmpty(source) || (offset < source.Length), "offset < source.Length");

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2178,10 +2178,7 @@ namespace System.Management.Automation
 
         private ScriptBlockSerializationHelper(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
 
             _scriptText = info.GetValue("ScriptText", typeof(string)) as string;
             if (_scriptText == null)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -2777,10 +2777,8 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(enumerator != null, "The ForEach() operator should never receive a null enumerator value from the runtime.");
             Diagnostics.Assert(arguments != null, "The ForEach() operator should never receive a null value for the 'arguments' parameter from the runtime.");
-            if (expression == null)
-            {
-                throw new ArgumentNullException(nameof(expression));
-            }
+
+            ArgumentNullException.ThrowIfNull(expression);
 
             var context = Runspace.DefaultRunspace.ExecutionContext;
 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -5933,10 +5933,7 @@ namespace System.Management.Automation
         public PSPrimitiveDictionary(Hashtable other)
             : base(StringComparer.OrdinalIgnoreCase)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
 
             foreach (DictionaryEntry entry in other)
             {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8146,7 +8146,7 @@ namespace System.Management.Automation.Internal
         /// <returns>The list of streams (and their size) in the file.</returns>
         internal static List<AlternateStreamData> GetStreams(string path)
         {
-            if (path == null) throw new ArgumentNullException(nameof(path));
+            ArgumentNullException.ThrowIfNull(path);
 
             List<AlternateStreamData> alternateStreams = new List<AlternateStreamData>();
 
@@ -8239,15 +8239,9 @@ namespace System.Management.Automation.Internal
         /// <returns>True if the stream was successfully created, otherwise false.</returns>
         internal static bool TryCreateFileStream(string path, string streamName, FileMode mode, FileAccess access, FileShare share, out FileStream stream)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
+            ArgumentNullException.ThrowIfNull(path);
 
-            if (streamName == null)
-            {
-                throw new ArgumentNullException(nameof(streamName));
-            }
+            ArgumentNullException.ThrowIfNull(streamName);
 
             if (mode == FileMode.Append)
             {
@@ -8274,8 +8268,9 @@ namespace System.Management.Automation.Internal
         /// <param name="streamName">The name of the alternate data stream to delete.</param>
         internal static void DeleteFileStream(string path, string streamName)
         {
-            if (path == null) throw new ArgumentNullException(nameof(path));
-            if (streamName == null) throw new ArgumentNullException(nameof(streamName));
+            ArgumentNullException.ThrowIfNull(path);
+
+            ArgumentNullException.ThrowIfNull(streamName);
 
             string adjustedStreamName = streamName.Trim();
             if (adjustedStreamName.IndexOf(':') != 0)

--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -1640,8 +1640,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         public void SetAccessControl(TransactedRegistrySecurity registrySecurity)
         {
             EnsureWriteable();
-            if (registrySecurity == null)
-                throw new ArgumentNullException("registrySecurity");
+            ArgumentNullException.ThrowIfNull(registrySecurity);
             // Require a transaction. This will throw for "Base" keys because they aren't associated with a transaction.
             VerifyTransaction();
 

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -430,10 +430,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static byte[] Protect(byte[] userData, byte[] optionalEntropy, DataProtectionScope scope)
         {
-            if (userData == null)
-            {
-                throw new ArgumentNullException(nameof(userData));
-            }
+            ArgumentNullException.ThrowIfNull(userData);
 
             GCHandle pbDataIn = new GCHandle();
             GCHandle pOptionalEntropy = new GCHandle();
@@ -518,10 +515,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static byte[] Unprotect(byte[] encryptedData, byte[] optionalEntropy, DataProtectionScope scope)
         {
-            if (encryptedData == null)
-            {
-                throw new ArgumentNullException(nameof(encryptedData));
-            }
+            ArgumentNullException.ThrowIfNull(encryptedData);
 
             GCHandle pbDataIn = new GCHandle();
             GCHandle pOptionalEntropy = new GCHandle();

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -97,10 +97,7 @@ namespace System.Management.Automation.Internal
 
         private static RSA FromCapiPublicKeyBlob(byte[] blob, int offset)
         {
-            if (blob == null)
-            {
-                throw new ArgumentNullException(nameof(blob));
-            }
+            ArgumentNullException.ThrowIfNull(blob);
 
             if (offset > blob.Length)
             {
@@ -123,10 +120,7 @@ namespace System.Management.Automation.Internal
 
         private static RSAParameters GetParametersFromCapiPublicKeyBlob(byte[] blob, int offset)
         {
-            if (blob == null)
-            {
-                throw new ArgumentNullException(nameof(blob));
-            }
+            ArgumentNullException.ThrowIfNull(blob);
 
             if (offset > blob.Length)
             {
@@ -175,10 +169,7 @@ namespace System.Management.Automation.Internal
 
         internal static byte[] ToCapiPublicKeyBlob(RSA rsa)
         {
-            if (rsa == null)
-            {
-                throw new ArgumentNullException(nameof(rsa));
-            }
+            ArgumentNullException.ThrowIfNull(rsa);
 
             RSAParameters p = rsa.ExportParameters(false);
             int keyLength = p.Modulus.Length;   // in bytes
@@ -221,10 +212,7 @@ namespace System.Management.Automation.Internal
 
         internal static byte[] FromCapiSimpleKeyBlob(byte[] blob)
         {
-            if (blob == null)
-            {
-                throw new ArgumentNullException(nameof(blob));
-            }
+            ArgumentNullException.ThrowIfNull(blob);
 
             if (blob.Length < SIMPLEBLOB_HEADER_LEN)
             {
@@ -237,10 +225,7 @@ namespace System.Management.Automation.Internal
 
         internal static byte[] ToCapiSimpleKeyBlob(byte[] encryptedKey)
         {
-            if (encryptedKey == null)
-            {
-                throw new ArgumentNullException(nameof(encryptedKey));
-            }
+            ArgumentNullException.ThrowIfNull(encryptedKey);
 
             // formulate the PUBLICKEYSTRUCT
             byte[] blob = new byte[SIMPLEBLOB_HEADER_LEN + encryptedKey.Length];

--- a/src/System.Management.Automation/utils/ExecutionExceptions.cs
+++ b/src/System.Management.Automation/utils/ExecutionExceptions.cs
@@ -30,10 +30,7 @@ namespace System.Management.Automation
         internal CmdletInvocationException(ErrorRecord errorRecord)
             : base(RetrieveMessage(errorRecord), RetrieveException(errorRecord))
         {
-            if (errorRecord == null)
-            {
-                throw new ArgumentNullException(nameof(errorRecord));
-            }
+            ArgumentNullException.ThrowIfNull(errorRecord);
 
             _errorRecord = errorRecord;
             if (errorRecord.Exception != null)
@@ -55,10 +52,7 @@ namespace System.Management.Automation
                                            InvocationInfo invocationInfo)
             : base(RetrieveMessage(innerException), innerException)
         {
-            if (innerException == null)
-            {
-                throw new ArgumentNullException(nameof(innerException));
-            }
+            ArgumentNullException.ThrowIfNull(innerException);
             // invocationInfo may be null
 
             IContainsErrorRecord icer = innerException as IContainsErrorRecord;
@@ -201,10 +195,7 @@ namespace System.Management.Automation
                     InvocationInfo myInvocation)
             : base(GetInnerException(innerException), myInvocation)
         {
-            if (innerException == null)
-            {
-                throw new ArgumentNullException(nameof(innerException));
-            }
+            ArgumentNullException.ThrowIfNull(innerException);
 
             _providerInvocationException = innerException;
         }
@@ -464,10 +455,7 @@ namespace System.Management.Automation
         internal ActionPreferenceStopException(ErrorRecord error)
             : this(RetrieveMessage(error))
         {
-            if (error == null)
-            {
-                throw new ArgumentNullException(nameof(error));
-            }
+            ArgumentNullException.ThrowIfNull(error);
 
             _errorRecord = error;
         }
@@ -492,10 +480,7 @@ namespace System.Management.Automation
                                                string message)
             : this(invocationInfo, message)
         {
-            if (errorRecord == null)
-            {
-                throw new ArgumentNullException(nameof(errorRecord));
-            }
+            ArgumentNullException.ThrowIfNull(errorRecord);
 
             _errorRecord = errorRecord;
         }

--- a/src/System.Management.Automation/utils/ObjectReader.cs
+++ b/src/System.Management.Automation/utils/ObjectReader.cs
@@ -23,10 +23,7 @@ namespace System.Management.Automation.Internal
         /// <exception cref="ArgumentNullException">Thrown if the specified stream is null.</exception>
         protected ObjectReaderBase([In, Out] ObjectStreamBase stream)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream), "stream may not be null");
-            }
+            ArgumentNullException.ThrowIfNull(stream);
 
             _stream = stream;
         }

--- a/src/System.Management.Automation/utils/ObjectWriter.cs
+++ b/src/System.Management.Automation/utils/ObjectWriter.cs
@@ -23,10 +23,7 @@ namespace System.Management.Automation.Internal
         /// <exception cref="ArgumentNullException">Thrown if the specified stream is null.</exception>
         public ObjectWriter([In, Out] ObjectStreamBase stream)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
 
             _stream = stream;
 #if (false)

--- a/src/System.Management.Automation/utils/SessionStateExceptions.cs
+++ b/src/System.Management.Automation/utils/SessionStateExceptions.cs
@@ -95,10 +95,7 @@ namespace System.Management.Automation
             : base(RuntimeException.RetrieveMessage(errorRecord),
                     RuntimeException.RetrieveException(errorRecord))
         {
-            if (errorRecord == null)
-            {
-                throw new ArgumentNullException(nameof(errorRecord));
-            }
+            ArgumentNullException.ThrowIfNull(errorRecord);
 
             _message = base.Message;
             _providerInfo = provider;

--- a/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
@@ -134,10 +134,7 @@ namespace System.Management.Automation.PerformanceData
         protected CounterSetRegistrarBase(
             CounterSetRegistrarBase srcCounterSetRegistrarBase)
         {
-            if (srcCounterSetRegistrarBase == null)
-            {
-                throw new ArgumentNullException(nameof(srcCounterSetRegistrarBase));
-            }
+            ArgumentNullException.ThrowIfNull(srcCounterSetRegistrarBase);
 
             ProviderId = srcCounterSetRegistrarBase.ProviderId;
             CounterSetId = srcCounterSetRegistrarBase.CounterSetId;
@@ -241,10 +238,7 @@ namespace System.Management.Automation.PerformanceData
             PSCounterSetRegistrar srcPSCounterSetRegistrar)
             : base(srcPSCounterSetRegistrar)
         {
-            if (srcPSCounterSetRegistrar == null)
-            {
-                throw new ArgumentNullException(nameof(srcPSCounterSetRegistrar));
-            }
+            ArgumentNullException.ThrowIfNull(srcCounterSetRegistrar);
         }
 
         #endregion

--- a/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
@@ -238,7 +238,7 @@ namespace System.Management.Automation.PerformanceData
             PSCounterSetRegistrar srcPSCounterSetRegistrar)
             : base(srcPSCounterSetRegistrar)
         {
-            ArgumentNullException.ThrowIfNull(srcCounterSetRegistrar);
+            ArgumentNullException.ThrowIfNull(srcPSCounterSetRegistrar);
         }
 
         #endregion

--- a/src/System.Management.Automation/utils/tracing/EtwActivity.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivity.cs
@@ -113,15 +113,9 @@ namespace System.Management.Automation.Tracing
             /// <param name="callback"></param>
             public CorrelatedCallback(EtwActivity tracer, CallbackNoParameter callback)
             {
-                if (callback == null)
-                {
-                    throw new ArgumentNullException(nameof(callback));
-                }
+                ArgumentNullException.ThrowIfNull(callback);
 
-                if (tracer == null)
-                {
-                    throw new ArgumentNullException(nameof(tracer));
-                }
+                ArgumentNullException.ThrowIfNull(tracer);
 
                 this.tracer = tracer;
                 this.parentActivityId = EtwActivity.GetActivityId();
@@ -135,15 +129,9 @@ namespace System.Management.Automation.Tracing
             /// <param name="callback"></param>
             public CorrelatedCallback(EtwActivity tracer, CallbackWithState callback)
             {
-                if (callback == null)
-                {
-                    throw new ArgumentNullException(nameof(callback));
-                }
+                ArgumentNullException.ThrowIfNull(callback);
 
-                if (tracer == null)
-                {
-                    throw new ArgumentNullException(nameof(tracer));
-                }
+                ArgumentNullException.ThrowIfNull(tracer);
 
                 this.tracer = tracer;
                 this.parentActivityId = EtwActivity.GetActivityId();
@@ -157,15 +145,9 @@ namespace System.Management.Automation.Tracing
             /// <param name="callback"></param>
             public CorrelatedCallback(EtwActivity tracer, AsyncCallback callback)
             {
-                if (callback == null)
-                {
-                    throw new ArgumentNullException(nameof(callback));
-                }
+                ArgumentNullException.ThrowIfNull(callback);
 
-                if (tracer == null)
-                {
-                    throw new ArgumentNullException(nameof(tracer));
-                }
+                ArgumentNullException.ThrowIfNull(tracer);
 
                 this.tracer = tracer;
                 this.parentActivityId = EtwActivity.GetActivityId();
@@ -184,15 +166,9 @@ namespace System.Management.Automation.Tracing
             /// <param name="callback"></param>
             public CorrelatedCallback(EtwActivity tracer, CallbackWithStateAndArgs callback)
             {
-                if (callback == null)
-                {
-                    throw new ArgumentNullException(nameof(callback));
-                }
+                ArgumentNullException.ThrowIfNull(callback);
 
-                if (tracer == null)
-                {
-                    throw new ArgumentNullException(nameof(tracer));
-                }
+                ArgumentNullException.ThrowIfNull(tracer);
 
                 this.tracer = tracer;
                 this.parentActivityId = EtwActivity.GetActivityId();
@@ -371,10 +347,7 @@ namespace System.Management.Automation.Tracing
         /// <returns></returns>
         public CallbackNoParameter Correlate(CallbackNoParameter callback)
         {
-            if (callback == null)
-            {
-                throw new ArgumentNullException(nameof(callback));
-            }
+            ArgumentNullException.ThrowIfNull(callback);
 
             return new CorrelatedCallback(this, callback).Callback;
         }
@@ -386,10 +359,7 @@ namespace System.Management.Automation.Tracing
         /// <returns></returns>
         public CallbackWithState Correlate(CallbackWithState callback)
         {
-            if (callback == null)
-            {
-                throw new ArgumentNullException(nameof(callback));
-            }
+            ArgumentNullException.ThrowIfNull(callback);
 
             return new CorrelatedCallback(this, callback).Callback;
         }
@@ -401,10 +371,7 @@ namespace System.Management.Automation.Tracing
         /// <returns></returns>
         public AsyncCallback Correlate(AsyncCallback callback)
         {
-            if (callback == null)
-            {
-                throw new ArgumentNullException(nameof(callback));
-            }
+            ArgumentNullException.ThrowIfNull(callback);
 
             return new CorrelatedCallback(this, callback).Callback;
         }
@@ -417,10 +384,7 @@ namespace System.Management.Automation.Tracing
         /// <returns></returns>
         public CallbackWithStateAndArgs Correlate(CallbackWithStateAndArgs callback)
         {
-            if (callback == null)
-            {
-                throw new ArgumentNullException(nameof(callback));
-            }
+            ArgumentNullException.ThrowIfNull(callback);
 
             return new CorrelatedCallback(this, callback).Callback;
         }

--- a/src/System.Management.Automation/utils/tracing/EtwActivityReverterMethodInvoker.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivityReverterMethodInvoker.cs
@@ -21,10 +21,7 @@ namespace System.Management.Automation.Tracing
 
         public EtwActivityReverterMethodInvoker(IEtwEventCorrelator eventCorrelator)
         {
-            if (eventCorrelator == null)
-            {
-                throw new ArgumentNullException(nameof(eventCorrelator));
-            }
+            ArgumentNullException.ThrowIfNull(eventCorrelator); 
 
             _eventCorrelator = eventCorrelator;
             _invoker = DoInvoke;

--- a/src/System.Management.Automation/utils/tracing/EtwEventCorrelator.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwEventCorrelator.cs
@@ -64,10 +64,7 @@ namespace System.Management.Automation.Tracing
         ///     during activity correlation.</param>
         public EtwEventCorrelator(EventProvider transferProvider, EventDescriptor transferEvent)
         {
-            if (transferProvider == null)
-            {
-                throw new ArgumentNullException(nameof(transferProvider));
-            }
+            ArgumentNullException.ThrowIfNull(transferProvider);
 
             _transferProvider = transferProvider;
             _transferEvent = transferEvent;

--- a/src/powershell/Program.cs
+++ b/src/powershell/Program.cs
@@ -119,10 +119,7 @@ namespace Microsoft.PowerShell
                 pwshPath = Marshal.PtrToStringAnsi(linkPathPtr, (int)bufSize);
                 Marshal.FreeHGlobal(linkPathPtr);
 
-                if (pwshPath == null)
-                {
-                    throw new ArgumentNullException(nameof(pwshPath));
-                }
+                ArgumentNullException.ThrowIfNull(pwshPath);
 
                 // exec pwsh
                 ThrowOnFailure("exec", ExecPwshLogin(args, pwshPath, isMacOS: false));
@@ -207,10 +204,7 @@ namespace Microsoft.PowerShell
                 // Get the pwshPath from exec_path
                 pwshPath = Marshal.PtrToStringAnsi(executablePathPtr);
 
-                if (pwshPath == null)
-                {
-                    throw new ArgumentNullException(nameof(pwshPath));
-                }
+                ArgumentNullException.ThrowIfNull(pwshPath);
 
                 // exec pwsh
                 ThrowOnFailure("exec", ExecPwshLogin(args, pwshPath, isMacOS: true));


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Replaces all instances of:
```cs
if (XXX == null)
{
    throw new ArgumentNullException(nameof(XXX));
}
```
with:
```cs
ArgumentNullException.ThrowIfNull(XXX)
```
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Proposed in #18596

The new API [ArgumentNullException.ThrowIfNull](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception.throwifnull?view=net-7.0#system-argumentnullexception-throwifnull(system-object-system-string)) allows you to omit the parameter name, in which case it will use the name of the argument passed in. The passed in argument usually is the parameter to be validated, so that's just the right name to use when calling `ArgumentNullException.ThrowIfNull(argument)`.