### PR TITLE
Enable creating composite subsystem implementation in modules

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -138,6 +138,10 @@ namespace System.Management.Automation.Runspaces
                 ViewsOf_System_Management_Automation_Subsystem_SubsystemInfo());
 
             yield return new ExtendedTypeDefinition(
+                "System.Management.Automation.Subsystem.SubsystemInfo+ImplementationInfo",
+                ViewsOf_System_Management_Automation_Subsystem_SubsystemInfo_ImplementationInfo());
+
+            yield return new ExtendedTypeDefinition(
                 "System.Management.Automation.ShellVariable",
                 ViewsOf_System_Management_Automation_ShellVariable());
 
@@ -772,6 +776,21 @@ namespace System.Management.Automation.Runspaces
                         .AddPropertyColumn("Implementations")
                     .EndRowDefinition()
                 .EndTable());
+        }
+
+        private static IEnumerable<FormatViewDefinition> ViewsOf_System_Management_Automation_Subsystem_SubsystemInfo_ImplementationInfo()
+        {
+            yield return new FormatViewDefinition(
+                "System.Management.Automation.Subsystem.SubsystemInfo+ImplementationInfo",
+                ListControl.Create()
+                    .StartEntry()
+                        .AddItemProperty(@"Id")
+                        .AddItemProperty(@"Kind")
+                        .AddItemProperty(@"Name")
+                        .AddItemProperty(@"Description")
+                        .AddItemProperty(@"ImplementationType")
+                    .EndEntry()
+                .EndList());
         }
 
         private static IEnumerable<FormatViewDefinition> ViewsOf_System_Management_Automation_ShellVariable()

--- a/src/System.Management.Automation/engine/Subsystem/DscSubsystem/ICrossPlatformDsc.cs
+++ b/src/System.Management.Automation/engine/Subsystem/DscSubsystem/ICrossPlatformDsc.cs
@@ -16,11 +16,6 @@ namespace System.Management.Automation.Subsystem.DSC
     public interface ICrossPlatformDsc : ISubsystem
     {
         /// <summary>
-        /// Subsystem kind.
-        /// </summary>
-        SubsystemKind ISubsystem.Kind => SubsystemKind.CrossPlatformDsc;
-
-        /// <summary>
         /// Default implementation. No function is required for this subsystem.
         /// </summary>
         Dictionary<string, string>? ISubsystem.FunctionsToDefine => null;

--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
@@ -25,11 +25,6 @@ namespace System.Management.Automation.Subsystem.Feedback
         Dictionary<string, string>? ISubsystem.FunctionsToDefine => null;
 
         /// <summary>
-        /// Default implementation for `ISubsystem.Kind`.
-        /// </summary>
-        SubsystemKind ISubsystem.Kind => SubsystemKind.FeedbackProvider;
-
-        /// <summary>
         /// Gets feedback based on the given commandline and error record.
         /// </summary>
         /// <returns></returns>
@@ -122,8 +117,6 @@ namespace System.Management.Automation.Subsystem.Feedback
         }
 
         Dictionary<string, string>? ISubsystem.FunctionsToDefine => null;
-
-        SubsystemKind ISubsystem.Kind => SubsystemKind.FeedbackProvider | SubsystemKind.CommandPredictor;
 
         public Guid Id => _guid;
 

--- a/src/System.Management.Automation/engine/Subsystem/ISubsystem.cs
+++ b/src/System.Management.Automation/engine/Subsystem/ISubsystem.cs
@@ -11,6 +11,10 @@ namespace System.Management.Automation.Subsystem
     /// <summary>
     /// Define the kinds of subsystems.
     /// </summary>
