### PR TITLE
WIP: Fix decoration leaking into newline at end of screen buffer

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -656,7 +656,7 @@ namespace Microsoft.PowerShell
                 if (newLine)
                 {
                     // write the newline after resetting the colors so there isn't a buffer wide colored line when buffer scrolls
-                    WriteLineToConsole(string.Empty, transcribeResult: true);
+                    WriteToConsole(string.Empty, transcribeResult: true, newLine: true);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -818,6 +818,11 @@ namespace Microsoft.PowerShell
                 RawUI.ForegroundColor = foregroundColor;
                 RawUI.BackgroundColor = backgroundColor;
 
+                if (SupportsVirtualTerminal)
+                {
+                    value += PSStyle.Instance.Reset;
+                }
+
                 try
                 {
                     this.WriteImpl(value, newLine);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -748,6 +748,11 @@ namespace Microsoft.PowerShell
             }
             else
             {
+                if (SupportsVirtualTerminal)
+                {
+                    value += PSStyle.Instance.Reset;
+                }
+
                 if (newLine)
                 {
                     writer.WriteLine(value);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -645,12 +645,18 @@ namespace Microsoft.PowerShell
 
                 try
                 {
-                    WriteToConsole(text, transcribeResult: true, newLine);
+                    WriteToConsole(text, transcribeResult: true, newLine: false);
                 }
                 finally
                 {
                     RawUI.ForegroundColor = fg;
                     RawUI.BackgroundColor = bg;
+                }
+
+                if (newLine)
+                {
+                    // write the newline after resetting the colors so there isn't a buffer wide colored line when buffer scrolls
+                    WriteLineToConsole(string.Empty, transcribeResult: true);
                 }
             }
         }
@@ -823,19 +829,20 @@ namespace Microsoft.PowerShell
                 RawUI.ForegroundColor = foregroundColor;
                 RawUI.BackgroundColor = backgroundColor;
 
-                if (SupportsVirtualTerminal && Console.CursorTop == Console.BufferHeight - 1)
-                {
-                    value += PSStyle.Instance.Reset;
-                }
-
                 try
                 {
-                    this.WriteImpl(value, newLine);
+                    this.WriteImpl(value, newLine: false);
                 }
                 finally
                 {
                     RawUI.ForegroundColor = fg;
                     RawUI.BackgroundColor = bg;
+                }
+
+                if (newLine)
+                {
+                    // write the newline after resetting the colors so there isn't a buffer wide colored line when buffer scrolls
+                    this.WriteImpl(string.Empty, newLine: true);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -748,7 +748,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                if (SupportsVirtualTerminal)
+                if (SupportsVirtualTerminal && Console.CursorTop == Console.BufferHeight - 1)
                 {
                     value += PSStyle.Instance.Reset;
                 }
@@ -823,7 +823,7 @@ namespace Microsoft.PowerShell
                 RawUI.ForegroundColor = foregroundColor;
                 RawUI.BackgroundColor = backgroundColor;
 
-                if (SupportsVirtualTerminal)
+                if (SupportsVirtualTerminal && Console.CursorTop == Console.BufferHeight - 1)
                 {
                     value += PSStyle.Instance.Reset;
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -6,13 +6,13 @@ Describe "Write-Host with default Console Host" -Tags "Slow","Feature" {
         $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
 
         $testData = @(
-            @{ Name = '-Separator';       Command = "Write-Host a,b,c -Separator '+'";                 returnCount = 1; returnValue = @("a+b+c") }
-            @{ Name = '-NoNewline=true';  Command = "Write-Host a,b -NoNewline:`$true;Write-Host a,b"; returnCount = 1; returnValue = @("a ba b") }
-            @{ Name = '-NoNewline=false'; Command = "Write-Host a1,b1;Write-Host a2,b2";               returnCount = 2; returnValue = @("a1 b1","a2 b2") }
+            @{ Name = '-Separator';       Command = "`$PSStyle.OutputRendering='Plaintext';Write-Host a,b,c -Separator '+'";                 returnCount = 1; returnValue = @("a+b+c") }
+            @{ Name = '-NoNewline=true';  Command = "`$PSStyle.OutputRendering='Plaintext';Write-Host a,b -NoNewline:`$true;Write-Host a,b"; returnCount = 1; returnValue = @("a ba b") }
+            @{ Name = '-NoNewline=false'; Command = "`$PSStyle.OutputRendering='Plaintext';Write-Host a1,b1;Write-Host a2,b2";               returnCount = 2; returnValue = @("a1 b1","a2 b2") }
         )
     }
 
-    It "write-Host works with '<Name>' switch" -TestCases:$testData -Pending:$IsMacOS {
+    It "write-Host works with '<Name>' switch" -TestCases:$testData {
         param($Command, $returnCount, $returnValue)
 
         [array]$result = & $powershell -noprofile -c $Command


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When writing content and the screen buffer scrolls, the decorations also get written to the next line.  This is most evident when using a background color and the entire newline contains the background color.  Fix is to insert a VT Reset sequence if the terminal supports VT.

This was validated on macOS and Windows.  This shows the before and after:

https://user-images.githubusercontent.com/11859881/214211835-5aab202f-5e4f-49be-87cd-100d450ee638.mp4

## PR Context

This fixes part of the issue reported below, but PSCal needs to account for when the screen buffer scrolls and the cursor position has changed.  Ideally, it should not be using cursor position to render, but instead pre-calculate all the rows.

Fix https://github.com/PowerShell/PowerShell/issues/18984

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
