### PR TITLE
Support HTTP persistent connections in Web Cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebProxy.cs
@@ -6,7 +6,7 @@ using System.Net;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class WebProxy : IWebProxy
+    internal class WebProxy : IWebProxy, IEquatable<WebProxy>
     {
         private ICredentials _credentials;
         private readonly Uri _proxyAddress;
@@ -16,6 +16,23 @@ namespace Microsoft.PowerShell.Commands
             ArgumentNullException.ThrowIfNull(address);
 
             _proxyAddress = address;
+        }
+
+        public override bool Equals(object obj) => Equals(obj as WebProxy);
+
+        public override int GetHashCode() => HashCode.Combine(_proxyAddress, _credentials, BypassProxyOnLocal);
+
+        public bool Equals(WebProxy other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            // _proxyAddress cannot be null as it is set in the constructor            
+            return other._credentials == _credentials
+                && _proxyAddress.Equals(other._proxyAddress)
+                && BypassProxyOnLocal == other.BypassProxyOnLocal;
         }
 
         public ICredentials Credentials

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
@@ -4,15 +4,37 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
     /// WebRequestSession for holding session infos.
     /// </summary>
-    public class WebRequestSession
+    public class WebRequestSession : IDisposable
     {
+        private HttpClient _client;
+        private CookieContainer _cookies;
+        private bool _useDefaultCredentials;
+        private ICredentials _credentials;
+        private X509CertificateCollection _certificates;
+        private IWebProxy _proxy;
+        private int _maximumRedirection;
+        private WebSslProtocol _sslProtocol;
+        private bool _allowAutoRedirect;
+        private bool _skipCertificateCheck;
+        private bool _noProxy;
+        private bool _disposed;
+        private int _timeoutSec;
+
+        /// <summary>
+        /// Contains true if an existing HttpClient had to be disposed and recreated since the WebSession was last used.
+        /// </summary>
+        private bool _disposedClient;
+
         /// <summary>
         /// Gets or sets the Header property.
         /// </summary>
@@ -27,25 +49,25 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the Cookies property.
         /// </summary>
-        public CookieContainer Cookies { get; set; }
+        public CookieContainer Cookies { get => _cookies; set => SetClassVar(ref _cookies, value); }
 
         #region Credentials
 
         /// <summary>
         /// Gets or sets the UseDefaultCredentials property.
         /// </summary>
-        public bool UseDefaultCredentials { get; set; }
+        public bool UseDefaultCredentials { get => _useDefaultCredentials; set => SetStructVar(ref _useDefaultCredentials, value); }
 
         /// <summary>
         /// Gets or sets the Credentials property.
         /// </summary>
-        public ICredentials Credentials { get; set; }
+        public ICredentials Credentials { get => _credentials; set => SetClassVar(ref _credentials, value); }
 
         /// <summary>
         /// Gets or sets the Certificates property.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public X509CertificateCollection Certificates { get; set; }
+        public X509CertificateCollection Certificates { get => _certificates; set => SetClassVar(ref _certificates, value); }
 
         #endregion
 
@@ -57,12 +79,23 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the Proxy property.
         /// </summary>
-        public IWebProxy Proxy { get; set; }
+        public IWebProxy Proxy
+        {
+            get => _proxy;
+            set
+            {
+                SetClassVar(ref _proxy, value);
+                if (_proxy is not null)
+                {
+                    NoProxy = false;
+                }
+            }
+        }
 
         /// <summary>
-        /// Gets or sets the RedirectMax property.
+        /// Gets or sets the MaximumRedirection property.
         /// </summary>
-        public int MaximumRedirection { get; set; }
+        public int MaximumRedirection { get => _maximumRedirection; set => SetStructVar(ref _maximumRedirection, value); }
 
         /// <summary>
         /// Gets or sets the count of retries for request failures.
@@ -79,23 +112,42 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public WebRequestSession()
         {
-            // build the headers collection
+            // Build the headers collection
             Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             ContentHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            // build the cookie jar
-            Cookies = new CookieContainer();
+            // Build the cookie jar
+            _cookies = new CookieContainer();
 
-            // initialize the credential and certificate caches
-            UseDefaultCredentials = false;
-            Credentials = null;
-            Certificates = null;
+            // Initialize the credential and certificate caches
+            _useDefaultCredentials = false;
+            _credentials = null;
+            _certificates = null;
 
-            // setup the default UserAgent
+            // Setup the default UserAgent
             UserAgent = PSUserAgent.UserAgent;
 
-            Proxy = null;
-            MaximumRedirection = -1;
+            _proxy = null;
+            _maximumRedirection = -1;
+            _allowAutoRedirect = true;
+        }
+
+        internal WebSslProtocol SslProtocol { set => SetStructVar(ref _sslProtocol, value); }
+
+        internal bool SkipCertificateCheck { set => SetStructVar(ref _skipCertificateCheck, value); }
+
+        internal int TimeoutSec { set => SetStructVar(ref _timeoutSec, value); }
+
+        internal bool NoProxy
+        {
+            set
+            {
+                SetStructVar(ref _noProxy, value);
+                if (_noProxy)
+                {
+                    Proxy = null;
+                }
+            }
         }
 
         /// <summary>
@@ -105,8 +157,139 @@ namespace Microsoft.PowerShell.Commands
         internal void AddCertificate(X509Certificate certificate)
         {
             Certificates ??= new X509CertificateCollection();
+            if (!Certificates.Contains(certificate))
+            {
+                ResetClient();
+                Certificates.Add(certificate);
+            }
+        }
 
-            Certificates.Add(certificate);
+        /// <summary>
+        /// Gets an existing or creates a new HttpClient for this WebRequest session if none currently exists (either because it was never
+        /// created, or because changes to the WebSession properties required the existing HttpClient to be disposed).
+        /// </summary>
+        /// <param name="suppressHttpClientRedirects">True if the caller does not want the HttpClient to ever handle redirections automatically.</param>
+        /// <param name="clientWasReset">Contains true if an existing HttpClient had to be disposed and recreated since the WebSession was last used.</param>
+        /// <returns>The HttpClient cached in the WebSession, based on all current settings.</returns>
+        internal HttpClient GetHttpClient(bool suppressHttpClientRedirects, out bool clientWasReset)
+        {
+            // Do not auto redirect if the the caller does not want it, or maximum redirections is 0
+            SetStructVar(ref _allowAutoRedirect, !(suppressHttpClientRedirects || MaximumRedirection == 0));
+
+            clientWasReset = _disposedClient;
+
+            if (_client is null)
+            {
+                _client = CreateHttpClient();
+                _disposedClient = false;
+            }
+
+            return _client;
+        }
+
+        private HttpClient CreateHttpClient()
+        {
+            HttpClientHandler handler = new();
+
+            handler.CookieContainer = Cookies;
+            handler.AutomaticDecompression = DecompressionMethods.All;
+
+            if (Credentials is not null)
+            {
+                handler.Credentials = Credentials;
+            }
+            else
+            {
+                handler.UseDefaultCredentials = UseDefaultCredentials;
+            }
+
+            if (_noProxy)
+            {
+                handler.UseProxy = false;
+            }
+            else if (Proxy is not null)
+            {
+                handler.Proxy = Proxy;
+            }
+
+            if (Certificates is not null)
+            {
+                handler.ClientCertificates.AddRange(Certificates);
+            }
+
+            if (_skipCertificateCheck)
+            {
+                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+            }
+
+            handler.AllowAutoRedirect = _allowAutoRedirect;
+            if (_allowAutoRedirect && MaximumRedirection > 0)
+            {
+                handler.MaxAutomaticRedirections = MaximumRedirection;
+            }
+
+            handler.SslProtocols = (SslProtocols)_sslProtocol;
+
+            // Check timeout setting (in seconds instead of milliseconds as in HttpWebRequest)
+            return new HttpClient(handler)
+            {
+                Timeout = _timeoutSec is 0 ? TimeSpan.FromMilliseconds(Timeout.Infinite) : TimeSpan.FromSeconds(_timeoutSec)
+            };
+        }
+
+        private void SetClassVar<T>(ref T oldValue, T newValue) where T : class
+        {
+            if (oldValue != newValue)
+            {
+                ResetClient();
+                oldValue = newValue;
+            }
+        }
+
+        private void SetStructVar<T>(ref T oldValue, T newValue) where T : struct
+        {
+            if (!oldValue.Equals(newValue))
+            {
+                ResetClient();
+                oldValue = newValue;
+            }
+        }
+
+        private void ResetClient()
+        {
+            if (_client is not null)
+            {
+                _disposedClient = true;
+                _client.Dispose();
+                _client = null;
+            }
+        }
+
+        /// <summary>
+        /// Dispose the WebRequestSession.
+        /// </summary>
+        /// <param name="disposing">True when called from Dispose() and false when called from finalizer.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _client?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Dispose the WebRequestSession.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -249,4 +249,7 @@
   <data name="JsonMaxDepthReached" xml:space="preserve">
     <value>Resulting JSON is truncated as serialization has exceeded the set depth of {0}.</value>
   </data>
+  <data name="WebSessionConnectionRecreated" xml:space="preserve">
+    <value>The WebSession properties were changed between requests forcing all HTTP connections in the session to be recreated.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2241,6 +2241,148 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             $pathologicalRatio | Should -BeGreaterThan 5
         }
     }