+    /// <remarks>
+    /// This enum uses power of 2 as the values for the enum elements, so as to make sure
+    /// the bitwise 'or' operation of the elements always results in an invalid value.
+    /// </remarks>
     public enum SubsystemKind : uint
     {
         /// <summary>

--- a/src/System.Management.Automation/engine/Subsystem/ISubsystem.cs
+++ b/src/System.Management.Automation/engine/Subsystem/ISubsystem.cs
@@ -10,9 +10,7 @@ namespace System.Management.Automation.Subsystem
 {
     /// <summary>
     /// Define the kinds of subsystems.
-    /// Allow composite enum values to enable one subsystem implementation to serve as multiple subystems.
     /// </summary>
-    [Flags]
     public enum SubsystemKind : uint
     {
         /// <summary>
@@ -36,12 +34,8 @@ namespace System.Management.Automation.Subsystem
     /// The API contracts for specific subsystems are defined within the specific interfaces/abstract classes that implements this interface.
     /// </summary>
     /// <remarks>
-    /// There are two purposes to have the internal member `Kind` declared in 'ISubsystem':
-    /// 1. Make the mapping from an `ISubsystem` implementation to the `SubsystemKind` easy;
-    /// 2. Make sure a user cannot directly implement 'ISubsystem', but have to derive from one of the concrete subsystem interface or abstract class.
-    /// <para/>
-    /// The internal member needs to have a default implementation defined by the specific subsystem interfaces or abstract class,
-    /// because it should be the same for a specific kind of subsystem.
+    /// A user should not directly implement <see cref="ISubsystem"/>, but instead should derive from one of the concrete subsystem interfaces or abstract classes.
+    /// The instance of a type that only implements 'ISubsystem' cannot be registered to the <see cref="SubsystemManager"/>.
     /// </remarks>
     public interface ISubsystem
     {
@@ -65,10 +59,5 @@ namespace System.Management.Automation.Subsystem
         /// Key: function name; Value: function script.
         /// </summary>
         Dictionary<string, string>? FunctionsToDefine { get; }
-
-        /// <summary>
-        /// Gets the subsystem kind.
-        /// </summary>
-        internal SubsystemKind Kind { get; }
     }
 }

--- a/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/ICommandPredictor.cs
@@ -22,11 +22,6 @@ namespace System.Management.Automation.Subsystem.Prediction
         Dictionary<string, string>? ISubsystem.FunctionsToDefine => null;
 
         /// <summary>
-        /// Default implementation for `ISubsystem.Kind`.
-        /// </summary>
-        SubsystemKind ISubsystem.Kind => SubsystemKind.CommandPredictor;
-
-        /// <summary>
         /// Get the predictive suggestions. It indicates the start of a suggestion rendering session.
         /// </summary>
         /// <param name="client">Represents the client that initiates the call.</param>

--- a/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
+++ b/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
@@ -217,6 +217,7 @@ namespace System.Management.Automation.Subsystem
         /// In the subsystem scenario, registration operations will be minimum, and in most cases, the registered
         /// implementation will never be unregistered, so optimization for reading is more important.
         /// </remarks>
+        /// <param name="rawImpl">The subsystem implementation to be added.</param>
         private protected override void AddImplementation(ISubsystem rawImpl)
         {
             lock (_syncObj)
@@ -273,6 +274,8 @@ namespace System.Management.Automation.Subsystem
         /// In the subsystem scenario, registration operations will be minimum, and in most cases, the registered
         /// implementation will never be unregistered, so optimization for reading is more important.
         /// </remarks>
+        /// <param name="id">The id of the subsystem implementation to be removed.</param>
+        /// <returns>The subsystem implementation that was removed.</returns>
         private protected override ISubsystem RemoveImplementation(Guid id)
         {
             if (!AllowUnregistration)

--- a/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
+++ b/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
@@ -18,22 +18,22 @@ namespace System.Management.Automation.Subsystem
         #region "Metadata of a Subsystem (public)"
 
         /// <summary>
-        /// The kind of a concrete subsystem.
+        /// Gets the kind of a concrete subsystem.
         /// </summary>
         public SubsystemKind Kind { get; }
 
         /// <summary>
-        /// The type of a concrete subsystem.
+        /// Gets the type of a concrete subsystem.
         /// </summary>
         public Type SubsystemType { get; }
 
         /// <summary>
-        /// Indicate whether the subsystem allows to unregister an implementation.
+        /// Gets a value indicating whether the subsystem allows to unregister an implementation.
         /// </summary>
         public bool AllowUnregistration { get; private set; }
 
         /// <summary>
-        /// Indicate whether the subsystem allows to have multiple implementations registered.
+        /// Gets a value indicating whether the subsystem allows to have multiple implementations registered.
         /// </summary>
         public bool AllowMultipleRegistration { get; private set; }
 

--- a/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
+++ b/src/System.Management.Automation/engine/Subsystem/SubsystemInfo.cs
@@ -78,8 +78,6 @@ namespace System.Management.Automation.Subsystem
 
         private protected SubsystemInfo(SubsystemKind kind, Type subsystemType)
         {
-            Requires.OneSpecificSubsystemKind(kind);
-
             _syncObj = new object();
             _cachedImplInfos = Utils.EmptyReadOnlyCollection<ImplementationInfo>();
 
@@ -161,10 +159,10 @@ namespace System.Management.Automation.Subsystem
         /// </summary>
         public class ImplementationInfo
         {
-            internal ImplementationInfo(ISubsystem implementation)
+            internal ImplementationInfo(SubsystemKind kind, ISubsystem implementation)
             {
                 Id = implementation.Id;
-                Kind = implementation.Kind;
+                Kind = kind;
                 Name = implementation.Name;
                 Description = implementation.Description;
                 ImplementationType = implementation.GetType();
@@ -228,7 +226,7 @@ namespace System.Management.Automation.Subsystem
                 if (_registeredImpls.Count == 0)
                 {
                     _registeredImpls = new ReadOnlyCollection<TConcreteSubsystem>(new[] { impl });
-                    _cachedImplInfos = new ReadOnlyCollection<ImplementationInfo>(new[] { new ImplementationInfo(impl) });
+                    _cachedImplInfos = new ReadOnlyCollection<ImplementationInfo>(new[] { new ImplementationInfo(Kind, impl) });
                     return;
                 }
 
@@ -252,12 +250,17 @@ namespace System.Management.Automation.Subsystem
                     }
                 }
 
-                var list = new List<TConcreteSubsystem>(_registeredImpls.Count + 1);
-                list.AddRange(_registeredImpls);
-                list.Add(impl);
+                int newCapacity = _registeredImpls.Count + 1;
+                var implList = new List<TConcreteSubsystem>(newCapacity);
+                implList.AddRange(_registeredImpls);
+                implList.Add(impl);
 
-                _registeredImpls = new ReadOnlyCollection<TConcreteSubsystem>(list);
-                _cachedImplInfos = new ReadOnlyCollection<ImplementationInfo>(list.ConvertAll(static s => new ImplementationInfo(s)));
+                var implInfo = new List<ImplementationInfo>(newCapacity);
+                implInfo.AddRange(_cachedImplInfos);
+                implInfo.Add(new ImplementationInfo(Kind, impl));
+
+                _registeredImpls = new ReadOnlyCollection<TConcreteSubsystem>(implList);
+                _cachedImplInfos = new ReadOnlyCollection<ImplementationInfo>(implInfo);
             }
         }
 
@@ -316,7 +319,10 @@ namespace System.Management.Automation.Subsystem
                 }
                 else
                 {
-                    var list = new List<TConcreteSubsystem>(_registeredImpls.Count - 1);
+                    int newCapacity = _registeredImpls.Count - 1;
+                    var implList = new List<TConcreteSubsystem>(newCapacity);
+                    var implInfo = new List<ImplementationInfo>(newCapacity);
+
                     for (int i = 0; i < _registeredImpls.Count; i++)
                     {
                         if (index == i)
@@ -324,11 +330,12 @@ namespace System.Management.Automation.Subsystem
                             continue;
                         }
 
-                        list.Add(_registeredImpls[i]);
+                        implList.Add(_registeredImpls[i]);
+                        implInfo.Add(_cachedImplInfos[i]);
                     }
 
-                    _registeredImpls = new ReadOnlyCollection<TConcreteSubsystem>(list);
-                    _cachedImplInfos = new ReadOnlyCollection<ImplementationInfo>(list.ConvertAll(static s => new ImplementationInfo(s)));
+                    _registeredImpls = new ReadOnlyCollection<TConcreteSubsystem>(implList);
+                    _cachedImplInfos = new ReadOnlyCollection<ImplementationInfo>(implInfo);
                 }
 
                 return target;

--- a/src/System.Management.Automation/engine/Subsystem/SubsystemManager.cs
+++ b/src/System.Management.Automation/engine/Subsystem/SubsystemManager.cs
@@ -139,9 +139,12 @@ namespace System.Management.Automation.Subsystem
             }
 
             throw new ArgumentException(
-                StringUtil.Format(
-                    SubsystemStrings.SubsystemTypeUnknown,
-                    subsystemType.FullName));
+                subsystemType == typeof(ISubsystem)
+                    ? SubsystemStrings.MustUseConcreteSubsystemType
+                    : StringUtil.Format(
+                        SubsystemStrings.SubsystemTypeUnknown,
+                        subsystemType.FullName),
+                nameof(subsystemType));
         }
 
         /// <summary>
