### PR TITLE
WIP: Provide a way to convert the output of native executables to objects

### DIFF
--- a/experimental-feature-linux.json
+++ b/experimental-feature-linux.json
@@ -3,6 +3,7 @@
   "PSCustomTableHeaderLabelDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
+  "PSNativeJsonAdapter",
   "PSSubsystemPluginModel",
   "PSModuleAutoLoadSkipOfflineFiles",
   "PSFeedbackProvider",

--- a/experimental-feature-windows.json
+++ b/experimental-feature-windows.json
@@ -3,6 +3,7 @@
   "PSCustomTableHeaderLabelDecoration",
   "PSLoadAssemblyFromNativeCode",
   "PSNativeCommandErrorActionPreference",
+  "PSNativeJsonAdapter",
   "PSSubsystemPluginModel",
   "PSModuleAutoLoadSkipOfflineFiles",
   "PSFeedbackProvider",

--- a/src/System.Management.Automation/engine/ApplicationInfo.cs
+++ b/src/System.Management.Automation/engine/ApplicationInfo.cs
@@ -51,9 +51,12 @@ namespace System.Management.Automation
             Extension = System.IO.Path.GetExtension(path);
             _context = context;
 
-            // Look for a json adapter.
-            // These take the shape of name-json.extension
-            FindJsonAdapter();
+            if (ExperimentalFeature.IsEnabled("PSNativeJsonAdapter"))
+            {
+                // Look for a json adapter.
+                // These take the shape of name-json.extension
+                FindJsonAdapter();
+            }
         }
 
         private readonly ExecutionContext _context;
@@ -70,15 +73,10 @@ namespace System.Management.Automation
         public string Extension { get; } = string.Empty;
 
         /// <summary>
-        /// Does this native application have a json adapter
+        /// The Json adapter for this application.
+        /// If this is not null, the adapter will be added to the pipeline following the application.
         /// </summary>
         public CommandInfo JsonAdapter { get; private set; } = null;
-
-        /// <summary>
-        /// Should we automatically call ConvertFrom-Json after the JsonAdapter is called.
-        /// This can also be used if the native command emits json.
-        /// </summary>
-        public bool AutoJsonConversion { get; private set; } = false;
 
         /// <summary>
         /// Gets the path of the application file.
@@ -154,14 +152,14 @@ namespace System.Management.Automation
 
         private ReadOnlyCollection<PSTypeName> _outputType = null;
 
+        /// <summary>
+        /// Search for a Json adapter for this application.
+        /// It will have the shape of name-json.extension, it can be any type of command.
+        /// </summary>
         private void FindJsonAdapter()
         {
             string jsonAdapterName = string.Format("{0}-json{1}", System.IO.Path.GetFileNameWithoutExtension(this.Path), Extension);
             JsonAdapter = _context.SessionState.InvokeCommand.GetCommand(jsonAdapterName, CommandTypes.All);
-            if (JsonAdapter != null)
-            {
-                AutoJsonConversion = true;
-            }
             return;
         }
     }

--- a/src/System.Management.Automation/engine/ApplicationInfo.cs
+++ b/src/System.Management.Automation/engine/ApplicationInfo.cs
@@ -158,7 +158,7 @@ namespace System.Management.Automation
         /// </summary>
         private void FindJsonAdapter()
         {
-            string jsonAdapterName = string.Format("{0}-json{1}", System.IO.Path.GetFileNameWithoutExtension(this.Path), Extension);
+            string jsonAdapterName = string.Format("{0}-json", System.IO.Path.GetFileNameWithoutExtension(this.Path));
             JsonAdapter = _context.SessionState.InvokeCommand.GetCommand(jsonAdapterName, CommandTypes.All);
             return;
         }

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -132,6 +132,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSCommandWithArgs,
                     description: "Enable `-CommandWithArgs` parameter for pwsh"),
