### PR TITLE
Revert a few changes to not use 'ArgumentNullException.ThrowIfNull'

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1733,11 +1733,6 @@ namespace System.Management.Automation.Internal
     /// </summary>
     internal static class Requires
     {
-        internal static void NotNull(object value, string paramName)
-        {
-            ArgumentNullException.ThrowIfNull(value, paramName);
-        }
-
         internal static void NotNullOrEmpty(string value, string paramName)
         {
             if (string.IsNullOrEmpty(value))
@@ -1748,9 +1743,7 @@ namespace System.Management.Automation.Internal
 
         internal static void NotNullOrEmpty(ICollection value, string paramName)
         {
-            ArgumentNullException.ThrowIfNull(value, paramName);
-
-            if (value.Count == 0)
+            if (value is null || value.Count == 0)
             {
                 throw new ArgumentNullException(paramName);
             }

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -1138,9 +1138,10 @@ namespace System.Management.Automation
         /// <param name="command">The command you're calling this from (i.e. instance of PSCmdlet or value of $PSCmdlet variable).</param>
         public void Begin(InternalCommand command)
         {
-            ArgumentNullException.ThrowIfNull(command);
-
-            ArgumentNullException.ThrowIfNull(command.MyInvocation, nameof(command));
+            if (command is null || command.MyInvocation is null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
 
             Begin(command.MyInvocation.ExpectingInput, command.commandRuntime);
         }

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -530,10 +530,11 @@ namespace System.Management.Automation.Language
             // Get the value of the index and value and call the compiler
             var index = indexExpressionAst.Index.Accept(this);
             var target = indexExpressionAst.Target.Accept(this);
-            
-            ArgumentNullException.ThrowIfNull(index, nameof(indexExpressionAst));
 
-            ArgumentNullException.ThrowIfNull(target, nameof(indexExpressionAst));
+            if (index is null || target is null)
+            {
+                throw new ArgumentNullException(nameof(indexExpressionAst));
+            }
 
             return GetIndexedValueFromTarget(target, index);
         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7969,6 +7969,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw new ArgumentNullException(nameof(target));
             }
+
             using (SafeHandle handle = WinOpenReparsePoint(path, FileAccess.Write))
             {
                 byte[] mountPointBytes = Encoding.Unicode.GetBytes(NonInterpretedPathPrefix + Path.GetFullPath(target));

--- a/src/System.Management.Automation/utils/ParserException.cs
+++ b/src/System.Management.Automation/utils/ParserException.cs
@@ -129,9 +129,7 @@ namespace System.Management.Automation
         /// <param name="errors">The collection of error messages.</param>
         public ParseException(ParseError[] errors)
         {
-            ArgumentNullException.ThrowIfNull(errors);
-
-            if (errors.Length == 0)
+            if (errors is null || errors.Length == 0)
             {
                 throw new ArgumentNullException(nameof(errors));
             }

--- a/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
@@ -108,9 +108,7 @@ namespace System.Management.Automation.PerformanceData
             CounterSetInstType = counterSetInstType;
             CounterSetName = counterSetName;
 
-            ArgumentNullException.ThrowIfNull(counterInfoArray);
-
-            if (counterInfoArray.Length == 0)
+            if (counterInfoArray is null || counterInfoArray.Length == 0)
             {
                 throw new ArgumentNullException(nameof(counterInfoArray));
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Revert a few changes to not use 'ArgumentNullException.ThrowIfNull'.
They are all combined checks on the arguments, which should be kept as it was.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