@@ -151,8 +154,6 @@ namespace System.Management.Automation.Subsystem
         /// <returns>The <see cref="SubsystemInfo"/> object that represents the concrete subsystem.</returns>
         public static SubsystemInfo GetSubsystemInfo(SubsystemKind kind)
         {
-            Requires.OneSpecificSubsystemKind(kind);
-
             if (s_subSystemKindMap.TryGetValue(kind, out SubsystemInfo? subsystemInfo))
             {
                 return subsystemInfo;
@@ -161,7 +162,8 @@ namespace System.Management.Automation.Subsystem
             throw new ArgumentException(
                 StringUtil.Format(
                     SubsystemStrings.SubsystemKindUnknown,
-                    kind.ToString()));
+                    kind.ToString()),
+                nameof(kind));
         }
 
         #endregion
@@ -191,19 +193,19 @@ namespace System.Management.Automation.Subsystem
         public static void RegisterSubsystem(SubsystemKind kind, ISubsystem proxy)
         {
             Requires.NotNull(proxy, nameof(proxy));
-            Requires.OneSpecificSubsystemKind(kind);
 
-            if (!proxy.Kind.HasFlag(kind))
+            SubsystemInfo info = GetSubsystemInfo(kind);
+            if (!info.SubsystemType.IsAssignableFrom(proxy.GetType()))
             {
                 throw new ArgumentException(
                     StringUtil.Format(
-                        SubsystemStrings.ImplementationMismatch,
-                        proxy.Kind.ToString(),
-                        kind.ToString()),
+                        SubsystemStrings.ConcreteSubsystemNotImplemented,
+                        kind.ToString(),
+                        info.SubsystemType.Name),
                     nameof(proxy));
             }
 
