### PR TITLE
Speed up Resolve-Path relative path resolution

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -103,8 +103,8 @@ namespace Microsoft.PowerShell.Commands
 
                     if (_relative)
                     {
-                        string basePathCache = string.Empty;
-                        string resolvedPathCache = string.Empty;
+                        ReadOnlySpan<char> baseCache = null;
+                        ReadOnlySpan<char> adjustedBaseCache = null;
                         foreach (PathInfo currentPath in result)
                         {
                             // When result path and base path is on different PSDrive
@@ -119,14 +119,14 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             int leafIndex = currentPath.Path.LastIndexOf(currentPath.Provider.ItemSeparator);
-                            string basePath = currentPath.Path.Substring(0, leafIndex);
-                            if (basePath == basePathCache)
+                            var basePath = currentPath.Path.AsSpan(0, leafIndex);
+                            if (basePath == baseCache)
                             {
-                                WriteObject(string.Concat(resolvedPathCache, currentPath.Path.AsSpan(leafIndex + 1)), enumerateCollection: false);
+                                WriteObject(string.Concat(adjustedBaseCache, currentPath.Path.AsSpan(leafIndex + 1)), enumerateCollection: false);
                                 continue;
                             }
 
-                            basePathCache = basePath;
+                            baseCache = basePath;
                             string adjustedPath = SessionState.Path.NormalizeRelativePath(currentPath.Path,
                                 SessionState.Path.CurrentLocation.ProviderPath);
 
@@ -139,7 +139,7 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             leafIndex = adjustedPath.LastIndexOf(currentPath.Provider.ItemSeparator);
-                            resolvedPathCache = adjustedPath.Substring(0, leafIndex + 1);
+                            adjustedBaseCache = adjustedPath.AsSpan(0, leafIndex + 1);
 
                             WriteObject(adjustedPath, enumerateCollection: false);
                         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Improves the performance of Resolve-Path relative when resolving multiple paths in the same directory, for example when using it like this: `Resolve-Path -Path C:\Windows\System32\* -Relative`  
This is done by saving the resolved base path and reusing it every time a new item in the same directory is encountered.

On my system `Measure-Command -Expression {Resolve-Path -Path C:\Windows\System32\* -Relative}` takes 1 second and 200 ms on average without this fix, and around 90ms with this fix.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
