### PR TITLE
Cleanup webresponseobject.common

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.Commands
             BaseResponse = response;
 
             MemoryStream ms = contentStream as MemoryStream;
-            if (ms != null)
+            if (ms is not null)
             {
                 RawContentStream = ms;
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private void InitializeContent()
         {
-            this.Content = this.RawContentStream.ToArray();
+            Content = RawContentStream.ToArray();
         }
 
         private void InitializeRawContent(HttpResponseMessage baseResponse)
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.Commands
                 raw.Append(this.ToString());
             }
 
-            this.RawContent = raw.ToString();
+            RawContent = raw.ToString();
         }
 
         private static bool IsPrintable(char c) => char.IsLetterOrDigit(c) 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -75,8 +75,7 @@ namespace Microsoft.PowerShell.Commands
         /// Initializes a new instance of the <see cref="WebResponseObject"/> class.
         /// </summary>
         /// <param name="response"></param>
-        public WebResponseObject(HttpResponseMessage response)
-            : this(response, null)
+        public WebResponseObject(HttpResponseMessage response) : this(response, null)
         { }
 
         /// <summary>
@@ -125,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void SetResponse(HttpResponseMessage response, Stream contentStream)
         {
-            if (response is null) { throw new ArgumentNullException(nameof(response)); }
+            ArgumentNullException.ThrowIfNull(response);
 
             BaseResponse = response;
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Small cleanup  WebResponseObject.Common.cs, removed `this.*`