### PR TITLE
Initialize Regex lazy in BasicHtmlWebResponseObject

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -220,26 +220,27 @@ namespace Microsoft.PowerShell.Commands
         }
 
         #endregion Methods
-    }
 
-    internal static class HtmlParser
-    {
-        internal static Regex s_tagRegex = new Regex(@"<\w+((\s+[^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>",
+        // This class is needed so the static Regexes are initialized only the first time they are used
+        private static class HtmlParser
+        {
+            internal static Regex s_tagRegex = new Regex(@"<\w+((\s+[^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>",
+                    RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+            internal static Regex s_attribsRegex = new Regex(@"(?<=\s+)([^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)",
                 RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        internal static Regex s_attribsRegex = new Regex(@"(?<=\s+)([^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)",
-            RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static Regex s_attribNameValueRegex = new Regex(@"([^""'>/=\s\p{Cc}]+)(?:\s*=\s*(?:""(.*?)""|'(.*?)'|([^'"">\s]+)))?",
+                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        internal static Regex s_attribNameValueRegex = new Regex(@"([^""'>/=\s\p{Cc}]+)(?:\s*=\s*(?:""(.*?)""|'(.*?)'|([^'"">\s]+)))?",
-            RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static Regex s_inputFieldRegex = new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)",
+                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        internal static Regex s_inputFieldRegex = new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)",
-            RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static Regex s_linkRegex = new Regex(@"<a\s+[^>]*(/>|>.*?</a>)",
+                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        internal static Regex s_linkRegex = new Regex(@"<a\s+[^>]*(/>|>.*?</a>)",
-            RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        internal static Regex s_imageRegex = new Regex(@"<img\s[^>]*?>",
-            RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static Regex s_imageRegex = new Regex(@"<img\s[^>]*?>",
+                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -224,22 +224,22 @@ namespace Microsoft.PowerShell.Commands
         // This class is needed so the static Regexes are initialized only the first time they are used
         private static class HtmlParser
         {
-            internal static Regex s_tagRegex = new Regex(@"<\w+((\s+[^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>",
+            internal static readonly Regex s_tagRegex = new Regex(@"<\w+((\s+[^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>",
                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static Regex s_attribsRegex = new Regex(@"(?<=\s+)([^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)",
+            internal static readonly Regex s_attribsRegex = new Regex(@"(?<=\s+)([^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)",
                 RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static Regex s_attribNameValueRegex = new Regex(@"([^""'>/=\s\p{Cc}]+)(?:\s*=\s*(?:""(.*?)""|'(.*?)'|([^'"">\s]+)))?",
+            internal static readonly Regex s_attribNameValueRegex = new Regex(@"([^""'>/=\s\p{Cc}]+)(?:\s*=\s*(?:""(.*?)""|'(.*?)'|([^'"">\s]+)))?",
                 RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static Regex s_inputFieldRegex = new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)",
+            internal static readonly Regex s_inputFieldRegex = new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)",
                 RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static Regex s_linkRegex = new Regex(@"<a\s+[^>]*(/>|>.*?</a>)",
+            internal static readonly Regex s_linkRegex = new Regex(@"<a\s+[^>]*(/>|>.*?</a>)",
                 RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static Regex s_imageRegex = new Regex(@"<img\s[^>]*?>",
+            internal static readonly Regex s_imageRegex = new Regex(@"<img\s[^>]*?>",
                 RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.Commands
                 if (_inputFields == null)
                 {
                     List<PSObject> parsedFields = new();
-                    MatchCollection fieldMatch = HtmlParser.s_inputFieldRegex.Matches(Content);
+                    MatchCollection fieldMatch = HtmlParser.InputFieldRegex.Matches(Content);
                     foreach (Match field in fieldMatch)
                     {
                         parsedFields.Add(CreateHtmlObject(field.Value, "INPUT"));
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.Commands
                 if (_links == null)
                 {
                     List<PSObject> parsedLinks = new();
-                    MatchCollection linkMatch = HtmlParser.s_linkRegex.Matches(Content);
+                    MatchCollection linkMatch = HtmlParser.LinkRegex.Matches(Content);
                     foreach (Match link in linkMatch)
                     {
                         parsedLinks.Add(CreateHtmlObject(link.Value, "A"));
@@ -121,7 +121,7 @@ namespace Microsoft.PowerShell.Commands
                 if (_images == null)
                 {
                     List<PSObject> parsedImages = new();
-                    MatchCollection imageMatch = HtmlParser.s_imageRegex.Matches(Content);
+                    MatchCollection imageMatch = HtmlParser.ImageRegex.Matches(Content);
                     foreach (Match image in imageMatch)
                     {
                         parsedImages.Add(CreateHtmlObject(image.Value, "IMG"));
@@ -184,16 +184,16 @@ namespace Microsoft.PowerShell.Commands
             {
                 // Extract just the opening tag of the HTML element (omitting the closing tag and any contents,
                 // including contained HTML elements)
-                Match match = HtmlParser.s_tagRegex.Match(outerHtml);
+                Match match = HtmlParser.TagRegex.Match(outerHtml);
 
                 // Extract all the attribute specifications within the HTML element opening tag
-                MatchCollection attribMatches = HtmlParser.s_attribsRegex.Matches(match.Value);
+                MatchCollection attribMatches = HtmlParser.AttribsRegex.Matches(match.Value);
 
                 foreach (Match attribMatch in attribMatches)
                 {
                     // Extract the name and value for this attribute (allowing for variations like single/double/no
                     // quotes, and no value at all)
-                    Match nvMatches = HtmlParser.s_attribNameValueRegex.Match(attribMatch.Value);
+                    Match nvMatches = HtmlParser.AttribNameValueRegex.Match(attribMatch.Value);
                     Debug.Assert(nvMatches.Groups.Count == 5);
 
                     // Name is always captured by group #1
@@ -224,23 +224,17 @@ namespace Microsoft.PowerShell.Commands
         // This class is needed so the static Regexes are initialized only the first time they are used
         private static class HtmlParser
         {
-            internal static readonly Regex s_tagRegex = new Regex(@"<\w+((\s+[^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>",
-                    RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static readonly Regex AttribsRegex = new Regex(@"(?<=\s+)([^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static readonly Regex s_attribsRegex = new Regex(@"(?<=\s+)([^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)",
-                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static readonly Regex AttribNameValueRegex = new Regex(@"([^""'>/=\s\p{Cc}]+)(?:\s*=\s*(?:""(.*?)""|'(.*?)'|([^'"">\s]+)))?", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static readonly Regex s_attribNameValueRegex = new Regex(@"([^""'>/=\s\p{Cc}]+)(?:\s*=\s*(?:""(.*?)""|'(.*?)'|([^'"">\s]+)))?",
-                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static readonly Regex ImageRegex = new Regex(@"<img\s[^>]*?>", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static readonly Regex s_inputFieldRegex = new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)",
-                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static readonly Regex InputFieldRegex = new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static readonly Regex s_linkRegex = new Regex(@"<a\s+[^>]*(/>|>.*?</a>)",
-                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static readonly Regex LinkRegex = new Regex(@"<a\s+[^>]*(/>|>.*?</a>)", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            internal static readonly Regex s_imageRegex = new Regex(@"<img\s[^>]*?>",
-                RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            internal static readonly Regex TagRegex = new Regex(@"<\w+((\s+[^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
         }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -26,10 +26,15 @@ namespace Microsoft.PowerShell.Commands
         private static readonly Regex s_tagRegex = CreateTagRegex();
 
         private static Regex CreateAttribsRegex() => new Regex(@"(?<=\s+)([^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static Regex CreateAttribNameValueRegex() => new Regex(@"([^""'>/=\s\p{Cc}]+)(?:\s*=\s*(?:""(.*?)""|'(.*?)'|([^'"">\s]+)))?", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static Regex CreateImageRegex() => new Regex(@"<img\s[^>]*?>", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static Regex CreateInputFieldRegex() => new Regex(@"<input\s+[^>]*(/?>|>.*?</input>)", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static Regex CreateLinkRegex() => new Regex(@"<a\s+[^>]*(/>|>.*?</a>)", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         private static Regex CreateTagRegex() => new Regex(@"<\w+((\s+[^""'>/=\s\p{Cc}]+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         #endregion Private Fields


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Reorganize regex in `BasicHtmlWebResponseObject.Common.cs`


<!-- Summarize your PR between here and the checklist. -->

## PR Context
DIscussed with @iSazonov in #19359

Used the same conventions found here:
https://github.com/dotnet/runtime/blob/673afec8a76cb4437eba318d7132140b7da9b111/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs#L50

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
