### PR TITLE
Fix bug with managing redirection and keepAuthorization in Web cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -968,20 +968,13 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // This indicates GetResponse will handle redirects.
-            if (handleRedirect)
+            if (handleRedirect || WebSession.MaximumRedirection == 0)
             {
                 handler.AllowAutoRedirect = false;
             }
-            else if (WebSession.MaximumRedirection > -1)
+            else if (WebSession.MaximumRedirection > 0)
             {
-                if (WebSession.MaximumRedirection == 0)
-                {
-                    handler.AllowAutoRedirect = false;
-                }
-                else
-                {
-                    handler.MaxAutomaticRedirections = WebSession.MaximumRedirection;
-                }
+                handler.MaxAutomaticRedirections = WebSession.MaximumRedirection;
             }
 
             handler.SslProtocols = (SslProtocols)SslProtocol;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1313,9 +1313,10 @@ namespace Microsoft.PowerShell.Commands
                 _cancelToken = new CancellationTokenSource();
                 response = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
 
-                bool sessionRedirect = WebSession.MaximumRedirection > 0 || WebSession.MaximumRedirection == -1;
-
-                if (keepAuthorization && sessionRedirect && IsRedirectCode(response.StatusCode) && response.Headers.Location is not null)
+                if (keepAuthorization
+                    && WebSession.MaximumRedirection is not 0
+                    && IsRedirectCode(response.StatusCode)
+                    && response.Headers.Location is not null)
                 {
                     _cancelToken.Cancel();
                     _cancelToken = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1287,7 +1287,7 @@ namespace Microsoft.PowerShell.Commands
             );
         }
 
-        internal virtual HttpResponseMessage GetResponse(HttpClient client, HttpRequestMessage request, bool keepAuthorizationOnRedirect)
+        internal virtual HttpResponseMessage GetResponse(HttpClient client, HttpRequestMessage request, bool handleRedirect)
         {
             ArgumentNullException.ThrowIfNull(client);
 
@@ -1305,8 +1305,6 @@ namespace Microsoft.PowerShell.Commands
 
                 _cancelToken = new CancellationTokenSource();
                 response = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
-
-                bool handleRedirect = keepAuthorizationOnRedirect; // || AllowInsicureRedirect || PreserveHTTPMethodOnRedirect
 
                 if (handleRedirect
                     && WebSession.MaximumRedirection is not 0
@@ -1335,7 +1333,7 @@ namespace Microsoft.PowerShell.Commands
                     using (client = GetHttpClient(handleRedirect))
                     using (HttpRequestMessage redirectRequest = GetRequest(currentUri))
                     {
-                        response = GetResponse(client, redirectRequest, keepAuthorizationOnRedirect);
+                        response = GetResponse(client, redirectRequest, handleRedirect);
                     }
                 }
 
@@ -1373,7 +1371,7 @@ namespace Microsoft.PowerShell.Commands
                         
                         WriteVerbose(reqVerboseMsg);
 
-                        return GetResponse(client, requestWithoutRange, keepAuthorizationOnRedirect);
+                        return GetResponse(client, requestWithoutRange, handleRedirect);
                     }
                 }
 
@@ -1490,7 +1488,7 @@ namespace Microsoft.PowerShell.Commands
 
                                 WriteVerbose(reqVerboseMsg);
 
-                                HttpResponseMessage response = GetResponse(client, request, keepAuthorizationOnRedirect);
+                                HttpResponseMessage response = GetResponse(client, request, handleRedirect);
 
                                 string contentType = ContentHelper.GetContentType(response);
                                 string respVerboseMsg = string.Format(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1416,10 +1416,8 @@ namespace Microsoft.PowerShell.Commands
 
                 // If the request contains an authorization header and PreserveAuthorizationOnRedirect is not set,
                 // it needs to be stripped on the first redirect.
-                bool keepAuthorizationOnRedirect = WebSession is not null
-                                                   && WebSession.Headers is not null
-                                                   && PreserveAuthorizationOnRedirect.IsPresent
-                                                   && WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
+                bool keepAuthorizationOnRedirect = PreserveAuthorizationOnRedirect.IsPresent
+                                                   && WebSession?.Headers?.ContainsKey(HttpKnownHeaderNames.Authorization);
 
                 bool handleRedirect = keepAuthorizationOnRedirect || AllowInsecureRedirect;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1417,7 +1417,7 @@ namespace Microsoft.PowerShell.Commands
                 // If the request contains an authorization header and PreserveAuthorizationOnRedirect is not set,
                 // it needs to be stripped on the first redirect.
                 bool keepAuthorizationOnRedirect = PreserveAuthorizationOnRedirect.IsPresent
-                                                   && WebSession?.Headers?.ContainsKey(HttpKnownHeaderNames.Authorization);
+                                                   && WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
 
                 bool handleRedirect = keepAuthorizationOnRedirect || AllowInsecureRedirect;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1294,7 +1294,7 @@ namespace Microsoft.PowerShell.Commands
             );
         }
 
