### PR TITLE
[release/v7.3.2] Remove unnecessary reference to `System.Runtime.CompilerServices.Unsafe`

### DIFF
--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
     <!--PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" /-->
     <PackageReference Include="System.Management" Version="7.0.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="7.0.0-preview.3.22119.2" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.2-mauipre.1.22102.15" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.0" />
     <PackageReference Include="System.Security.Permissions" Version="7.0.0" />


### PR DESCRIPTION
back port  (#18806)