### PR TITLE
Use `ArgumentException.ThrowIfNullOrEmpty` part 1

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
@@ -314,11 +314,8 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         /// <param name="optionValue"></param>
         public override void AddQueryOption(string optionName, object optionValue)
         {
-            if (string.IsNullOrEmpty(optionName))
-            {
-                throw new ArgumentNullException(nameof(optionName));
-            }
-
+            ArgumentException.ThrowIfNullOrEmpty(optionName);
+            
             ArgumentNullException.ThrowIfNull(optionValue); 
 
             this.queryOptions[optionName] = optionValue;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
@@ -315,7 +315,6 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         public override void AddQueryOption(string optionName, object optionValue)
         {
             ArgumentException.ThrowIfNullOrEmpty(optionName);
-            
             ArgumentNullException.ThrowIfNull(optionValue); 
 
             this.queryOptions[optionName] = optionValue;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CIMHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CIMHelper.cs
@@ -79,8 +79,7 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         internal static T GetFirst<T>(CimSession session, string nameSpace, string wmiClassName) where T : class, new()
         {
-            if (string.IsNullOrEmpty(wmiClassName))
-                throw new ArgumentException("String argument may not be null or empty", nameof(wmiClassName));
+            ArgumentException.ThrowIfNullOrEmpty(wmiClassName);
 
             try
             {
@@ -132,9 +131,8 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         internal static T[] GetAll<T>(CimSession session, string nameSpace, string wmiClassName) where T : class, new()
         {
-            if (string.IsNullOrEmpty(wmiClassName))
-                throw new ArgumentException("String argument may not be null or empty", nameof(wmiClassName));
-
+            ArgumentException.ThrowIfNullOrEmpty(wmiClassName);
+            
             var rv = new List<T>();
 
             try

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/PingPathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/PingPathCommand.cs
@@ -186,19 +186,21 @@ namespace Microsoft.PowerShell.Commands
             {
                 bool result = false;
 
-                if (path == null)
-                {
-                    WriteError(new ErrorRecord(
-                        new ArgumentNullException(TestPathResources.PathIsNullOrEmptyCollection),
-                        "NullPathNotPermitted",
-                        ErrorCategory.InvalidArgument,
-                        Path));
-                    continue;
-                }
-
                 if (string.IsNullOrWhiteSpace(path))
                 {
-                    WriteObject(result);
+                    if (path is null)
+                    {
+                        WriteError(new ErrorRecord(
+                            new ArgumentNullException(TestPathResources.PathIsNullOrEmptyCollection),
+                            "NullPathNotPermitted",
+                            ErrorCategory.InvalidArgument,
+                            Path));
+                    }
+                    else
+                    {
+                        WriteObject(result);
+                    }
+                    
                     continue;
                 }
 


### PR DESCRIPTION
Use `ArgumentException.ThrowIfNullOrEmpty` in _Microsoft.PowerShell.Commands.Management_.

Contributes to #19212.

### Changes

* Throws `ArgumentException` instead of `ArgumentNullException` when a string is empty.
  * Possible breaking change as `ArgumentException` is a less derived type.
* Throws `ArgumentNullException` instead of `ArgumentException` when a string is null.
  * Clearly non-breaking as `ArgumentNullException` is a more derived type.

### Breaking changes contract

_[Bucket 4: Clearly Non-Public](https://github.com/PowerShell/PowerShell/blob/master/docs/dev-process/breaking-change-contract.md#bucket-4-clearly-non-public)_

* Modifies internal class `Microsoft.PowerShell.Cmdletization.Cim.CimQuery`
* Modifies internal class `Microsoft.PowerShell.Commands.CIMHelper`

### Other changes

608186d0a3524a986f471f2db60058d5f63c7f10 is a related refactoring that does not change behavior.
