### PR TITLE
Replace `Requires.Condition` with `ArgumentOutOfRangeException.ThrowIfNegativeOrZero`

### DIFF
--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/FeedbackHub.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/FeedbackHub.cs
@@ -60,7 +60,7 @@ namespace System.Management.Automation.Subsystem.Feedback
         /// </summary>
         public static List<FeedbackResult>? GetFeedback(Runspace runspace, int millisecondsTimeout)
         {
-            Requires.Condition(millisecondsTimeout > 0, nameof(millisecondsTimeout));
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(millisecondsTimeout);
 
             var localRunspace = runspace as LocalRunspace;
             if (localRunspace is null)

--- a/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/CommandPrediction.cs
+++ b/src/System.Management.Automation/engine/Subsystem/PredictionSubsystem/CommandPrediction.cs
@@ -74,7 +74,7 @@ namespace System.Management.Automation.Subsystem.Prediction
         /// <returns>A list of <see cref="PredictionResult"/> objects.</returns>
         public static async Task<List<PredictionResult>?> PredictInputAsync(PredictionClient client, Ast ast, Token[] astTokens, int millisecondsTimeout)
         {
-            Requires.Condition(millisecondsTimeout > 0, nameof(millisecondsTimeout));
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(millisecondsTimeout);
 
             var predictors = SubsystemManager.GetSubsystems<ICommandPredictor>();
             if (predictors.Count == 0)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1748,13 +1748,5 @@ namespace System.Management.Automation.Internal
                 throw new ArgumentNullException(paramName);
             }
         }
-
-        internal static void Condition([DoesNotReturnIf(false)] bool precondition, string paramName)
-        {
-            if (!precondition)
-            {
-                throw new ArgumentException(paramName);
-            }
-        }
     }
 }


### PR DESCRIPTION
Changes the exception from `ArgumentException` to `ArgumentOutOfRangeException` which is not a breaking change since the latter is derived from the former.