-            RegisterSubsystem(GetSubsystemInfo(kind), proxy);
+            RegisterSubsystem(info, proxy);
         }
 
         private static void RegisterSubsystem(SubsystemInfo subsystemInfo, ISubsystem proxy)
@@ -278,8 +280,6 @@ namespace System.Management.Automation.Subsystem
         /// <param name="id">The Id of the implementation to be unregistered.</param>
         public static void UnregisterSubsystem(SubsystemKind kind, Guid id)
         {
-            Requires.OneSpecificSubsystemKind(kind);
-
             UnregisterSubsystem(GetSubsystemInfo(kind), id);
         }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1768,19 +1768,5 @@ namespace System.Management.Automation.Internal
                 throw new ArgumentException(paramName);
             }
         }
-
-        internal static void OneSpecificSubsystemKind(Subsystem.SubsystemKind kind)
-        {
-            uint value = (uint)kind;
-            if (value == 0 || (value & (value - 1)) != 0)
-            {
-                // The value is either invalid or a composite value because it's not power of 2.
-                throw new ArgumentException(
-                    StringUtil.Format(
-                        SubsystemStrings.RequireOneSpecificSubsystemKind,
-                        kind.ToString()),
-                    nameof(kind));
-            }
-        }
     }
 }

--- a/src/System.Management.Automation/resources/SubsystemStrings.resx
+++ b/src/System.Management.Automation/resources/SubsystemStrings.resx
@@ -135,11 +135,14 @@
   <data name="SubsystemTypeUnknown" xml:space="preserve">
     <value>The specified subsystem type '{0}' is unknown.</value>
   </data>
+  <data name="MustUseConcreteSubsystemType" xml:space="preserve">
+    <value>You must specify a concrete subsystem type instead of the base interface 'ISubsystem'.</value>
+  </data>
   <data name="SubsystemKindUnknown" xml:space="preserve">
     <value>The specified subsystem kind '{0}' is unknown.</value>
   </data>
-  <data name="ImplementationMismatch" xml:space="preserve">
-    <value>The specified implementation instance implements the subsystem '{0}', which does not match the target subsystem '{1}'.</value>
+  <data name="ConcreteSubsystemNotImplemented" xml:space="preserve">
+    <value>For the target subsystem kind '{0}', the specified subsystem instance needs to implement the corresponding concrete interface or abstract class '{1}'.</value>
   </data>
   <data name="InvalidSubsystemInfo" xml:space="preserve">
     <value>The declared metadata for subsystem kind '{0}' is invalid. A subsystem that requires cmdlets or functions to be defined cannot allow multiple registrations because that would result in one implementation overwriting the commands defined by another implementation.</value>
@@ -152,8 +155,5 @@
   </data>
   <data name="NullOrEmptyImplementationDescription" xml:space="preserve">
     <value>The 'Description' property of an implementation for the subsystem '{0}' cannot be null or an empty string.</value>
-  </data>
-  <data name="RequireOneSpecificSubsystemKind" xml:space="preserve">
-    <value>The subsystem kind here should represent one specific subsystem, but the given value is either invalid or a composite enum value: '{0}'.</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #18853

Enable creating composite subsystem implementation in modules.
It turns out the `Kind` member in `ISubsystem` is not needed. Whether an implementation derives from the target subsystem interface should be the only criteria to check if this implementation can be registered to the target subsystem.

Refactored the subsystem code to remove the `Kind` member from the base interface `ISubsystem`, so as to allow one class to implement multiple subsystem interfaces.

This is not a breaking change because the `Kind` member was made internal to prevent users from directly implement it. Now one can directly implements `ISubsystem`, but that implementation won't be able to be registered to PowerShell.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
