### PR TITLE
Remove two ThreadStatic fields from Parser

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -7998,15 +7998,8 @@ namespace System.Management.Automation.Language
             ErrorList.Add(error);
         }
 
-        private void SaveError(IScriptExtent extent, string errorId, string errorMsg, bool incompleteInput, params object[] args)
+        private void SaveError(IScriptExtent extent, string errorId, string errorMsg, bool incompleteInput)
         {
-            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
-
-            if (args != null && args.Length > 0)
-            {
-                errorMsg = string.Format(CultureInfo.CurrentCulture, errorMsg, args);
-            }
-
             ParseError errorToSave = new ParseError(extent, errorId, errorMsg, incompleteInput);
             SaveError(errorToSave);
         }
@@ -8047,75 +8040,85 @@ namespace System.Management.Automation.Language
             Diagnostics.Assert(msgCorrespondsToString, string.Format("Parser error ID \"{0}\" must correspond to the error message \"{1}\"", errorId, errorMsg));
         }
 
-        private static object[] arrayOfOneArg
-        {
-            get { return t_arrayOfOneArg ??= new object[1]; }
-        }
-
-        [ThreadStatic]
-        private static object[] t_arrayOfOneArg;
-
-        private static object[] arrayOfTwoArgs
-        {
-            get { return t_arrayOfTwoArgs ??= new object[2]; }
-        }
-
-        [ThreadStatic]
-        private static object[] t_arrayOfTwoArgs;
-
         internal bool ReportIncompleteInput(IScriptExtent extent, string errorId, string errorMsg)
         {
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
             // If the error position isn't at the end of the input, then we don't want to mark the error
             // as incomplete input.
             bool incompleteInput = _tokenizer.IsAtEndOfScript(extent, checkCommentsAndWhitespace: true);
-            SaveError(extent, errorId, errorMsg, incompleteInput, null);
+            SaveError(extent, errorId, errorMsg, incompleteInput);
             return incompleteInput;
         }
 
         internal bool ReportIncompleteInput(IScriptExtent extent, string errorId, string errorMsg, object arg)
         {
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
+            errorMsg = string.Format(CultureInfo.CurrentCulture, errorMsg, arg);
+
             // If the error position isn't at the end of the input, then we don't want to mark the error
             // as incomplete input.
             bool incompleteInput = _tokenizer.IsAtEndOfScript(extent, checkCommentsAndWhitespace: true);
-            arrayOfOneArg[0] = arg;
-            SaveError(extent, errorId, errorMsg, incompleteInput, arrayOfOneArg);
+            SaveError(extent, errorId, errorMsg, incompleteInput);
             return incompleteInput;
         }
 
         internal bool ReportIncompleteInput(IScriptExtent errorPosition,
                                             IScriptExtent errorDetectedPosition,
                                             string errorId,
-                                            string errorMsg,
-                                            params object[] args)
+                                            string errorMsg)
         {
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
             // If the error position isn't at the end of the input, then we don't want to mark the error
             // as incomplete input.
             bool incompleteInput = _tokenizer.IsAtEndOfScript(errorDetectedPosition, checkCommentsAndWhitespace: true);
-            SaveError(errorPosition, errorId, errorMsg, incompleteInput, args);
+            SaveError(errorPosition, errorId, errorMsg, incompleteInput);
             return incompleteInput;
         }
 
         internal void ReportError(IScriptExtent extent, string errorId, string errorMsg)
         {
-            SaveError(extent, errorId, errorMsg, false, null);
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
+            SaveError(extent, errorId, errorMsg, incompleteInput: false);
         }
 
         internal void ReportError(IScriptExtent extent, string errorId, string errorMsg, object arg)
         {
-            arrayOfOneArg[0] = arg;
-            SaveError(extent, errorId, errorMsg, false, arrayOfOneArg);
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
+            errorMsg = string.Format(CultureInfo.CurrentCulture, errorMsg, arg);
+
+            SaveError(extent, errorId, errorMsg, incompleteInput: false);
         }
 
         internal void ReportError(IScriptExtent extent, string errorId, string errorMsg, object arg1, object arg2)
         {
-            arrayOfTwoArgs[0] = arg1;
-            arrayOfTwoArgs[1] = arg2;
-            SaveError(extent, errorId, errorMsg, false, arrayOfTwoArgs);
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
+            errorMsg = string.Format(CultureInfo.CurrentCulture, errorMsg, arg1, arg2);
+
+            SaveError(extent, errorId, errorMsg, incompleteInput: false);
+        }
+
+        internal void ReportError(IScriptExtent extent, string errorId, string errorMsg, object arg1, object arg2, object arg3)
+        {
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
+            errorMsg = string.Format(CultureInfo.CurrentCulture, errorMsg, arg1, arg2, arg3);
+
+            SaveError(extent, errorId, errorMsg, incompleteInput: false);
         }
 
         internal void ReportError(IScriptExtent extent, string errorId, string errorMsg, params object[] args)
         {
-            SaveError(extent, errorId, errorMsg, false, args);
+            AssertErrorIdCorrespondsToMsgString(errorId, errorMsg);
+
+            errorMsg = string.Format(CultureInfo.CurrentCulture, errorMsg, args);
+
+            SaveError(extent, errorId, errorMsg, incompleteInput: false);
         }
 
         internal void ReportError(ParseError error)

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1842,21 +1842,22 @@ namespace System.Management.Automation.Language
             Utils.EnsureModuleLoaded("Microsoft.PowerShell.Utility", context);
         }
 
