### PR TITLE
Fix using xml -Body in webcmdlets without an encoding

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1522,7 +1522,7 @@ namespace Microsoft.PowerShell.Commands
 
             byte[] bytes = null;
             XmlDocument doc = xmlNode as XmlDocument;
-            if (doc?.FirstChild is XmlDeclaration decl)
+            if (doc?.FirstChild is XmlDeclaration decl && !string.IsNullOrEmpty(decl.Encoding))
             {
                 Encoding encoding = Encoding.GetEncoding(decl.Encoding);
                 bytes = StreamHelper.EncodeToBytes(doc.OuterXml, encoding);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -581,6 +581,16 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $object.Data | Should -BeExactly 'проверка'
     }
 
+    It "Invoke-WebRequest supports sending XML requests without encoding" {
+        $uri = Get-WebListenerUrl -Test POST
+        $body = '<?xml version="1.0"?><foo/>'
+        $command = "Invoke-WebRequest -Uri '$uri' -body $([xml]$body) -ContentType 'text/xml' -method 'POST'"
+
+        $result = ExecuteWebCommand -command $command
+        $object = $result.Output.Content | ConvertFrom-Json
+        $object.Data | Should -BeExactly $body
+    }
+
     It "Invoke-WebRequest supports request that returns page containing CodPage 936 data." {
         $uri = Get-WebListenerUrl -Test 'Encoding' -TestValue 'CP936'
         $command = "Invoke-WebRequest -Uri '$uri'"
@@ -2345,6 +2355,15 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
 
         $result = ExecuteWebCommand -command $command
         $Result.Output.Data | Should -BeExactly 'проверка'
+    }
+
+    It "Invoke-RestMethod supports sending XML requests without encoding" {
+        $uri = Get-WebListenerUrl -Test POST
+        $body = '<?xml version="1.0"?><foo/>'
+        $command = "Invoke-RestMethod -Uri '$uri' -body $([xml]$body) -ContentType 'text/xml' -method 'POST'"
+
+        $result = ExecuteWebCommand -command $command
+        $Result.Output.Data | Should -BeExactly $body
     }
 
     It "Invoke-RestMethod supports request that returns page containing Code Page 936 data." {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -584,11 +584,9 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     It "Invoke-WebRequest supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
         $body = '<?xml version="1.0"?><foo/>'
-        $xmlbody = [xml]$body
-        $command = "Invoke-WebRequest -Uri '$uri' -body '$xmlbody' -ContentType 'text/xml' -method 'POST'"
+        $result = Invoke-WebRequest -Uri $uri -body [xml]$body -ContentType 'text/xml' -method 'POST'
 
-        $result = ExecuteWebCommand -command $command
-        $object = $result.Output.Content | ConvertFrom-Json
+        $object = $result.Content | ConvertFrom-Json
         $object.Data | Should -BeExactly $body
     }
 
@@ -2361,11 +2359,9 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     It "Invoke-RestMethod supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
         $body = '<?xml version="1.0"?><foo/>'
-        $xmlbody = [xml]$body
-        $command = "Invoke-RestMethod -Uri '$uri' -body '$xmlbody' -ContentType 'text/xml' -method 'POST'"
+        $result = Invoke-RestMethod -Uri $uri -body [xml]$body -ContentType 'text/xml' -method 'POST'
 
-        $result = ExecuteWebCommand -command $command
-        $Result.Output.Data | Should -BeExactly $body
+        $result.Data | Should -BeExactly $body
     }
 
     It "Invoke-RestMethod supports request that returns page containing Code Page 936 data." {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -584,7 +584,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     It "Invoke-WebRequest supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
         $body = '<?xml version="1.0"?><foo/>'
-        $result = Invoke-WebRequest -Uri $uri -body [xml]$body -ContentType 'text/xml' -method 'POST'
+        $result = Invoke-WebRequest -Uri $uri -body ([xml]$body) -ContentType 'text/xml' -method 'POST'
 
         $object = $result.Content | ConvertFrom-Json
         $object.Data | Should -BeExactly $body
@@ -2359,7 +2359,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     It "Invoke-RestMethod supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
         $body = '<?xml version="1.0"?><foo/>'
-        $result = Invoke-RestMethod -Uri $uri -body [xml]$body -ContentType 'text/xml' -method 'POST'
+        $result = Invoke-RestMethod -Uri $uri -body ([xml]$body) -ContentType 'text/xml' -method 'POST'
 
         $result.Data | Should -BeExactly $body
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -584,7 +584,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
     It "Invoke-WebRequest supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
         $body = '<?xml version="1.0"?><foo/>'
-        $command = "Invoke-WebRequest -Uri '$uri' -body $([xml]$body) -ContentType 'text/xml' -method 'POST'"
+        $xmlbody = [xml]$body
+        $command = "Invoke-WebRequest -Uri '$uri' -body '$xmlbody' -ContentType 'text/xml' -method 'POST'"
 
         $result = ExecuteWebCommand -command $command
         $object = $result.Output.Content | ConvertFrom-Json
@@ -2360,7 +2361,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
     It "Invoke-RestMethod supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
         $body = '<?xml version="1.0"?><foo/>'
-        $command = "Invoke-RestMethod -Uri '$uri' -body $([xml]$body) -ContentType 'text/xml' -method 'POST'"
+        $xmlbody = [xml]$body
+        $command = "Invoke-RestMethod -Uri '$uri' -body '$xmlbody' -ContentType 'text/xml' -method 'POST'"
 
         $result = ExecuteWebCommand -command $command
         $Result.Output.Data | Should -BeExactly $body

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2358,7 +2358,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
 
     It "Invoke-RestMethod supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
-        $body = '<?xml version="1.0"?><foo/>'
+        $body = '<?xml version="1.0"?><foo />'
         $result = Invoke-RestMethod -Uri $uri -body ([xml]$body) -ContentType 'text/xml' -method 'POST'
 
         $result.Data | Should -BeExactly $body

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -583,7 +583,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
 
     It "Invoke-WebRequest supports sending XML requests without encoding" {
         $uri = Get-WebListenerUrl -Test POST
-        $body = '<?xml version="1.0"?><foo/>'
+        $body = '<?xml version="1.0"?><foo />'
         $result = Invoke-WebRequest -Uri $uri -body ([xml]$body) -ContentType 'text/xml' -method 'POST'
 
         $object = $result.Content | ConvertFrom-Json


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Allow using xml -Body in webcmdlets without an encoding
<!-- Summarize your PR between here and the checklist. -->

## PR Context
fix #19280
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
