### PR TITLE
Fix reference assembly generation logic for Microsoft.PowerShell.Commands.Utility

### DIFF
--- a/.vsts-ci/windows/templates/windows-packaging.yml
+++ b/.vsts-ci/windows/templates/windows-packaging.yml
@@ -74,6 +74,7 @@ jobs:
   - pwsh: |
       Import-Module .\tools\ci.psm1
       New-CodeCoverageAndTestPackage
+      Find-Dotnet -SetDotnetRoot
       Invoke-CIFinish -Runtime ${{ parameters.runtimePrefix }}-${{ parameters.architecture }} -channel ${{ parameters.channel }} -Stage Package
     displayName: Package and Test
     workingDirectory: $(repoPath)

--- a/.vsts-ci/windows/templates/windows-packaging.yml
+++ b/.vsts-ci/windows/templates/windows-packaging.yml
@@ -71,10 +71,17 @@ jobs:
       displayName: SBOM
       sourceScanPath: '$(repoPath)\tools'
 
+  # This is needed as SBOM task removed the installed .NET and installs .NET 3.1
+  - pwsh: |
+      Import-Module .\tools\ci.psm1
+      Invoke-CIInstall -SkipUser
+    displayName: Bootstrap
+    condition: succeeded()
+    workingDirectory: $(repoPath)
+
   - pwsh: |
       Import-Module .\tools\ci.psm1
       New-CodeCoverageAndTestPackage
-      Find-Dotnet -SetDotnetRoot
       Invoke-CIFinish -Runtime ${{ parameters.runtimePrefix }}-${{ parameters.architecture }} -channel ${{ parameters.channel }} -Stage Package
     displayName: Package and Test
     workingDirectory: $(repoPath)

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2574,7 +2574,8 @@ function CleanupGeneratedSourceCode
         '[Microsoft.PowerShell.Commands.HttpVersionCompletionsAttribute]'
         '[System.Management.Automation.ArgumentToVersionTransformationAttribute]'
         '[Microsoft.PowerShell.Commands.InvokeCommandCommand.ArgumentToPSVersionTransformationAttribute]'
-        '[Microsoft.PowerShell.Commands.InvokeCommandCommand.ValidateVersionAttribute]'
+        '[Microsoft.PowerShell.Commands.InvokeCommandCommand.ValidateVersionAttribute]',
+        '[System.Management.Automation.OutputTypeAttribute(new System.Type[]{ typeof(Microsoft.PowerShell.Commands.Internal.Format.FormatStartData), typeof(Microsoft.PowerShell.Commands.Internal.Format.FormatEntryData), typeof(Microsoft.PowerShell.Commands.Internal.Format.FormatEndData), typeof(Microsoft.PowerShell.Commands.Internal.Format.GroupStartData), typeof(Microsoft.PowerShell.Commands.Internal.Format.GroupEndData)})]'
         )
 
     $patternsToReplace = @(

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2835,6 +2835,8 @@ function New-NugetContentPackage
     Write-Log "Setting dotnet root"
     Find-Dotnet -SetDotnetRoot
 
+    Start-NativeExecution -sb { dotnet --info }
+
     Write-Log "PackageVersion: $PackageVersion"
     $nugetSemanticVersion = Get-NugetSemanticVersion -Version $PackageVersion
     Write-Log "nugetSemanticVersion: $nugetSemanticVersion"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2832,6 +2832,9 @@ function New-NugetContentPackage
         $Force
     )
 
+    Write-Log "Setting dotnet root"
+    Find-Dotnet -SetDotnetRoot
+
     Write-Log "PackageVersion: $PackageVersion"
     $nugetSemanticVersion = Get-NugetSemanticVersion -Version $PackageVersion
     Write-Log "nugetSemanticVersion: $nugetSemanticVersion"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2832,11 +2832,6 @@ function New-NugetContentPackage
         $Force
     )
 
-    Write-Log "Performing start PS boot strap"
-    Start-PSBootstrap
-
-    Start-NativeExecution -sb { dotnet --info }
-
     Write-Log "PackageVersion: $PackageVersion"
     $nugetSemanticVersion = Get-NugetSemanticVersion -Version $PackageVersion
     Write-Log "nugetSemanticVersion: $nugetSemanticVersion"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2832,8 +2832,8 @@ function New-NugetContentPackage
         $Force
     )
 
-    Write-Log "Setting dotnet root"
-    Find-Dotnet -SetDotnetRoot
+    Write-Log "Performing start PS boot strap"
+    Start-PSBootstrap
 
     Start-NativeExecution -sb { dotnet --info }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

NuGet package needs a reference assembly. The reference assembly has internal types as output types and hence they are not found. This change removes the usage from the generated reference assembly source code.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
