### PR TITLE
Remove code which delete GUID from Progress, Verbose, Debug and Warning messages

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1206,9 +1206,6 @@ namespace Microsoft.PowerShell
         /// </exception>
         public override void WriteDebugLine(string message)
         {
-            // don't lock here as WriteLine is already protected.
-            message = HostUtilities.RemoveGuidFromMessage(message);
-
             // We should write debug to error stream only if debug is redirected.)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)
             {
@@ -1266,9 +1263,6 @@ namespace Microsoft.PowerShell
         /// </exception>
         public override void WriteVerboseLine(string message)
         {
-            // don't lock here as WriteLine is already protected.
-            message = HostUtilities.RemoveGuidFromMessage(message);
-
             // NTRAID#Windows OS Bugs-1061752-2004/12/15-sburns should read a skin setting here...)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)
             {
@@ -1309,9 +1303,6 @@ namespace Microsoft.PowerShell
         /// </exception>
         public override void WriteWarningLine(string message)
         {
-            // don't lock here as WriteLine is already protected.
-            message = HostUtilities.RemoveGuidFromMessage(message);
-
             // NTRAID#Windows OS Bugs-1061752-2004/12/15-sburns should read a skin setting here...)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)
             {
@@ -1344,13 +1335,6 @@ namespace Microsoft.PowerShell
             {
                 // Do not write progress bar when the stdout is redirected.
                 return;
-            }
-
-            bool matchPattern;
-            string currentOperation = HostUtilities.RemoveIdentifierInfoFromMessage(record.CurrentOperation, out matchPattern);
-            if (matchPattern)
-            {
-                record = new ProgressRecord(record) { CurrentOperation = currentOperation };
             }
 
             // We allow only one thread at a time to update the progress state.)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1207,7 +1207,7 @@ namespace Microsoft.PowerShell
         public override void WriteDebugLine(string message)
         {
             // don't lock here as WriteLine is already protected.
-            message = HostUtilities.RemoveGuidFromMessage(message, out _);
+            message = HostUtilities.RemoveGuidFromMessage(message);
 
             // We should write debug to error stream only if debug is redirected.)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)
@@ -1267,7 +1267,7 @@ namespace Microsoft.PowerShell
         public override void WriteVerboseLine(string message)
         {
             // don't lock here as WriteLine is already protected.
-            message = HostUtilities.RemoveGuidFromMessage(message, out _);
+            message = HostUtilities.RemoveGuidFromMessage(message);
 
             // NTRAID#Windows OS Bugs-1061752-2004/12/15-sburns should read a skin setting here...)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)
@@ -1310,7 +1310,7 @@ namespace Microsoft.PowerShell
         public override void WriteWarningLine(string message)
         {
             // don't lock here as WriteLine is already protected.
-            message = HostUtilities.RemoveGuidFromMessage(message, out _);
+            message = HostUtilities.RemoveGuidFromMessage(message);
 
             // NTRAID#Windows OS Bugs-1061752-2004/12/15-sburns should read a skin setting here...)
             if (_parent.ErrorFormat == Serialization.DataFormat.XML)

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -496,64 +496,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Remove the GUID from the message if the message is in the pre-defined format.
-        /// </summary>
-        /// <param name="message"></param>
-        /// <returns></returns>
-        internal static string RemoveGuidFromMessage(string message)
-        {
-            if (message is null ||
-                message.Length < 37 ||
-                message[36] != ':' ||
-                message[23] != '-' ||
-                message[18] != '-' ||
-                message[13] != '-' ||
-                message[8] != '-')
-            {
-                // Fast return if the message does not start with 'GUID:'.
-                return message;
-            }
-
-            const string pattern = @"^([\d\w]{8}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{12}:).*";
-            Match matchResult = Regex.Match(message, pattern);
-            if (matchResult.Success)
-            {
-                string partToRemove = matchResult.Groups[1].Captures[0].Value;
-                message = message.Remove(0, partToRemove.Length);
-            }
-
-            return message;
-        }
-
-        internal static string RemoveIdentifierInfoFromMessage(string message, out bool matchPattern)
-        {
-            matchPattern = false;
-            if (message is null ||
-                message.Length < 40 ||
-                message[37] != '[' ||
-                message[36] != ':' ||
-                message[23] != '-' ||
-                message[18] != '-' ||
-                message[13] != '-' ||
-                message[8] != '-')
-            {
-                // Fast return if the message does not start with 'GUID:[]:'.
-                return message;
-            }
-
-            const string pattern = @"^([\d\w]{8}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{12}:\[.*\]:).*";
-            Match matchResult = Regex.Match(message, pattern);
-            if (matchResult.Success)
-            {
-                string partToRemove = matchResult.Groups[1].Captures[0].Value;
-                message = message.Remove(0, partToRemove.Length);
-                matchPattern = true;
-            }
-
-            return message;
-        }
-
-        /// <summary>
         /// Create suggestion with string rule and scriptblock suggestion.
         /// </summary>
         /// <param name="id">Identifier for the suggestion.</param>

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -523,12 +523,12 @@ namespace System.Management.Automation
         {
             matchPattern = false;
             if (message is null ||
-                message.Length < 36 ||
-                message[33] != '[' ||
-                message[32] != ':' ||
-                message[20] != '-' ||
-                message[16] != '-' ||
-                message[12] != '-' ||
+                message.Length < 40 ||
+                message[37] != '[' ||
+                message[36] != ':' ||
+                message[23] != '-' ||
+                message[18] != '-' ||
+                message[13] != '-' ||
                 message[8] != '-')
             {
                 // Fast return if the message does not start with 'GUID:[]:'.

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -504,8 +504,17 @@ namespace System.Management.Automation
         internal static string RemoveGuidFromMessage(string message, out bool matchPattern)
         {
             matchPattern = false;
-            if (string.IsNullOrEmpty(message))
+            if (message is null ||
+                message.Length < 37 ||
+                message[36] != ':' ||
+                message[23] != '-' ||
+                message[18] != '-' ||
+                message[13] != '-' ||
+                message[8] != '-')
+            {
+                // Fast return if the message does not start with 'GUID:'.
                 return message;
+            }
 
             const string pattern = @"^([\d\w]{8}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{12}:).*";
             Match matchResult = Regex.Match(message, pattern);

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -522,8 +522,18 @@ namespace System.Management.Automation
         internal static string RemoveIdentifierInfoFromMessage(string message, out bool matchPattern)
         {
             matchPattern = false;
-            if (string.IsNullOrEmpty(message))
+            if (message is null ||
+                message.Length < 36 ||
+                message[33] != '[' ||
+                message[32] != ':' ||
+                message[20] != '-' ||
+                message[16] != '-' ||
+                message[12] != '-' ||
+                message[8] != '-')
+            {
+                // Fast return if the message does not start with 'GUID:[]:'.
                 return message;
+            }
 
             const string pattern = @"^([\d\w]{8}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{4}\-[\d\w]{12}:\[.*\]:).*";
             Match matchResult = Regex.Match(message, pattern);

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -499,11 +499,9 @@ namespace System.Management.Automation
         /// Remove the GUID from the message if the message is in the pre-defined format.
         /// </summary>
         /// <param name="message"></param>
-        /// <param name="matchPattern"></param>
         /// <returns></returns>
-        internal static string RemoveGuidFromMessage(string message, out bool matchPattern)
+        internal static string RemoveGuidFromMessage(string message)
         {
-            matchPattern = false;
             if (message is null ||
                 message.Length < 37 ||
                 message[36] != ':' ||
@@ -522,7 +520,6 @@ namespace System.Management.Automation
             {
                 string partToRemove = matchResult.Groups[1].Captures[0].Value;
                 message = message.Remove(0, partToRemove.Length);
-                matchPattern = true;
             }
 
             return message;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Since nobody can find where GUID is added to a message we can remove RemoveGuidFromMessage and RemoveIdentifierInfoFromMessage methods and wait feedback. I guess it is not used for years (maybe it was in psworkflows?).
Notice, the methods are perf expensive since process every message by Regex.

See also https://github.com/PowerShell/PowerShell/pull/18871#pullrequestreview-1302134792

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