+
+    Context 'Invoke-WebSession: Connection persistence in a WebSession' {
+        # Match verbose message from resource name WebSessionConnectionRecreated with message:
+        # The WebSession properties were changed between requests forcing all HTTP connections in the session to be recreated.
+        $matchConnRecreatedMessage = [regex]::new('WebSession.+HTTP')
+
+        function RunCheckingPersistence {
+            param(
+                [uri]$Uri,
+                [string]$Command,
+                [object]$Session,
+                [switch]$ExpectConnectionRecreated,
+                [switch]$CaptureSession
+            )
+
+            $pwsh = [PowerShell]::Create()
+            $pwsh.Runspace.SessionStateProxy.SetVariable('uri', $Uri)
+            if ($Session) {
+                $pwsh.Runspace.SessionStateProxy.SetVariable('Session', $Session)
+                $command = "$command -WebSession `$Session"
+            }
+            if ($CaptureSession) {
+                $command = "$command -SessionVariable Session"
+            }
+            $script = "`$null = $command -Verbose"
+            $pwsh.AddScript($script).Invoke()
+            $session = $pwsh.Runspace.SessionStateProxy.GetVariable('Session')
+
+            $expectedConnRecreatedCount = if ($ExpectConnectionRecreated) { 1 } else { 0 }
+            ($pwsh.Streams.Verbose | Where-Object { $matchConnRecreatedMessage.Matches($_.Message) }).Count | Should -Be $expectedConnRecreatedCount
+
+            $pwsh.Dispose()
+
+            return $session
+        }
+
+        It 'Connection persistence maintained' {
+            $uri = Get-WebListenerUrl
+            $Session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -CaptureSession
+            1 .. 3 | ForEach-Object {
+                RunCheckingPersistence -Uri $uri  -Command 'Invoke-WebRequest -Uri $uri' -Session $Session
+            }
+        }
+
+        It 'Connection persistence impacted by changing SkipCertificateCheck' {
+            $uri = Get-WebListenerUrl -Https
+            # This first request will throw because the certificate is invalid
+            $session = $null
+            $session = RunCheckingPersistence -Uri $uri  -Command 'Invoke-WebRequest -Uri $uri' -CaptureSession
+            # No change in setting
+            $session = RunCheckingPersistence -Uri $uri  -Command 'Invoke-WebRequest -Uri $uri -SkipCertificateCheck:$false' -Session $session
+            # Skipping cert check changes persistence
+            $session = RunCheckingPersistence -Uri $uri  -Command 'Invoke-WebRequest -Uri $uri -SkipCertificateCheck' -Session $session -ExpectConnectionRecreated
+            # Same settings won't lose persistence
+            $session = RunCheckingPersistence -Uri $uri  -Command 'Invoke-WebRequest -Uri $uri -SkipCertificateCheck' -Session $session
+            # Lose persistence due to changing cert check - this will also throw
+            $session = RunCheckingPersistence -Uri $uri  -Command 'Invoke-WebRequest -Uri $uri -SkipCertificateCheck:$false' -Session $session -ExpectConnectionRecreated
+        }
+
+        It 'Connection persistence is not impacted by changing request headers' {
+            $uri = Get-WebListenerUrl
+            $session = $null
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -CaptureSession
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -Headers @{ A = "B" }' -Session $session
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -Headers @{}' -Session $session
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -Headers @{ A = "C"; B = "D"}' -Session $session
+        }
+
+        It 'Connection persistence is impacted by changing the session cookie jar' {
+            $uri = Get-WebListenerUrl
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -CaptureSession
+            $session.Cookies = New-Object System.Net.CookieContainer
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -Session $session -ExpectConnectionRecreated
+
+            # Adding a cookie to the container does not lose persistence
+            $Session.Cookies.Add('http://localhost', [system.net.cookie]::new('cookie', 'value'))
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -Session $session
+        }
+
+        It 'Connection persistence is not impacted by changing the user agent' {
+            $uri = Get-WebListenerUrl
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -UserAgent Powershell' -CaptureSession
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -UserAgent "PowerShell Core"' -Session $session
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -UserAgent "PowerShell Core with HttpClient"' -Session $session
+            # Ensure persistence is lost when we change a different setting
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -NoProxy -UserAgent "PowerShell Core"' -Session $session -ExpectConnectionRecreated
+        }
+
+        It 'Connection persistence is not impacted when NoProxy parameter is not supplied' {
+            $uri = Get-WebListenerUrl
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -CaptureSession
+            # Explicitly prevent proxy - connection lost
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -NoProxy' -Session $session -ExpectConnectionRecreated
+            # Provide explicit switch value - connection maintained
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -NoProxy:$true' -Session $session
+            # No spec for proxy - connection maintained
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -Session $session
+            # Two follow up calls without altering anything do not lose connection
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -Session $session
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -Session $session
+        }
+
+        It 'Connection persistence is not impacted when SslProtocol parameter is not supplied' {
+            $uri = Get-WebListenerUrl
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -SslProtocol Tls12' -CaptureSession
+            # No SslProtocol provided - keeps last value - connection retained
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -Session $session
+            # Explicit default - loses connection
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -SslProtocol Default' -Session $session -ExpectConnectionRecreated
+            # No SslProtocol provided - keeps last value - connection retained
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -Session $session
+            # Explicitly set to same value as last time it was set - connection retained
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -SslProtocol Default' -Session $session
+        }
+
+        It 'Connection persistence is not impacted by Proxy and NoProxy unless changed parameters are used between invocations' {
+            $uri = Get-WebListenerUrl
+            $session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -CaptureSession
+            $proxy = 'http://127.0.0.1:8080'
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri -proxy $proxy" -Session $session -ExpectConnectionRecreated
+            # same proxy - do not lose persistence
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri -proxy $proxy" -Session $session
+            # No proxy at all - use previous setting and don't lose connection
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri" -Session $session
+
+            # NoProxy toggles proxy off - loses connection
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri -NoProxy" -Session $session -ExpectConnectionRecreated
+            # No setting at all - retains NoProxy setting
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri" -Session $session
+
+            # Use proxy again - lose connection
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri -proxy $proxy" -Session $session -ExpectConnectionRecreated
+            # No proxy specified - connection retained
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri" -Session $session
+
+            # Proxy changed - lose connection
+            $proxy = 'http://localhost:8080'
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri -proxy $proxy" -Session $session -ExpectConnectionRecreated
+            # No proxy specified - connection retained
+            $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri" -Session $session
+        }
+    }
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fis #12764

