### PR TITLE
Hotfix/nuget packages

### DIFF
--- a/test/perf/benchmarks/assets/compiler.test.ps1
+++ b/test/perf/benchmarks/assets/compiler.test.ps1
@@ -2278,6 +2278,7 @@ function Start-PSPackage {
                     PackageVersion = $Version
                     PackageRuntime = $Runtime
                     PackageConfiguration = $Configuration
+                    IncludeSymbols = $IncludeSymbols
                     Force = $Force
                 }
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -438,6 +438,7 @@ function Start-PSPackage {
                     PackageVersion = $Version
                     PackageRuntime = $Runtime
                     PackageConfiguration = $Configuration
+                    IncludeSymbols = $IncludeSymbols
                     Force = $Force
                 }
 
@@ -2831,7 +2832,7 @@ function New-NugetContentPackage
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $PackageSourcePath,
-
+        [switch] $IncludeSymbols,
         [Switch]
         $Force
     )
@@ -2858,12 +2859,21 @@ function New-NugetContentPackage
     $projectFolder = Join-Path $PSScriptRoot 'projects/nuget'
 
     $arguments = @('pack')
+    if($IncludeSymbols.IsPresent)
+    {
+        $arguments += '--include-symbols'
+    }
     $arguments += @('--output',$nugetFolder)
     $arguments += @('--configuration',$PackageConfiguration)
     $arguments += "/p:StagingPath=$stagingRoot"
     $arguments += "/p:RID=$PackageRuntime"
     $arguments += "/p:SemVer=$nugetSemanticVersion"
     $arguments += "/p:PackageName=$nuspecPackageName"
+    if($env:TF_BUILD)
+    {
+        $arguments += "/p:ContinuousIntegrationBuild=true"
+        $arguments += "/p:EmbedUntrackedSources=true"
+    }
     $arguments += $projectFolder
 
     Write-Log "Running dotnet $arguments"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2264,7 +2264,11 @@ function CopyReferenceAssemblies
 
     $supportedRefList = @(
         "Microsoft.PowerShell.Commands.Utility",
-        "Microsoft.PowerShell.ConsoleHost")
+        "Microsoft.PowerShell.ConsoleHost",
+        "Microsoft.PowerShell.Commands.Management",
+        "Microsoft.PowerShell.Commands.Diagnostics",
+        "Microsoft.PowerShell.Security",
+        "Microsoft.WSMan.Management")
 
     switch ($assemblyName) {
         { $_ -in $supportedRefList } {

--- a/tools/releaseBuild/azureDevOps/templates/nuget-pkg-sbom.yml
+++ b/tools/releaseBuild/azureDevOps/templates/nuget-pkg-sbom.yml
@@ -66,5 +66,5 @@ steps:
       Import-Module -Name $env:REPOROOT\build.psm1
       Import-Module -Name $env:REPOROOT\tools\packaging
       Find-DotNet
-      New-ILNugetPackageFromSource -FileName $FileName -PackageVersion '${{ parameters.PackageVersion }}' -PackagePath '${{ parameters.PackagePath }}'
+      New-ILNugetPackageFromSource -FileName $FileName -PackageVersion '${{ parameters.PackageVersion }}' -PackagePath '${{ parameters.PackagePath }}' -IncludeSymbols
     displayName: 'Create NuGet Package for single file'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Should fix https://github.com/PowerShell/PowerShell/issues/16862

Microsoft.PowerShell.SDK is missing references to
* Microsoft.PowerShell.Commands.Management
* Microsoft.PowerShell.Commands.Diagnostics
* Microsoft.PowerShell.Security
* Microsoft.WSMan.Management

This was OK because you could manually specify the a Reference via a HintPath but this workaround broke in 7.2 preview 7 due to this change: https://github.com/PowerShell/PowerShell/commit/046dec4d7c5eba2b00e7ee8c1fe5efeb9e620898#r98046816

Since then, it is literally impossible to reference types in any of those 4 libraries like ResolvePathCommand among dozens of others.

The only way I was able to work around this was by using a hex editor to modify the Microsoft.PowerShell.Commands.Management.DLL file to reference System.Management.Automation 7.X.X.0 instead of 7.X.X.500

Additionally, added symbols to the nuget packages so SourceLink could work which will help app developers using the PowerShell SDK tremendously.

This change should not have any negative consequences as the nuget packages are unusable anyway, however I don't have a great way to test this as the devops pipeline only works in the Microsoft DevOps environment.


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
