### PR TITLE
Invoke-RestMethod/WebRequest: Support CTRL-C when reading data using cancellation token

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -8,6 +8,7 @@ using System.Management.Automation;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -32,19 +33,21 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class.
         /// </summary>
-        /// <param name="response"></param>
-        public BasicHtmlWebResponseObject(HttpResponseMessage response) : this(response, null) { }
+        /// <param name="response">The response.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public BasicHtmlWebResponseObject(HttpResponseMessage response, CancellationToken cancellationToken) : this(response, null, cancellationToken) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class
         /// with the specified <paramref name="contentStream"/>.
         /// </summary>
-        /// <param name="response"></param>
-        /// <param name="contentStream"></param>
-        public BasicHtmlWebResponseObject(HttpResponseMessage response, Stream contentStream) : base(response, contentStream)
+        /// <param name="response">The response.</param>
+        /// <param name="contentStream">The content stream associated with the response.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public BasicHtmlWebResponseObject(HttpResponseMessage response, Stream contentStream, CancellationToken cancellationToken) : base(response, contentStream, cancellationToken)
         {
             EnsureHtmlParser();
-            InitializeContent();
+            InitializeContent(cancellationToken);
             InitializeRawContent(response);
         }
 
@@ -159,7 +162,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Reads the response content from the web response.
         /// </summary>
-        protected void InitializeContent()
+        /// <param name="cancellationToken">The cancellation token.</param>
+        protected void InitializeContent(CancellationToken cancellationToken)
         {
             string contentType = ContentHelper.GetContentType(BaseResponse);
             if (ContentHelper.IsText(contentType))
@@ -167,7 +171,7 @@ namespace Microsoft.PowerShell.Commands
                 // Fill the Content buffer
                 string characterSet = WebResponseHelper.GetCharacterSet(BaseResponse);
 
-                Content = StreamHelper.DecodeStream(RawContentStream, characterSet, out Encoding encoding);
+                Content = StreamHelper.DecodeStream(RawContentStream, characterSet, out Encoding encoding, cancellationToken);
                 Encoding = encoding;
             }
             else

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -611,7 +611,7 @@ namespace Microsoft.PowerShell.Commands
                                 string detailMsg = string.Empty;
                                 try
                                 {
-                                    string error = StreamHelper.GetResponseString(response);
+                                    string error = StreamHelper.GetResponseString(response, _cancelToken.Token);
                                     detailMsg = FormatErrorMessage(error, contentType);
                                 }
                                 catch
@@ -655,6 +655,11 @@ namespace Microsoft.PowerShell.Commands
                             }
 
                             ThrowTerminatingError(er);
+                        }
+                        finally 
+                        {
+                            _cancelToken?.Dispose();
+                            _cancelToken = null;
                         }
 
                         if (_followRelLink)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.Commands
         {
             ArgumentNullException.ThrowIfNull(response);
 
-            Stream responseStream = StreamHelper.GetResponseStream(response);
+            Stream responseStream = StreamHelper.GetResponseStream(response, _cancelToken.Token);
             if (ShouldWriteToPipeline)
             {
                 // creating a MemoryStream wrapper to response stream here to support IsStopping.
@@ -42,8 +42,9 @@ namespace Microsoft.PowerShell.Commands
                     responseStream,
                     StreamHelper.ChunkSize,
                     this,
-                    response.Content.Headers.ContentLength.GetValueOrDefault());
-                WebResponseObject ro = WebResponseObjectFactory.GetResponseObject(response, responseStream, this.Context);
+                    response.Content.Headers.ContentLength.GetValueOrDefault(),
+                    _cancelToken.Token);
+                WebResponseObject ro = WebResponseObjectFactory.GetResponseObject(response, responseStream, this.Context, _cancelToken.Token);
                 ro.RelationLink = _relationLink;
                 WriteObject(ro);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObjectFactory.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObjectFactory.CoreClr.cs