+                new ExperimentalFeature(
+                    name: "PSNativeJsonAdapter",
+                    description: "Automatically call an adapter to convert output to Json when a native command is executed."),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -1001,7 +1001,7 @@ namespace System.Management.Automation.Runspaces
             // History id is greater than zero if entry was added to history
             if (AddToHistory)
             {
-                LocalRunspace.History.AddEntry(InstanceId, HistoryString, PipelineState, _pipelineStartTime, DateTime.Now, skipIfLocked);
+                LocalRunspace.History.AddEntry(InstanceId, HistoryString, ConstructedPipeline, PipelineState, _pipelineStartTime, DateTime.Now, skipIfLocked);
             }
         }
 
@@ -1030,7 +1030,7 @@ namespace System.Management.Automation.Runspaces
 
             if (AddToHistory)
             {
-                _historyIdForThisPipeline = LocalRunspace.History.AddEntry(InstanceId, HistoryString, PipelineState, _pipelineStartTime, DateTime.Now, false);
+                _historyIdForThisPipeline = LocalRunspace.History.AddEntry(InstanceId, HistoryString, ConstructedPipeline, PipelineState, _pipelineStartTime, DateTime.Now, false);
             }
         }
 

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -5251,6 +5251,12 @@ namespace System.Management.Automation
         public string HistoryString { get; set; }
 
         /// <summary>
+        /// The string representing the constructed pipeline
+        /// which includes the json adapter.
+        /// </summary>
+        public string ConstructedPipeline { get; set; }
+
+        /// <summary>
         /// Extra commands to run in a single invocation.
         /// </summary>
         internal Collection<PSCommand> ExtraCommands { get; }

--- a/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
@@ -976,6 +976,11 @@ namespace System.Management.Automation.Runspaces
         /// by invoke-cmd to place correct string in history.</remarks>
         internal string HistoryString { get; set; }
 
+        /// <summary>
+        /// String which represents the actual pipeline.
+        /// </summary>
+        public string ConstructedPipeline { get; set; }
+
         #endregion history
 
         #region misc

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -463,6 +463,20 @@ namespace System.Management.Automation
                             var ast = Parser.ParseInput(applicationInfo.JsonAdapter.Name, out tokenList, out errorList);
                             CommandBaseAst cmdAst = ast?.Find(a => a is CommandBaseAst, false) as CommandBaseAst;
                             CommandAst jsonCommandAst = ast?.Find(a => a is CommandAst, false) as CommandAst;
+
+                            // We want to not add the json adapter if the next element in the pipeline is the json adapter.
+                            // We peek at the next element of the pipeline to see if it is the json adapter, and
+                            // if it is, we will not add the adapter to the pipeline automatically.
+                            if (i + 1 < pipeElements.Length)
+                            {
+                                var nextCommand = pipeElementAsts[i + 1] as CommandAst;
+                                if (nextCommand != null && nextCommand.GetCommandName().Equals(applicationInfo.JsonAdapter.Name, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    // The next element is the json adapter, so we will not add this one to the pipeline.
+                                    jsonCommandAst = null;
+                                }
+                            }
+
                             // Process the Json adapter and add it to the pipeline.
                             if (jsonCommandAst != null && errorList.Length == 0)
                             {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -482,7 +482,7 @@ namespace System.Management.Automation
                                     var splatting = (exprAst is VariableExpressionAst && ((VariableExpressionAst)exprAst).Splatted);
                                     commandParameters.Add(CommandParameterInternal.CreateArgument(argument, exprAst, splatting));
                                 }
-                                
+
                                 // Attach the parameters of the original native command as arguments for the adapter.
                                 // Output from the original native command will be piped to the adapter.
                                 foreach (var commandElement in pipeElements[i])
@@ -3701,7 +3701,7 @@ namespace System.Management.Automation
             }
             catch (PSSecurityException)
             {
-                // ReportContent() will throw PSSecurityException if AMSI detects malware, which 
+                // ReportContent() will throw PSSecurityException if AMSI detects malware, which
                 // must be propagated.
                 throw;
             }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -482,7 +482,7 @@ namespace System.Management.Automation
                                     var splatting = (exprAst is VariableExpressionAst && ((VariableExpressionAst)exprAst).Splatted);
                                     commandParameters.Add(CommandParameterInternal.CreateArgument(argument, exprAst, splatting));
                                 }
