### PR TITLE
Added minor readability and refactoring fixes to Process.cs

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1559,10 +1559,7 @@ namespace Microsoft.PowerShell.Commands
                     catch (CimException e)
                     {
                         string message = e.Message;
-                        if (!string.IsNullOrEmpty(message))
-                        {
-                            message = message.Trim();
-                        }
+                        message = message?.Trim();
 
                         var errorRecord = new ErrorRecord(
                                 new InvalidOperationException(StringUtil.Format(ProcessResources.DebuggerError, message)),

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -519,14 +519,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = NameWithUserNameParameterSet, Mandatory = true)]
         [Parameter(ParameterSetName = IdWithUserNameParameterSet, Mandatory = true)]
         [Parameter(ParameterSetName = InputObjectWithUserNameParameterSet, Mandatory = true)]
-        public SwitchParameter IncludeUserName
-        {
-            get { return _includeUserName; }
-
-            set { _includeUserName = value; }
-        }
-
-        private bool _includeUserName = false;
+        public SwitchParameter IncludeUserName { get; set; }
 
         /// <summary>
         /// To display the modules of a process.
@@ -744,7 +737,10 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 int error;
-                if (!Win32Native.OpenProcessToken(process.Handle, TOKEN_QUERY, out processTokenHandler)) { return null; }
+                if (!Win32Native.OpenProcessToken(process.Handle, TOKEN_QUERY, out processTokenHandler))
+                {
+                    return null;
+                }
 
                 // Set the default length to be 256, so it will be sufficient for most cases.
                 int tokenInfoLength = 256;
@@ -757,7 +753,10 @@ namespace Microsoft.PowerShell.Commands
                         Marshal.FreeHGlobal(tokenUserInfo);
                         tokenUserInfo = Marshal.AllocHGlobal(tokenInfoLength);
 
-                        if (!Win32Native.GetTokenInformation(processTokenHandler, Win32Native.TOKEN_INFORMATION_CLASS.TokenUser, tokenUserInfo, tokenInfoLength, out tokenInfoLength)) { return null; }
+                        if (!Win32Native.GetTokenInformation(processTokenHandler, Win32Native.TOKEN_INFORMATION_CLASS.TokenUser, tokenUserInfo, tokenInfoLength, out tokenInfoLength))
+                        {
+                            return null;
+                        }
                     }
                     else
                     {
@@ -1165,7 +1164,10 @@ namespace Microsoft.PowerShell.Commands
                             SafeGetProcessName(process),
                             SafeGetProcessId(process));
 
-                if (!ShouldProcess(targetString)) { continue; }
+                if (!ShouldProcess(targetString))
+                {
+                    continue;
+                }
 
                 try
                 {
@@ -1323,7 +1325,10 @@ namespace Microsoft.PowerShell.Commands
             }
             finally
             {
-                if (ph != IntPtr.Zero) { Win32Native.CloseHandle(ph); }
+                if (ph != IntPtr.Zero)
+                {
+                    Win32Native.CloseHandle(ph);
+                }
             }
 
             return false;
@@ -1483,7 +1488,10 @@ namespace Microsoft.PowerShell.Commands
                             SafeGetProcessName(process),
                             SafeGetProcessId(process));
 
-                if (!ShouldProcess(targetMessage)) { continue; }
+                if (!ShouldProcess(targetMessage))
+                {
+                    continue;
+                }
 
                 // Sometimes Idle process has processid zero,so handle that because we cannot attach debugger to it.
                 if (process.Id == 0)
@@ -1498,7 +1506,10 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // If the process has exited, we skip it. If the process is from a remote
                     // machine, then we generate a non-terminating error.
