### PR TITLE
Simplify ContentHelper methods

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -61,28 +61,6 @@ namespace Microsoft.PowerShell.Commands
 
         internal static bool IsJson(string contentType)
         {
-            contentType = GetContentTypeSignature(contentType);
-            return CheckIsJson(contentType);
-        }
-
-        internal static bool IsText(string contentType)
-        {
-            contentType = GetContentTypeSignature(contentType);
-            return CheckIsText(contentType);
-        }
-
-        internal static bool IsXml(string contentType)
-        {
-            contentType = GetContentTypeSignature(contentType);
-            return CheckIsXml(contentType);
-        }
-
-        #endregion Internal Methods
-
-        #region Private Helper Methods
-
-        private static bool CheckIsJson(string contentType)
-        {
             if (string.IsNullOrEmpty(contentType))
             {
                 return false;
@@ -102,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
             return isJson;
         }
 
-        private static bool CheckIsText(string contentType)
+        internal static bool IsText(string contentType)
         {
             if (string.IsNullOrEmpty(contentType))
             {
@@ -111,8 +89,8 @@ namespace Microsoft.PowerShell.Commands
 
             // Any text, xml or json types are text
             bool isText = contentType.StartsWith("text/", StringComparison.OrdinalIgnoreCase)
-                        || CheckIsXml(contentType)
-                        || CheckIsJson(contentType);
+                        || IsXml(contentType)
+                        || IsJson(contentType);
 
             // Further content type analysis is available on Windows
             if (Platform.IsWindows && !isText)
@@ -141,7 +119,7 @@ namespace Microsoft.PowerShell.Commands
             return isText;
         }
 
-        private static bool CheckIsXml(string contentType)
+        internal static bool IsXml(string contentType)
         {
             if (string.IsNullOrEmpty(contentType))
             {
@@ -157,17 +135,6 @@ namespace Microsoft.PowerShell.Commands
             return isXml;
         }
 
-        private static string GetContentTypeSignature(string contentType)
-        {
-            if (string.IsNullOrEmpty(contentType))
-            {
-                return null;
-            }
-
-            string sig = contentType.Split(';', 2)[0].ToUpperInvariant();
-            return sig;
-        }
-
-        #endregion Private Helper Methods
+        #endregion Internal Methods
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -383,13 +383,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal static string DecodeStream(Stream stream, string characterSet, out Encoding encoding)
         {
-            bool isDefaultEncoding = false;
-            if (!TryGetEncoding(characterSet, out encoding))
-            {
-                // Use the default encoding if one wasn't provided
-                encoding = ContentHelper.GetDefaultEncoding();
-                isDefaultEncoding = true;
-            }
+            bool isDefaultEncoding = !TryGetEncoding(characterSet, out encoding);
 
             string content = StreamToString(stream, encoding);
             if (isDefaultEncoding)
@@ -433,7 +427,8 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (ArgumentException)
             {
-                encoding = null;
+                // Use the default encoding if one wasn't provided
+                encoding = ContentHelper.GetDefaultEncoding();
             }
 
             return result;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Merge before #19359 @iSazonov :

Removed `GetContentTypeSignature()`:
- Not useful because `contentType` is obtained from `GetContentType() => response.Content.Headers.ContentType?.MediaType` and `MediaType` already splits `ContentType`
- Reworked `CheckIsJson`, `CheckIsXml` and `CheckIsText`
- Reworked `TryGetEncoding()`

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
