### PR TITLE
Make exception errors in PowerShell able to associate with the right history entry

### DIFF
--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -105,12 +105,22 @@ namespace System.Management.Automation
 
             if (errors.Length > 0)
             {
-                if (errors[0].IncompleteInput)
+                ParseException ex = errors[0].IncompleteInput
+                    ? new IncompleteParseException(errors[0].Message, errors[0].ErrorId)
+                    : new ParseException(errors);
+
+                if (addToHistory)
                 {
-                    throw new IncompleteParseException(errors[0].Message, errors[0].ErrorId);
+                    // Try associating the parsing error with the history item if we can.
+                    InvocationInfo invInfo = ex.ErrorRecord.InvocationInfo;
+                    LocalRunspace localRunspace = Context.CurrentRunspace as LocalRunspace;
+                    if (invInfo is not null && localRunspace is not null && localRunspace.History is not null)
+                    {
+                        invInfo.HistoryId = localRunspace.History.GetNextHistoryId();
+                    }
                 }
 
-                throw new ParseException(errors);
+                throw ex;
             }
 
             return new ScriptBlock(ast, isFilter: false);

--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -114,7 +114,7 @@ namespace System.Management.Automation
                     // Try associating the parsing error with the history item if we can.
                     InvocationInfo invInfo = ex.ErrorRecord.InvocationInfo;
                     LocalRunspace localRunspace = Context.CurrentRunspace as LocalRunspace;
-                    if (invInfo is not null && localRunspace is not null && localRunspace.History is not null)
+                    if (invInfo is not null && localRunspace?.History is not null)
                     {
                         invInfo.HistoryId = localRunspace.History.GetNextHistoryId();
                     }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1982,7 +1982,7 @@ namespace System.Management.Automation
                 return;
             }
 
-            if (context is null || context.CurrentCommandProcessor is null)
+            if (context?.CurrentCommandProcessor is null)
             {
                 return;
             }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1973,6 +1973,22 @@ namespace System.Management.Automation
                 }
             }
         }
+
+        internal static void UpdateExceptionErrorRecordHistoryId(RuntimeException exception, ExecutionContext context)
+        {
+            InvocationInfo invInfo = exception.ErrorRecord.InvocationInfo;
+            if (invInfo is null || invInfo.HistoryId != -1)
+            {
+                return;
+            }
+
+            if (context is null || context.CurrentCommandProcessor is null)
+            {
+                return;
+            }
+
+            invInfo.HistoryId = context.CurrentCommandProcessor.Command.MyInvocation.HistoryId;
+        }
     }
     #endregion InterpreterError
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1977,7 +1977,7 @@ namespace System.Management.Automation
         internal static void UpdateExceptionErrorRecordHistoryId(RuntimeException exception, ExecutionContext context)
         {
             InvocationInfo invInfo = exception.ErrorRecord.InvocationInfo;
-            if (invInfo is null || invInfo.HistoryId != -1)
+            if (invInfo is not { HistoryId: -1 })
             {
                 return;
             }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1266,7 +1266,7 @@ namespace System.Management.Automation
             }
             catch (Exception exception)
             {
-                if (!(exception is RuntimeException rte))
+                if (exception is not RuntimeException rte)
                 {
                     throw ExceptionHandlingOps.ConvertToRuntimeException(exception, functionDefinitionAst.Extent);
                 }
@@ -1622,6 +1622,9 @@ namespace System.Management.Automation
             {
                 InterpreterError.UpdateExceptionErrorRecordPosition(rte, funcContext.CurrentPosition);
             }
+
+            // Update the history id if needed to associate the exception with the right history item.
+            InterpreterError.UpdateExceptionErrorRecordHistoryId(rte, funcContext._executionContext);
 
             var context = funcContext._executionContext;
             var outputPipe = funcContext._outputPipe;

--- a/src/System.Management.Automation/utils/ParserException.cs
+++ b/src/System.Management.Automation/utils/ParserException.cs
@@ -127,9 +127,7 @@ namespace System.Management.Automation
         /// Initializes a new instance of the ParseException class with a collection of error messages.
         /// </summary>
         /// <param name="errors">The collection of error messages.</param>
-        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors",
-            Justification = "ErrorRecord is not overridden in classes deriving from ParseException")]
-        public ParseException(Language.ParseError[] errors)
+        public ParseException(ParseError[] errors)
         {
             ArgumentNullException.ThrowIfNull(errors);
 

--- a/test/powershell/Language/Scripting/ErrorHistoryId.Tests.ps1
+++ b/test/powershell/Language/Scripting/ErrorHistoryId.Tests.ps1
@@ -11,27 +11,8 @@ Describe "Error HistoryId Tests" -Tags "CI" {
             $ps.Commands.Clear()
             $ps.AddScript($command).Invoke($null, $setting)
         }
-    }
 