@@ -9,9 +9,9 @@ namespace Microsoft.PowerShell.Commands
 {
     internal static class WebResponseObjectFactory
     {
-        internal static WebResponseObject GetResponseObject(HttpResponseMessage response, Stream responseStream, ExecutionContext executionContext)
+        internal static WebResponseObject GetResponseObject(HttpResponseMessage response, Stream responseStream, ExecutionContext executionContext, System.Threading.CancellationToken cancellationToken)
         {
-            WebResponseObject output = WebResponseHelper.IsText(response) ? new BasicHtmlWebResponseObject(response, responseStream) : new WebResponseObject(response, responseStream);
+            WebResponseObject output = WebResponseHelper.IsText(response) ? new BasicHtmlWebResponseObject(response, responseStream, cancellationToken) : new WebResponseObject(response, responseStream, cancellationToken);
 
             return output;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -25,8 +25,9 @@ namespace Microsoft.PowerShell.Commands
 
         private readonly long? _contentLength;
         private readonly Stream _originalStreamToProxy;
-        private bool _isInitialized = false;
         private readonly Cmdlet _ownerCmdlet;
+        private readonly CancellationToken _cancellationToken;
+        private bool _isInitialized = false;
 
         #endregion Data
 
@@ -34,15 +35,17 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Initializes a new instance of the <see cref="WebResponseContentMemoryStream"/> class.
         /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="initialCapacity"></param>
+        /// <param name="stream">Response stream.</param>
+        /// <param name="initialCapacity">Presize the memory stream.</param>
         /// <param name="cmdlet">Owner cmdlet if any.</param>
         /// <param name="contentLength">Expected download size in Bytes.</param>
-        internal WebResponseContentMemoryStream(Stream stream, int initialCapacity, Cmdlet cmdlet, long? contentLength) : base(initialCapacity)
+        /// <param name="cancellationToken">Cancellation token.</param>
+        internal WebResponseContentMemoryStream(Stream stream, int initialCapacity, Cmdlet cmdlet, long? contentLength, CancellationToken cancellationToken) : base(initialCapacity)
         {
             this._contentLength = contentLength;
             _originalStreamToProxy = stream;
             _ownerCmdlet = cmdlet;
+            _cancellationToken = cancellationToken;
         }
         #endregion Constructors
 
@@ -77,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            Initialize();
+            Initialize(cancellationToken);
             return base.CopyToAsync(destination, bufferSize, cancellationToken);
         }
 
@@ -102,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            Initialize();
+            Initialize(cancellationToken);
             return base.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
@@ -153,7 +156,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            Initialize();
+            Initialize(cancellationToken);
             return base.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
@@ -182,13 +185,16 @@ namespace Microsoft.PowerShell.Commands
             base.Dispose(disposing);
         }
 
-        /// <summary>
-        /// </summary>
-        private void Initialize()
+        private void Initialize(CancellationToken cancellationToken = default)
         {
-            if (_isInitialized) 
+            if (_isInitialized)
             {
                 return;
+            }
+
+            if (cancellationToken == default)
+            {
+                cancellationToken = _cancellationToken;
             }
 
             _isInitialized = true;
@@ -220,7 +226,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
 
-                    read = _originalStreamToProxy.Read(buffer, 0, buffer.Length);
+                    read = _originalStreamToProxy.ReadAsync(buffer, 0, buffer.Length, cancellationToken).GetAwaiter().GetResult();
 
                     if (read > 0)
                     {
@@ -237,11 +243,11 @@ namespace Microsoft.PowerShell.Commands
 
                 // Make sure the length is set appropriately
                 base.SetLength(totalRead);
-                base.Seek(0, SeekOrigin.Begin);
+                Seek(0, SeekOrigin.Begin);
             }
             catch (Exception)
             {
-                base.Dispose();
+                Dispose();
                 throw;
             }
         }
@@ -329,7 +335,7 @@ namespace Microsoft.PowerShell.Commands
             WriteToStream(stream, output, cmdlet, contentLength, cancellationToken);
         }
 
-        private static string StreamToString(Stream stream, Encoding encoding)
+        private static string StreamToString(Stream stream, Encoding encoding, CancellationToken cancellationToken)
         {
             StringBuilder result = new(capacity: ChunkSize);
             Decoder decoder = encoding.GetDecoder();
@@ -347,7 +353,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // Read at most the number of bytes that will fit in the input buffer. The
                 // return value is the actual number of bytes read, or zero if no bytes remain.
-                bytesRead = stream.Read(bytes, 0, useBufferSize * 4);
+                bytesRead = stream.ReadAsync(bytes, 0, useBufferSize * 4, cancellationToken).GetAwaiter().GetResult();
 
                 bool completed = false;
                 int byteIndex = 0;
@@ -355,10 +361,8 @@ namespace Microsoft.PowerShell.Commands
                 while (!completed)
                 {
                     // If this is the last input data, flush the decoder's internal buffer and state.
-                    bool flush = (bytesRead == 0);
-                    decoder.Convert(bytes, byteIndex, bytesRead - byteIndex,
-                                    chars, 0, useBufferSize, flush,
-                                    out int bytesUsed, out int charsUsed, out completed);
+                    bool flush = bytesRead == 0;
+                    decoder.Convert(bytes, byteIndex, bytesRead - byteIndex, chars, 0, useBufferSize, flush, out int bytesUsed, out int charsUsed, out completed);
 
                     // The conversion produced the number of characters indicated by charsUsed. Write that number
                     // of characters to our result buffer
@@ -376,12 +380,13 @@ namespace Microsoft.PowerShell.Commands
                         break;
                     }
                 }
