### PR TITLE
Increase the timeout when waiting for the event log

### DIFF
--- a/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
+++ b/test/powershell/engine/Basic/GroupPolicySettings.Tests.ps1
@@ -90,7 +90,7 @@ Describe 'Group policy settings tests' -Tag CI,RequireAdminOnWindows {
                 # usually event becomes visible in the log after ~500 ms
                 # set timeout for 5 seconds
                 Wait-UntilTrue -sb { Get-WinEvent -FilterHashtable @{ ProviderName="PowerShellCore"; Id = 4103 } -MaxEvents 5 |
-                    Where-Object {$_.Message.Contains($RareCommand)} } -TimeoutInMilliseconds (5*1000) -IntervalInMilliseconds 100 |
+                    Where-Object {$_.Message.Contains($RareCommand)} } -TimeoutInMilliseconds (10*1000) -IntervalInMilliseconds 100 |
                         Should -BeTrue
             }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Increase the timeout when waiting for the event log.
This is to fix a flaky Group policy settings test in our CI:

```
  Describing Group policy settings tests
    Context Group policy settings tests
+
      [-] Module logging policy test 5.73s
        Expected $true, but got $false.
        94:                         Should -BeTrue
        at TestFeature, D:\a\1\s\test\powershell\engine\Basic\GroupPolicySettings.Tests.ps1: line 92
        at <ScriptBlock>, D:\a\1\s\test\powershell\engine\Basic\GroupPolicySettings.Tests.ps1: line 100
```

CI link: https://dev.azure.com/powershell/PowerShell/_build/results?buildId=124341&view=logs&j=99798060-e5bf-55b9-b3b5-109e6acacce3&t=b493f01d-4a7a-51fa-c890-01f5c3320034&l=316
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