-    BeforeEach {
-        $ps = [PowerShell]::Create("NewRunspace")
-    }
-
-    AfterEach {
-        $ps.Dispose()
-    }
-
-    It "Error from 'Write-Error' has the right history Id" {
-        $null = RunCommand $ps "function bar { Write-Error 'abc' }"   ## 1st in history
-        $null = RunCommand $ps "bar"                                  ## 2nd in history
-
-        $ps.HadErrors | Should -BeTrue
-        RunCommand $ps '$Error[0].InvocationInfo.HistoryId' | Should -Be 2
-    }
-
-    It "Error from 'PSCmdlet.WriteError' has the right history Id" {
-        ## 1st in history
-        $null = RunCommand $ps @'
+        $funcBarUseWriteErrorApi = @'
 function bar {
     [CmdletBinding()]
     param()
@@ -44,18 +25,7 @@ function bar {
     $PSCmdlet.WriteError($er)
 }
 '@
-        ## 2nd in history
-        $null = RunCommand $ps 'bar'
-
-        $ps.HadErrors | Should -BeTrue
-        $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly "PSCmdlet.WriteError,bar"
-        $err.InvocationInfo.HistoryId | Should -Be 2
-    }
-
-    It "Error from 'PSCmdlet.ThrowTerminatingError' has the right history Id" {
-        ## 1st in history
-        $null = RunCommand $ps @'
+        $funcBarThrowTermError = @'
 function bar {
     [CmdletBinding()]
     param()
@@ -68,20 +38,27 @@ function bar {
     $PSCmdlet.ThrowTerminatingError($er)
 }
 '@
-        ## 2nd in history
-        $null = RunCommand $ps 'bar'
-        $ps.HadErrors | Should -BeTrue
-        $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly "PSCmdlet.ThrowTerminatingError,bar"
-        $err.InvocationInfo.HistoryId | Should -Be 2
     }
 
-    It "Error from 'Throw' has the right history Id - 1" {
+    BeforeEach {
+        $ps = [PowerShell]::Create("NewRunspace")
+    }
+
+    AfterEach {
+        $ps.Dispose()
+    }
+
+    It "Error from <caption> has the right history Id" -TestCases @(
+        @{ caption = "'throw' in global scope"; cmd1 = "1+1";                          cmd2 = "throw 'abc'" }
+        @{ caption = "'throw' in function";     cmd1 = "function bar { throw 'abc' }"; cmd2 = "bar" }
+    ) {
+        param($cmd1, $cmd2)
+
         try {
             ## 1st in history
-            $null = RunCommand $ps '1+1'
+            $null = RunCommand $ps $cmd1
             ## 2nd in history
-            $null = RunCommand $ps "throw 'abc'"
+            $null = RunCommand $ps $cmd2
         } catch {
             ## ignore the exception
         }
@@ -92,79 +69,26 @@ function bar {
         $err.InvocationInfo.HistoryId | Should -Be 2
     }
 
-    It "Error from 'Throw' has the right history Id - 2" {
-        try {
-            ## 1st in history
-            $null = RunCommand $ps "function bar { throw 'abc' }"
-            ## 2nd in history
-            $null = RunCommand $ps 'bar'
-        } catch {
-            ## ignore the exception
-        }
+    It "Error from <caption> has the right history Id" -TestCases @(
+        @{ caption = "parameter binding";     cmd1 = "1+1";                  cmd2 = "Get-Verb -abc"; errId = "NamedParameterNotFound,Microsoft.PowerShell.Commands.GetVerbCommand" }
+        @{ caption = "'1/0' in global scope"; cmd1 = "1+1";                  cmd2 = "1/0";           errId = "RuntimeException" }
+        @{ caption = "'1/0' in function";     cmd1 = "function bar { 1/0 }"; cmd2 = "bar";           errId = "RuntimeException" }
+        @{ caption = "method exception in global scope"; cmd1 = "1+1";       cmd2 = "[System.IO.Path]::GetExtension()"; errId = "MethodCountCouldNotFindBest" }
+        @{ caption = "method exception in function"; cmd1 = "function bar { [System.IO.Path]::GetExtension() }"; cmd2 = "bar"; errId = "MethodCountCouldNotFindBest" }
+        @{ caption = "'Write-Error'";         cmd1 = "function bar { Write-Error 'abc' }"; cmd2 = "bar"; errId = "Microsoft.PowerShell.Commands.WriteErrorException,bar" }
+        @{ caption = "'PSCmdlet.WriteError'"; cmd1 = $funcBarUseWriteErrorApi;             cmd2 = "bar"; errId = "PSCmdlet.WriteError,bar" }
+        @{ caption = "'PSCmdlet.ThrowTerminatingError'"; cmd1 = $funcBarThrowTermError;    cmd2 = "bar"; errId = "PSCmdlet.ThrowTerminatingError,bar" }
+    ) {
+        param($cmd1, $cmd2, $errId)
 
-        $ps.HadErrors | Should -BeTrue
-        $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly 'abc'
-        $err.InvocationInfo.HistoryId | Should -Be 2
-    }
-
-    It "Error from parameter binding has the right history Id" {
         ## 1st in history
-        $null = RunCommand $ps '1+1'
+        $null = RunCommand $ps $cmd1
         ## 2nd in history
-        $null = RunCommand $ps 'Get-Verb -abc'
+        $null = RunCommand $ps $cmd2
 
         $ps.HadErrors | Should -BeTrue
         $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly 'NamedParameterNotFound,Microsoft.PowerShell.Commands.GetVerbCommand'
-        $err.InvocationInfo.HistoryId | Should -Be 2
-    }
-
-    It "Error from language exception has the right history Id - 1" {
-        ## 1st in history
-        $null = RunCommand $ps '1+1'
-        ## 2nd in history
-        $null = RunCommand $ps "1/0"
-
-        $ps.HadErrors | Should -BeTrue
-        $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly 'RuntimeException'
-        $err.InvocationInfo.HistoryId | Should -Be 2
-    }
-
-    It "Error from language exception has the right history Id - 2" {
-        ## 1st in history
-        $null = RunCommand $ps 'function bar { 1/0 }'
-        ## 2nd in history
-        $null = RunCommand $ps 'bar'
-
-        $ps.HadErrors | Should -BeTrue
-        $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly 'RuntimeException'
-        $err.InvocationInfo.HistoryId | Should -Be 2
-    }
-
-    It "Error from language exception has the right history Id - 3" {
-        ## 1st in history
-        $null = RunCommand $ps '1+1'
-        ## 2nd in history
-        $null = RunCommand $ps '[System.IO.Path]::GetExtension()'
-
-        $ps.HadErrors | Should -BeTrue
-        $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly 'MethodCountCouldNotFindBest'
-        $err.InvocationInfo.HistoryId | Should -Be 2
-    }
-
-    It "Error from language exception has the right history Id - 4" {
-        ## 1st in history
-        $null = RunCommand $ps 'function bar { [System.IO.Path]::GetExtension() }'
-        ## 2nd in history
-        $null = RunCommand $ps 'bar'
-
-        $ps.HadErrors | Should -BeTrue
-        $err = RunCommand $ps '$Error[0]'
-        $err.FullyQualifiedErrorId | Should -BeExactly 'MethodCountCouldNotFindBest'
+        $err.FullyQualifiedErrorId | Should -BeExactly $errId
         $err.InvocationInfo.HistoryId | Should -Be 2
     }
 

--- a/test/powershell/Language/Scripting/ErrorHistoryId.Tests.ps1
+++ b/test/powershell/Language/Scripting/ErrorHistoryId.Tests.ps1
@@ -1,0 +1,186 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Error HistoryId Tests" -Tags "CI" {
+
+    BeforeAll {
+        $setting = [System.Management.Automation.PSInvocationSettings]::New()
+        $setting.AddToHistory = $true
+
+        function RunCommand($ps, $command) {
+            $ps.Commands.Clear()
+            $ps.AddScript($command).Invoke($null, $setting)
+        }
+    }
+
+    BeforeEach {
+        $ps = [PowerShell]::Create("NewRunspace")
+    }
+
+    AfterEach {
+        $ps.Dispose()
+    }
+
+    It "Error from 'Write-Error' has the right history Id" {
+        $null = RunCommand $ps "function bar { Write-Error 'abc' }"   ## 1st in history
+        $null = RunCommand $ps "bar"                                  ## 2nd in history
+
+        $ps.HadErrors | Should -BeTrue
+        RunCommand $ps '$Error[0].InvocationInfo.HistoryId' | Should -Be 2
+    }
+
+    It "Error from 'PSCmdlet.WriteError' has the right history Id" {
+        ## 1st in history
+        $null = RunCommand $ps @'
+function bar {
+    [CmdletBinding()]
+    param()
+
+    $er = [System.Management.Automation.ErrorRecord]::new(
+        [System.ArgumentException]::new(),
+        'PSCmdlet.WriteError',
+        [System.Management.Automation.ErrorCategory]::InvalidOperation,
+        $null)
+    $PSCmdlet.WriteError($er)
+}
+'@
+        ## 2nd in history
+        $null = RunCommand $ps 'bar'
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly "PSCmdlet.WriteError,bar"
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from 'PSCmdlet.ThrowTerminatingError' has the right history Id" {
+        ## 1st in history
+        $null = RunCommand $ps @'
+function bar {
+    [CmdletBinding()]
+    param()
+
+    $er = [System.Management.Automation.ErrorRecord]::new(
+        [System.ArgumentException]::new(),
+        'PSCmdlet.ThrowTerminatingError',
+        [System.Management.Automation.ErrorCategory]::InvalidOperation,
+        $null)
+    $PSCmdlet.ThrowTerminatingError($er)
+}
+'@
+        ## 2nd in history
+        $null = RunCommand $ps 'bar'
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly "PSCmdlet.ThrowTerminatingError,bar"
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from 'Throw' has the right history Id - 1" {
+        try {
+            ## 1st in history
+            $null = RunCommand $ps '1+1'
+            ## 2nd in history
+            $null = RunCommand $ps "throw 'abc'"
+        } catch {
+            ## ignore the exception
+        }
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly 'abc'
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from 'Throw' has the right history Id - 2" {
+        try {
+            ## 1st in history
+            $null = RunCommand $ps "function bar { throw 'abc' }"
+            ## 2nd in history
+            $null = RunCommand $ps 'bar'
+        } catch {
+            ## ignore the exception
+        }
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly 'abc'
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from parameter binding has the right history Id" {
+        ## 1st in history
+        $null = RunCommand $ps '1+1'
+        ## 2nd in history
+        $null = RunCommand $ps 'Get-Verb -abc'
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly 'NamedParameterNotFound,Microsoft.PowerShell.Commands.GetVerbCommand'
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from language exception has the right history Id - 1" {
+        ## 1st in history
+        $null = RunCommand $ps '1+1'
+        ## 2nd in history
+        $null = RunCommand $ps "1/0"
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly 'RuntimeException'
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from language exception has the right history Id - 2" {
+        ## 1st in history
+        $null = RunCommand $ps 'function bar { 1/0 }'
+        ## 2nd in history
+        $null = RunCommand $ps 'bar'
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly 'RuntimeException'
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from language exception has the right history Id - 3" {
+        ## 1st in history
+        $null = RunCommand $ps '1+1'
+        ## 2nd in history
+        $null = RunCommand $ps '[System.IO.Path]::GetExtension()'
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly 'MethodCountCouldNotFindBest'
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "Error from language exception has the right history Id - 4" {
+        ## 1st in history
+        $null = RunCommand $ps 'function bar { [System.IO.Path]::GetExtension() }'
+        ## 2nd in history
+        $null = RunCommand $ps 'bar'
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err.FullyQualifiedErrorId | Should -BeExactly 'MethodCountCouldNotFindBest'
+        $err.InvocationInfo.HistoryId | Should -Be 2
+    }
+
+    It "ParseError has the right history Id" {
+        try {
+            ## 1st in history
+            $null = RunCommand $ps '1+1'
+            ## 2nd in history
+            $null = RunCommand $ps 'for (int i = 2; i < 3; i++) { foreach {} }'
+        } catch {
+            ## ignore the exception
+        }
+
+        $ps.HadErrors | Should -BeTrue
+        $err = RunCommand $ps '$Error[0]'
+        $err | Should -BeOfType 'System.Management.Automation.ParseException'
+        $err.ErrorRecord.InvocationInfo.HistoryId | Should -Be 2
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Make errors in PowerShell able to associate with the right history entry, by adjusting the `HistoryId` property of the `InvocationInfo` of an `ErrorRecord`.

## PR Context

`ErrorRecord.InvocationInfo.HistoryId` should point to the history entry which contains the command-line that triggered the error. This is true for errors stemmed from `Write-Error`, `$PSCmdlet.WriteError`, `$PSCmdlet.ThrowTerminatingError`, and parameter binding failures.

However, it's not the case for errors stemmed from `throw` statement and other exceptions, such as `1/0` or method call exceptions. For those exceptions, the `HistoryId` turns out to be `-1`, which cannot be used to associate with the command from history that triggered the exception. This becomes a problem to the feedback provider feature we are working on, which needs to reliably tell if an error is resulted by the command that was just done execution.

This PR is to address this issue, to make errors stemmed from exceptions also points to the right history command that triggered the exception.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
