### PR TITLE
Revert " Requires.NotNull-->ArgumentNullException.ThrowIfNull (#18820)"

### DIFF
--- a/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/CommandPrediction.cs
+++ b/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/CommandPrediction.cs
@@ -142,7 +142,7 @@ namespace System.Management.Automation.Subsystem.Prediction
         /// <param name="history">History command lines provided as references for prediction.</param>
         public static void OnCommandLineAccepted(PredictionClient client, IReadOnlyList<string> history)
         {
-            ArgumentNullException.ThrowIfNull(history);
+            Requires.NotNull(history, nameof(history));
 
             var predictors = SubsystemManager.GetSubsystems<ICommandPredictor>();
             if (predictors.Count == 0)

--- a/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/ICommandPredictor.cs
@@ -181,8 +181,8 @@ namespace System.Management.Automation.Subsystem.Prediction
         /// <param name="inputTokens">The <see cref="Token"/> objects from parsing the current command line input.</param>
         public PredictionContext(Ast inputAst, Token[] inputTokens)
         {
-            ArgumentNullException.ThrowIfNull(inputAst);
-            ArgumentNullException.ThrowIfNull(inputTokens);
+            Requires.NotNull(inputAst, nameof(inputAst));
+            Requires.NotNull(inputTokens, nameof(inputTokens));
 
             var cursor = inputAst.Extent.EndScriptPosition;
             var astContext = CompletionAnalysis.ExtractAstContext(inputAst, inputTokens, cursor);

--- a/src/System.Management.Automation/engine/Subsystem/SubsystemManager.cs
+++ b/src/System.Management.Automation/engine/Subsystem/SubsystemManager.cs
@@ -131,7 +131,7 @@ namespace System.Management.Automation.Subsystem
         /// <returns>The <see cref="SubsystemInfo"/> object that represents the concrete subsystem.</returns>
         public static SubsystemInfo GetSubsystemInfo(Type subsystemType)
         {
-            ArgumentNullException.ThrowIfNull(subsystemType);
+            Requires.NotNull(subsystemType, nameof(subsystemType));
 
             if (s_subSystemTypeMap.TryGetValue(subsystemType, out SubsystemInfo? subsystemInfo))
             {
@@ -180,7 +180,7 @@ namespace System.Management.Automation.Subsystem
             where TConcreteSubsystem : class, ISubsystem
             where TImplementation : class, TConcreteSubsystem
         {
-            ArgumentNullException.ThrowIfNull(proxy);
+            Requires.NotNull(proxy, nameof(proxy));
 
             RegisterSubsystem(GetSubsystemInfo(typeof(TConcreteSubsystem)), proxy);
         }
@@ -192,7 +192,7 @@ namespace System.Management.Automation.Subsystem
         /// <param name="proxy">An instance of the implementation.</param>
         public static void RegisterSubsystem(SubsystemKind kind, ISubsystem proxy)
         {
-            ArgumentNullException.ThrowIfNull(proxy);
+            Requires.NotNull(proxy, nameof(proxy));
 
             SubsystemInfo info = GetSubsystemInfo(kind);
             if (!info.SubsystemType.IsAssignableFrom(proxy.GetType()))


### PR DESCRIPTION
## PR Summary

Reverts https://github.com/PowerShell/PowerShell/pull/18820.

The changes missed the param name when calling `ArgumentNullException.ThrowIfNull`, which caused the thrown exception to not have the parameter name included.

