### PR TITLE
Add '-Force' to Move-Item to fix the workflow

### DIFF
--- a/.github/workflows/exp-json.yml
+++ b/.github/workflows/exp-json.yml
@@ -117,20 +117,20 @@ jobs:
           Write-Verbose -Verbose "Create PR Windows == $createPrWin"
 
           $createPrLinux = ShouldCreatePR $currentLinuxFile $newLinuxFile
-          Write-Verbose -Verbose "Create PR Windows == $createPrLinux"
+          Write-Verbose -Verbose "Create PR Linux == $createPrLinux"
 
           $createPr = $createPrWin -or $createPrLinux
           Write-Verbose -Verbose "Create PR == $createPr"
 
           if ($createPrWin) {
-            Move-Item $newWinFile $currentWinFile -Verbose
+            Move-Item $newWinFile $currentWinFile -Verbose -Force
           }
           else {
             Remove-Item $newWinFile -Verbose
           }
 
           if ($createPrLinux) {
-            Move-Item $newLinuxFile $currentLinuxFile -Verbose
+            Move-Item $newLinuxFile $currentLinuxFile -Verbose -Force
           }
           else {
             Remove-Item $newLinuxFile -Verbose


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Add '-Force' to Move-Item to fix the workflow. This is to partially fix the "PowerShell Experimental Features Json Update" GitHub action:
https://github.com/PowerShell/PowerShell/actions/workflows/exp-json.yml

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