-        internal virtual HttpResponseMessage GetResponse(HttpClient client, HttpRequestMessage request, bool keepAuthorization)
+        internal virtual HttpResponseMessage GetResponse(HttpClient client, HttpRequestMessage request, bool keepAuthorizationOnRedirect)
         {
             ArgumentNullException.ThrowIfNull(client);
 
@@ -1493,7 +1493,7 @@ namespace Microsoft.PowerShell.Commands
 
                                 WriteVerbose(reqVerboseMsg);
 
-                                HttpResponseMessage response = GetResponse(client, request, keepAuthorization);
+                                HttpResponseMessage response = GetResponse(client, request, keepAuthorizationOnRedirect);
 
                                 string contentType = ContentHelper.GetContentType(response);
                                 string respVerboseMsg = string.Format(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1313,7 +1313,9 @@ namespace Microsoft.PowerShell.Commands
                 _cancelToken = new CancellationTokenSource();
                 response = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
 
-                if (keepAuthorizationOnRedirect
+                bool handleRedirect = keepAuthorizationOnRedirect; // || AllowInsicureRedirect || PreserveHTTPMethodOnRedirect
+
+                if (handleRedirect
                     && WebSession.MaximumRedirection is not 0
                     && IsRedirectCode(response.StatusCode)
                     && response.Headers.Location is not null)
@@ -1337,7 +1339,7 @@ namespace Microsoft.PowerShell.Commands
 
                     currentUri = new Uri(request.RequestUri, response.Headers.Location);
                     // Continue to handle redirection
-                    using (client = GetHttpClient(handleRedirect: true))
+                    using (client = GetHttpClient(handleRedirect))
                     using (HttpRequestMessage redirectRequest = GetRequest(currentUri))
                     {
                         response = GetResponse(client, redirectRequest, keepAuthorizationOnRedirect);
@@ -1459,7 +1461,9 @@ namespace Microsoft.PowerShell.Commands
                                                    PreserveAuthorizationOnRedirect &&
                                                    WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
 
-                using (HttpClient client = GetHttpClient(keepAuthorizationOnRedirect))
+                bool handleRedirect = keepAuthorizationOnRedirect; // || AllowInsicureRedirect || PreserveHTTPMethodOnRedirect
+
+                using (HttpClient client = GetHttpClient(handleRedirect))
                 {
                     int followedRelLink = 0;
                     Uri uri = Uri;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1449,7 +1449,7 @@ namespace Microsoft.PowerShell.Commands
                 // it needs to be stripped on the first redirect.
                 bool keepAuthorizationOnRedirect = WebSession is not null &&
                                                    WebSession.Headers is not null &&
-                                                   PreserveAuthorizationOnRedirect &&
+                                                   PreserveAuthorizationOnRedirect.IsPresent &&
                                                    WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
 
                 bool handleRedirect = keepAuthorizationOnRedirect; // || AllowInsicureRedirect || PreserveHTTPMethodOnRedirect

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1313,7 +1313,9 @@ namespace Microsoft.PowerShell.Commands
                 _cancelToken = new CancellationTokenSource();
                 response = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
 
-                if (keepAuthorization && IsRedirectCode(response.StatusCode) && response.Headers.Location is not null)
+                bool sessionRedirect = WebSession.MaximumRedirection > 0 || WebSession.MaximumRedirection == -1;
+
+                if (keepAuthorization && sessionRedirect && IsRedirectCode(response.StatusCode) && response.Headers.Location is not null)
                 {
                     _cancelToken.Cancel();
                     _cancelToken = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1452,7 +1452,7 @@ namespace Microsoft.PowerShell.Commands
                                                    PreserveAuthorizationOnRedirect.IsPresent &&
                                                    WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
 
-                bool handleRedirect = keepAuthorizationOnRedirect; // || AllowInsicureRedirect || PreserveHTTPMethodOnRedirect
+                bool handleRedirect = keepAuthorizationOnRedirect;
 
                 using (HttpClient client = GetHttpClient(handleRedirect))
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1313,7 +1313,7 @@ namespace Microsoft.PowerShell.Commands
                 _cancelToken = new CancellationTokenSource();
                 response = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
 
-                if (keepAuthorization
+                if (keepAuthorizationOnRedirect
                     && WebSession.MaximumRedirection is not 0
                     && IsRedirectCode(response.StatusCode)
                     && response.Headers.Location is not null)
@@ -1340,7 +1340,7 @@ namespace Microsoft.PowerShell.Commands
                     using (client = GetHttpClient(handleRedirect: true))
                     using (HttpRequestMessage redirectRequest = GetRequest(currentUri))
                     {
-                        response = GetResponse(client, redirectRequest, keepAuthorization);
+                        response = GetResponse(client, redirectRequest, keepAuthorizationOnRedirect);
                     }
                 }
 
@@ -1378,7 +1378,7 @@ namespace Microsoft.PowerShell.Commands
                         
                         WriteVerbose(reqVerboseMsg);
 
-                        return GetResponse(client, requestWithoutRange, keepAuthorization);
+                        return GetResponse(client, requestWithoutRange, keepAuthorizationOnRedirect);
                     }
                 }
 
@@ -1454,12 +1454,12 @@ namespace Microsoft.PowerShell.Commands
 
                 // if the request contains an authorization header and PreserveAuthorizationOnRedirect is not set,
                 // it needs to be stripped on the first redirect.
-                bool keepAuthorization = WebSession is not null &&
+                bool keepAuthorizationOnRedirect = WebSession is not null &&
                                          WebSession.Headers is not null &&
                                          PreserveAuthorizationOnRedirect.IsPresent &&
                                          WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
 
-                using (HttpClient client = GetHttpClient(keepAuthorization))
+                using (HttpClient client = GetHttpClient(keepAuthorizationOnRedirect))
                 {
                     int followedRelLink = 0;
                     Uri uri = Uri;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -533,7 +533,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Resume requires OutFile.
-            if (Resume && OutFile is null)
+            if (Resume.IsPresent && OutFile is null)
             {
                 ErrorRecord error = GetValidationError(WebCmdletStrings.OutFileMissing, "WebCmdletOutFileMissingException", nameof(Resume));
                 ThrowTerminatingError(error);
@@ -666,7 +666,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Determines whether writing to a file should Resume and append rather than overwrite.
         /// </summary>
-        internal bool ShouldResume => Resume && _resumeSuccess;
+        internal bool ShouldResume => Resume.IsPresent && _resumeSuccess;
 
         #endregion Helper Properties
 
@@ -1095,7 +1095,7 @@ namespace Microsoft.PowerShell.Commands
 
             // If the file to resume downloading exists, create the Range request header using the file size.
             // If not, create a Range to request the entire file.
-            if (Resume)
+            if (Resume.IsPresent)
             {
                 var fileInfo = new FileInfo(QualifiedOutFile);
                 if (fileInfo.Exists)
@@ -1342,7 +1342,7 @@ namespace Microsoft.PowerShell.Commands
                 // Request again without the Range header because the server indicated the range was not satisfiable.
                 // This happens when the local file is larger than the remote file.
                 // If the size of the remote file is the same as the local file, there is nothing to resume.
-                if (Resume &&
+                if (Resume.IsPresent &&
                     response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable &&
                     (response.Content.Headers.ContentRange.HasLength &&
                     response.Content.Headers.ContentRange.Length != _resumeFileSize))
@@ -1505,7 +1505,7 @@ namespace Microsoft.PowerShell.Commands
 
                                 // Check if the Resume range was not satisfiable because the file already completed downloading.
                                 // This happens when the local file is the same size as the remote file.
-                                if (Resume &&
+                                if (Resume.IsPresent &&
                                     response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable &&
                                     response.Content.Headers.ContentRange.HasLength &&
                                     response.Content.Headers.ContentRange.Length == _resumeFileSize)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -533,7 +533,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Resume requires OutFile.
-            if (Resume.IsPresent && OutFile is null)
+            if (Resume && OutFile is null)
             {
                 ErrorRecord error = GetValidationError(WebCmdletStrings.OutFileMissing, "WebCmdletOutFileMissingException", nameof(Resume));
                 ThrowTerminatingError(error);
@@ -666,7 +666,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Determines whether writing to a file should Resume and append rather than overwrite.
         /// </summary>
-        internal bool ShouldResume => Resume.IsPresent && _resumeSuccess;
+        internal bool ShouldResume => Resume && _resumeSuccess;
 
         #endregion Helper Properties
 
@@ -1102,7 +1102,7 @@ namespace Microsoft.PowerShell.Commands
 
             // If the file to resume downloading exists, create the Range request header using the file size.
             // If not, create a Range to request the entire file.
-            if (Resume.IsPresent)
+            if (Resume)
             {
                 var fileInfo = new FileInfo(QualifiedOutFile);
                 if (fileInfo.Exists)
@@ -1347,7 +1347,7 @@ namespace Microsoft.PowerShell.Commands
                 // Request again without the Range header because the server indicated the range was not satisfiable.
                 // This happens when the local file is larger than the remote file.
                 // If the size of the remote file is the same as the local file, there is nothing to resume.
-                if (Resume.IsPresent &&
+                if (Resume &&
                     response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable &&
                     (response.Content.Headers.ContentRange.HasLength &&
                     response.Content.Headers.ContentRange.Length != _resumeFileSize))
@@ -1455,9 +1455,9 @@ namespace Microsoft.PowerShell.Commands
                 // if the request contains an authorization header and PreserveAuthorizationOnRedirect is not set,
                 // it needs to be stripped on the first redirect.
                 bool keepAuthorizationOnRedirect = WebSession is not null &&
-                                         WebSession.Headers is not null &&
-                                         PreserveAuthorizationOnRedirect.IsPresent &&
-                                         WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
+                                                   WebSession.Headers is not null &&
+                                                   PreserveAuthorizationOnRedirect &&
+                                                   WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
 
                 using (HttpClient client = GetHttpClient(keepAuthorizationOnRedirect))
                 {
@@ -1508,7 +1508,7 @@ namespace Microsoft.PowerShell.Commands
 
                                 // Check if the Resume range was not satisfiable because the file already completed downloading.
                                 // This happens when the local file is the same size as the remote file.
-                                if (Resume.IsPresent &&
+                                if (Resume &&
                                     response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable &&
                                     response.Content.Headers.ContentRange.HasLength &&
                                     response.Content.Headers.ContentRange.Length == _resumeFileSize)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -144,7 +144,7 @@ function ExecuteRedirectRequest {
     try {
         $headers = @{"Authorization" = "test"}
         if ($Cmdlet -eq 'Invoke-WebRequest') {
-            if ($MaximumRedirection) {
+            if ($MaximumRedirection -gt 0) {
                 $result.Output = Invoke-WebRequest -Uri $uri -Headers $headers -PreserveAuthorizationOnRedirect:$PreserveAuthorizationOnRedirect.IsPresent -Method $Method -MaximumRedirection:$MaximumRedirection
             } else {
                 $result.Output = Invoke-WebRequest -Uri $uri -Headers $headers -PreserveAuthorizationOnRedirect:$PreserveAuthorizationOnRedirect.IsPresent -Method $Method


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current behaviour of `if (keepAuthorization && IsRedirectCode(response.StatusCode) && response.Headers.Location is not null)` is wrong, I tested it by setting `keepAuthorization = true` --> this sets `handleRetirect = true` --> and then sets `handler.AllowAutoRedirect = false`. Without `sessionRedirect` (we can choose a better name) it ignores the `MaximumRedirection` parameter.

Test: maunally set `keepAuthorization = true` before the `if`, then
`Invoke-WebRequest "http://mockbin.org/redirect/308?to=https://mockbin.org/redirect/302?to=https://mockbin.org/status/200" -MaximumRedirection 0 -SkipHttpErrorCheck` --> expected 308, result 200

Proposed fix --> 
```cs
bool sessionRedirect = WebSession.MaximumRedirection > 0 || WebSession.MaximumRedirection == -1;
if (keepAuthorization  && sessionRedirect && IsRedirectCode(response.StatusCode) && response.Headers.Location is not null)
```

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Fix Bug, merge before #18546 and #18894

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

