### PR TITLE
-Encoding add ANSI option

### DIFF
--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -11,20 +11,20 @@ namespace System.Management.Automation
 {
     internal static class EncodingConversion
     {
+        internal const string ANSI = "ansi";
         internal const string Ascii = "ascii";
         internal const string BigEndianUnicode = "bigendianunicode";
         internal const string BigEndianUtf32 = "bigendianutf32";
         internal const string Default = "default";
         internal const string OEM = "oem";
+        internal const string String = "string";
         internal const string Unicode = "unicode";
+        internal const string Unknown = "unknown";
         internal const string Utf7 = "utf7";
         internal const string Utf8 = "utf8";
         internal const string Utf8Bom = "utf8BOM";
         internal const string Utf8NoBom = "utf8NoBOM";
         internal const string Utf32 = "utf32";
-        internal const string ANSI = "ansi";
-        internal const string String = "string";
-        internal const string Unknown = "unknown";
 
         internal static readonly string[] TabCompletionResults = {
                 Ascii, BigEndianUnicode, BigEndianUtf32, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
@@ -32,22 +32,22 @@ namespace System.Management.Automation
 
         internal static readonly Dictionary<string, Encoding> encodingMap = new(StringComparer.OrdinalIgnoreCase)
         {
+            { ANSI, Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.ANSICodePage) },
             { Ascii, Encoding.ASCII },
             { BigEndianUnicode, Encoding.BigEndianUnicode },
             { BigEndianUtf32, new UTF32Encoding(bigEndian: true, byteOrderMark: true) },
             { Default, Encoding.Default },
             { OEM, ClrFacade.GetOEMEncoding() },
+            { String, Encoding.Unicode },
             { Unicode, Encoding.Unicode },
+            { Unknown, Encoding.Unicode },
 #pragma warning disable SYSLIB0001
             { Utf7, Encoding.UTF7 },
 #pragma warning restore SYSLIB0001
             { Utf8, Encoding.Default },
             { Utf8Bom, Encoding.UTF8 },
             { Utf8NoBom, Encoding.Default },
-            { Utf32, Encoding.UTF32 },
-            { ANSI, Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.ANSICodePage) },
-            { String, Encoding.Unicode },
-            { Unknown, Encoding.Unicode },
+            { Utf32, Encoding.UTF32 },  
         };
 
         /// <summary>

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 using System.Management.Automation.Internal;
@@ -10,25 +11,26 @@ namespace System.Management.Automation
 {
     internal static class EncodingConversion
     {
-        internal const string Unknown = "unknown";
-        internal const string String = "string";
-        internal const string Unicode = "unicode";
+        internal const string Ascii = "ascii";
         internal const string BigEndianUnicode = "bigendianunicode";
         internal const string BigEndianUtf32 = "bigendianutf32";
-        internal const string Ascii = "ascii";
-        internal const string Utf8 = "utf8";
-        internal const string Utf8NoBom = "utf8NoBOM";
-        internal const string Utf8Bom = "utf8BOM";
-        internal const string Utf7 = "utf7";
-        internal const string Utf32 = "utf32";
         internal const string Default = "default";
         internal const string OEM = "oem";
+        internal const string Unicode = "unicode";
+        internal const string Utf7 = "utf7";
+        internal const string Utf8 = "utf8";
+        internal const string Utf8Bom = "utf8BOM";
+        internal const string Utf8NoBom = "utf8NoBOM";
+        internal const string Utf32 = "utf32";
+        internal const string ANSI = "ansi";
+        internal const string String = "string";
+        internal const string Unknown = "unknown";
 
         internal static readonly string[] TabCompletionResults = {
                 Ascii, BigEndianUnicode, BigEndianUtf32, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
             };
 
-        internal static readonly Dictionary<string, Encoding> encodingMap = new Dictionary<string, Encoding>(StringComparer.OrdinalIgnoreCase)
+        internal static readonly Dictionary<string, Encoding> encodingMap = new(StringComparer.OrdinalIgnoreCase)
         {
             { Ascii, Encoding.ASCII },
             { BigEndianUnicode, Encoding.BigEndianUnicode },
@@ -43,6 +45,7 @@ namespace System.Management.Automation
             { Utf8Bom, Encoding.UTF8 },
             { Utf8NoBom, Encoding.Default },
             { Utf32, Encoding.UTF32 },
+            { ANSI, Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.ANSICodePage) },
             { String, Encoding.Unicode },
             { Unknown, Encoding.Unicode },
         };
@@ -60,8 +63,7 @@ namespace System.Management.Automation
                 return Encoding.Default;
             }
 
-            Encoding foundEncoding;
-            if (encodingMap.TryGetValue(encoding, out foundEncoding))
+            if (encodingMap.TryGetValue(encoding, out Encoding foundEncoding))
             {
                 // Write a warning if using utf7 as it is obsolete in .NET5
                 if (string.Equals(encoding, Utf7, StringComparison.OrdinalIgnoreCase))
@@ -122,10 +124,10 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        return System.Text.Encoding.GetEncoding(stringName);
+                        return Encoding.GetEncoding(stringName);
                     }
                 case int intName:
-                    return System.Text.Encoding.GetEncoding(intName);
+                    return Encoding.GetEncoding(intName);
             }
 
             return inputData;

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -27,7 +27,7 @@ namespace System.Management.Automation
         internal const string Utf32 = "utf32";
 
         internal static readonly string[] TabCompletionResults = {
-                Ascii, BigEndianUnicode, BigEndianUtf32, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
+                ANSI, Ascii, BigEndianUnicode, BigEndianUtf32, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
             };
 
         internal static readonly Dictionary<string, Encoding> encodingMap = new(StringComparer.OrdinalIgnoreCase)
