### PR TITLE
Add RelativeBasePath parameter to Resolve-Path

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -22,6 +22,8 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = "Path",
                    Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Position = 0, ParameterSetName = "PathWithRelativeBase",
+                   Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         public string[] Path
         {
             get
@@ -39,6 +41,8 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the literal path parameter to the command.
         /// </summary>
         [Parameter(ParameterSetName = "LiteralPath",
+                   Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = "LiteralPathWithRelativeBase",
                    Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
         [Alias("PSPath", "LP")]
         public string[] LiteralPath
@@ -59,7 +63,8 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the value that determines if the resolved path should
         /// be resolved to its relative version.
         /// </summary>
-        [Parameter()]
+        [Parameter(ParameterSetName = "Path")]
+        [Parameter(ParameterSetName = "LiteralPath")]
         public SwitchParameter Relative
         {
             get
@@ -78,8 +83,21 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the path the resolved relative path should be based off.
         /// </summary>
-        [Parameter()]
-        public string RelativeBasePath { get; set; }
+        [Parameter(Mandatory = true, ParameterSetName = "PathWithRelativeBase")]
+        [Parameter(Mandatory = true, ParameterSetName = "LiteralPathWithRelativeBase")]
+        public string RelativeBasePath
+        { 
+            get
+            {
+                return _relativeBasePath;
+            }
+
+            set
+            {
+                _relative = true;
+                _relativeBasePath = value;
+            }
+        }
 
         #endregion Parameters
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -49,6 +49,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         }
     }
     It 'Resolve-Path -Relative should support user specified base paths' {
-        Resolve-Path -Path $fakeRoot -Relative -RelativeBasePath $testRoot | Should -BeExactly '.\fakeroot'
+        $Expected = Join-Path -Path .\ -ChildPath fakeroot
+        Resolve-Path -Path $fakeRoot -Relative -RelativeBasePath $testRoot | Should -BeExactly $Expected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -50,6 +50,6 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
     }
     It 'Resolve-Path -Relative should support user specified base paths' {
         $Expected = Join-Path -Path .\ -ChildPath fakeroot
-        Resolve-Path -Path $fakeRoot -Relative -RelativeBasePath $testRoot | Should -BeExactly $Expected
+        Resolve-Path -Path $fakeRoot -RelativeBasePath $testRoot | Should -BeExactly $Expected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -48,4 +48,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             Pop-Location
         }
     }
+    It 'Resolve-Path -Relative should support user specified base paths' {
+        Resolve-Path -Path $fakeRoot -Relative -RelativeBasePath $testRoot | Should -BeExactly '.\fakeroot'
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -48,7 +48,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             Pop-Location
         }
     }
-    It 'Resolve-Path -Relative should support user specified base paths' {
+    It 'Resolve-Path should support user specified base paths' {
         $Expected = Join-Path -Path .\ -ChildPath fakeroot
         Resolve-Path -Path $fakeRoot -RelativeBasePath $testRoot | Should -BeExactly $Expected
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Adds a `RelativeBasePath` path parameter to `Resolve-Path` which allows the user to specify a path to base the relative path off.

For example, if the current location is C:\Windows\System32 and the user wants to resolve the relative path to the temp folder from their home folder they can do it like this: Resolve-Path -Path $env:TEMP -RelativeBasePath $HOME which would output: .\AppData\Local\Temp  
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/8435
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9940 <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
