### PR TITLE
Revert "Use ArgumentNullException.ThrowIfNull part 2"

### DIFF
--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/ListOrganizer.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/ListOrganizer.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Management.UI.Internal
 
         partial void OnSelectItemExecutedImplementation(ExecutedRoutedEventArgs e)
         {
-            ArgumentNullException.ThrowIfNull(e.Parameter);
+            if (e.Parameter == null)
+            {
+                throw new ArgumentException("e.Parameter is null", "e");
+            }
 
             this.RaiseEvent(new DataRoutedEventArgs<object>(e.Parameter, ItemSelectedEvent));
             this.picker.IsOpen = false;
@@ -50,7 +53,10 @@ namespace Microsoft.Management.UI.Internal
 
         partial void OnDeleteItemExecutedImplementation(ExecutedRoutedEventArgs e)
         {
-            ArgumentNullException.ThrowIfNull(e.Parameter);
+            if (e.Parameter == null)
+            {
+                throw new ArgumentException("e.Parameter is null", "e");
+            }
 
             this.RaiseEvent(new DataRoutedEventArgs<object>(e.Parameter, ItemDeletedEvent));
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertyValueSelectorFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertyValueSelectorFilterRule.cs
@@ -76,7 +76,10 @@ namespace Microsoft.Management.UI.Internal
 
             foreach (FilterRule rule in rules)
             {
-                ArgumentNullException.ThrowIfNull(rule);
+                if (rule == null)
+                {
+                    throw new ArgumentException("A value within rules is null", "rules");
+                }
 
                 this.AvailableRules.AvailableValues.Add(rule);
             }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanel.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanel.cs
@@ -230,7 +230,10 @@ namespace Microsoft.Management.UI.Internal
         {
             Debug.Assert(e != null, "not null");
 
-            ArgumentNullException.ThrowIfNull(e.Parameter);
+            if (e.Parameter == null)
+            {
+                throw new ArgumentException("e.Parameter is null.", "e");
+            }
 
             List<FilterRulePanelItem> itemsToAdd = new List<FilterRulePanelItem>();
 
@@ -262,7 +265,10 @@ namespace Microsoft.Management.UI.Internal
         {
             Debug.Assert(e != null, "not null");
 
-            ArgumentNullException.ThrowIfNull(e.Parameter);
+            if (e.Parameter == null)
+            {
+                throw new ArgumentException("e.Parameter is null.", "e");
+            }
 
             FilterRulePanelItem item = e.Parameter as FilterRulePanelItem;
             if (item == null)

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRuleToDisplayNameConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRuleToDisplayNameConverter.cs
@@ -41,7 +41,10 @@ namespace Microsoft.Management.UI.Internal
             }
 
             FilterRule rule = value as FilterRule;
-            ArgumentNullException.ThrowIfNull(rule);
+            if (rule == null)
+            {
+                throw new ArgumentException("value of type FilterRule expected.", "value");
+            }
 
             return rule.DisplayName;
         }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueGetter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/PropertyValueGetter.cs
@@ -43,7 +43,11 @@ namespace Microsoft.Management.UI.Internal
         {
             propertyValue = null;
 
-            ArgumentNullException.ThrowIfNullOrEmpty(propertyName);
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                throw new ArgumentException("propertyName is empty", "propertyName");
+            }
+
             ArgumentNullException.ThrowIfNull(value);
 
             PropertyDescriptor descriptor = this.GetPropertyDescriptor(propertyName, value);

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/managementlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/managementlist.cs
@@ -340,7 +340,10 @@ namespace Microsoft.Management.UI.Internal
 
         private void ViewManager_ItemSelected(object sender, DataRoutedEventArgs<object> e)
         {
-            ArgumentNullException.ThrowIfNull(e.Data);
+            if (e.Data == null)
+            {
+                throw new ArgumentException("e.Data is null", "e");
+            }
 
             StateDescriptor<ManagementList> sd = (StateDescriptor<ManagementList>)e.Data;
             sd.RestoreState(this);
@@ -350,7 +353,10 @@ namespace Microsoft.Management.UI.Internal
 
         private void ViewManager_ItemDeleted(object sender, DataRoutedEventArgs<object> e)
         {
-            ArgumentNullException.ThrowIfNull(e.Data);
+            if (e.Data == null)
+            {
+                throw new ArgumentException("e.Data is null", "e");
+            }
 
             StateDescriptor<ManagementList> sd = (StateDescriptor<ManagementList>)e.Data;
             this.Views.Remove(sd);

--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
@@ -29,7 +29,10 @@ namespace Microsoft.PowerShell
         /// </summary>
         internal PropVariant(string value)
         {
-            ArgumentNullException.ThrowIfNull(value);
+            if (value == null)
+            {
+                throw new ArgumentException("PropVariantNullString", nameof(value));
+            }
 
 #pragma warning disable CS0618 // Type or member is obsolete (might get deprecated in future versions
             _valueType = (ushort)VarEnum.VT_LPWSTR;

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
@@ -44,9 +44,7 @@ namespace System.Diagnostics.Eventing
                 ArgumentNullException.ThrowIfNull(value, nameof(Delimiter));
 
                 if (value.Length == 0)
-                {
                     throw new ArgumentException(DotNetEventingStrings.Argument_NeedNonemptyDelimiter);
-                }
 
                 _delimiter = value;
             }
@@ -76,9 +74,7 @@ namespace System.Diagnostics.Eventing
             ArgumentNullException.ThrowIfNull(delimiter);
 
             if (delimiter.Length == 0)
-            {
                 throw new ArgumentException(DotNetEventingStrings.Argument_NeedNonemptyDelimiter);
-            }
 
             _delimiter = delimiter;
             InitProvider(providerId);

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -413,7 +413,8 @@ namespace System.Management.Automation
                     {
                         suggestion["Enabled"] = false;
 
-                        throw new ArgumentException(SuggestionStrings.RuleMustBeScriptBlock, "Rule");
+                        throw new ArgumentException(
+                            SuggestionStrings.RuleMustBeScriptBlock, "Rule");
                     }
 
                     try
@@ -481,7 +482,9 @@ namespace System.Management.Automation
                     {
                         suggestion["Enabled"] = false;
 
-                        throw new ArgumentException(SuggestionStrings.InvalidMatchType, "MatchType");
+                        throw new ArgumentException(
+                            SuggestionStrings.InvalidMatchType,
+                            "MatchType");
                     }
 
                     // If the text matches, evaluate the suggestion

--- a/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
@@ -369,11 +369,7 @@ namespace System.Management.Automation
         internal void AddChildJobWithoutBlocking(StartableJob childJob, ChildJobFlags flags, Action jobEnqueuedAction = null)
         {
             ArgumentNullException.ThrowIfNull(childJob);
-            if (childJob.JobStateInfo.State != JobState.NotStarted) 
-            {
-                throw new ArgumentException(RemotingErrorIdStrings.ThrottlingJobChildAlreadyRunning, nameof(childJob));
-            }
-
+            if (childJob.JobStateInfo.State != JobState.NotStarted) throw new ArgumentException(RemotingErrorIdStrings.ThrottlingJobChildAlreadyRunning, nameof(childJob));
             this.AssertNotDisposed();
 
             JobStateInfo newJobStateInfo = null;

--- a/src/System.Management.Automation/engine/runtime/MutableTuple.cs
+++ b/src/System.Management.Automation/engine/runtime/MutableTuple.cs
@@ -365,10 +365,7 @@ namespace System.Management.Automation
         {
             // ContractUtils.RequiresNotNull(tupleType, "tupleType");
 
-            if (index < 0 || index >= size)
-            {
-                throw new ArgumentException("index");
-            }
+            if (index < 0 || index >= size) throw new ArgumentException("index");
 
             foreach (int curIndex in GetAccessPath(size, index))
             {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7673,7 +7673,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (!fileSysInfo.Exists)
                 {
-                    throw new ArgumentException(StringUtil.Format(SessionStateStrings.PathNotFound, fileSysInfo.FullName));
+                    throw new ArgumentException(
+                        StringUtil.Format(SessionStateStrings.PathNotFound, fileSysInfo.FullName));
                 }
 
                 return fileSysInfo.LinkTarget;

--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -560,9 +560,7 @@ namespace Microsoft.PowerShell.Commands.Internal
             else
             { // there is no key which also means there is no subkey
                 if (throwOnMissingSubKey)
-                {
                     throw new ArgumentException(RegistryProviderStrings.ArgumentException_RegSubKeyAbsent);
-                }
             }
         }
 
@@ -1398,9 +1396,7 @@ namespace Microsoft.PowerShell.Commands.Internal
             }
 
             if (!Enum.IsDefined(typeof(RegistryValueKind), valueKind))
-            {
                 throw new ArgumentException(RegistryProviderStrings.Arg_RegBadKeyKind);
-            }
 
             EnsureWriteable();
 
@@ -2041,18 +2037,14 @@ namespace Microsoft.PowerShell.Commands.Internal
             while (nextSlash != -1)
             {
                 if ((nextSlash - current) > MaxKeyLength)
-                {
                     throw new ArgumentException(RegistryProviderStrings.Arg_RegKeyStrLenBug);
-                }
 
                 current = nextSlash + 1;
                 nextSlash = name.IndexOf('\\', current);
             }
 
             if ((name.Length - current) > MaxKeyLength)
-            {
                 throw new ArgumentException(RegistryProviderStrings.Arg_RegKeyStrLenBug);
-            }
         }
 
         private static void ValidateKeyMode(RegistryKeyPermissionCheck mode)

--- a/test/perf/dotnet-tools/ResultsComparer/Program.cs
+++ b/test/perf/dotnet-tools/ResultsComparer/Program.cs
@@ -149,9 +149,7 @@ namespace ResultsComparer
             var diffFiles = GetFilesToParse(args.DiffPath);
 
             if (!baseFiles.Any() || !diffFiles.Any())
-            {
                 throw new ArgumentException($"Provided paths contained no {FullBdnJsonFileExtension} files.");
-            }
 
             var baseResults = baseFiles.Select(ReadFromFile);
             var diffResults = diffFiles.Select(ReadFromFile);


### PR DESCRIPTION
Reverts PowerShell/PowerShell#19258

Revert this change because some of the exception changes are incorrect -- the original exception has better error message and the right parameter name. Examples:
- https://github.com/PowerShell/PowerShell/pull/19258#discussion_r1123510784
- https://github.com/PowerShell/PowerShell/pull/19258#discussion_r1123515823
- https://github.com/PowerShell/PowerShell/pull/19258#discussion_r1123510435
