### PR TITLE
Adjust PUT method behavior to POST one for default content type in WebCmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1106,7 +1106,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 WebSession.ContentHeaders[HttpKnownHeaderNames.ContentType] = ContentType;
             }
-            else if (request.Method == HttpMethod.Post)
+            else if (request.Method == HttpMethod.Post || request.Method == HttpMethod.Put)
             {
                 // Win8:545310 Invoke-WebRequest does not properly set MIME type for POST
                 WebSession.ContentHeaders.TryGetValue(HttpKnownHeaderNames.ContentType, out string contentType);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -752,18 +752,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         ($result.Output.Content | ConvertFrom-Json).method | Should -Be "TEST"
     }
 
-    It "Validate Invoke-WebRequest default ContentType for CustomMethod POST" {
-        $uri = Get-WebListenerUrl -Test 'Post'
-        $command = "Invoke-WebRequest -Uri '$uri' -CustomMethod POST -Body 'testparam=testvalue'"
-        $result = ExecuteWebCommand -command $command
-        $jsonResult = $result.Output.Content | ConvertFrom-Json
-        $jsonResult.form.testparam | Should -Be "testvalue"
-        $jsonResult.Headers.'Content-Type' | Should -Be "application/x-www-form-urlencoded"
-    }
+    It "Validate Invoke-WebRequest default ContentType for CustomMethod <method>" -TestCases @(
+        @{method = POST}
+        @{method = PUT}
+    ) {
+        param($method)
 
-    It "Validate Invoke-WebRequest default ContentType for CustomMethod PUT" {
-        $uri = Get-WebListenerUrl -Test 'Put'
-        $command = "Invoke-WebRequest -Uri '$uri' -CustomMethod PUT -Body 'testparam=testvalue'"
+        $uri = Get-WebListenerUrl -Test $method
+        $command = "Invoke-WebRequest -Uri '$uri' -CustomMethod $method -Body 'testparam=testvalue'"
         $result = ExecuteWebCommand -command $command
         $jsonResult = $result.Output.Content | ConvertFrom-Json
         $jsonResult.form.testparam | Should -Be "testvalue"
@@ -2518,17 +2514,13 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.Output.method | Should -Be "TEST"
     }
 
-    It "Validate Invoke-RestMethod default ContentType for CustomMethod POST" {
-        $uri = Get-WebListenerUrl -Test 'Post'
-        $command = "Invoke-RestMethod -Uri '$uri' -CustomMethod POST -Body 'testparam=testvalue'"
-        $result = ExecuteWebCommand -command $command
-        $result.Output.form.testparam | Should -Be "testvalue"
-        $result.Output.Headers.'Content-Type' | Should -Be "application/x-www-form-urlencoded"
-    }
-
-    It "Validate Invoke-RestMethod default ContentType for CustomMethod PUT" {
-        $uri = Get-WebListenerUrl -Test 'Put'
-        $command = "Invoke-RestMethod -Uri '$uri' -CustomMethod PUT -Body 'testparam=testvalue'"
+    It "Validate Invoke-RestMethod default ContentType for CustomMethod POST" -TestCases @(
+        @{method = POST}
+        @{method = PUT}
+    ) {
+        param($method)
+        $uri = Get-WebListenerUrl -Test $method
+        $command = "Invoke-RestMethod -Uri '$uri' -CustomMethod $method -Body 'testparam=testvalue'"
         $result = ExecuteWebCommand -command $command
         $result.Output.form.testparam | Should -Be "testvalue"
         $result.Output.Headers.'Content-Type' | Should -Be "application/x-www-form-urlencoded"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -761,6 +761,15 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $jsonResult.Headers.'Content-Type' | Should -Be "application/x-www-form-urlencoded"
     }
 
+    It "Validate Invoke-WebRequest default ContentType for CustomMethod PUT" {
+        $uri = Get-WebListenerUrl -Test 'Put'
+        $command = "Invoke-WebRequest -Uri '$uri' -CustomMethod PUT -Body 'testparam=testvalue'"
+        $result = ExecuteWebCommand -command $command
+        $jsonResult = $result.Output.Content | ConvertFrom-Json
+        $jsonResult.form.testparam | Should -Be "testvalue"
+        $jsonResult.Headers.'Content-Type' | Should -Be "application/x-www-form-urlencoded"
+    }
+
     It "Validate Invoke-WebRequest body is converted to query params for CustomMethod GET" {
         $uri = Get-WebListenerUrl -Test 'Get'
         $command = "Invoke-WebRequest -Uri '$uri' -CustomMethod GET -Body @{'testparam'='testvalue'}"
@@ -2512,6 +2521,14 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     It "Validate Invoke-RestMethod default ContentType for CustomMethod POST" {
         $uri = Get-WebListenerUrl -Test 'Post'
         $command = "Invoke-RestMethod -Uri '$uri' -CustomMethod POST -Body 'testparam=testvalue'"
+        $result = ExecuteWebCommand -command $command
+        $result.Output.form.testparam | Should -Be "testvalue"
+        $result.Output.Headers.'Content-Type' | Should -Be "application/x-www-form-urlencoded"
+    }
+
+    It "Validate Invoke-RestMethod default ContentType for CustomMethod PUT" {
+        $uri = Get-WebListenerUrl -Test 'Put'
+        $command = "Invoke-RestMethod -Uri '$uri' -CustomMethod PUT -Body 'testparam=testvalue'"
         $result = ExecuteWebCommand -command $command
         $result.Output.form.testparam | Should -Be "testvalue"
         $result.Output.Headers.'Content-Type' | Should -Be "application/x-www-form-urlencoded"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -753,8 +753,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     }
 
     It "Validate Invoke-WebRequest default ContentType for CustomMethod <method>" -TestCases @(
-        @{method = POST}
-        @{method = PUT}
+        @{method = "POST"}
+        @{method = "PUT"}
     ) {
         param($method)
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2514,9 +2514,9 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.Output.method | Should -Be "TEST"
     }
 
-    It "Validate Invoke-RestMethod default ContentType for CustomMethod POST" -TestCases @(
-        @{method = POST}
-        @{method = PUT}
+    It "Validate Invoke-RestMethod default ContentType for CustomMethod <method>" -TestCases @(
+        @{method = "POST"}
+        @{method = "PUT"}
     ) {
         param($method)
         $uri = Get-WebListenerUrl -Test $method


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
If -ContentType is null, -Headers don't contain `Content-Type` and -Method is POST or PUT --> `WebSession.ContentHeaders[HttpKnownHeaderNames.ContentType] = "application/x-www-form-urlencoded"`

@iSazonov

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes #16318

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9863<!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