-            } while (bytesRead != 0);
+            }
+            while (bytesRead != 0);
 
             return result.ToString();
         }
 
-        internal static string DecodeStream(Stream stream, string characterSet, out Encoding encoding)
+        internal static string DecodeStream(Stream stream, string characterSet, out Encoding encoding, CancellationToken cancellationToken)
         {
             bool isDefaultEncoding = false;
             if (!TryGetEncoding(characterSet, out encoding))
@@ -391,7 +396,7 @@ namespace Microsoft.PowerShell.Commands
                 isDefaultEncoding = true;
             }
 
-            string content = StreamToString(stream, encoding);
+            string content = StreamToString(stream, encoding, cancellationToken);
             if (isDefaultEncoding)
             {
                 // We only look within the first 1k characters as the meta element and
@@ -400,13 +405,13 @@ namespace Microsoft.PowerShell.Commands
 
                 // Check for a charset attribute on the meta element to override the default
                 Match match = s_metaRegex.Match(substring);
-                
+
                 // Check for a encoding attribute on the xml declaration to override the default
                 if (!match.Success)
                 {
                     match = s_xmlRegex.Match(substring);
                 }
-                
+
                 if (match.Success)
                 {
                     characterSet = match.Groups["charset"].Value;
@@ -414,7 +419,7 @@ namespace Microsoft.PowerShell.Commands
                     if (TryGetEncoding(characterSet, out Encoding localEncoding))
                     {
                         stream.Seek(0, SeekOrigin.Begin);
-                        content = StreamToString(stream, localEncoding);
+                        content = StreamToString(stream, localEncoding, cancellationToken);
                         encoding = localEncoding;
                     }
                 }
@@ -443,11 +448,11 @@ namespace Microsoft.PowerShell.Commands
                 @"<meta\s.*[^.><]*charset\s*=\s*[""'\n]?(?<charset>[A-Za-z].[^\s""'\n<>]*)[\s""'\n>]",
                 RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.NonBacktracking
             );
-        
+
         private static readonly Regex s_xmlRegex = new(
                 @"<\?xml\s.*[^.><]*encoding\s*=\s*[""'\n]?(?<charset>[A-Za-z].[^\s""'\n<>]*)[\s""'\n>]",
                 RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.NonBacktracking
-            ); 
+            );
 
         internal static byte[] EncodeToBytes(string str, Encoding encoding)
         {
@@ -457,9 +462,9 @@ namespace Microsoft.PowerShell.Commands
             return encoding.GetBytes(str);
         }
 
-        internal static string GetResponseString(HttpResponseMessage response) => response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        internal static string GetResponseString(HttpResponseMessage response, CancellationToken cancellationToken) => response.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
 
-        internal static Stream GetResponseStream(HttpResponseMessage response) => response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+        internal static Stream GetResponseStream(HttpResponseMessage response, CancellationToken cancellationToken) => response.Content.ReadAsStreamAsync(cancellationToken).GetAwaiter().GetResult();
 
         #endregion Static Methods
     }


### PR DESCRIPTION
APIs that should be cancelled are passed the cancellation token and _cancelToken is configured with CancelAfter() when request timeout is specified.

Switched use of synchronous stream APIs to asynchronous APIs that use the cancellation token.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR closes #16145

The root cause of these issues was that once the response headers are read, the cancellation token was not always being passed to APIs that deal with reading the response stream. 

In some scenarios, CTRL-C worked (where the cancellation token was being passed down), but this was not occurring in all scenarios and the use of blocking read APIs that do not take cancellation tokens prevented the early cancellation when CTRL-C was used.

## PR Context

This PR helps because it allows all I/O in the web requests cmdlets to be cancelled if the user uses CTRL-C to terminate processing.

A previous iteration of this PR added a timeout, but was incorrect as the desired behaviour is to cancel if the connection is stalled for 5 minutes, not after a fixed timeout.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
