### PR TITLE
Add `-ProgressAction` common parameter

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -2740,7 +2740,7 @@ function Get-PSImplicitRemotingClientSideParameters
 
     $clientSideParameters = @{}
 
-    $parametersToLeaveRemote = 'ErrorAction', 'WarningAction', 'InformationAction'
+    $parametersToLeaveRemote = 'ErrorAction', 'WarningAction', 'InformationAction', 'ProgressAction'
 
     Modify-PSImplicitRemotingParameters $clientSideParameters $PSBoundParameters 'AsJob'
     if ($proxyForCmdlet)

--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -127,7 +127,7 @@ namespace System.Management.Automation.Internal
         /// Gets or sets the value of the ProgressAction parameter for the cmdlet.
         /// </summary>
         /// <remarks>
-        /// This parameter tells the command what to do when an progress record occurs.
+        /// This parameter tells the command what to do when a progress record occurs.
         /// </remarks>
         /// <!--
         /// NOTE: The "proga" alias name does not follow the same alias naming convention used

--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -134,7 +134,8 @@ namespace System.Management.Automation.Internal
         /// with other common parameter aliases that control stream functionality; however,
         /// "pa" was already taken as a parameter alias in other commands when this parameter
         /// was added to PowerShell, so "proga" was chosen instead.
-        /// -->        [Parameter]
+        /// -->
+        [Parameter]
         [Alias("proga")]
         public ActionPreference ProgressAction
         {

--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -124,6 +124,21 @@ namespace System.Management.Automation.Internal
         }
 
         /// <summary>
+        /// Gets or sets the value of the ProgressAction parameter for the cmdlet.
+        /// </summary>
+        /// <remarks>
+        /// This parameter tells the command what to do when an progress record occurs.
+        /// </remarks>
+        [Parameter]
+        [Alias("pa")]
+        public ActionPreference ProgressAction
+        {
+            get { return _commandRuntime.ProgressPreference; }
+
+            set { _commandRuntime.ProgressPreference = value; }
+        }
+
+        /// <summary>
         /// Gets or sets the value of the ErrorVariable parameter for the cmdlet.
         /// </summary>
         /// <remarks>

--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -129,8 +129,13 @@ namespace System.Management.Automation.Internal
         /// <remarks>
         /// This parameter tells the command what to do when an progress record occurs.
         /// </remarks>
-        [Parameter]
-        [Alias("pa")]
+        /// <!--
+        /// NOTE: The "proga" alias name does not follow the same alias naming convention used
+        /// with other common parameter aliases that control stream functionality; however,
+        /// "pa" was already taken as a parameter alias in other commands when this parameter
+        /// was added to PowerShell, so "proga" was chosen instead.
+        /// -->        [Parameter]
+        [Alias("proga")]
         public ActionPreference ProgressAction
         {
             get { return _commandRuntime.ProgressPreference; }

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -385,10 +385,11 @@ namespace Microsoft.PowerShell.Commands
         private void InitParallelParameterSet()
         {
             // The following common parameters are not (yet) supported in this parameter set.
-            //  ErrorAction, WarningAction, InformationAction, PipelineVariable.
+            //  ErrorAction, WarningAction, InformationAction, ProgressAction, PipelineVariable.
             if (MyInvocation.BoundParameters.ContainsKey(nameof(CommonParamSet.ErrorAction)) ||
                 MyInvocation.BoundParameters.ContainsKey(nameof(CommonParamSet.WarningAction)) ||
                 MyInvocation.BoundParameters.ContainsKey(nameof(CommonParamSet.InformationAction)) ||
+                MyInvocation.BoundParameters.ContainsKey(nameof(CommonParamSet.ProgressAction)) ||
                 MyInvocation.BoundParameters.ContainsKey(nameof(CommonParamSet.PipelineVariable)))
             {
                 ThrowTerminatingError(

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -3330,7 +3330,7 @@ namespace System.Management.Automation
         {
             get
             {
-                if (_isProgressPreferenceSet)
+                if (IsProgressActionSet)
                     return _progressPreference;
 
                 if (!_isProgressPreferenceCached)
@@ -3351,12 +3351,14 @@ namespace System.Management.Automation
                 }
 
                 _progressPreference = value;
-                _isProgressPreferenceSet = true;
+                IsProgressActionSet = true;
             }
         }
 
         private ActionPreference _progressPreference = InitialSessionState.DefaultProgressPreference;
-        private bool _isProgressPreferenceSet = false;
+
+        internal bool IsProgressActionSet { get; private set; } = false;
+
         private bool _isProgressPreferenceCached = false;
 
         /// <summary>

--- a/src/System.Management.Automation/engine/ReflectionParameterBinder.cs
+++ b/src/System.Management.Automation/engine/ReflectionParameterBinder.cs
@@ -207,6 +207,12 @@ namespace System.Management.Automation
                     v ??= LanguagePrimitives.ThrowInvalidCastException(null, typeof(ActionPreference));
                     ((CommonParameters)o).InformationAction = (ActionPreference)v;
                 });
+            s_setterMethods.TryAdd(Tuple.Create(typeof(CommonParameters), "ProgressAction"),
+                (o, v) =>
+                {
+                    v ??= LanguagePrimitives.ThrowInvalidCastException(null, typeof(ActionPreference));
+                    ((CommonParameters)o).ProgressAction = (ActionPreference)v;
+                });
             s_setterMethods.TryAdd(Tuple.Create(typeof(CommonParameters), "Verbose"), static (o, v) => ((CommonParameters)o).Verbose = (SwitchParameter)v);
             s_setterMethods.TryAdd(Tuple.Create(typeof(CommonParameters), "Debug"), static (o, v) => ((CommonParameters)o).Debug = (SwitchParameter)v);
             s_setterMethods.TryAdd(Tuple.Create(typeof(CommonParameters), "ErrorVariable"), static (o, v) => ((CommonParameters)o).ErrorVariable = (string)v);

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -419,5 +419,6 @@ namespace System.Management.Automation
         Warning = 13,
         Information = 14,
         Confirm = 15,
+        Progress = 16,
     }
 }

