### PR TITLE
Replace `Requires.NotNullOrEmpty(string)` with `ArgumentException.ThrowIfNullOrEmpty`

### DIFF
--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
@@ -89,7 +89,7 @@ namespace System.Management.Automation.Subsystem.Feedback
         /// <param name="layout">The layout for displaying the actions.</param>
         public FeedbackItem(string header, List<string>? actions, string? footer, FeedbackDisplayLayout layout)
         {
-            Requires.NotNullOrEmpty(header, nameof(header));
+            ArgumentException.ThrowIfNullOrEmpty(header);
 
             Header = header;
             RecommendedActions = actions;

--- a/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/CommandPrediction.cs
+++ b/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/CommandPrediction.cs
@@ -249,7 +249,7 @@ namespace System.Management.Automation.Subsystem.Prediction
         /// <param name="suggestionText">The accepted suggestion text.</param>
         public static void OnSuggestionAccepted(PredictionClient client, Guid predictorId, uint session, string suggestionText)
         {
-            Requires.NotNullOrEmpty(suggestionText, nameof(suggestionText));
+            ArgumentException.ThrowIfNullOrEmpty(suggestionText);
 
             var predictors = SubsystemManager.GetSubsystems<ICommandPredictor>();
             if (predictors.Count == 0)

--- a/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/ICommandPredictor.cs
+++ b/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/ICommandPredictor.cs
@@ -201,7 +201,7 @@ namespace System.Management.Automation.Subsystem.Prediction
         /// <returns>A <see cref="PredictionContext"/> object.</returns>
         public static PredictionContext Create(string input)
         {
-            Requires.NotNullOrEmpty(input, nameof(input));
+            ArgumentException.ThrowIfNullOrEmpty(input);
 
             Ast ast = Parser.ParseInput(input, out Token[] tokens, out _);
             return new PredictionContext(ast, tokens);
@@ -239,7 +239,7 @@ namespace System.Management.Automation.Subsystem.Prediction
         /// <param name="toolTip">The tooltip of the suggestion.</param>
         public PredictiveSuggestion(string suggestion, string? toolTip)
         {
-            Requires.NotNullOrEmpty(suggestion, nameof(suggestion));
+            ArgumentException.ThrowIfNullOrEmpty(suggestion);
 
             SuggestionText = suggestion;
             ToolTip = toolTip;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1733,14 +1733,6 @@ namespace System.Management.Automation.Internal
     /// </summary>
     internal static class Requires
     {
-        internal static void NotNullOrEmpty(string value, string paramName)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentNullException(paramName);
-            }
-        }
-
         internal static void NotNullOrEmpty(ICollection value, string paramName)
         {
             if (value is null || value.Count == 0)


### PR DESCRIPTION
Breaking change: _Bucket 3: Unlikely Grey Area_

This PR makes changes to public APIs so that an `ArgumentException` is thrown instead of `ArgumentNullException` when a string is empty rather than null.

* [System.Management.Automation.Subsystem.Prediction.PredictionContext.Create(String)](https://learn.microsoft.com/dotnet/api/system.management.automation.subsystem.prediction.predictioncontext.create#system-management-automation-subsystem-prediction-predictioncontext-create(system-string))
* [System.Management.Automation.Subsystem.Prediction.PredictiveSuggestion..ctor(String)](https://learn.microsoft.com/dotnet/api/system.management.automation.subsystem.prediction.predictivesuggestion.-ctor#system-management-automation-subsystem-prediction-predictivesuggestion-ctor(system-string))
* [System.Management.Automation.Subsystem.Prediction.PredictiveSuggestion..ctor(String, String)](https://learn.microsoft.com/dotnet/api/system.management.automation.subsystem.prediction.predictivesuggestion.-ctor#system-management-automation-subsystem-prediction-predictivesuggestion-ctor(system-string-system-string))
* [System.Management.Automation.Subsystem.Prediction.CommandPrediction.OnSuggestionAccepted(PredictionClient, Guid, UInt32, String)](https://learn.microsoft.com/dotnet/api/system.management.automation.subsystem.prediction.commandprediction.onsuggestionaccepted#system-management-automation-subsystem-prediction-commandprediction-onsuggestionaccepted(system-management-automation-subsystem-prediction-predictionclient-system-guid-system-uint32-system-string))

If a consumer caught the `ArgumentNullException` and not the base class `ArgumentException` this is a change in behavior.

However, it seems unlikely to depend on a specific exception being thrown, because if specific behavior was required, the caller could have implemented the necessary business logic.
