### PR TITLE
Add `-NoHeader` parameter to `ConvertTo-Csv` and `Export-Csv` cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -72,6 +72,12 @@ namespace Microsoft.PowerShell.Commands
         [Alias("UQ")]
         public QuoteKind UseQuotes { get; set; } = QuoteKind.Always;
 
+        /// <summary>
+        /// Gets or sets property that writes headerless csv file.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter NoHeader { get; set; }
+
         #endregion Command Line Parameters
 
         /// <summary>
@@ -301,7 +307,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // write headers (row1: typename + row2: column names)
-                if (!_isActuallyAppending)
+                if (!_isActuallyAppending && !NoHeader.IsPresent)
                 {
                     if (NoTypeInformation == false)
                     {
@@ -727,16 +733,20 @@ namespace Microsoft.PowerShell.Commands
             if (_propertyNames == null)
             {
                 _propertyNames = ExportCsvHelper.BuildPropertyNames(InputObject, _propertyNames);
-                if (NoTypeInformation == false)
-                {
-                    WriteCsvLine(ExportCsvHelper.GetTypeString(InputObject));
-                }
 
-                // Write property information
-                string properties = _helper.ConvertPropertyNamesCSV(_propertyNames);
-                if (!properties.Equals(string.Empty))
+                if (!NoHeader.IsPresent)
                 {
-                    WriteCsvLine(properties);
+                    if (NoTypeInformation == false)
+                    {
+                        WriteCsvLine(ExportCsvHelper.GetTypeString(InputObject));
+                    }
+
+                    // Write property information
+                    string properties = _helper.ConvertPropertyNamesCSV(_propertyNames);
+                    if (!properties.Equals(string.Empty))
+                    {
+                        WriteCsvLine(properties);
+                    }
                 }
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.Commands
         public QuoteKind UseQuotes { get; set; } = QuoteKind.Always;
 
         /// <summary>
-        /// Gets or sets property that writes headerless csv file.
+        /// Gets or sets property that writes csv file with no headers.
         /// </summary>
         [Parameter]
         public SwitchParameter NoHeader { get; set; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -93,7 +93,7 @@ Describe "ConvertTo-Csv" -Tags "CI" {
 
     It "Does not include headers with -NoHeader" {
         $result = $testObject | ConvertTo-Csv -NoHeader
-        $result | Should -MatchExactly '"Hello","World"'
+        $result | Should -BeExactly '"Hello","World"'
     }
 
     It "Does not support -UseQuotes and -QuoteFields at the same time" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -91,6 +91,11 @@ Describe "ConvertTo-Csv" -Tags "CI" {
         $result | Should -Not -Match ([regex]::Escape('#TYPE'))
     }
 
+    It "Does not include headers with -NoHeader" {
+        $result = $testObject | ConvertTo-Csv -NoHeader
+        $result | Should -MatchExactly '"Hello","World"'
+    }
+
     It "Does not support -UseQuotes and -QuoteFields at the same time" {
         { $testObject | ConvertTo-Csv -UseQuotes Always -QuoteFields "TestFieldName" } |
             Should -Throw -ErrorId "CannotSpecifyQuoteFieldsAndUseQuotes,Microsoft.PowerShell.Commands.ConvertToCsvCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -68,6 +68,14 @@ Describe "Export-Csv" -Tags "CI" {
         $results[0] | Should -Not -Match ([regex]::Escape("#TYPE"))
     }
 
+    It "Does not include headers with -NoHeader when exported and can imported with headers" {
+        $P1 | Export-Csv -Path $testCsv -NoHeader
+        $results = Get-Content -Path $testCsv
+        $results | Should -MatchExactly "first"
+        $results = Import-Csv -Path $testCsv -Header "P1"
+        $results[0].P1 | Should -BeExactly "first"
+    }
+
     It "Includes type information when -IncludeTypeInformation is supplied" {
         $testObject | Export-Csv -Path $testCsv -IncludeTypeInformation
         $results = Get-Content -Path $testCsv

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Export-Csv" -Tags "CI" {
         $results[0].P1 | Should -BeExactly "first"
     }
 
-    It "Does not include headers when CSV is imported with headers and exported using -NoHeader" {
+    It "Does not include headers imported with headers and exported using -NoHeader" {
         $P1 | Export-Csv -Path $testCsv
         (Import-Csv -Path $testCsv) | Export-Csv -Path $testCsv -NoHeader
         $results = Get-Content -Path $testCsv

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -76,6 +76,13 @@ Describe "Export-Csv" -Tags "CI" {
         $results[0].P1 | Should -BeExactly "first"
     }
 
+    It "Does not include headers when CSV is imported with headers and exported using -NoHeader" {
+        $P1 | Export-Csv -Path $testCsv
+        (Import-Csv -Path $testCsv) | Export-Csv -Path $testCsv -NoHeader
+        $results = Get-Content -Path $testCsv
+        $results | Should -MatchExactly "first"
+    }
+
     It "Includes type information when -IncludeTypeInformation is supplied" {
         $testObject | Export-Csv -Path $testCsv -IncludeTypeInformation
         $results = Get-Content -Path $testCsv

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Export-Csv" -Tags "CI" {
         $results[0].P1 | Should -BeExactly "first"
     }
 
-    It "Does not include headers imported with headers and exported using -NoHeader" {
+    It "Does not include headers when imported with headers and exported using -NoHeader" {
         $P1 | Export-Csv -Path $testCsv
         (Import-Csv -Path $testCsv) | Export-Csv -Path $testCsv -NoHeader
         $results = Get-Content -Path $testCsv

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -71,7 +71,7 @@ Describe "Export-Csv" -Tags "CI" {
     It "Does not include headers with -NoHeader when exported and can imported with headers" {
         $P1 | Export-Csv -Path $testCsv -NoHeader
         $results = Get-Content -Path $testCsv
-        $results | Should -MatchExactly "first"
+        $results | Should -BeExactly '"first"'
         $results = Import-Csv -Path $testCsv -Header "P1"
         $results[0].P1 | Should -BeExactly "first"
     }
@@ -80,7 +80,7 @@ Describe "Export-Csv" -Tags "CI" {
         $P1 | Export-Csv -Path $testCsv
         (Import-Csv -Path $testCsv) | Export-Csv -Path $testCsv -NoHeader
         $results = Get-Content -Path $testCsv
-        $results | Should -MatchExactly "first"
+        $results | Should -BeExactly '"first"'
     }
 
     It "Includes type information when -IncludeTypeInformation is supplied" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #17527

Added `-NoHeader` to `ConvertTo-Csv` and `Export-Csv` cmdlets.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Currently we have no easy way to export a CSV file without headers, but we have the ability to import CSV files with headers using `Import-Csv -Header`.

This change allows `ConvertTo-Csv` and `Export-Csv` to export without headers. This simplifies scenarios where the user may not care about headers and removes need to manipulate the CSV to achieve a header less CSV.

So instead of always having to skip the first row when writing to CSV:

```powershell
PS C:\> $myObjects = @(
>     [PSCustomObject]@{
>         Name = 'John'
>         LastName = 'Smith'
>     }
>     [PSCustomObject]@{
>         Name = 'Freddy'
>         LastName = 'Kruger'
>     }
> )
PS C:\> $myObjects | ConvertTo-Csv | Select-Object -Skip 1 | Out-File -FilePath 'output.csv'
PS C:\> cat 'output.csv'
"John","Smith"
"Freddy","Kruger"
```

You can now convert to CSV without headers using `ConvertTo-Csv -NoHeader`:

```powershell
PS C:\> $myObjects | ConvertTo-Csv -NoHeader | Out-File -FilePath 'output.csv'
PS C:\> cat 'output.csv'
"John","Smith"
"Freddy","Kruger"
```

You can also choose to export without headers using `Export-Csv -NoHeader`:

```powershell
PS C:\> $myObjects | Export-Csv -Path 'output.csv' -NoHeader
PS C:\> cat 'output.csv'
"John","Smith"
"Freddy","Kruger"
```

Or import first, manipulate pipeline object to something else, then export again with no headers:

```powershell
PS C:\> (Import-Csv -Path 'output.csv' | Select-Object -Property Name) | Export-Csv -Path 'output.csv' -NoHeader
PS C:\> cat 'output.csv'
"John"
"Freddy"
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9809
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