This PR addresses [12764](https://github.com/PowerShell/PowerShell/issues/12764) by using persistent HTTP connections when Invoke-WebRequest uses the -Session variable. It does this by 
1. Tracking the  HttpClient object in the saved WebRequestSession.
2. Monitoring properties in WebRequestSession and rebuilding the HttpClient if they are changed. This is done to ensure that existing scripts that might tweak parameters between invocations of IWR actually apply the changes so they will behave in a backwards compatible manner. When anything that impacts the HttpClient is changed, the persistent connection is abandoned by disposing the HttpClient and underlying HttpClientHandler and constructing a new one. A warning is logged when this occurs as it has a performance impact (though no worse than the existing behaviour).
3. To support point 2, many parameters are stored as internal set-only properties in the WebRequestSession so changes between invocations that would require a new connection can be detected and the handler rebuilt appropriately.

## PR Context

This PR makes a considerable difference to performance when using Invoke-WebRequest or Invoke-RestMethod with sessions when multiple requests are made to the same host. This is particularly evident for HTTPS requests, as each HTTPS connection can take hundreds of milliseconds to establish.

This PR as written passes existing tests in `WebCmdlets.Tests.ps1` and additional WebSession tests that verify the HttpClient is rebuilt when appropriate.

The PR provides as much backwards compatibility as possible at the expense of the complexity of tracking how the HttpClient used in the WebSession was constructed and recreating the HttpClient in the case it would have been constructed differently between invocations in scripts that assume it is okay to change parameters between invocations with the same WebSession.

This PR squashes the commits in the original PR#19173 following multiple round of reviews by @iSazonov and @CarloToso on a previous version of the PR. PR#19173 has been withdrawn due to number of commits and volume of review comments.

## Performance Impact
Performance impact of maintaining HTTP connection persistence is measured by comparing PowerShell 7.3.3 with this PR using this simple script:

```powershell
(Measure-Command {
    $null =Invoke-WebRequest https://postman-echo.com/get?i=1 -SessionVariable Session
    1..10 | ForEach-Object {
            $null =Invoke-WebRequest https://postman-echo.com/get?i=$_ -WebSession $Session
    }
}).ToString()
```

### PowerShell 7.3.3
> 00:00:08.3019013

### PR Branch
> 00:00:03.4589770

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