-                    if (process.HasExited) { continue; }
+                    if (process.HasExited)
+                    {
+                        continue;
+                    }
                 }
                 catch (NotSupportedException ex)
                 {
@@ -1550,7 +1561,10 @@ namespace Microsoft.PowerShell.Commands
                     catch (CimException e)
                     {
                         string message = e.Message;
-                        if (!string.IsNullOrEmpty(message)) { message = message.Trim(); }
+                        if (!string.IsNullOrEmpty(message))
+                        {
+                            message = message.Trim();
+                        }
 
                         var errorRecord = new ErrorRecord(
                                 new InvalidOperationException(StringUtil.Format(ProcessResources.DebuggerError, message)),
@@ -1569,12 +1583,24 @@ namespace Microsoft.PowerShell.Commands
             string errorMessage = string.Empty;
             switch (returnCode)
             {
-                case 2: errorMessage = ProcessResources.AttachDebuggerReturnCode2; break;
-                case 3: errorMessage = ProcessResources.AttachDebuggerReturnCode3; break;
-                case 8: errorMessage = ProcessResources.AttachDebuggerReturnCode8; break;
-                case 9: errorMessage = ProcessResources.AttachDebuggerReturnCode9; break;
-                case 21: errorMessage = ProcessResources.AttachDebuggerReturnCode21; break;
-                default: Diagnostics.Assert(false, "Unreachable code."); break;
+                case 2:
+                    errorMessage = ProcessResources.AttachDebuggerReturnCode2;
+                    break;
+                case 3:
+                    errorMessage = ProcessResources.AttachDebuggerReturnCode3;
+                    break;
+                case 8:
+                    errorMessage = ProcessResources.AttachDebuggerReturnCode8;
+                    break;
+                case 9:
+                    errorMessage = ProcessResources.AttachDebuggerReturnCode9;
+                    break;
+                case 21:
+                    errorMessage = ProcessResources.AttachDebuggerReturnCode21;
+                    break;
+                default:
+                    Diagnostics.Assert(false, "Unreachable code.");
+                    break;
             }
 
             return errorMessage;
@@ -2006,13 +2032,19 @@ namespace Microsoft.PowerShell.Commands
             }
             else if (ParameterSetName.Equals("UseShellExecute"))
             {
-                if (Verb != null) { startInfo.Verb = Verb; }
+                if (Verb != null)
+                {
+                    startInfo.Verb = Verb;
+                }
 
                 startInfo.WindowStyle = _windowstyle;
             }
 
             string targetMessage = StringUtil.Format(ProcessResources.StartProcessTarget, startInfo.FileName, startInfo.Arguments.Trim());
-            if (!ShouldProcess(targetMessage)) { return; }
+            if (!ShouldProcess(targetMessage))
+            {
+                return;
+            }
 
             Process process = Start(startInfo);
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1584,10 +1584,7 @@ namespace Microsoft.PowerShell.Commands
                 _ => string.Empty
             };
 
-            if (string.IsNullOrEmpty(errorMessage))
-            {
-                Diagnostics.Assert(false, "Unreachable code.");
-            }
+            Diagnostics.Assert(!string.IsNullOrEmpty(errorMessage), "error message should not be null or empty");
 
             return errorMessage;
         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1584,7 +1584,7 @@ namespace Microsoft.PowerShell.Commands
                 _ => string.Empty
             };
 
-            Diagnostics.Assert(!string.IsNullOrEmpty(errorMessage), "error message should not be null or empty");
+            Diagnostics.Assert(!string.IsNullOrEmpty(errorMessage), "Error message should not be null or empty.");
 
             return errorMessage;
         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -21,8 +21,6 @@ using System.Threading;
 using Microsoft.Management.Infrastructure;
 using Microsoft.PowerShell.Commands.Internal;
 using Microsoft.Win32.SafeHandles;
-using DWORD = System.UInt32;
-using FileNakedHandle = System.IntPtr;
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1558,8 +1558,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     catch (CimException e)
                     {
-                        string message = e.Message;
-                        message = message?.Trim();
+                        string message = e.Message?.Trim();
 
                         var errorRecord = new ErrorRecord(
                                 new InvalidOperationException(StringUtil.Format(ProcessResources.DebuggerError, message)),
@@ -1575,27 +1574,19 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private static string MapReturnCodeToErrorMessage(int returnCode)
         {
-            string errorMessage = string.Empty;
-            switch (returnCode)
+            string errorMessage = returnCode switch
             {
-                case 2:
-                    errorMessage = ProcessResources.AttachDebuggerReturnCode2;
-                    break;
-                case 3:
-                    errorMessage = ProcessResources.AttachDebuggerReturnCode3;
-                    break;
-                case 8:
-                    errorMessage = ProcessResources.AttachDebuggerReturnCode8;
-                    break;
-                case 9:
-                    errorMessage = ProcessResources.AttachDebuggerReturnCode9;
-                    break;
-                case 21:
-                    errorMessage = ProcessResources.AttachDebuggerReturnCode21;
-                    break;
-                default:
-                    Diagnostics.Assert(false, "Unreachable code.");
-                    break;
+                2 => ProcessResources.AttachDebuggerReturnCode2,
+                3 => ProcessResources.AttachDebuggerReturnCode3,
+                8 => ProcessResources.AttachDebuggerReturnCode8,
+                9 => ProcessResources.AttachDebuggerReturnCode9,
+                21 => ProcessResources.AttachDebuggerReturnCode21,
+                _ => string.Empty
+            };
+
+            if (string.IsNullOrEmpty(errorMessage))
+            {
+                Diagnostics.Assert(false, "Unreachable code.");
             }
 
             return errorMessage;
@@ -2998,7 +2989,7 @@ namespace Microsoft.PowerShell.Commands
             base.GetObjectData(info, context);
 
             ArgumentNullException.ThrowIfNull(info);
-            
+
             info.AddValue("ProcessName", _processName);
         }
         #endregion Serialization


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Added the following readability fixes to `Process.cs`:

- Remove `_includeUserName` private member as its not used. Any checking with this switch parameter uses `IncludeUserName.IsPresent`.
- Put inline `if` statements on new lines, makes it easier to read.
- Put inline `switch` and `case` into expression.
- Removed unused `DWORD` and `FileNakedHandle` alias directives.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
