### PR TITLE
Add Statement property to $MyInvocation

### DIFF
--- a/src/System.Management.Automation/engine/InvocationInfo.cs
+++ b/src/System.Management.Automation/engine/InvocationInfo.cs
@@ -279,7 +279,7 @@ namespace System.Management.Automation
         {
             get
             {
-                return ScriptPosition.Text ?? string.Empty;
+                return ScriptPosition.Text;
             }
         }
 

--- a/src/System.Management.Automation/engine/InvocationInfo.cs
+++ b/src/System.Management.Automation/engine/InvocationInfo.cs
@@ -272,6 +272,18 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// The full text of the invocation statement, may span multiple lines.
+        /// </summary>
+        /// <value>Statement that was entered to invoke this command</value>
+        public string Statement
+        {
+            get
+            {
+                return ScriptPosition.Text ?? string.Empty;
+            }
+        }
+
+        /// <summary>
         /// Formatted message indicating where the cmdlet appeared
         /// in the line.
         /// </summary>

--- a/src/System.Management.Automation/engine/InvocationInfo.cs
+++ b/src/System.Management.Automation/engine/InvocationInfo.cs
@@ -274,7 +274,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The full text of the invocation statement, may span multiple lines.
         /// </summary>
-        /// <value>Statement that was entered to invoke this command</value>
+        /// <value>Statement that was entered to invoke this command.</value>
         public string Statement
         {
             get

--- a/test/powershell/Language/Scripting/MyInvocation.Tests.ps1
+++ b/test/powershell/Language/Scripting/MyInvocation.Tests.ps1
@@ -23,6 +23,25 @@ Describe 'Testing of MyInvocation' -Tags "CI" {
         { & myfilter } | Should -Not -Throw
     }
 
+    Context 'MyInvocation works with multi-line invocations' {
+        It 'MyInvocation.Statement works in & Script block' {
+            $a = & {
+                $MyInvocation.Statement
+            }
+            $a.IndexOf('& {
+                $MyInvocation.Statement
+            }') |Should -BeGreaterThan -1
+        }
+        It 'MyInvocation.Statement works in dot sourced Script block' {
+            $a = . {
+                $MyInvocation.Statement
+            }
+            $a.IndexOf('. {
+                $MyInvocation.Statement
+            }') |Should -BeGreaterThan -1
+        }
+    }
+
     Context 'MyInvocation works in Script block' {
 
         It 'MyInvocation works in dot sourced Script block' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #12609

It's currently near-impossible to obtain the exact invocation statement of the current callsite in a script block or script function if the invocation spans multiple lines:

```
PS ~> function Capture-Extent { return $MyInvocation.Line.Substring($MyInvocation.OffSetInLine - 1) }
PS ~> $ext = Capture-Extent @'
these are not the droids you're looking for
'@
PS ~> $ext
Capture-Extent @'
PS ~>
```

This PR exposes the full text of the current invocation via a new instance property `Statement`, allowing command authors to capture multi-line invocations:

```
PS ~> function Capture-Extent { return $MyInvocation.Statement }
PS ~> $ext = Capture-Extent @'
Now we can see what's going on down here!
'@
PS ~> $ext
Capture-Extent @'
Now we can see what's going on down here!
'@
PS ~>
```

<!-- Summarize your PR between here and the checklist. -->

## PR Context

WG-Engine previously [discussed this behavior](https://github.com/PowerShell/PowerShell/issues/12609#issuecomment-1209090602) and found no good reason not to expose the full text, but decided against modifying any existing behavior, hence this additional property.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
