### PR TITLE
Fix Start-Process -Wait with -Credential

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -2777,22 +2777,6 @@ namespace Microsoft.PowerShell.Commands
         internal static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string lpName);
 
         /// <summary>
-        /// AssignProcessToJobObject API is used to assign a process to an existing job object.
-        /// </summary>
-        /// <param name="hJob">
-        /// A handle to the job object to which the process will be associated.
-        /// </param>
-        /// <param name="hProcess">
-        /// A handle to the process to associate with the job object.
-        /// </param>
-        /// <returns>If the function succeeds, the return value is nonzero.
-        /// If the function fails, the return value is zero.
-        /// </returns>
-        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool AssignProcessToJobObject(SafeHandle hJob, IntPtr hProcess);
-
-        /// <summary>
         /// Retrieves job state information from the job object.
         /// </summary>
         /// <param name="hJob">

--- a/src/System.Management.Automation/engine/Interop/Windows/AssignProcessToJobObject.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/AssignProcessToJobObject.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Windows
+    {
+        [LibraryImport("Kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool AssignProcessToJobObject(nint hJob, nint hProcess);
+    }
+}

--- a/src/System.Management.Automation/engine/Interop/Windows/CloseHandle.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/CloseHandle.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Windows
+    {
+        [LibraryImport("api-ms-win-core-handle-l1-1-0.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static partial bool CloseHandle(nint hObject);
+    }
+}


### PR DESCRIPTION
# PR Summary

Allows a non-administrator user to be able to -Wait on a Start-Process call with a custom credential specified.

~~Currently thinking off a way I can test out this scenario.~~ After creating a test to run in CI I've found that it's too hard to create a reliable test that wouldn't block the whole runner on a failing scenario. The test itself also required admin access and was quite complicated to set up all the synchronisation work so I've decided not to include it.

Fixes: https://github.com/PowerShell/PowerShell/issues/17033
Alternative to https://github.com/PowerShell/PowerShell/pull/19082

## PR Context

https://github.com/PowerShell/PowerShell/issues/17033

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
