### PR TITLE
Allow system lock down test debug hook to work with new wldp API (fixes system lock down tests)

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-    <PackageReference Include="PSReadLine" Version="2.2.7" />
+    <PackageReference Include="PSReadLine" Version="2.2.6" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,11 +14,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-<<<<<<< HEAD
     <PackageReference Include="PSReadLine" Version="2.2.6" />
-=======
-    <PackageReference Include="PSReadLine" Version="2.2.2" />
->>>>>>> Bump PSReadLine from 2.1.0 to 2.2.2 in /src/Modules
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,7 +14,11 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
+<<<<<<< HEAD
     <PackageReference Include="PSReadLine" Version="2.2.6" />
+=======
+    <PackageReference Include="PSReadLine" Version="2.2.2" />
+>>>>>>> Bump PSReadLine from 2.1.0 to 2.2.2 in /src/Modules
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-    <PackageReference Include="PSReadLine" Version="2.2.5" />
+    <PackageReference Include="PSReadLine" Version="2.2.2" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-    <PackageReference Include="PSReadLine" Version="2.2.6" />
+    <PackageReference Include="PSReadLine" Version="2.2.7" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,15 +14,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-<<<<<<< HEAD
-<<<<<<< HEAD
-    <PackageReference Include="PSReadLine" Version="2.2.6" />
-=======
-    <PackageReference Include="PSReadLine" Version="2.2.2" />
->>>>>>> Bump PSReadLine from 2.1.0 to 2.2.2 in /src/Modules
-=======
-    <PackageReference Include="PSReadLine" Version="2.2.2" />
->>>>>>> Bump PSReadLine from 2.1.0 to 2.2.2 in /src/Modules
+    <PackageReference Include="PSReadLine" Version="2.2.5" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-    <PackageReference Include="PSReadLine" Version="2.2.2" />
+    <PackageReference Include="PSReadLine" Version="2.2.6" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -15,7 +15,11 @@
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
 <<<<<<< HEAD
+<<<<<<< HEAD
     <PackageReference Include="PSReadLine" Version="2.2.6" />
+=======
+    <PackageReference Include="PSReadLine" Version="2.2.2" />
+>>>>>>> Bump PSReadLine from 2.1.0 to 2.2.2 in /src/Modules
 =======
     <PackageReference Include="PSReadLine" Version="2.2.2" />
 >>>>>>> Bump PSReadLine from 2.1.0 to 2.2.2 in /src/Modules

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -110,9 +110,9 @@ namespace System.Management.Automation.Security
         {
             SafeHandle fileHandle = fileStream.SafeFileHandle;
 
-            // First check latest WDAC APIs if available.
+            // First check latest WDAC APIs if available.  Also revert to legacy APIs if debug hook is in effect.
             Exception errorException = null;
-            if (s_wldpCanExecuteAvailable)
+            if (s_wldpCanExecuteAvailable && !s_allowDebugOverridePolicy)
             {
                 try
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR fixes system lock down tests when running on a Windows platform version with CanExecuteFile API.

## PR Context

The system lock down code first looks for CanExecuteFile API before reverting to legacy API when testing a single script file.  However, the test debug hook is implemented in the legacy API.  So when the debug hook is in effect, it should always use legacy API for single script file check.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