@@ -140,6 +140,7 @@ namespace System.Management.Automation
     internal sealed class ArgumentEncodingCompletionsAttribute : ArgumentCompletionsAttribute
     {
         public ArgumentEncodingCompletionsAttribute() : base(
+            EncodingConversion.ANSI,
             EncodingConversion.Ascii,
             EncodingConversion.BigEndianUnicode,
             EncodingConversion.BigEndianUtf32,

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -45,7 +45,7 @@ Describe "Redirection operator now supports encoding changes" -Tags "CI" {
         }
     }
 
-    $availableEncodings = 
+    $availableEncodings =
         @([System.Text.Encoding]::ASCII
           [System.Text.Encoding]::BigEndianUnicode
           [System.Text.UTF32Encoding]::new($true,$true)
@@ -53,7 +53,7 @@ Describe "Redirection operator now supports encoding changes" -Tags "CI" {
           [System.Text.Encoding]::UTF7
           [System.Text.Encoding]::UTF8
           [System.Text.Encoding]::UTF32)
-              
+
     foreach($encoding in $availableEncodings) {
 
         $encodingName = $encoding.EncodingName

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -104,7 +104,7 @@ Describe "Get-Content" -Tags "CI" {
         @{EncodingName = 'UTF8NoBOM'},
         @{EncodingName = 'UTF7'},
         @{EncodingName = 'UTF32'},
-        @{EncodingName = 'Ascii'}
+        @{EncodingName = 'Ascii'},
         @{EncodingName = 'ANSI'}
         ){
         param($EncodingName)
@@ -115,7 +115,7 @@ Describe "Get-Content" -Tags "CI" {
               @('𐍈1','𐍈𐍈2','𐍈𐍈𐍈3','𐍈𐍈𐍈𐍈4','𐍈𐍈𐍈𐍈𐍈5')) # utf-32
         ForEach ($content in $contentSets)
         {
-            $tailCount = 3
+            $tailCount = 4
             $testPath = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
             $content | Set-Content -Path $testPath -Encoding $EncodingName
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -105,6 +105,7 @@ Describe "Get-Content" -Tags "CI" {
         @{EncodingName = 'UTF7'},
         @{EncodingName = 'UTF32'},
         @{EncodingName = 'Ascii'}
+        @{EncodingName = 'ANSI'}
         ){
         param($EncodingName)
 
@@ -221,7 +222,7 @@ Describe "Get-Content" -Tags "CI" {
         $expected = 'He', 'o,', '', 'Wor', "d${nl}He", 'o2,', '', 'Wor', "d2${nl}"
         for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]    | Should -BeExactly $expected[$i]}
     }
-    
+
     Context "Alternate Data Stream support on Windows" {
         It "Should support NTFS streams using colon syntax" -Skip:(!$IsWindows) {
             Set-Content "${testPath}:Stream" -Value "Foo"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Hex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Hex.Tests.ps1
@@ -438,7 +438,7 @@ public enum TestSByteEnum : sbyte {
                 Count                = 2
                 ExpectedResult       = "0000000000000000   00 00 00 68 00 00 00 65 00 00 00 6C 00 00 00 6C     h   e   l   l"
                 ExpectedSecondResult = "0000000000000010   00 00 00 6F                                         o"
-            }           
+            }
             @{
                 Name           = "Can process Unicode encoding 'fhx -InputObject 'hello' -Encoding Unicode'"
                 Encoding       = "Unicode"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Add ANSI option to -Encoding
- Small cleanup
- Reorder stuff

-Encoding ANSI equals to `[System.Text.Encoding]::GetEncoding([CultureInfo]::CurrentCulture.TextInfo.ANSICodePage)`
or `-Encoding [CultureInfo]::CurrentCulture.TextInfo.ANSICodePage`

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/6562 @mklement0 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9887<!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
