### PR TITLE
Add support for Cert:\Service certificates

### DIFF
--- a/src/Microsoft.PowerShell.Security/resources/CertificateProviderStrings.resx
+++ b/src/Microsoft.PowerShell.Security/resources/CertificateProviderStrings.resx
@@ -151,7 +151,7 @@
       <value>You cannot move a certificate container. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>You cannot move a certificate between user, machine, or service locations. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
     <value>You cannot move a certificate to the same store. </value>

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
@@ -64,6 +64,7 @@ namespace System.Management.Automation.Runspaces
                 ListControl.Create()
                     .StartEntry(entrySelectedByType: new[] { "Microsoft.PowerShell.Commands.X509StoreLocation" })
                         .AddItemProperty(@"Location")
+                        .AddItemProperty(@"LocationName")
                         .AddItemProperty(@"StoreNames")
                     .EndEntry()
                     .StartEntry(entrySelectedByType: new[] { "System.Security.Cryptography.X509Certificates.X509Store" })

--- a/src/System.Management.Automation/engine/Interop/Windows/CertEnumSystemStore.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/CertEnumSystemStore.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Keep native meth arg names.")]
+    internal static unsafe partial class Windows
+    {
+        [LibraryImport("Crypt32.dll", EntryPoint = "CertEnumSystemStore", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static unsafe partial bool CertEnumSystemStore(
+            uint dwFlags,
+            string? pvSystemStoreLocation,
+            nint pvArg,
+            PfnCertEnumSystemStore pfnEnum);
+
+        internal delegate bool PfnCertEnumSystemStore(
+            [MarshalAs(UnmanagedType.LPWStr)] string storeName,
+            uint dwFlags,
+            nint pStoreInfo,
+            nint pvReserved,
+            nint pvArg);
+    }
+}

--- a/src/System.Management.Automation/security/nativeMethods.cs
+++ b/src/System.Management.Automation/security/nativeMethods.cs
@@ -143,24 +143,6 @@ namespace System.Management.Automation.Security
         // crypt32.dll stuff
         //
 
-        [DllImport("crypt32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        internal static extern
-        bool CertEnumSystemStore(CertStoreFlags Flags,
-                                 IntPtr notUsed1,
-                                 IntPtr notUsed2,
-                                 CertEnumSystemStoreCallBackProto fn);
-
-        /// <summary>
-        /// Signature of call back function used by CertEnumSystemStore.
-        /// </summary>
-        internal delegate
-        bool CertEnumSystemStoreCallBackProto([MarshalAs(UnmanagedType.LPWStr)]
-                                               string storeName,
-                                               DWORD dwFlagsNotUsed,
-                                               IntPtr notUsed1,
-                                               IntPtr notUsed2,
-                                               IntPtr notUsed3);
-
         /// <summary>
         /// Signature of cert enumeration function.
         /// </summary>


### PR DESCRIPTION
# PR Summary

Add support for managing service certificate stores using the Cert:\Service\$serviceName\$storeName syntax. This expands on the existing set of locations CurrentUser and LocalMachine and also sets up the code to support future store locations like User.

## PR Context

Windows supports certificates to be stored in a service context which can be used by services like NTDS to store a certificate used for LDAPS. Currently the `Cert` provider only supports the `CurrentUser` and `LocalMachine` locations and dotnet does not offer a managed way to open any other locations. This adds the capability to manage stores for another service under `Cert:\Service\$serviceName`, for example `Get-ChildItem -Path Cert:\Service\NTDS\My` will enumerate all the certificates in the `Personal\My` store for the `NTDS` service.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/pull/9932
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
