### PR TITLE
Revert "Replace ArgumentNullException(nameof()) -> ArgumentNullExcept…

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
@@ -149,8 +149,10 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             uint operationTimeout)
         {
             DebugHelper.WriteLogEx("queryDialect = '{0}'; queryExpression = '{1}'", 0, queryDialect, queryExpression);
-
-            ArgumentNullException.ThrowIfNull(cimSession, string.Format(CultureInfo.CurrentUICulture, CimCmdletStrings.NullArgument, nameof(cimSession)));
+            if (cimSession == null)
+            {
+                throw new ArgumentNullException(string.Format(CultureInfo.CurrentUICulture, CimCmdletStrings.NullArgument, nameof(cimSession)));
+            }
 
             this.TargetComputerName = cimSession.ComputerName;
             CimSessionProxy proxy = CreateSessionProxy(cimSession, operationTimeout);

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/Utils.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/Utils.cs
@@ -361,7 +361,10 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="argumentName"></param>
         public static void ValidateNoNullArgument(object obj, string argumentName)
         {
-            ArgumentNullException.ThrowIfNull(obj, argumentName);
+            if (obj == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/WpfHelp.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/WpfHelp.cs
@@ -214,7 +214,10 @@ namespace Microsoft.Management.UI.Internal
         {
             ArgumentNullException.ThrowIfNull(element);
 
-            ArgumentNullException.ThrowIfNull(parent, nameof(element));
+            if (parent == null)
+            {
+                throw new ArgumentNullException("element");
+            }
 
             ContentControl parentContentControl = parent as ContentControl;
 
@@ -367,7 +370,10 @@ namespace Microsoft.Management.UI.Internal
         /// <exception cref="ArgumentNullException">The specified value is a null reference.</exception>
         public static T FindVisualAncestor<T>(this DependencyObject @object) where T : class
         {
-            ArgumentNullException.ThrowIfNull(@object, nameof(@object));
+            if (@object == null)
+            {
+                throw new ArgumentNullException("object");
+            }
 
             DependencyObject parent = VisualTreeHelper.GetParent(@object);
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/DefaultStringConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/DefaultStringConverter.cs
@@ -62,9 +62,7 @@ namespace Microsoft.Management.UI.Internal
         /// </remarks>
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            ArgumentNullException.ThrowIfNull(values);
-
-            if (values.Length != 1)
+            if (values == null || values.Length != 1)
             {
                 throw new ArgumentNullException("values");
             }

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/AllModulesViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/AllModulesViewModel.cs
@@ -79,9 +79,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="commands">Commands to show.</param>
         public AllModulesViewModel(Dictionary<string, ShowCommandModuleInfo> importedModules, IEnumerable<ShowCommandCommandInfo> commands)
         {
-            ArgumentNullException.ThrowIfNull(commands);
-
-            if (!commands.GetEnumerator().MoveNext())
+            if (commands == null || !commands.GetEnumerator().MoveNext())
             {
                 throw new ArgumentNullException("commands");
             }

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
@@ -82,8 +82,7 @@ namespace Microsoft.PowerShell.Cmdletization
 
             set
             {
-                ArgumentNullException.ThrowIfNull(value);
-                _session = value;
+                _session = value ?? throw new ArgumentNullException(nameof(value));
                 _sessionWasSpecified = true;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -575,12 +575,10 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                ArgumentNullException.ThrowIfNull(replyResult);
-
                 WriteObject(new PingMtuStatus(
                     Source,
                     resolvedTargetName,
-                    replyResult,
+                    replyResult ?? throw new ArgumentNullException(nameof(replyResult)),
                     CurrentMTUSize));
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell.Commands
 
         private static RestReturnType CheckReturnType(HttpResponseMessage response)
         {
-            ArgumentNullException.ThrowIfNull(response);
+            if (response == null) { throw new ArgumentNullException(nameof(response)); }
 
             RestReturnType rt = RestReturnType.Detect;
             string contentType = ContentHelper.GetContentType(response);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -835,7 +835,10 @@ namespace Microsoft.PowerShell
 
             for (int i = 0; i < args.Length; i++)
             {
-                ArgumentNullException.ThrowIfNull(args[i], CommandLineParameterParserStrings.NullElementInArgs);
+                if (args[i] is null)
+                {
+                    throw new ArgumentNullException(nameof(args), CommandLineParameterParserStrings.NullElementInArgs);
+                }
             }
 
             // Indicates that we've called this method on this instance, and that when it's done, the state variables

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
@@ -41,7 +41,8 @@ namespace System.Diagnostics.Eventing
             [SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly")]
             set
             {
-                ArgumentNullException.ThrowIfNull(value, nameof(Delimiter));
+                if (value == null)
+                    throw new ArgumentNullException(nameof(Delimiter));
 
                 if (value.Length == 0)
                     throw new ArgumentException(DotNetEventingStrings.Argument_NeedNonemptyDelimiter);

--- a/src/Microsoft.WSMan.Management/ConfigProvider.cs
+++ b/src/Microsoft.WSMan.Management/ConfigProvider.cs
@@ -3413,7 +3413,7 @@ namespace Microsoft.WSMan.Management
         /// </exception>
         private PSObject GetItemValue(string path)
         {
-            if (string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path) || (path.Length == 0))
             {
                 throw new ArgumentNullException(path);
             }

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -580,9 +580,7 @@ namespace System.Management.Automation
         public static void SetPowerShellAssemblyLoadContext([MarshalAs(UnmanagedType.LPWStr)] string basePaths)
         {
             if (string.IsNullOrEmpty(basePaths))
-            {
                 throw new ArgumentNullException(nameof(basePaths));
-            }
 
             PowerShellAssemblyLoadContext.InitializeSingleton(basePaths);
         }

--- a/src/System.Management.Automation/engine/ComInterop/Helpers.cs
+++ b/src/System.Management.Automation/engine/ComInterop/Helpers.cs
@@ -35,7 +35,10 @@ namespace System.Management.Automation.ComInterop
         [System.Diagnostics.Conditional("DEBUG")]
         internal static void NotNull(object value, string paramName)
         {
-            ArgumentNullException.ThrowIfNull(value, paramName);
+            if (value == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
         }
 
         [System.Diagnostics.Conditional("DEBUG")]

--- a/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
@@ -21,7 +21,8 @@ namespace System.Management.Automation
         /// </summary>
         public DefaultCommandRuntime(List<object> outputList)
         {
-            ArgumentNullException.ThrowIfNull(outputList);
+            if (outputList == null)
+                throw new System.ArgumentNullException(nameof(outputList));
 
             _output = outputList;
         }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -278,9 +278,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                ArgumentNullException.ThrowIfNull(value);
-
-                _parameterNames = value;
+                _parameterNames = value ?? throw new ArgumentNullException(nameof(value));
                 _parameterNameWildcards = SessionStateUtilities.CreateWildcardsFromStrings(
                     _parameterNames,
                     WildcardOptions.CultureInvariant | WildcardOptions.IgnoreCase);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3805,7 +3805,11 @@ namespace System.Management.Automation.Runspaces
 
         internal PSSnapInInfo ImportPSSnapIn(PSSnapInInfo psSnapInInfo, out PSSnapInException warning)
         {
-            ArgumentNullException.ThrowIfNull(psSnapInInfo);
+            if (psSnapInInfo == null)
+            {
+                ArgumentNullException e = new ArgumentNullException(nameof(psSnapInInfo));
+                throw e;
+            }
 
             // See if the snapin is already loaded. If has been then there will be an entry in the
             // Assemblies list for it already...
@@ -3981,7 +3985,11 @@ namespace System.Management.Automation.Runspaces
 
         internal void ImportCmdletsFromAssembly(Assembly assembly, PSModuleInfo module)
         {
-            ArgumentNullException.ThrowIfNull(assembly);
+            if (assembly == null)
+            {
+                ArgumentNullException e = new ArgumentNullException(nameof(assembly));
+                throw e;
+            }
 
             string assemblyPath = assembly.Location;
             PSSnapInHelpers.AnalyzePSSnapInAssembly(

--- a/src/System.Management.Automation/engine/PSClassInfo.cs
+++ b/src/System.Management.Automation/engine/PSClassInfo.cs
@@ -62,9 +62,7 @@ namespace System.Management.Automation
         internal PSClassMemberInfo(string name, string memberType, string defaultValue)
         {
             if (string.IsNullOrEmpty(name))
-            {
                 throw new ArgumentNullException(nameof(name));
-            }
 
             this.Name = name;
             this.TypeName = memberType;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1735,7 +1735,10 @@ namespace System.Management.Automation.Internal
     {
         internal static void NotNull(object value, string paramName)
         {
-            ArgumentNullException.ThrowIfNull(value, paramName);
+            if (value == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
         }
 
         internal static void NotNullOrEmpty(string value, string paramName)
@@ -1748,9 +1751,7 @@ namespace System.Management.Automation.Internal
 
         internal static void NotNullOrEmpty(ICollection value, string paramName)
         {
-            ArgumentNullException.ThrowIfNull(value, paramName);
-
-            if (value.Count == 0)
+            if (value == null || value.Count == 0)
             {
                 throw new ArgumentNullException(paramName);
             }

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -1138,9 +1138,10 @@ namespace System.Management.Automation
         /// <param name="command">The command you're calling this from (i.e. instance of PSCmdlet or value of $PSCmdlet variable).</param>
         public void Begin(InternalCommand command)
         {
-            ArgumentNullException.ThrowIfNull(command);
-
-            ArgumentNullException.ThrowIfNull(command.MyInvocation, nameof(command));
+            if (command == null || command.MyInvocation == null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
 
             Begin(command.MyInvocation.ExpectingInput, command.commandRuntime);
         }

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -530,10 +530,10 @@ namespace System.Management.Automation.Language
             // Get the value of the index and value and call the compiler
             var index = indexExpressionAst.Index.Accept(this);
             var target = indexExpressionAst.Target.Accept(this);
-            
-            ArgumentNullException.ThrowIfNull(index, nameof(indexExpressionAst));
-
-            ArgumentNullException.ThrowIfNull(target, nameof(indexExpressionAst));
+            if (index == null || target == null)
+            {
+                throw new ArgumentNullException(nameof(indexExpressionAst));
+            }
 
             return GetIndexedValueFromTarget(target, index);
         }

--- a/src/System.Management.Automation/engine/remoting/commands/JobRepository.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/JobRepository.cs
@@ -19,7 +19,10 @@ namespace System.Management.Automation
         /// <param name="item">Object to add.</param>
         public void Add(T item)
         {
-            ArgumentNullException.ThrowIfNull(item, _identifier);
+            if (item == null)
+            {
+                throw new ArgumentNullException(_identifier);
+            }
 
             lock (_syncObject)
             {
@@ -42,7 +45,10 @@ namespace System.Management.Automation
         /// <param name="item">Object to remove.</param>
         public void Remove(T item)
         {
-            ArgumentNullException.ThrowIfNull(item, _identifier);
+            if (item == null)
+            {
+                throw new ArgumentNullException(_identifier);
+            }
 
             lock (_syncObject)
             {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7969,6 +7969,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw new ArgumentNullException(nameof(target));
             }
+
             using (SafeHandle handle = WinOpenReparsePoint(path, FileAccess.Write))
             {
                 byte[] mountPointBytes = Encoding.Unicode.GetBytes(NonInterpretedPathPrefix + Path.GetFullPath(target));

--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -1388,7 +1388,8 @@ namespace Microsoft.PowerShell.Commands.Internal
         [ComVisible(false)]
         public unsafe void SetValue(string name, object value, RegistryValueKind valueKind)
         {
-            ArgumentNullException.ThrowIfNull(value, RegistryProviderStrings.Arg_Value);
+            if (value == null)
+                throw new ArgumentNullException(RegistryProviderStrings.Arg_Value);
 
             if (name != null && name.Length > MaxValueNameLength)
             {
@@ -2030,7 +2031,10 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         private static void ValidateKeyName(string name)
         {
-            ArgumentNullException.ThrowIfNull(name, RegistryProviderStrings.Arg_Name);
+            if (name == null)
+            {
+                throw new ArgumentNullException(RegistryProviderStrings.Arg_Name);
+            }
 
             int nextSlash = name.IndexOf('\\');
             int current = 0;

--- a/src/System.Management.Automation/utils/BackgroundDispatcher.cs
+++ b/src/System.Management.Automation/utils/BackgroundDispatcher.cs
@@ -70,8 +70,7 @@ namespace System.Management.Automation
         // internal for unit testing only.  Otherwise, would be private.
         internal BackgroundDispatcher(IMethodInvoker etwActivityMethodInvoker)
         {
-            ArgumentNullException.ThrowIfNull(etwActivityMethodInvoker);
-            _etwActivityMethodInvoker = etwActivityMethodInvoker;
+            _etwActivityMethodInvoker = etwActivityMethodInvoker ?? throw new ArgumentNullException(nameof(etwActivityMethodInvoker));
             _invokerWaitCallback = DoInvoker;
         }
 

--- a/src/System.Management.Automation/utils/ParserException.cs
+++ b/src/System.Management.Automation/utils/ParserException.cs
@@ -129,9 +129,7 @@ namespace System.Management.Automation
         /// <param name="errors">The collection of error messages.</param>
         public ParseException(ParseError[] errors)
         {
-            ArgumentNullException.ThrowIfNull(errors);
-
-            if (errors.Length == 0)
+            if ((errors == null) || (errors.Length == 0))
             {
                 throw new ArgumentNullException(nameof(errors));
             }

--- a/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
@@ -107,10 +107,8 @@ namespace System.Management.Automation.PerformanceData
             CounterSetId = counterSetId;
             CounterSetInstType = counterSetInstType;
             CounterSetName = counterSetName;
-
-            ArgumentNullException.ThrowIfNull(counterInfoArray);
-
-            if (counterInfoArray.Length == 0)
+            if ((counterInfoArray == null)
+                || (counterInfoArray.Length == 0))
             {
                 throw new ArgumentNullException(nameof(counterInfoArray));
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Reverts https://github.com/PowerShell/PowerShell/pull/18792

Some changes didn't include the param name in the ArgumentNullException.ThrowIfNull call, causing the parameter name not included in the thrown exception.