-                                
+
                                 // Attach the parameters of the original native command as arguments for the adapter.
                                 // Output from the original native command will be piped to the adapter.
                                 foreach (var commandElement in pipeElements[i])

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -538,7 +538,7 @@ namespace System.Management.Automation
                 if (commandAdded)
                 {
                     // We've added a json adapter, update the history string.
-                    UpdateHistory(context, pipelineProcessor);
+                    AddConstructedPipeline(context, pipelineProcessor);
                 }
 
                 context.PushPipelineProcessor(pipelineProcessor);
@@ -558,8 +558,9 @@ namespace System.Management.Automation
             }
         }
 
-        // This is best effort to change history.
-        internal static void UpdateHistory(ExecutionContext context, PipelineProcessor pipelineProcessor)
+        // Add the constructed pipeline in the case of a discovered JSON adapter.
+        // This is best effort, if an exception occurs that is not a fatal error.
+        internal static void AddConstructedPipeline(ExecutionContext context, PipelineProcessor pipelineProcessor)
         {
             try
             {
@@ -568,12 +569,13 @@ namespace System.Management.Automation
                 {
                     return;
                 }
+
                 List<string> commands = new List<string>();
                 foreach (var commandProcessor in pipelineProcessor.Commands)
                 {
                     commands.Add(commandProcessor.Command.InvocationExtent.Text);
                 }
-                runningPipeline.HistoryString = string.Join(" | ", commands);
+                runningPipeline.ConstructedPipeline = string.Join(" | ", commands);
             }
             catch (Exception)
             {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -482,7 +482,7 @@ namespace System.Management.Automation
                                     var splatting = (exprAst is VariableExpressionAst && ((VariableExpressionAst)exprAst).Splatted);
                                     commandParameters.Add(CommandParameterInternal.CreateArgument(argument, exprAst, splatting));
                                 }
-
+                                
                                 // Attach the parameters of the original native command as arguments for the adapter.
                                 // Output from the original native command will be piped to the adapter.
                                 foreach (var commandElement in pipeElements[i])

--- a/test/powershell/engine/Basic/NativeJsonAdapter.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeJsonAdapter.Tests.ps1
@@ -1,0 +1,115 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Native commands will properly call a JSON adapter" {
+    BeforeAll {
+        # no useful overlap in commands, we have use specific commands for each platform
+        $winCmd = "whoami"
+        $winArguments = "/USER","FO","CSV"
+
+        $nixCmd = "hostname"
+        $nixArguments = "-f"
+
+        # start with a clean slate
+        if (test-path "function:${cmd}-json") {
+            Remove-Item -Force "function:${cmd}-json"
+        }
+
+        $platformArguments = $IsWindows ? $winArguments : $nixArguments
+        $cmd = $IsWindows ? $winCmd : $nixCmd
+
+        # adapters
+        $psAdapterName = "hostname-json.ps1"
+        $winAdapterName = "whoami-json.bat"
+        $nixAdapterName = "hostname-json.sh"
+        $nativeAdapterName = $IsWindows ? $winAdapterName : $nixAdapterName
+
+        # path to the adapter
+        $psAdapterPath = Join-Path -Path $PSScriptRoot -ChildPath assets -AdditionalChildPath $psAdapterName
+        $winAdapterPath = Join-Path -Path $PSScriptRoot -ChildPath assets -AdditionalChildPath $winAdapterName
+        $nixAdapterPath = Join-Path -Path $PSScriptRoot -ChildPath assets -AdditionalChildPath $nixAdapterName
+        $nativeAdapterPath = $IsWindows ? $winAdapterPath : $nixAdapterPath
+
+        # the scriptblock we use for the powershell adapter
+        $adapterSB = [scriptblock]::Create((Get-Content -Raw $psAdapterPath))
+
+        # All the adapters should return the same data, except with regard to the passed arguments
+        # so the expected results will differ based on platform
+        $expectedResults = & $cmd ${platformArguments} | & $adapterSB $cmd ${platformArguments}
+    }
+
+    BeforeEach {
+        $originalPath = $env:PATH
+        ${env:PATH} = "${TESTDRIVE}" + [io.path]::PathSeparator + "${env:PATH}"
+    }
+
+    AfterEach {
+        ${env:PATH} = $originalPath
+    }
+
+    Context "A JSON adapter exists" {
+
+        It "will call a function adapter if it exists" {
+            # create the adapter function
+            Set-Content -Path "function:${cmd}-json" -Value $adapterSB
+
+            # collect the results
+            $observedResult = & $cmd ${platformArguments}
+            $observedResult | Should -Be $expectedResults
+        }
+
+        It "A powershell script will be called if it is in the Path" {
+            # copy the adapter script to the path
+            Copy-Item -Path $psAdapterPath -Destination ${TESTDRIVE} -Force
+
+            # collect the results
+            $observedResult = & $cmd ${platformArguments}
+            $observedResult | Should -Be $expectedResults
+        }
+
+        It "A native script will be called if it is in the path" {
+            # copy the adapter script to the path
+            Copy-Item -Path $nativeAdapterPath -Destination ${TESTDRIVE} -Force
+
+            # collect the results
+            $observedResult = & $cmd ${platformArguments}
+            $observedResult | Should -Be $expectedResults
+        }
+    }
+
+    Context "JSON Adapter History" {
+        AfterEach {
+            If (Test-Path "function:${cmd}-json") {
+                Remove-Item -Force "function:${cmd}-json"
+            }
+            $nativeAdapterTestPath = Join-Path ${TESTDRIVE} $nativeAdapterName
+            if (Test-Path $nativeAdapterTestPath) {
+                Remove-Item -Force $nativeAdapterTestPath
+            }
+        }
+
+        It "History has the new property with the correct value for a function adapter" {
+            # create the adapter function
+            Set-Content -Path "function:${cmd}-json" -Value $adapterSB
+
+            $null = $IsWindows ? (& $cmd ${winArguments}) : (& $cmd ${nixArguments})
+            $history = Get-History -Count 1
+            $history.ConstructedPipeline | Should -Match "| ${cmd}-json$"
+        }
+
+        It "History has the new property with the correct value for powershell script adapter" {
+            Copy-Item $psAdapterPath $TESTDRIVE -Force
+            $null = & $cmd ${platformArguments}
+            $history = Get-History -Count 1
+            $history.ConstructedPipeline | Should -Match " | ${psAdapterName}$"
+        }
+
+        It "History has the new property with the correct value for native script adapter '$nativeAdapterName'" {
+            Copy-Item $nativeAdapterPath $TESTDRIVE -Force
+            $null = & $cmd ${platformArguments}
+            $history = Get-History -Count 1
+            $history.ConstructedPipeline | Should -Match " | ${nativeAdapterName}$"
+        }
+    }
+
+}

