### PR TITLE
Fix to unwrap `PSObject` when setting data to `DataRow` and `DataRowView`

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -5755,11 +5755,12 @@ namespace System.Management.Automation
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             DataRow dataRow = (DataRow)property.baseObject;
-            dataRow[(string)property.adapterData] = setValue;
+            dataRow[(string)property.adapterData] = PSObject.Base(setValue);
             return;
         }
         #endregion virtual
     }
+
     /// <summary>
     /// Deals with DataRowView objects.
     /// </summary>
@@ -5878,7 +5879,7 @@ namespace System.Management.Automation
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             DataRowView dataRowView = (DataRowView)property.baseObject;
-            dataRowView[(string)property.adapterData] = setValue;
+            dataRowView[(string)property.adapterData] = PSObject.Base(setValue);
             return;
         }
         #endregion virtual

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -4677,8 +4677,8 @@ namespace System.Management.Automation.Language
             }
 
             // For set-index operation on 'DataRow' and 'DataRowView', we unwrap its argument value if it's appropriate.
-            // We treat those 2 types specially because their indexers accepts 'object' in its siganature, but actaully
-            // checks for the data type internally, and thus will fail if the argument is wrapped in PSObject.
+            // We treat those 2 types specially because their indexers accept 'object' arguments in the signatures, but
+            // actually check the data type internally and will fail if the argument is wrapped in PSObject.
             Type targetType = setter.DeclaringType;
             bool unwrapArgIfNeed = targetType == typeof(DataRow) || targetType == typeof(DataRowView);
 

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -134,4 +134,35 @@ public class NullStringTest {
         $result = & $powershell -noprofile -c '[System.Text.Encoding]::GetEncoding("IBM437").WebName'
         $result | Should -BeExactly "ibm437"
     }
+
+    It 'Can set DataRow with PSObject through adapter and indexer' {
+        $dataTable = [Data.DataTable]::new()
+        $null = $dataTable.Columns.Add('Date', [DateTime])
+        $row = $dataTable.Rows.Add((Get-Date))
+
+        $date1 = Get-Date
+        $row.Date = $date1
+        $row.Date.Ticks | Should -Be $date1.Ticks
+
+        $date2 = Get-Date
+        $row['Date'] = $date2
+        $row.Date.Ticks | Should -Be $date2.Ticks
+    }
+
+    It 'Can set DataRowView with PSObject through adapter and indexer' {
+        $dataTable = [Data.DataTable]::new()
+        $null = $dataTable.Columns.Add('Date', [DateTime])
+        $dataTable.Rows.Add((Get-Date))
+
+        $dataView = [System.Data.DataView]::new($dataTable)
+        $rowView = $dataView[0]
+
+        $date1 = Get-Date
+        $rowView.Date = $date1
+        $rowView.Date.Ticks | Should -Be $date1.Ticks
+
+        $date2 = Get-Date
+        $rowView['Date'] = $date2
+        $rowView.Date.Ticks | Should -Be $date2.Ticks
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #17627

Fix to unwrap `PSObject` when setting data to `DataRow` and `DataRowView`.

For set-index operation on `DataRow` and `DataRowView`, we unwrap its argument value if it's appropriate.
We treat those 2 types specially because their indexers accept 'object' arguments in the signatures, but actually check the data type internally and will fail if the argument is wrapped in PSObject.

This fixes a regression introduced in PowerShell v7.2.0, see https://github.com/PowerShell/PowerShell/issues/17627#issuecomment-1409606761 for details.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