-        private void ReportError(Ast ast, string errorId, string errorMsg, params object[] args)
+        private void ReportError(IScriptExtent extent, string errorId, string errorMsg)
         {
-            ReportError(ast.Extent, errorId, errorMsg, args);
+            _parser.ReportError(extent, errorId, errorMsg);
             FoundError = true;
         }
 
-        private void ReportError(IScriptExtent extent, string errorId, string errorMsg, params object[] args)
+        private void ReportError(IScriptExtent extent, string errorId, string errorMsg, object arg)
         {
-            _parser.ReportError(extent, errorId, errorMsg, args);
+            _parser.ReportError(extent, errorId, errorMsg, arg);
             FoundError = true;
         }
 
         public override AstVisitAction VisitScriptBlock(ScriptBlockAst scriptBlockAst)
         {
-            ReportError(scriptBlockAst,
+            ReportError(
+                scriptBlockAst.Extent,
                 nameof(ParserStrings.ScriptBlockNotSupportedInDataSection),
                 ParserStrings.ScriptBlockNotSupportedInDataSection);
 
@@ -1865,7 +1866,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitParamBlock(ParamBlockAst paramBlockAst)
         {
-            ReportError(paramBlockAst,
+            ReportError(
+                paramBlockAst.Extent,
                 nameof(ParserStrings.ParameterDeclarationNotSupportedInDataSection),
                 ParserStrings.ParameterDeclarationNotSupportedInDataSection);
 
@@ -1890,7 +1892,8 @@ namespace System.Management.Automation.Language
             // If we couldn't resolve the type, then it's definitely an error.
             if (type == null || ((type.IsArray ? type.GetElementType() : type).GetTypeCode() == TypeCode.Object))
             {
-                ReportError(ast,
+                ReportError(
+                    ast.Extent,
                     nameof(ParserStrings.TypeNotAllowedInDataSection),
                     ParserStrings.TypeNotAllowedInDataSection,
                     typename.FullName);
@@ -1907,7 +1910,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitAttribute(AttributeAst attributeAst)
         {
             Diagnostics.Assert(FoundError, "an error should have been reported elsewhere, making this redunant");
-            ReportError(attributeAst,
+            ReportError(
+                attributeAst.Extent,
                 nameof(ParserStrings.AttributeNotSupportedInDataSection),
                 ParserStrings.AttributeNotSupportedInDataSection);
 
@@ -1930,7 +1934,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
         {
-            ReportError(functionDefinitionAst,
+            ReportError(
+                functionDefinitionAst.Extent,
                 nameof(ParserStrings.FunctionDeclarationNotSupportedInDataSection),
                 ParserStrings.FunctionDeclarationNotSupportedInDataSection);
 
@@ -1953,7 +1958,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitTrap(TrapStatementAst trapStatementAst)
         {
-            ReportError(trapStatementAst,
+            ReportError(
+                trapStatementAst.Extent,
                 nameof(ParserStrings.TrapStatementNotSupportedInDataSection),
                 ParserStrings.TrapStatementNotSupportedInDataSection);
 
@@ -1962,7 +1968,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitSwitchStatement(SwitchStatementAst switchStatementAst)
         {
-            ReportError(switchStatementAst,
+            ReportError(
+                switchStatementAst.Extent,
                 nameof(ParserStrings.SwitchStatementNotSupportedInDataSection),
                 ParserStrings.SwitchStatementNotSupportedInDataSection);
 
@@ -1971,7 +1978,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitDataStatement(DataStatementAst dataStatementAst)
         {
-            ReportError(dataStatementAst,
+            ReportError(
+                dataStatementAst.Extent,
                 nameof(ParserStrings.DataSectionStatementNotSupportedInDataSection),
                 ParserStrings.DataSectionStatementNotSupportedInDataSection);
 
@@ -1980,7 +1988,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitForEachStatement(ForEachStatementAst forEachStatementAst)
         {
-            ReportError(forEachStatementAst,
+            ReportError(
+                forEachStatementAst.Extent,
                 nameof(ParserStrings.ForeachStatementNotSupportedInDataSection),
                 ParserStrings.ForeachStatementNotSupportedInDataSection);
 
@@ -1989,7 +1998,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitDoWhileStatement(DoWhileStatementAst doWhileStatementAst)
         {
-            ReportError(doWhileStatementAst,
+            ReportError(
+                doWhileStatementAst.Extent,
                 nameof(ParserStrings.DoWhileStatementNotSupportedInDataSection),
                 ParserStrings.DoWhileStatementNotSupportedInDataSection);
 
@@ -1998,7 +2008,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitForStatement(ForStatementAst forStatementAst)
         {
-            ReportError(forStatementAst,
+            ReportError(
+                forStatementAst.Extent,
                 nameof(ParserStrings.ForWhileStatementNotSupportedInDataSection),
                 ParserStrings.ForWhileStatementNotSupportedInDataSection);
 
@@ -2007,7 +2018,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitWhileStatement(WhileStatementAst whileStatementAst)
         {
-            ReportError(whileStatementAst,
+            ReportError(
+                whileStatementAst.Extent,
                 nameof(ParserStrings.ForWhileStatementNotSupportedInDataSection),
                 ParserStrings.ForWhileStatementNotSupportedInDataSection);
 
@@ -2023,7 +2035,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitTryStatement(TryStatementAst tryStatementAst)
         {
-            ReportError(tryStatementAst,
+            ReportError(
+                tryStatementAst.Extent,
                 nameof(ParserStrings.TryStatementNotSupportedInDataSection),
                 ParserStrings.TryStatementNotSupportedInDataSection);
 
@@ -2032,7 +2045,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitBreakStatement(BreakStatementAst breakStatementAst)
         {
-            ReportError(breakStatementAst,
+            ReportError(
+                breakStatementAst.Extent,
                 nameof(ParserStrings.FlowControlStatementNotSupportedInDataSection),
                 ParserStrings.FlowControlStatementNotSupportedInDataSection);
 
@@ -2041,7 +2055,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitContinueStatement(ContinueStatementAst continueStatementAst)
         {
-            ReportError(continueStatementAst,
+            ReportError(
+                continueStatementAst.Extent,
                 nameof(ParserStrings.FlowControlStatementNotSupportedInDataSection),
                 ParserStrings.FlowControlStatementNotSupportedInDataSection);
 
@@ -2050,7 +2065,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitReturnStatement(ReturnStatementAst returnStatementAst)
         {
-            ReportError(returnStatementAst,
+            ReportError(
+                returnStatementAst.Extent,
                 nameof(ParserStrings.FlowControlStatementNotSupportedInDataSection),
                 ParserStrings.FlowControlStatementNotSupportedInDataSection);
 
@@ -2059,7 +2075,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitExitStatement(ExitStatementAst exitStatementAst)
         {
-            ReportError(exitStatementAst,
+            ReportError(
+                exitStatementAst.Extent,
                 nameof(ParserStrings.FlowControlStatementNotSupportedInDataSection),
                 ParserStrings.FlowControlStatementNotSupportedInDataSection);
 
@@ -2068,7 +2085,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitThrowStatement(ThrowStatementAst throwStatementAst)
         {
-            ReportError(throwStatementAst,
+            ReportError(
+                throwStatementAst.Extent,
                 nameof(ParserStrings.FlowControlStatementNotSupportedInDataSection),
                 ParserStrings.FlowControlStatementNotSupportedInDataSection);
 
@@ -2077,7 +2095,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitDoUntilStatement(DoUntilStatementAst doUntilStatementAst)
         {
-            ReportError(doUntilStatementAst,
+            ReportError(
+                doUntilStatementAst.Extent,
                 nameof(ParserStrings.DoWhileStatementNotSupportedInDataSection),
                 ParserStrings.DoWhileStatementNotSupportedInDataSection);
 
@@ -2087,7 +2106,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst)
         {
             // Assignments are never allowed.
-            ReportError(assignmentStatementAst,
+            ReportError(
+                assignmentStatementAst.Extent,
                 nameof(ParserStrings.AssignmentStatementNotSupportedInDataSection),
                 ParserStrings.AssignmentStatementNotSupportedInDataSection);
 
@@ -2110,7 +2130,8 @@ namespace System.Management.Automation.Language
 
             if (commandAst.InvocationOperator == TokenKind.Dot)
             {
-                ReportError(commandAst,
+                ReportError(
+                    commandAst.Extent,
                     nameof(ParserStrings.DotSourcingNotSupportedInDataSection),
                     ParserStrings.DotSourcingNotSupportedInDataSection);
                 return AstVisitAction.Continue;
@@ -2124,14 +2145,16 @@ namespace System.Management.Automation.Language
             {
                 if (commandAst.InvocationOperator == TokenKind.Ampersand)
                 {
-                    ReportError(commandAst,
+                    ReportError(
+                        commandAst.Extent,
                         nameof(ParserStrings.OperatorNotSupportedInDataSection),
                         ParserStrings.OperatorNotSupportedInDataSection,
                         TokenKind.Ampersand.Text());
                 }
                 else
                 {
-                    ReportError(commandAst,
+                    ReportError(
+                        commandAst.Extent,
                         nameof(ParserStrings.CmdletNotInAllowedListForDataSection),
                         ParserStrings.CmdletNotInAllowedListForDataSection,
                         commandAst.Extent.Text);
@@ -2145,7 +2168,8 @@ namespace System.Management.Automation.Language
                 return AstVisitAction.Continue;
             }
 
-            ReportError(commandAst,
+            ReportError(
+                commandAst.Extent,
                 nameof(ParserStrings.CmdletNotInAllowedListForDataSection),
                 ParserStrings.CmdletNotInAllowedListForDataSection,
                 commandName);
@@ -2169,7 +2193,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitMergingRedirection(MergingRedirectionAst mergingRedirectionAst)
         {
-            ReportError(mergingRedirectionAst,
+            ReportError(
+                mergingRedirectionAst.Extent,
                 nameof(ParserStrings.RedirectionNotSupportedInDataSection),
                 ParserStrings.RedirectionNotSupportedInDataSection);
 
@@ -2178,7 +2203,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitFileRedirection(FileRedirectionAst fileRedirectionAst)
         {
-            ReportError(fileRedirectionAst,
+            ReportError(
+                fileRedirectionAst.Extent,
                 nameof(ParserStrings.RedirectionNotSupportedInDataSection),
                 ParserStrings.RedirectionNotSupportedInDataSection);
 
@@ -2212,7 +2238,8 @@ namespace System.Management.Automation.Language
         {
             if (unaryExpressionAst.TokenKind.HasTrait(TokenFlags.DisallowedInRestrictedMode))
             {
-                ReportError(unaryExpressionAst,
+                ReportError(
+                    unaryExpressionAst.Extent,
                     nameof(ParserStrings.OperatorNotSupportedInDataSection),
                     ParserStrings.OperatorNotSupportedInDataSection,
                     unaryExpressionAst.TokenKind.Text());
@@ -2298,7 +2325,8 @@ namespace System.Management.Automation.Language
                 resourceArg = argBuilder.ToString();
             }
 
-            ReportError(variableExpressionAst,
+            ReportError(
+                variableExpressionAst.Extent,
                 nameof(ParserStrings.VariableReferenceNotSupportedInDataSection),
                 ParserStrings.VariableReferenceNotSupportedInDataSection,
                 resourceArg);
@@ -2308,7 +2336,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitMemberExpression(MemberExpressionAst memberExpressionAst)
         {
-            ReportError(memberExpressionAst,
+            ReportError(
+                memberExpressionAst.Extent,
                 nameof(ParserStrings.PropertyReferenceNotSupportedInDataSection),
                 ParserStrings.PropertyReferenceNotSupportedInDataSection);
 
@@ -2317,7 +2346,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitInvokeMemberExpression(InvokeMemberExpressionAst methodCallAst)
         {
-            ReportError(methodCallAst,
+            ReportError(
+                methodCallAst.Extent,
                 nameof(ParserStrings.MethodCallNotSupportedInDataSection),
                 ParserStrings.MethodCallNotSupportedInDataSection);
 
@@ -2347,7 +2377,8 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitScriptBlockExpression(ScriptBlockExpressionAst scriptBlockExpressionAst)
         {
-            ReportError(scriptBlockExpressionAst,
+            ReportError(
+                scriptBlockExpressionAst.Extent,
                 nameof(ParserStrings.ScriptBlockNotSupportedInDataSection),
                 ParserStrings.ScriptBlockNotSupportedInDataSection);
 
@@ -2373,7 +2404,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitIndexExpression(IndexExpressionAst indexExpressionAst)
         {
             // Array references are never allowed.  They could turn into function calls.
-            ReportError(indexExpressionAst,
+            ReportError(
+                indexExpressionAst.Extent,
                 nameof(ParserStrings.ArrayReferenceNotSupportedInDataSection),
                 ParserStrings.ArrayReferenceNotSupportedInDataSection);
 
@@ -2383,7 +2415,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitAttributedExpression(AttributedExpressionAst attributedExpressionAst)
         {
             // Attributes are not allowed, they may code in attribute constructors.
-            ReportError(attributedExpressionAst,
+            ReportError(
+                attributedExpressionAst.Extent,
                 nameof(ParserStrings.AttributeNotSupportedInDataSection),
                 ParserStrings.AttributeNotSupportedInDataSection);
 
@@ -2393,7 +2426,8 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitBlockStatement(BlockStatementAst blockStatementAst)
         {
             // Keyword blocks are not allowed
-            ReportError(blockStatementAst,
+            ReportError(
+                blockStatementAst.Extent,
                 nameof(ParserStrings.ParallelAndSequenceBlockNotSupportedInDataSection),
                 ParserStrings.ParallelAndSequenceBlockNotSupportedInDataSection);
 

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1143,9 +1143,14 @@ namespace System.Management.Automation.Language
             }
         }
 
-        private void ReportError(int errorOffset, string errorId, string errorMsg, params object[] args)
+        private void ReportError(int errorOffset, string errorId, string errorMsg)
         {
-            _parser.ReportError(NewScriptExtent(errorOffset, errorOffset + 1), errorId, errorMsg, args);
+            _parser.ReportError(NewScriptExtent(errorOffset, errorOffset + 1), errorId, errorMsg);
+        }
+
+        private void ReportError(int errorOffset, string errorId, string errorMsg, object arg)
+        {
+            _parser.ReportError(NewScriptExtent(errorOffset, errorOffset + 1), errorId, errorMsg, arg);
         }
 
         private void ReportError(IScriptExtent extent, string errorId, string errorMsg)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Remove old (per thread) optimization for `param object[]` excluding allocations.
Instead, we use new optimized `string.Format()` overloads. As result, signatures of some helper methods were changed too.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