--- a/test/powershell/engine/Basic/NativeJsonAdapter.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeJsonAdapter.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Native commands will properly call a JSON adapter" -Tag "CI" {
     BeforeAll {
         # no useful overlap in commands, we have use specific commands for each platform
         $winCmd = "whoami"
-        $winArguments = "/USER","FO","CSV"
+        $winArguments = "/USER","/FO","CSV"
 
         $nixCmd = "hostname"
         $nixArguments = "-f"
@@ -19,13 +19,15 @@ Describe "Native commands will properly call a JSON adapter" -Tag "CI" {
         $cmd = $IsWindows ? $winCmd : $nixCmd
 
         # adapters
-        $psAdapterName = "hostname-json.ps1"
+        $nixPSAdapterName = "hostname-json.ps1"
+        $winPSAdapterName = "whoami-json.ps1"
         $winAdapterName = "whoami-json.bat"
         $nixAdapterName = "hostname-json.sh"
         $nativeAdapterName = $IsWindows ? $winAdapterName : $nixAdapterName
+        $scriptAdapterName = $IsWindows ? $winPSAdapterName : $nixPSAdapterName
 
         # path to the adapter
-        $psAdapterPath = Join-Path -Path $PSScriptRoot -ChildPath assets -AdditionalChildPath $psAdapterName
+        $psAdapterPath = Join-Path -Path $PSScriptRoot -ChildPath assets -AdditionalChildPath $scriptAdapterName
         $winAdapterPath = Join-Path -Path $PSScriptRoot -ChildPath assets -AdditionalChildPath $winAdapterName
         $nixAdapterPath = Join-Path -Path $PSScriptRoot -ChildPath assets -AdditionalChildPath $nixAdapterName
         $nativeAdapterPath = $IsWindows ? $winAdapterPath : $nixAdapterPath

--- a/test/powershell/engine/Basic/assets/hostname-json.ps1
+++ b/test/powershell/engine/Basic/assets/hostname-json.ps1
@@ -1,0 +1,6 @@
+'piped=' + $input
+# args are numbered differently in powershell
+'arg0=' + $args[0]
+'arg1=' + $args[1]
+'arg2=' + $args[2]
+'arg3=' + $args[3]

--- a/test/powershell/engine/Basic/assets/hostname-json.sh
+++ b/test/powershell/engine/Basic/assets/hostname-json.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+read input
+echo "piped=$input"
+echo "arg0=$1"
+echo "arg1=$2"
+echo "arg2=$3"
+echo "arg3=$4"

--- a/test/powershell/engine/Basic/assets/whoami-json.bat
+++ b/test/powershell/engine/Basic/assets/whoami-json.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set /p "piped="
+echo piped: %piped%
+echo arg0: %0
+echo arg1: %1
+echo arg2: %2
+echo arg3: %3
+echo arg4: %4

--- a/test/powershell/engine/Basic/assets/whoami-json.ps1
+++ b/test/powershell/engine/Basic/assets/whoami-json.ps1
@@ -1,0 +1,5 @@
+'piped=' + $input
+'arg0=' + $args[0]
+'arg1=' + $args[1]
+'arg2=' + $args[2]
+'arg3=' + $args[3]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR is a partial implementation of https://github.com/PowerShell/PowerShell-RFC/pull/341

It enables automatically calling a function or script after a native application if that function has the name of <appname>-json. 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

As outlined in the RFC, interacting with the output of native executables could be improved by converting the text output to objects which can then take advantage of the rest of the PowerShell infrastructure. This PR implements an approach which automatically adding a function/script named in a specific way immediately following a command.

It is somewhat tiresome to have to provide an entire pipeline to do this:

`uname -a | jc --uname | convertfrom-json`

It would be more convenient to just be able to type:

`uname`

and have a resultant object returned into the PowerShell environment.
By implementing a simple function, it would be possible to support this.

```powershell
PS> function uname-json {
 if ($args -contains "-a" ) {
     $input | jc --uname | ConvertFrom-Json
 }
 else {
     $input
 }
}
PS> uname -a

machine        : x86_64
kernel_name    : Darwin
node_name      : JamesiMac20.local
kernel_release : 22.3.0
kernel_version : Darwin Kernel Version 22.3.0: Mon Jan 30 20:42:11 PST 2023; root:xnu-8792.81.3~2/RELEASE_X86_64

PS> uname
Darwin
```

 
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): PSNativeJsonAdapter
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
