### PR TITLE
Enable `Get-Help` pattern tests on Unix

### DIFF
--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -312,10 +312,6 @@ Describe "Get-Help should find help info within help files" -Tags @('CI') {
 
 Describe "Get-Help should find pattern help files" -Tags "CI" {
 
-    # There is a bug specific to Travis CI that suspends the test if "get-help" is used to search pattern string. This doesn't repro locally.
-    # This occurs even if Unix system just returns "Directory.GetFiles(path, pattern);" as the windows' code does.
-    # Since there's currently no way to get the vm from Travis CI and the test PASSES locally on both Ubuntu and MacOS, excluding pattern test under Unix system.
-
     BeforeAll {
         $helpFile1 = "about_testCase1.help.txt"
         $helpFile2 = "about_testCase.2.help.txt"
@@ -349,7 +345,7 @@ Describe "Get-Help should find pattern help files" -Tags "CI" {
         @{command = {Get-Help about_testCas?.2*}; testname = "test ?, * pattern with dot"; result = "about_test2"}
     )
 
-    It "Get-Help should find pattern help files - <testname>" -TestCases $testcases -Pending: (-not $IsWindows) {
+    It "Get-Help should find pattern help files - <testname>" -TestCases $testcases {
         param (
             $command,
             $result


### PR DESCRIPTION
`Get-Help` pattern tests were disabled to workaround an issue that is no longer applicable.

Follow-up #3852.