--- a/src/System.Management.Automation/engine/cmdlet.cs
+++ b/src/System.Management.Automation/engine/cmdlet.cs
@@ -50,7 +50,7 @@ namespace System.Management.Automation
             () =>
             {
                 return new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
-                    "Verbose", "Debug", "ErrorAction", "WarningAction", "InformationAction",
+                    "Verbose", "Debug", "ErrorAction", "WarningAction", "InformationAction", "ProgressAction",
                     "ErrorVariable", "WarningVariable", "OutVariable",
                     "OutBuffer", "PipelineVariable", "InformationVariable" };
             }

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2516,6 +2516,11 @@ namespace System.Management.Automation
                 _localsTuple.SetPreferenceVariable(PreferenceVariable.Information, _commandRuntime.InformationPreference);
             }
 
+            if (_commandRuntime.IsProgressActionSet)
+            {
+                _localsTuple.SetPreferenceVariable(PreferenceVariable.Progress, _commandRuntime.ProgressPreference);
+            }
+
             if (_commandRuntime.IsWhatIfFlagSet)
             {
                 _localsTuple.SetPreferenceVariable(PreferenceVariable.WhatIf, _commandRuntime.WhatIf);

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1621,7 +1621,7 @@ dir -Recurse `
             $inputStr = 'Get-Content @Splat -P'
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches | Should -HaveCount 6
-            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-Path,-PipelineVariable,-ProgressAction,,-proga,-PSPath,-pv"
+            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-Path,-PipelineVariable,-proga,-ProgressAction,-PSPath,-pv"
         }
 
         It "Test completion for HttpVersion parameter name" {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -2411,7 +2411,7 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
         @{path = "localhost\plugin"; parameter = "-ru"; expected = "RunAsCredential"},
         @{path = "localhost\plugin"; parameter = "-us"; expected = "UseSharedProcess"},
         @{path = "localhost\plugin"; parameter = "-au"; expected = "AutoRestart"},
-        @{path = "localhost\plugin"; parameter = "-pr"; expected = "ProcessIdleTimeoutSec"},
+        @{path = "localhost\plugin"; parameter = "-proc"; expected = "ProcessIdleTimeoutSec"},
         @{path = "localhost\Plugin\microsoft.powershell\Resources\"; parameter = "-re"; expected = "ResourceUri"},
         @{path = "localhost\Plugin\microsoft.powershell\Resources\"; parameter = "-ca"; expected = "Capability"}
     ) {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1620,8 +1620,8 @@ dir -Recurse `
         It "Test completion with splatted variable" {
             $inputStr = 'Get-Content @Splat -P'
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches | Should -HaveCount 4
-            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-Path,-PipelineVariable,-PSPath,-pv"
+            $res.CompletionMatches | Should -HaveCount 5
+            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-Path,-PipelineVariable,-ProgressAction,-PSPath,-pv"
         }
 
         It "Test completion for HttpVersion parameter name" {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1620,8 +1620,8 @@ dir -Recurse `
         It "Test completion with splatted variable" {
             $inputStr = 'Get-Content @Splat -P'
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches | Should -HaveCount 5
-            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-Path,-PipelineVariable,-ProgressAction,-PSPath,-pv"
+            $res.CompletionMatches | Should -HaveCount 6
+            [string]::Join(',', ($res.CompletionMatches.completiontext | Sort-Object)) | Should -BeExactly "-Path,-PipelineVariable,-ProgressAction,,-proga,-PSPath,-pv"
         }
 
         It "Test completion for HttpVersion parameter name" {

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -194,6 +194,7 @@ Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
         @{ name = "ErrorAction";       argValue = "AutomationNull"; arguments = @{ ErrorAction = [System.Management.Automation.Internal.AutomationNull]::Value } }
         @{ name = "WarningAction";     argValue = "AutomationNull"; arguments = @{ WarningAction = [System.Management.Automation.Internal.AutomationNull]::Value } }
         @{ name = "InformationAction"; argValue = "AutomationNull"; arguments = @{ InformationAction = [System.Management.Automation.Internal.AutomationNull]::Value } }
+        @{ name = "ProgressAction";    argValue = "AutomationNull"; arguments = @{ ProgressAction = [System.Management.Automation.Internal.AutomationNull]::Value } }
     ) {
         param($arguments)
 

--- a/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
+++ b/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
@@ -254,7 +254,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
 
         ## Common parameters + '-UserName', '-ComputerName', '-ConfigurationName', '-VMName', '-Port',
         ## '-Token', '-WebSocketUrl', '-ThrottleLimit' and '-Command'
-        $command.Parameters.Count | Should -Be ($CommonParameterCount + 9) -Becase ($command.Parameters.Keys -join ", ")
+        $command.Parameters.Count | Should -Be ($CommonParameterCount + 9) -Because ($command.Parameters.Keys -join ", ")
         $command.ParameterSets.Count | Should -Be 3
 
         $command.Parameters["UserName"].ParameterSets.Count | Should -Be 1

--- a/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
+++ b/test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1
@@ -236,7 +236,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command = Get-Command $Name
         $command.CommandType | Should -Be $CommandType
         ## Common parameters + '-Name' + '-SwitchOne' + '-SwitchTwo'
-        $command.Parameters.Count | Should -Be ($CommonParameterCount + 3)
+        $command.Parameters.Count | Should -Be ($CommonParameterCount + 3) -Because ($command.Parameters.Keys -join ", ")
         $command.ParameterSets.Count | Should -Be 3
 
         & $Name -Name Joe | Should -BeExactly "Hello World Joe."
@@ -254,7 +254,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
 
         ## Common parameters + '-UserName', '-ComputerName', '-ConfigurationName', '-VMName', '-Port',
         ## '-Token', '-WebSocketUrl', '-ThrottleLimit' and '-Command'
-        $command.Parameters.Count | Should -Be ($CommonParameterCount + 9)
+        $command.Parameters.Count | Should -Be ($CommonParameterCount + 9) -Becase ($command.Parameters.Keys -join ", ")
         $command.ParameterSets.Count | Should -Be 3
 
         $command.Parameters["UserName"].ParameterSets.Count | Should -Be 1
@@ -316,7 +316,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command = Get-Command $Name
         $command.CommandType | Should -Be $CommandType
         ## Common parameters + '-ComputerName'
-        $command.Parameters.Count | Should -Be ($CommonParameterCount + 1)
+        $command.Parameters.Count | Should -Be ($CommonParameterCount + 1) -Because ($command.Parameters.Keys -join ", ")
         $command.Parameters["ComputerName"].ParameterType.FullName | Should -BeExactly "System.String"
         $command.Parameters.ContainsKey("SessionName") | Should -BeFalse
     }
@@ -329,7 +329,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command = Get-Command $Name
         $command.CommandType | Should -Be $CommandType
         ## Common parameters + '-ByUrl', '-ByRadio', '-FileName', '-Destination'
-        $command.Parameters.Count | Should -Be ($CommonParameterCount + 4)
+        $command.Parameters.Count | Should -Be ($CommonParameterCount + 4) -Because ($command.Parameters.Keys -join ", ")
         $command.ParameterSets.Count | Should -Be 2
 
         $command.Parameters["ByUrl"].ParameterSets.Count | Should -Be 1
@@ -358,7 +358,7 @@ Describe "Experimental Feature Basic Tests - Feature-Enabled" -Tag "CI" {
         $command = Get-Command $Name
         $command.CommandType | Should -Be $CommandType
         ## Common parameters + '-Name' (dynamic parameters are not triggered)
-        $command.Parameters.Count | Should -Be ($CommonParameterCount + 1)
+        $command.Parameters.Count | Should -Be ($CommonParameterCount + 1) -Because ($command.Parameters.Keys -join ", ")
         $command.Parameters["Name"] | Should -Not -BeNullOrEmpty
 
         $command = Get-Command $Name -ArgumentList "Joe"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Per @PowerShell/wg-powershell-cmdlets review, we should have a `-ProgressAction` common parameter which we believe is a bucket 3 breaking change.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/18737

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9658
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
