### PR TITLE
Add StatusCode to HttpResponseException

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -816,7 +816,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="message">Message for the exception.</param>
         /// <param name="response">Response from the HTTP server.</param>
-        public HttpResponseException(string message, HttpResponseMessage response) : base(message)
+        public HttpResponseException(string message, HttpResponseMessage response) : base(message, inner: null, response.StatusCode)
         {
             Response = response;
         }
@@ -1529,10 +1529,6 @@ namespace Microsoft.PowerShell.Commands
                                         response.ReasonPhrase);
 
                                     HttpResponseException httpEx = new(message, response);
-                                    {
-                                        StatusCode = response.StatusCode;
-                                    }
-
                                     ErrorRecord er = new(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
                                     string detailMsg = string.Empty;
                                     StreamReader reader = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -817,7 +817,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="message">Message for the exception.</param>
         /// <param name="statusCode">Status Code from the HTTP server.</param>
         /// <param name="response">Response from the HTTP server.</param>
-        public HttpResponseException(string message, HttpStatusCode statusCode, HttpResponseMessage response) : base(message, null, statusCode)
+        public HttpResponseException(string message, HttpResponseMessage response) : base(message)
         {
             Response = response;
         }
@@ -1529,7 +1529,11 @@ namespace Microsoft.PowerShell.Commands
                                         (int)response.StatusCode,
                                         response.ReasonPhrase);
 
-                                    HttpResponseException httpEx = new(message, response.StatusCode, response);
+                                    HttpResponseException httpEx = new(message, response);
+                                    {
+                                        StatusCode = response.StatusCode;
+                                    }
+
                                     ErrorRecord er = new(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
                                     string detailMsg = string.Empty;
                                     StreamReader reader = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -815,7 +815,6 @@ namespace Microsoft.PowerShell.Commands
         /// Initializes a new instance of the <see cref="HttpResponseException"/> class.
         /// </summary>
         /// <param name="message">Message for the exception.</param>
-        /// <param name="statusCode">Status Code from the HTTP server.</param>
         /// <param name="response">Response from the HTTP server.</param>
         public HttpResponseException(string message, HttpResponseMessage response) : base(message)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -815,7 +815,7 @@ namespace Microsoft.PowerShell.Commands
         /// Initializes a new instance of the <see cref="HttpResponseException"/> class.
         /// </summary>
         /// <param name="message">Message for the exception.</param>
-        /// <param name="statusCode">Status Code from the HTTP server</param>
+        /// <param name="statusCode">Status Code from the HTTP server.</param>
         /// <param name="response">Response from the HTTP server.</param>
         public HttpResponseException(string message, HttpStatusCode statusCode, HttpResponseMessage response) : base(message, null, statusCode)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -815,8 +815,9 @@ namespace Microsoft.PowerShell.Commands
         /// Initializes a new instance of the <see cref="HttpResponseException"/> class.
         /// </summary>
         /// <param name="message">Message for the exception.</param>
+        /// <param name="statusCode">Status Code from the HTTP server</param>
         /// <param name="response">Response from the HTTP server.</param>
-        public HttpResponseException(string message, HttpResponseMessage response) : base(message)
+        public HttpResponseException(string message, HttpStatusCode statusCode, HttpResponseMessage response) : base(message, null, statusCode)
         {
             Response = response;
         }
@@ -1528,7 +1529,7 @@ namespace Microsoft.PowerShell.Commands
                                         (int)response.StatusCode,
                                         response.ReasonPhrase);
 
-                                    HttpResponseException httpEx = new(message, response);
+                                    HttpResponseException httpEx = new(message, response.StatusCode, response);
                                     ErrorRecord er = new(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
                                     string detailMsg = string.Empty;
                                     StreamReader reader = null;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
I noticed that HttpResponseException contained an empty StatusCode property, so I've added response.statusCode as content.
It might be a little redundant but it's easier to access

<!-- Summarize your PR between here and the checklist. -->

## PR Context
before:
![1a](https://user-images.githubusercontent.com/105941898/209241280-4eed68cc-11a5-4921-a616-2e737e752e6c.png)

after:
![1b](https://user-images.githubusercontent.com/105941898/209241285-5e5a11cd-6a85-4137-8527-183bd8a4be94.png)

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
