### PR TITLE
Fix `ConciseView` to handle custom `ParserError` ErrorRecords

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1089,7 +1089,7 @@ namespace System.Management.Automation.Runspaces
                                         $accentColor = $PSStyle.Formatting.ErrorAccent
                                     }
 
-                                    function Get-ConciseViewPositionMessage {
+                                    function Get-ConciseViewPositionMessage( $err ) {
 
                                         # returns a string cut to last whitespace
                                         function Get-TruncatedString($string, [int]$length) {
@@ -1108,9 +1108,8 @@ namespace System.Management.Automation.Runspaces
                                         $prefix = ''
 
                                         # Don't show line information if script module
-                                        if (($myinv -and $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1 -or $err.Type -is [System.Management.Automation.ParseException]) -and !($myinv.ScriptName -and $myinv.ScriptName.EndsWith('.psm1', [System.StringComparison]::OrdinalIgnoreCase))) {
+                                        if (((($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception -is 'System.Management.Automation.ParentContainsErrorRecordException') -or $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1)) -and !($myinv.ScriptName -match '\.psm1$')) {
                                             $useTargetObject = $false
-
                                             # Handle case where there is a TargetObject and we can show the error at the target rather than the script source
                                             if ($_.TargetObject.Line -and $_.TargetObject.LineText) {
                                                 $posmsg = ""${resetcolor}$($_.TargetObject.File)${newline}""
@@ -1298,7 +1297,7 @@ namespace System.Management.Automation.Runspaces
 
                                     $posmsg = ''
                                     if ($ErrorView -eq 'ConciseView') {
-                                        $posmsg = Get-ConciseViewPositionMessage
+                                        $posmsg = Get-ConciseViewPositionMessage -Err $_
                                     }
                                     elseif ($myinv -and ($myinv.MyCommand -or ($err.CategoryInfo.Category -ne 'ParserError'))) {
                                         $posmsg = $myinv.PositionMessage

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1111,7 +1111,7 @@ namespace System.Management.Automation.Runspaces
                                         # - check if `ParserError` and comes from PowerShell which eventually results in a ParseException, but during this execution it's an ErrorRecord
                                         # - check if invocation is a script or multiple lines in the console
                                         # - check that it's not a script module as expectation is that users don't want to see the line of error within a module
-                                        if (((($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception -is 'System.Management.Automation.ParentContainsErrorRecordException') -or $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1)) -and !($myinv.ScriptName -match '\.psm1$')) {
+                                        if ((($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception -is 'System.Management.Automation.ParentContainsErrorRecordException') -or $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1) -and !($myinv.ScriptName -match '\.psm1$')) {
                                             $useTargetObject = $false
                                             # Handle case where there is a TargetObject and we can show the error at the target rather than the script source
                                             if ($_.TargetObject.Line -and $_.TargetObject.LineText) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1089,7 +1089,7 @@ namespace System.Management.Automation.Runspaces
                                         $accentColor = $PSStyle.Formatting.ErrorAccent
                                     }
 
-                                    function Get-ConciseViewPositionMessage() {
+                                    function Get-ConciseViewPositionMessage {
 
                                         # returns a string cut to last whitespace
                                         function Get-TruncatedString($string, [int]$length) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1075,6 +1075,8 @@ namespace System.Management.Automation.Runspaces
                                 ")
                         .AddScriptBlockExpressionBinding(@"
                                     Set-StrictMode -Off
+                                    $ErrorActionPreference = 'Stop'
+                                    trap { 'Error found in error view definition: ' + $_.Exception.Message }
                                     $newline = [Environment]::Newline
 
                                     $resetColor = ''
@@ -1106,7 +1108,7 @@ namespace System.Management.Automation.Runspaces
                                         $prefix = ''
 
                                         # Don't show line information if script module
-                                        if (($myinv -and $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1 -or $err.CategoryInfo.Category -eq 'ParserError') -and !($myinv.ScriptName.EndsWith('.psm1', [System.StringComparison]::OrdinalIgnoreCase))) {
+                                        if (($myinv -and $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1 -or $err.Type -is [System.Management.Automation.ParseException]) -and !($myinv.ScriptName -and $myinv.ScriptName.EndsWith('.psm1', [System.StringComparison]::OrdinalIgnoreCase))) {
                                             $useTargetObject = $false
 
                                             # Handle case where there is a TargetObject and we can show the error at the target rather than the script source

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1107,7 +1107,10 @@ namespace System.Management.Automation.Runspaces
                                         $message = ''
                                         $prefix = ''
 
-                                        # Don't show line information if script module
+                                        # The checks here determine if we show line detailed error information:
+                                        # - check if `ParserError` and comes from PowerShell which eventually results in a ParseException, but during this execution it's an ErrorRecord
+                                        # - check if invocation is a script or multiple lines in the console
+                                        # - check that it's not a script module as expectation is that users don't want to see the line of error within a module
                                         if (((($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception -is 'System.Management.Automation.ParentContainsErrorRecordException') -or $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1)) -and !($myinv.ScriptName -match '\.psm1$')) {
                                             $useTargetObject = $false
                                             # Handle case where there is a TargetObject and we can show the error at the target rather than the script source

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1111,7 +1111,7 @@ namespace System.Management.Automation.Runspaces
                                         # - check if `ParserError` and comes from PowerShell which eventually results in a ParseException, but during this execution it's an ErrorRecord
                                         # - check if invocation is a script or multiple lines in the console
                                         # - check that it's not a script module as expectation is that users don't want to see the line of error within a module
-                                        if ((($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception -is 'System.Management.Automation.ParentContainsErrorRecordException') -or $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1) -and !($myinv.ScriptName -match '\.psm1$')) {
+                                        if ((($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception -is 'System.Management.Automation.ParentContainsErrorRecordException') -or $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1) -and $myinv.ScriptName -notmatch '\.psm1$') {
                                             $useTargetObject = $false
 
                                             # Handle case where there is a TargetObject and we can show the error at the target rather than the script source

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1089,7 +1089,7 @@ namespace System.Management.Automation.Runspaces
                                         $accentColor = $PSStyle.Formatting.ErrorAccent
                                     }
 
-                                    function Get-ConciseViewPositionMessage( $err ) {
+                                    function Get-ConciseViewPositionMessage() {
 
                                         # returns a string cut to last whitespace
                                         function Get-TruncatedString($string, [int]$length) {
@@ -1297,7 +1297,7 @@ namespace System.Management.Automation.Runspaces
 
                                     $posmsg = ''
                                     if ($ErrorView -eq 'ConciseView') {
-                                        $posmsg = Get-ConciseViewPositionMessage -Err $_
+                                        $posmsg = Get-ConciseViewPositionMessage
                                     }
                                     elseif ($myinv -and ($myinv.MyCommand -or ($err.CategoryInfo.Category -ne 'ParserError'))) {
                                         $posmsg = $myinv.PositionMessage

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1113,6 +1113,7 @@ namespace System.Management.Automation.Runspaces
                                         # - check that it's not a script module as expectation is that users don't want to see the line of error within a module
                                         if ((($err.CategoryInfo.Category -eq 'ParserError' -and $err.Exception -is 'System.Management.Automation.ParentContainsErrorRecordException') -or $myinv.ScriptName -or $myinv.ScriptLineNumber -gt 1) -and !($myinv.ScriptName -match '\.psm1$')) {
                                             $useTargetObject = $false
+
                                             # Handle case where there is a TargetObject and we can show the error at the target rather than the script source
                                             if ($_.TargetObject.Line -and $_.TargetObject.LineText) {
                                                 $posmsg = ""${resetcolor}$($_.TargetObject.File)${newline}""

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -109,7 +109,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
         }
 
         It "Error shows if `$PSModuleAutoLoadingPreference is set to 'none'" {
-            $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = ""none""; cmdletThatDoesntExist' 2>&1 | Out-String
+            $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = "none"; cmdletThatDoesntExist' 2>&1 | Out-String
             $e | Should -BeLike "*cmdletThatDoesntExist*"
         }
 
@@ -158,7 +158,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e | Should -Not -BeNullOrEmpty
             $e = $e.Split([Environment]::NewLine)
             $e[0] | Should -BeLike "ParserError:*"
-            $e[1] | Should -BeLike "Line *"
+            $e[1] | Should -BeLike "Line *" -Because ($e | Out-String)
             $e[2] | Should -BeLike "*|*1 ++ 1*"
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The fundamental issue is that `ConciseView` has code to handle PowerShell `ParserError` category, but the cmdlet in the issue was returning an ErrorRecord with that category (which is allowed), but the `ConciseView` script was only expecting an object that looked like what PowerShell would return. See the comment thread https://github.com/PowerShell/PowerShell/pull/19239#discussion_r1119467127 for some more details.

During execution of this script during formatting, what you get an a `ParseException` is actually an `ErrorRecord` where the `Exception` is a `ParentContainsErrorRecordException`.  So the way to check it's a parse error from PowerShell is to check that the `Category` is `ParseError` and the `Exception` type is `ParentContainsErrorRecordException`.   Not ideal, but the `ParseException` seems to be created somewhere else that gets put onto `$Error` but not available to the script during formatting.

Also added a trap at the start of that script in case there are other unknown issues so that users will get an error message that can be reported to us rather than no error.

Note that the actual issue, however, only repros over remoting which does it's own wrapping of remote errors so a PS Job is used for the test to cover this case.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/19223

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
