### PR TITLE
Add WDAC Audit mode logging as experimental feature

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -572,7 +572,8 @@ namespace Microsoft.PowerShell.Commands
                 SystemPolicy.LogWDACAuditMessage(
                     title: AddTypeStrings.AddTypeLogTitle,
                     message: AddTypeStrings.AddTypeLogMessage,
-                    fqid: "AddTypeCmdletDisabled");
+                    fqid: "AddTypeCmdletDisabled",
+                    dropIntoDebugger: true);
             }
 
             // 'ConsoleApplication' and 'WindowsApplication' types are currently not working in .NET Core

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -567,6 +567,13 @@ namespace Microsoft.PowerShell.Commands
                         targetObject: null));
             }
 
+            if (SessionState.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
+            {
+                SystemPolicy.LogWDACAuditMessage(
+                    Title: "Add-Type Cmdlet",
+                    Message: "Add-Type cmdlet would not be allowed in ConstrainedLanguage mode.");
+            }
+
             // 'ConsoleApplication' and 'WindowsApplication' types are currently not working in .NET Core
             if (OutputType != OutputAssemblyType.Library)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -571,7 +571,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Add-Type Cmdlet",
-                    Message: "Add-Type cmdlet would not be allowed in ConstrainedLanguage mode.");
+                    Message: "Add-Type cmdlet would not be allowed in ConstrainedLanguage mode.",
+                    FQID: "AddTypeCmdletDisabled");
             }
 
             // 'ConsoleApplication' and 'WindowsApplication' types are currently not working in .NET Core

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -570,9 +570,9 @@ namespace Microsoft.PowerShell.Commands
             if (SessionState.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 SystemPolicy.LogWDACAuditMessage(
-                    Title: "Add-Type Cmdlet",
-                    Message: "Add-Type cmdlet would not be allowed in ConstrainedLanguage mode.",
-                    FQID: "AddTypeCmdletDisabled");
+                    title: "Add-Type Cmdlet",
+                    message: "Add-Type cmdlet would not be allowed in ConstrainedLanguage mode.",
+                    fqid: "AddTypeCmdletDisabled");
             }
 
             // 'ConsoleApplication' and 'WindowsApplication' types are currently not working in .NET Core

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -570,8 +570,8 @@ namespace Microsoft.PowerShell.Commands
             if (SessionState.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 SystemPolicy.LogWDACAuditMessage(
-                    title: "Add-Type Cmdlet",
-                    message: "Add-Type cmdlet would not be allowed in ConstrainedLanguage mode.",
+                    title: AddTypeStrings.AddTypeLogTitle,
+                    message: AddTypeStrings.AddTypeLogMessage,
                     fqid: "AddTypeCmdletDisabled");
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -570,6 +570,7 @@ namespace Microsoft.PowerShell.Commands
             if (SessionState.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 SystemPolicy.LogWDACAuditMessage(
+                    context: Context,
                     title: AddTypeStrings.AddTypeLogTitle,
                     message: AddTypeStrings.AddTypeLogMessage,
                     fqid: "AddTypeCmdletDisabled",

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -161,9 +161,9 @@ namespace Microsoft.PowerShell.Commands
 
                     case PSLanguageMode.ConstrainedLanguageAudit:
                         SystemPolicy.LogWDACAuditMessage(
-                            Title: "Import-LocalizedData",
-                            Message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.",
-                            FQID: "SupportedCommandsDisabled");
+                            title: "Import-LocalizedData",
+                            message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.",
+                            fqid: "SupportedCommandsDisabled");
                         break;
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -153,7 +153,8 @@ namespace Microsoft.PowerShell.Commands
                 {
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Import-LocalizedData",
-                        Message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.");
+                        Message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.",
+                        FQID: "SupportedCommandsDisabled");
                 }
 
                 if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -163,7 +163,8 @@ namespace Microsoft.PowerShell.Commands
                         SystemPolicy.LogWDACAuditMessage(
                             title: ImportLocalizedDataStrings.WDACLogTitle,
                             message: ImportLocalizedDataStrings.WDACLogMessage,
-                            fqid: "SupportedCommandsDisabled");
+                            fqid: "SupportedCommandsDisabled",
+                            dropIntoDebugger: true);
                         break;
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -149,21 +149,22 @@ namespace Microsoft.PowerShell.Commands
             // Prevent additional commands in ConstrainedLanguage mode
             if (_setSupportedCommand)
             {
-                if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
+                switch (Context.LanguageMode)
                 {
-                    SystemPolicy.LogWDACAuditMessage(
-                        Title: "Import-LocalizedData",
-                        Message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.",
-                        FQID: "SupportedCommandsDisabled");
-                }
+                    case PSLanguageMode.ConstrainedLanguage:
+                        NotSupportedException nse =
+                            PSTraceSource.NewNotSupportedException(
+                                ImportLocalizedDataStrings.CannotDefineSupportedCommand);
+                        ThrowTerminatingError(
+                            new ErrorRecord(nse, "CannotDefineSupportedCommand", ErrorCategory.PermissionDenied, null));
+                        break;
 
-                if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
-                {
-                    NotSupportedException nse =
-                        PSTraceSource.NewNotSupportedException(
-                            ImportLocalizedDataStrings.CannotDefineSupportedCommand);
-                    ThrowTerminatingError(
-                        new ErrorRecord(nse, "CannotDefineSupportedCommand", ErrorCategory.PermissionDenied, null));
+                    case PSLanguageMode.ConstrainedLanguageAudit:
+                        SystemPolicy.LogWDACAuditMessage(
+                            Title: "Import-LocalizedData",
+                            Message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.",
+                            FQID: "SupportedCommandsDisabled");
+                        break;
                 }
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -161,8 +161,8 @@ namespace Microsoft.PowerShell.Commands
 
                     case PSLanguageMode.ConstrainedLanguageAudit:
                         SystemPolicy.LogWDACAuditMessage(
-                            title: "Import-LocalizedData",
-                            message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.",
+                            title: ImportLocalizedDataStrings.WDACLogTitle,
+                            message: ImportLocalizedDataStrings.WDACLogMessage,
                             fqid: "SupportedCommandsDisabled");
                         break;
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -161,6 +161,7 @@ namespace Microsoft.PowerShell.Commands
 
                     case PSLanguageMode.ConstrainedLanguageAudit:
                         SystemPolicy.LogWDACAuditMessage(
+                            context: Context,
                             title: ImportLocalizedDataStrings.WDACLogTitle,
                             message: ImportLocalizedDataStrings.WDACLogMessage,
                             fqid: "SupportedCommandsDisabled",

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
+using System.Management.Automation.Security;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -146,9 +147,16 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Prevent additional commands in ConstrainedLanguage mode
-            if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
+            if (_setSupportedCommand)
             {
-                if (_setSupportedCommand)
+                if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
+                {
+                    SystemPolicy.LogWDACAuditMessage(
+                        Title: "Import-LocalizedData",
+                        Message: "Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode under policy enforcement.");
+                }
+
+                if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
                 {
                     NotSupportedException nse =
                         PSTraceSource.NewNotSupportedException(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
@@ -49,7 +49,8 @@ namespace Microsoft.PowerShell.Commands
                 SystemPolicy.LogWDACAuditMessage(
                     title: UtilityCommonStrings.IEXWDACLogTitle,
                     message: UtilityCommonStrings.IEXWDACLogMessage,
-                    fqid: "InvokeExpressionCmdletConstrained");
+                    fqid: "InvokeExpressionCmdletConstrained",
+                    dropIntoDebugger: true);
             }
 
             var emptyArray = Array.Empty<object>();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
@@ -47,9 +47,9 @@ namespace Microsoft.PowerShell.Commands
             if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
             {
                 SystemPolicy.LogWDACAuditMessage(
-                    Title: "Invoke-Expression Cmdlet",
-                    Message: "Invoke-Expression cmdlet script block would be run in ConstrainedLanguage mode when policy is enforced.",
-                    FQID:"InvokeExpressionCmdletConstrained");
+                    title: "Invoke-Expression Cmdlet",
+                    message: "Invoke-Expression cmdlet script block would be run in ConstrainedLanguage mode when policy is enforced.",
+                    fqid: "InvokeExpressionCmdletConstrained");
             }
 
             var emptyArray = Array.Empty<object>();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
@@ -47,8 +47,8 @@ namespace Microsoft.PowerShell.Commands
             if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
             {
                 SystemPolicy.LogWDACAuditMessage(
-                    title: "Invoke-Expression Cmdlet",
-                    message: "Invoke-Expression cmdlet script block would be run in ConstrainedLanguage mode when policy is enforced.",
+                    title: UtilityCommonStrings.IEXWDACLogTitle,
+                    message: UtilityCommonStrings.IEXWDACLogMessage,
                     fqid: "InvokeExpressionCmdletConstrained");
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
+using System.Management.Automation.Security;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -41,6 +42,13 @@ namespace Microsoft.PowerShell.Commands
             if (Context.HasRunspaceEverUsedConstrainedLanguageMode)
             {
                 myScriptBlock.LanguageMode = PSLanguageMode.ConstrainedLanguage;
+            }
+
+            if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
+            {
+                SystemPolicy.LogWDACAuditMessage(
+                    Title: "Invoke-Expression Cmdlet",
+                    Message: "Invoke-Expression cmdlet script block would be run in ConstrainedLanguage mode when policy is enforced.");
             }
 
             var emptyArray = Array.Empty<object>();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
@@ -48,7 +48,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Invoke-Expression Cmdlet",
-                    Message: "Invoke-Expression cmdlet script block would be run in ConstrainedLanguage mode when policy is enforced.");
+                    Message: "Invoke-Expression cmdlet script block would be run in ConstrainedLanguage mode when policy is enforced.",
+                    FQID:"InvokeExpressionCmdletConstrained");
             }
 
             var emptyArray = Array.Empty<object>();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeExpressionCommand.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerShell.Commands
             if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
             {
                 SystemPolicy.LogWDACAuditMessage(
+                    context: Context,
                     title: UtilityCommonStrings.IEXWDACLogTitle,
                     message: UtilityCommonStrings.IEXWDACLogMessage,
                     fqid: "InvokeExpressionCmdletConstrained",

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -203,7 +203,8 @@ namespace Microsoft.PowerShell.Commands
                         {
                             SystemPolicy.LogWDACAuditMessage(
                                 Title: "New-Object",
-                                Message: $"Type {type.FullName} will not be created in ConstrainedLanguage mode under policy enforcement.");
+                                Message: $"Type {type.FullName} will not be created in ConstrainedLanguage mode under policy enforcement.",
+                                FQID:"NewObjectCmdletCannotCreateType");
                         }
                         break;
 
@@ -325,7 +326,8 @@ namespace Microsoft.PowerShell.Commands
 
                         SystemPolicy.LogWDACAuditMessage(
                             Title: "New-Object",
-                            Message: $"The COM object, {(ComObject ?? string.Empty)}, will not be created in ConstrainedLanguage mode under policy enforcement.");
+                            Message: $"The COM object, {(ComObject ?? string.Empty)}, will not be created in ConstrainedLanguage mode under policy enforcement.",
+                            FQID:"NewObjectCmdletCannotCreateCOM");
                     }
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -203,6 +203,7 @@ namespace Microsoft.PowerShell.Commands
                         if (!CoreTypes.Contains(type))
                         {
                             SystemPolicy.LogWDACAuditMessage(
+                                context: Context,
                                 title: NewObjectStrings.TypeWDACLogTitle,
                                 message: StringUtil.Format(NewObjectStrings.TypeWDACLogMessage, type.FullName),
                                 fqid: "NewObjectCmdletCannotCreateType",
@@ -330,6 +331,7 @@ namespace Microsoft.PowerShell.Commands
                         }
 
                         SystemPolicy.LogWDACAuditMessage(
+                            context: Context,
                             title: NewObjectStrings.ComWDACLogTitle,
                             message: StringUtil.Format(NewObjectStrings.ComWDACLogMessage, ComObject ?? string.Empty),
                             fqid: "NewObjectCmdletCannotCreateCOM",

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -205,7 +205,8 @@ namespace Microsoft.PowerShell.Commands
                             SystemPolicy.LogWDACAuditMessage(
                                 title: NewObjectStrings.TypeWDACLogTitle,
                                 message: StringUtil.Format(NewObjectStrings.TypeWDACLogMessage, type.FullName),
-                                fqid: "NewObjectCmdletCannotCreateType");
+                                fqid: "NewObjectCmdletCannotCreateType",
+                                dropIntoDebugger: true);
                         }
 
                         break;
@@ -331,7 +332,8 @@ namespace Microsoft.PowerShell.Commands
                         SystemPolicy.LogWDACAuditMessage(
                             title: NewObjectStrings.ComWDACLogTitle,
                             message: StringUtil.Format(NewObjectStrings.ComWDACLogMessage, ComObject ?? string.Empty),
-                            fqid: "NewObjectCmdletCannotCreateCOM");
+                            fqid: "NewObjectCmdletCannotCreateCOM",
+                            dropIntoDebugger: true);
                     }
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -203,8 +203,8 @@ namespace Microsoft.PowerShell.Commands
                         if (!CoreTypes.Contains(type))
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                title: "New-Object",
-                                message: $"Type {type.FullName} will not be created in ConstrainedLanguage mode under policy enforcement.",
+                                title: NewObjectStrings.TypeWDACLogTitle,
+                                message: StringUtil.Format(NewObjectStrings.TypeWDACLogMessage, type.FullName),
                                 fqid: "NewObjectCmdletCannotCreateType");
                         }
 
@@ -329,8 +329,8 @@ namespace Microsoft.PowerShell.Commands
                         }
 
                         SystemPolicy.LogWDACAuditMessage(
-                            title: "New-Object",
-                            message: $"The COM object, {(ComObject ?? string.Empty)}, will not be created in ConstrainedLanguage mode under policy enforcement.",
+                            title: NewObjectStrings.ComWDACLogTitle,
+                            message: StringUtil.Format(NewObjectStrings.ComWDACLogMessage, (ComObject ?? string.Empty)),
                             fqid: "NewObjectCmdletCannotCreateCOM");
                     }
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -304,6 +304,8 @@ namespace Microsoft.PowerShell.Commands
 #if !UNIX
             else // Parameterset -Com
             {
+                int result = NewObjectNativeMethods.CLSIDFromProgID(ComObject, out _comObjectClsId);
+
                 // If we're in ConstrainedLanguage, do additional restrictions
                 if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage || Context.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
                 {
@@ -313,7 +315,6 @@ namespace Microsoft.PowerShell.Commands
                     var systemLockdownPolicy = SystemPolicy.GetSystemLockdownPolicy();
                     if (systemLockdownPolicy == SystemEnforcementMode.Enforce || systemLockdownPolicy == SystemEnforcementMode.Audit)
                     {
-                        int result = NewObjectNativeMethods.CLSIDFromProgID(ComObject, out _comObjectClsId);
                         isAllowed = (result >= 0) && SystemPolicy.IsClassInApprovedList(_comObjectClsId);
                     }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.Commands
 
                         SystemPolicy.LogWDACAuditMessage(
                             title: NewObjectStrings.ComWDACLogTitle,
-                            message: StringUtil.Format(NewObjectStrings.ComWDACLogMessage, (ComObject ?? string.Empty)),
+                            message: StringUtil.Format(NewObjectStrings.ComWDACLogMessage, ComObject ?? string.Empty),
                             fqid: "NewObjectCmdletCannotCreateCOM");
                     }
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/New-Object.cs
@@ -196,16 +196,18 @@ namespace Microsoft.PowerShell.Commands
                                 new ErrorRecord(
                                     new PSNotSupportedException(NewObjectStrings.CannotCreateTypeConstrainedLanguage), "CannotCreateTypeConstrainedLanguage", ErrorCategory.PermissionDenied, null));
                         }
+
                         break;
 
                     case PSLanguageMode.ConstrainedLanguageAudit:
                         if (!CoreTypes.Contains(type))
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                Title: "New-Object",
-                                Message: $"Type {type.FullName} will not be created in ConstrainedLanguage mode under policy enforcement.",
-                                FQID:"NewObjectCmdletCannotCreateType");
+                                title: "New-Object",
+                                message: $"Type {type.FullName} will not be created in ConstrainedLanguage mode under policy enforcement.",
+                                fqid: "NewObjectCmdletCannotCreateType");
                         }
+
                         break;
 
                     case PSLanguageMode.NoLanguage:
@@ -221,6 +223,7 @@ namespace Microsoft.PowerShell.Commands
                                     ErrorCategory.PermissionDenied,
                                     targetObject: null));
                         }
+                        
                         break;
                 }
 
@@ -325,9 +328,9 @@ namespace Microsoft.PowerShell.Commands
                         }
 
                         SystemPolicy.LogWDACAuditMessage(
-                            Title: "New-Object",
-                            Message: $"The COM object, {(ComObject ?? string.Empty)}, will not be created in ConstrainedLanguage mode under policy enforcement.",
-                            FQID:"NewObjectCmdletCannotCreateCOM");
+                            title: "New-Object",
+                            message: $"The COM object, {(ComObject ?? string.Empty)}, will not be created in ConstrainedLanguage mode under policy enforcement.",
+                            fqid: "NewObjectCmdletCannotCreateCOM");
                     }
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/AddTypeStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/AddTypeStrings.resx
@@ -150,4 +150,10 @@
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
     <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
   </data>
+  <data name="AddTypeLogTitle" xml:space="preserve">
+    <value>Add-Type Cmdlet</value>
+  </data>
+  <data name="AddTypeLogMessage" xml:space="preserve">
+    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ImportLocalizedDataStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ImportLocalizedDataStrings.resx
@@ -143,4 +143,10 @@
   <data name="IncorrectVariableName" xml:space="preserve">
     <value>The BindingVariable name '{0}' is invalid.</value>
   </data>
+  <data name="WDACLogTitle" xml:space="preserve">
+    <value>Import-LocalizedData Cmdlet</value>
+  </data>
+  <data name="WDACLogMessage" xml:space="preserve">
+    <value>Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
@@ -147,4 +147,16 @@
   <data name="CannotCreateTypeLanguageMode" xml:space="preserve">
     <value>Cannot create type. Only core types are supported in {0} language mode on a policy locked down machine.</value>
   </data>
+  <data name="TypeWDACLogTitle" xml:space="preserve">
+    <value>New-Object Cmdlet Type Creation</value>
+  </data>
+  <data name="TypeWDACLogMessage" xml:space="preserve">
+    <value>The type {0} will not be created in ConstrainedLanguage mode.</value>
+  </data>
+  <data name="ComWDACLogTitle" xml:space="preserve">
+    <value>New-Object Cmdlet COM Object Creation</value>
+  </data>
+  <data name="ComWDACLogMessage" xml:space="preserve">
+    <value>The COM object '{0}' will not be created in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityCommonStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityCommonStrings.resx
@@ -168,4 +168,10 @@
   <data name="InvalidSDDL" xml:space="preserve">
     <value>Cannot construct a security descriptor from the given SDDL due to the following error: {0}</value>
   </data>
+  <data name="IEXWDACLogTitle" xml:space="preserve">
+    <value>Invoke-Expression Cmdlet</value>
+  </data>
+  <data name="IEXWDACLogMessage" xml:space="preserve">
+    <value>Invoke-Expression cmdlet script block will be run in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1842,6 +1842,10 @@ namespace Microsoft.PowerShell
                             s_theConsoleHost.UI.WriteLine(ManagedEntranceStrings.ShellBannerCLMode);
                             break;
 
+                        case PSLanguageMode.ConstrainedLanguageAudit:
+                            s_theConsoleHost.UI.WriteLine(ManagedEntranceStrings.ShellBannerCLAuditMode);
+                            break;
+
                         case PSLanguageMode.NoLanguage:
                             s_theConsoleHost.UI.WriteLine(ManagedEntranceStrings.ShellBannerNLMode);
                             break;

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -123,6 +123,9 @@
   <data name="ShellBannerCLMode" xml:space="preserve">
     <value>[Constrained Language Mode]</value>
   </data>
+  <data name="ShellBannerCLAuditMode" xml:space="preserve">
+    <value>[Constrained Language AUDIT Mode : No Restrictions]</value>
+  </data>
   <data name="ShellBannerNLMode" xml:space="preserve">
     <value>[No Language Mode]</value>
   </data>

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -441,10 +441,12 @@ namespace System.Management.Automation.Security
         /// <param name="title">Audit message title.</param>
         /// <param name="message">Audit message message.</param>
         /// <param name="fqid">Fully Qualified ID.</param>
+        /// <param name="dropIntoDebugger">Stops code execution and goes into debugger mode.</param>
         internal static void LogWDACAuditMessage(
             string title,
             string message,
-            string fqid)
+            string fqid,
+            bool dropIntoDebugger = false)
         {
         }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -438,13 +438,13 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Writes to PowerShell WDAC Audit mode ETW log.
         /// </summary>
-        /// <param name="Title">Audit message title.</param>
-        /// <param name="Message">Audit message message.</param>
-        /// <param name="FQID">Fully Qualified ID.</param>
+        /// <param name="title">Audit message title.</param>
+        /// <param name="message">Audit message message.</param>
+        /// <param name="fqid">Fully Qualified ID.</param>
         internal static void LogWDACAuditMessage(
-            string Title,
-            string Message,
-            string FQID )
+            string title,
+            string message,
+            string fqid)
         {
         }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -524,7 +524,12 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Script file is allowed to run in ConstrainedLanguage mode only.
         /// </summary>
-        AllowConstrained = 3
+        AllowConstrained = 3,
+
+        /// <summary>
+        /// Script file is allowed to run in FullLanguage mode but will emit ConstrainedLanguage restriction audit logs.
+        /// </summary>
+        AllowConstrainedAudit = 4
     }
 }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -438,11 +438,13 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Writes to PowerShell WDAC Audit mode ETW log.
         /// </summary>
+        /// <param name="context">Current execution context.</param>
         /// <param name="title">Audit message title.</param>
         /// <param name="message">Audit message message.</param>
         /// <param name="fqid">Fully Qualified ID.</param>
         /// <param name="dropIntoDebugger">Stops code execution and goes into debugger mode.</param>
         internal static void LogWDACAuditMessage(
+            ExecutionContext context,
             string title,
             string message,
             string fqid,

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -436,6 +436,19 @@ namespace System.Management.Automation.Security
         private SystemPolicy() { }
 
         /// <summary>
+        /// Writes to PowerShell WDAC Audit mode ETW log.
+        /// </summary>
+        /// <param name="Title">Audit message title.</param>
+        /// <param name="Message">Audit message message.</param>
+        /// <param name="FQID">Fully Qualified ID.</param>
+        internal static void LogWDACAuditMessage(
+            string Title,
+            string Message,
+            string FQID )
+        {
+        }
+
+        /// <summary>
         /// Gets the system lockdown policy.
         /// </summary>
         /// <remarks>Always return SystemEnforcementMode.None in CSS (trusted)</remarks>

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
@@ -620,7 +620,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             string fileContents = ps1xmlInfo.ScriptContents;
 
             isFullyTrusted = false;
-            if (ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage || ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
+            if (ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage)
             {
                 isFullyTrusted = true;
             }

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
@@ -620,7 +620,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             string fileContents = ps1xmlInfo.ScriptContents;
 
             isFullyTrusted = false;
-            if (ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage)
+            if (ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage || ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 isFullyTrusted = true;
             }

--- a/src/System.Management.Automation/engine/CommandProcessor.cs
+++ b/src/System.Management.Automation/engine/CommandProcessor.cs
@@ -226,7 +226,8 @@ namespace System.Management.Automation
                     oldLanguageMode = Context.LanguageMode;
                     Context.LanguageMode = scriptCmdletInfo.ScriptBlock.LanguageMode.Value;
 
-                    // If it's from ConstrainedLanguage to FullLanguage, indicate the transition before parameter binding takes place.
+                    // If it's from ConstrainedLanguage or ConstrainedLanguageAduit to FullLanguage, indicate the transition before parameter binding takes place.
+                    // When transitioning to FullLanguage mode, we don't want any ConstrainedLanguage restrictions or incorrect Audit messages.
                     if ((oldLanguageMode == PSLanguageMode.ConstrainedLanguage || oldLanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
                         Context.LanguageMode == PSLanguageMode.FullLanguage)
                     {

--- a/src/System.Management.Automation/engine/CommandProcessor.cs
+++ b/src/System.Management.Automation/engine/CommandProcessor.cs
@@ -227,7 +227,8 @@ namespace System.Management.Automation
                     Context.LanguageMode = scriptCmdletInfo.ScriptBlock.LanguageMode.Value;
 
                     // If it's from ConstrainedLanguage to FullLanguage, indicate the transition before parameter binding takes place.
-                    if (oldLanguageMode == PSLanguageMode.ConstrainedLanguage && Context.LanguageMode == PSLanguageMode.FullLanguage)
+                    if ((oldLanguageMode == PSLanguageMode.ConstrainedLanguage || oldLanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
+                        Context.LanguageMode == PSLanguageMode.FullLanguage)
                     {
                         oldLangModeTransitionStatus = Context.LanguageModeTransitionInParameterBinding;
                         Context.LanguageModeTransitionInParameterBinding = true;

--- a/src/System.Management.Automation/engine/CommandProcessor.cs
+++ b/src/System.Management.Automation/engine/CommandProcessor.cs
@@ -780,7 +780,7 @@ namespace System.Management.Automation
             // If the script has been dotted, throw an error if it's from a different language mode.
             if (!this.UseLocalScope)
             {
-                ValidateCompatibleLanguageMode(scriptCommandInfo.ScriptBlock, _context.LanguageMode, Command.MyInvocation);
+                ValidateCompatibleLanguageMode(scriptCommandInfo.ScriptBlock, _context, Command.MyInvocation);
             }
         }
 

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -240,8 +240,8 @@ namespace System.Management.Automation
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "Script Block Processing Dot-Source",
-                        message: $"Processing for script block, {scriptBlock.File ?? string.Empty}, would fail in Constrained Language mode because its language mode, {scriptBlock.LanguageMode}, does not match the current language mode, {languageMode}.",
+                        title: CommandBaseStrings.WDACLogTitle,
+                        message: StringUtil.Format(CommandBaseStrings.WDACLogTitle, (scriptBlock.File ?? string.Empty), scriptBlock.LanguageMode, languageMode),
                         fqid: "ScriptBlockDotSourceNotAllowed");
                 }
             }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -194,11 +194,11 @@ namespace System.Management.Automation
         /// be used when a script block is being dotted.
         /// </summary>
         /// <param name="scriptBlock">The script block being dotted.</param>
-        /// <param name="languageMode">The current language mode.</param>
+        /// <param name="context">The current execution context.</param>
         /// <param name="invocationInfo">The invocation info about the command.</param>
         protected static void ValidateCompatibleLanguageMode(
             ScriptBlock scriptBlock,
-            PSLanguageMode languageMode,
+            ExecutionContext context,
             InvocationInfo invocationInfo)
         {
             // If we are in a constrained language mode (Core or Restricted), block it.
@@ -207,6 +207,7 @@ namespace System.Management.Automation
             //      functions that were never designed to handle untrusted data.
             // This function won't be called for NoLanguage mode so the only direction checked is trusted
             // (FullLanguage mode) script running in a constrained/restricted session.
+            var languageMode = context.LanguageMode;
             if ((scriptBlock.LanguageMode.HasValue) &&
                 (scriptBlock.LanguageMode != languageMode) &&
                 ((languageMode == PSLanguageMode.RestrictedLanguage) ||
@@ -241,6 +242,7 @@ namespace System.Management.Automation
 
                     string scriptBlockId = $"{scriptBlock.Id}+{scriptBlock.GetFileName() ?? string.Empty}";
                     SystemPolicy.LogWDACAuditMessage(
+                        context: context,
                         title: CommandBaseStrings.WDACLogTitle,
                         message: StringUtil.Format(CommandBaseStrings.WDACLogMessage, scriptBlockId, scriptBlock.LanguageMode, languageMode),
                         fqid: "ScriptBlockDotSourceNotAllowed",

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -241,7 +241,8 @@ namespace System.Management.Automation
 
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Script Block Processing Dot-Source",
-                        Message: $"Processing for script block, {scriptBlock.File ?? string.Empty}, would fail in Constrained Language mode because its language mode, {scriptBlock.LanguageMode}, does not match the current language mode, {languageMode}.");
+                        Message: $"Processing for script block, {scriptBlock.File ?? string.Empty}, would fail in Constrained Language mode because its language mode, {scriptBlock.LanguageMode}, does not match the current language mode, {languageMode}.",
+                        FQID: "ScriptBlockDotSourceNotAllowed");
                 }
             }
         }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -243,7 +243,8 @@ namespace System.Management.Automation
                     SystemPolicy.LogWDACAuditMessage(
                         title: CommandBaseStrings.WDACLogTitle,
                         message: StringUtil.Format(CommandBaseStrings.WDACLogMessage, scriptBlockId, scriptBlock.LanguageMode, languageMode),
-                        fqid: "ScriptBlockDotSourceNotAllowed");
+                        fqid: "ScriptBlockDotSourceNotAllowed",
+                        dropIntoDebugger: true);
                 }
             }
         }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -240,9 +240,9 @@ namespace System.Management.Automation
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "Script Block Processing Dot-Source",
-                        Message: $"Processing for script block, {scriptBlock.File ?? string.Empty}, would fail in Constrained Language mode because its language mode, {scriptBlock.LanguageMode}, does not match the current language mode, {languageMode}.",
-                        FQID: "ScriptBlockDotSourceNotAllowed");
+                        title: "Script Block Processing Dot-Source",
+                        message: $"Processing for script block, {scriptBlock.File ?? string.Empty}, would fail in Constrained Language mode because its language mode, {scriptBlock.LanguageMode}, does not match the current language mode, {languageMode}.",
+                        fqid: "ScriptBlockDotSourceNotAllowed");
                 }
             }
         }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -208,11 +208,11 @@ namespace System.Management.Automation
             // This function won't be called for NoLanguage mode so the only direction checked is trusted
             // (FullLanguage mode) script running in a constrained/restricted session.
             var languageMode = context.LanguageMode;
-            if ((scriptBlock.LanguageMode.HasValue) &&
-                (scriptBlock.LanguageMode != languageMode) &&
-                ((languageMode == PSLanguageMode.RestrictedLanguage) ||
-                 (languageMode == PSLanguageMode.ConstrainedLanguage) ||
-                 (languageMode == PSLanguageMode.ConstrainedLanguageAudit)))
+            if (scriptBlock.LanguageMode.HasValue &&
+                scriptBlock.LanguageMode != languageMode &&
+                (languageMode == PSLanguageMode.RestrictedLanguage ||
+                 languageMode == PSLanguageMode.ConstrainedLanguage ||
+                 languageMode == PSLanguageMode.ConstrainedLanguageAudit))
             {
                 // Finally check if script block is really just PowerShell commands plus parameters.
                 // If so then it is safe to dot source across language mode boundaries.

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -241,7 +241,7 @@ namespace System.Management.Automation
 
                     SystemPolicy.LogWDACAuditMessage(
                         title: CommandBaseStrings.WDACLogTitle,
-                        message: StringUtil.Format(CommandBaseStrings.WDACLogTitle, (scriptBlock.File ?? string.Empty), scriptBlock.LanguageMode, languageMode),
+                        message: StringUtil.Format(CommandBaseStrings.WDACLogTitle, scriptBlock.File ?? string.Empty, scriptBlock.LanguageMode, languageMode),
                         fqid: "ScriptBlockDotSourceNotAllowed");
                 }
             }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -239,9 +239,10 @@ namespace System.Management.Automation
                         throw new CmdletInvocationException(errorRecord);
                     }
 
+                    string scriptBlockId = $"{scriptBlock.Id}+{scriptBlock.GetFileName() ?? string.Empty}";
                     SystemPolicy.LogWDACAuditMessage(
                         title: CommandBaseStrings.WDACLogTitle,
-                        message: StringUtil.Format(CommandBaseStrings.WDACLogTitle, scriptBlock.File ?? string.Empty, scriptBlock.LanguageMode, languageMode),
+                        message: StringUtil.Format(CommandBaseStrings.WDACLogMessage, scriptBlockId, scriptBlock.LanguageMode, languageMode),
                         fqid: "ScriptBlockDotSourceNotAllowed");
                 }
             }

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -844,18 +844,15 @@ namespace System.Management.Automation
             if ((result.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguage || result.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
                 (executionContext.LanguageMode == PSLanguageMode.FullLanguage))
             {
-                if (result.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
-                {
-                    SystemPolicy.LogWDACAuditMessage(
-                        Title: "Command Searcher",
-                        Message: $"Command {result.Name} in module {result.ModuleName ?? string.Empty} is untrusted and would not be accessible in ConstrainedLanguage mode.",
-                        FQID:"CommandSearchFailInConstrained");
-                }
-
                 if (result.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguage)
                 {
                     return true;
                 }
+
+                SystemPolicy.LogWDACAuditMessage(
+                    Title: "Command Searcher",
+                    Message: $"Command {result.Name} in module {result.ModuleName ?? string.Empty} is untrusted and would not be accessible in ConstrainedLanguage mode.",
+                    FQID:"CommandSearchFailInConstrained");
             }
 
             // Don't allow invocation of trusted functions from debug breakpoints.

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -850,6 +850,7 @@ namespace System.Management.Automation
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
+                    context: executionContext,
                     title: CommandBaseStrings.SearcherWDACLogTitle,
                     message: StringUtil.Format(CommandBaseStrings.SearcherWDACLogMessage, result.Name, result.ModuleName ?? string.Empty),
                     fqid: "CommandSearchFailureForUntrustedCommand");

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -850,9 +850,9 @@ namespace System.Management.Automation
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
-                    title: "Command Searcher",
-                    message: $"Command {result.Name} in module {result.ModuleName ?? string.Empty} is untrusted and would not be accessible in ConstrainedLanguage mode.",
-                    fqid: "CommandSearchFailInConstrained");
+                    title: CommandBaseStrings.SearcherWDACLogTitle,
+                    message: StringUtil.Format(CommandBaseStrings.SearcherWDACLogMessage, result.Name, result.ModuleName ?? string.Empty),
+                    fqid: "CommandSearchFailureForUntrustedCommand");
             }
 
             // Don't allow invocation of trusted functions from debug breakpoints.

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -848,7 +848,8 @@ namespace System.Management.Automation
                 {
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Command Searcher",
-                        Message: $"Command {result.Name} in module {result.ModuleName ?? string.Empty} is untrusted and would not be accessible in ConstrainedLanguage mode.");
+                        Message: $"Command {result.Name} in module {result.ModuleName ?? string.Empty} is untrusted and would not be accessible in ConstrainedLanguage mode.",
+                        FQID:"CommandSearchFailInConstrained");
                 }
 
                 if (result.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguage)

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -850,9 +850,9 @@ namespace System.Management.Automation
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
-                    Title: "Command Searcher",
-                    Message: $"Command {result.Name} in module {result.ModuleName ?? string.Empty} is untrusted and would not be accessible in ConstrainedLanguage mode.",
-                    FQID:"CommandSearchFailInConstrained");
+                    title: "Command Searcher",
+                    message: $"Command {result.Name} in module {result.ModuleName ?? string.Empty} is untrusted and would not be accessible in ConstrainedLanguage mode.",
+                    fqid: "CommandSearchFailInConstrained");
             }
 
             // Don't allow invocation of trusted functions from debug breakpoints.

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -26,7 +26,7 @@ namespace System.Management.Automation
         internal const string PSCustomTableHeaderLabelDecoration = "PSCustomTableHeaderLabelDecoration";
         internal const string PSFeedbackProvider = "PSFeedbackProvider";
         internal const string PSCommandWithArgs = "PSCommandWithArgs";
-        internal const string PSWDACAuditLogging = "PSWDACAuditLogging";
+        internal const string PSConstrainedAuditLogging = "PSConstrainedAuditLogging";
 
         #endregion
 
@@ -134,7 +134,7 @@ namespace System.Management.Automation
                     name: PSCommandWithArgs,
                     description: "Enable `-CommandWithArgs` parameter for pwsh"),
                 new ExperimentalFeature(
-                    name: PSWDACAuditLogging,
+                    name: PSConstrainedAuditLogging,
                     description: "PowerShell restriction logging when WDAC (Windows Defender Application Control) Code Integrity policy is set to Audit mode.")
             };
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -26,6 +26,7 @@ namespace System.Management.Automation
         internal const string PSCustomTableHeaderLabelDecoration = "PSCustomTableHeaderLabelDecoration";
         internal const string PSFeedbackProvider = "PSFeedbackProvider";
         internal const string PSCommandWithArgs = "PSCommandWithArgs";
+        internal const string PSWDACAuditLogging = "PSWDACAuditLogging";
 
         #endregion
 
@@ -132,6 +133,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSCommandWithArgs,
                     description: "Enable `-CommandWithArgs` parameter for pwsh"),
+                new ExperimentalFeature(
+                    name: PSWDACAuditLogging,
+                    description: "PowerShell restriction logging when WDAC (Windows Defender Application Control) Code Integrity policy is set to Audit mode.")
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -554,6 +554,7 @@ namespace System.Management.Automation
                                     // for WDAC in Audit mode, the performance degradation is acceptable.
                                     GetScriptBlockAst();
                                     SystemPolicy.LogWDACAuditMessage(
+                                        context: Context,
                                         title: SecuritySupportStrings.ExternalScriptWDACLogTitle,
                                         message: string.Format(Globalization.CultureInfo.CurrentUICulture, SecuritySupportStrings.ExternalScriptWDACLogMessage, _path, _scriptBlock?.Id ?? Guid.Empty),
                                         fqid: "ScriptFileNotTrustedByPolicy");

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -537,6 +537,7 @@ namespace System.Management.Automation
                                     {
                                         DefiningLanguageMode = Context.LanguageMode;
                                     }
+                                    
                                     break;
 
                                 case SystemScriptFileEnforcement.Allow:
@@ -549,9 +550,9 @@ namespace System.Management.Automation
 
                                 case SystemScriptFileEnforcement.AllowConstrainedAudit:
                                     SystemPolicy.LogWDACAuditMessage(
-                                        Title: "Script File Read",
-                                        Message: $"Script file {_path} is not trusted by policy and would run in Constrained Language mode under policy enforcement.",
-                                        FQID:"ScriptFileNotTrustedByPolicy");
+                                        title: "Script File Read",
+                                        message: $"Script file {_path} is not trusted by policy and would run in Constrained Language mode under policy enforcement.",
+                                        fqid: "ScriptFileNotTrustedByPolicy");
                                     DefiningLanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
                                     break;
 

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -532,7 +532,6 @@ namespace System.Management.Automation
                                     {
                                         DefiningLanguageMode = Context.LanguageMode;
                                     }
-
                                     break;
 
                                 case SystemScriptFileEnforcement.Allow:
@@ -541,6 +540,13 @@ namespace System.Management.Automation
 
                                 case SystemScriptFileEnforcement.AllowConstrained:
                                     DefiningLanguageMode = PSLanguageMode.ConstrainedLanguage;
+                                    break;
+
+                                case SystemScriptFileEnforcement.AllowConstrainedAudit:
+                                    SystemPolicy.LogWDACAuditMessage(
+                                        Title: "Script File Read",
+                                        Message: $"Script file {_path} is not trusted by policy and would run in Constrained Language mode under policy enforcement.");
+                                    DefiningLanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
                                     break;
 
                                 case SystemScriptFileEnforcement.Block:

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -103,14 +103,19 @@ namespace System.Management.Automation
                 // Get the lock down policy with no handle. This only impacts command discovery,
                 // as the real language mode assignment will be done when we read the script
                 // contents.
-                SystemEnforcementMode scriptSpecificPolicy = SystemPolicy.GetLockdownPolicy(_path, null);
-                if (scriptSpecificPolicy != SystemEnforcementMode.Enforce)
+                switch (SystemPolicy.GetLockdownPolicy(_path, null))
                 {
-                    this.DefiningLanguageMode = PSLanguageMode.FullLanguage;
-                }
-                else
-                {
-                    this.DefiningLanguageMode = PSLanguageMode.ConstrainedLanguage;
+                    case SystemEnforcementMode.None:
+                        DefiningLanguageMode = PSLanguageMode.FullLanguage;
+                        break;
+
+                    case SystemEnforcementMode.Audit:
+                        DefiningLanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
+                        break;
+
+                    case SystemEnforcementMode.Enforce:
+                        DefiningLanguageMode = PSLanguageMode.ConstrainedLanguage;
+                        break;
                 }
             }
         }

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -549,14 +549,10 @@ namespace System.Management.Automation
                                     break;
 
                                 case SystemScriptFileEnforcement.AllowConstrainedAudit:
-                                    // This causes the file script to be parsed and cached or retrieved from the cache.
-                                    // This is normally done lazily when needed for performance. But since this is only
-                                    // for WDAC in Audit mode, the performance degradation is acceptable.
-                                    GetScriptBlockAst();
                                     SystemPolicy.LogWDACAuditMessage(
                                         context: Context,
                                         title: SecuritySupportStrings.ExternalScriptWDACLogTitle,
-                                        message: string.Format(Globalization.CultureInfo.CurrentUICulture, SecuritySupportStrings.ExternalScriptWDACLogMessage, _path, _scriptBlock?.Id ?? Guid.Empty),
+                                        message: string.Format(Globalization.CultureInfo.CurrentUICulture, SecuritySupportStrings.ExternalScriptWDACLogMessage, _path),
                                         fqid: "ScriptFileNotTrustedByPolicy");
                                     DefiningLanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
                                     break;

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -549,6 +549,7 @@ namespace System.Management.Automation
                                     break;
 
                                 case SystemScriptFileEnforcement.AllowConstrainedAudit:
+                                    // TODO: this.ScriptBlock.Id
                                     SystemPolicy.LogWDACAuditMessage(
                                         title: SecuritySupportStrings.ExternalScriptWDACLogTitle,
                                         message: string.Format(Globalization.CultureInfo.CurrentUICulture, SecuritySupportStrings.ExternalScriptWDACLogMessage, _path),

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -550,7 +550,8 @@ namespace System.Management.Automation
                                 case SystemScriptFileEnforcement.AllowConstrainedAudit:
                                     SystemPolicy.LogWDACAuditMessage(
                                         Title: "Script File Read",
-                                        Message: $"Script file {_path} is not trusted by policy and would run in Constrained Language mode under policy enforcement.");
+                                        Message: $"Script file {_path} is not trusted by policy and would run in Constrained Language mode under policy enforcement.",
+                                        FQID:"ScriptFileNotTrustedByPolicy");
                                     DefiningLanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
                                     break;
 

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -550,8 +550,8 @@ namespace System.Management.Automation
 
                                 case SystemScriptFileEnforcement.AllowConstrainedAudit:
                                     SystemPolicy.LogWDACAuditMessage(
-                                        title: "Script File Read",
-                                        message: $"Script file {_path} is not trusted by policy and would run in Constrained Language mode under policy enforcement.",
+                                        title: SecuritySupportStrings.ExternalScriptWDACLogTitle,
+                                        message: string.Format(Globalization.CultureInfo.CurrentUICulture, SecuritySupportStrings.ExternalScriptWDACLogMessage, _path),
                                         fqid: "ScriptFileNotTrustedByPolicy");
                                     DefiningLanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
                                     break;

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -549,10 +549,13 @@ namespace System.Management.Automation
                                     break;
 
                                 case SystemScriptFileEnforcement.AllowConstrainedAudit:
-                                    // TODO: this.ScriptBlock.Id
+                                    // This causes the file script to be parsed and cached or retrieved from the cache.
+                                    // This is normally done lazily when needed for performance. But since this is only
+                                    // for WDAC in Audit mode, the performance degradation is acceptable.
+                                    GetScriptBlockAst();
                                     SystemPolicy.LogWDACAuditMessage(
                                         title: SecuritySupportStrings.ExternalScriptWDACLogTitle,
-                                        message: string.Format(Globalization.CultureInfo.CurrentUICulture, SecuritySupportStrings.ExternalScriptWDACLogMessage, _path),
+                                        message: string.Format(Globalization.CultureInfo.CurrentUICulture, SecuritySupportStrings.ExternalScriptWDACLogMessage, _path, _scriptBlock?.Id ?? Guid.Empty),
                                         fqid: "ScriptFileNotTrustedByPolicy");
                                     DefiningLanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
                                     break;

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1220,8 +1220,8 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "ForEach-Object Cmdlet",
-                        message: $"Method invocation on type {objectType.FullName} would not be allowed when run in non-audit policy enforcement mode.",
+                        title: InternalCommandStrings.WDACLogTitle,
+                        message: StringUtil.Format(InternalCommandStrings.WDACLogMessage, objectType.FullName),
                         fqid: "ForEachObjectCmdletMethodInvocationNotAllowed");
                 }
             }

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1222,7 +1222,8 @@ namespace Microsoft.PowerShell.Commands
                     SystemPolicy.LogWDACAuditMessage(
                         title: InternalCommandStrings.WDACLogTitle,
                         message: StringUtil.Format(InternalCommandStrings.WDACLogMessage, objectType.FullName),
-                        fqid: "ForEachObjectCmdletMethodInvocationNotAllowed");
+                        fqid: "ForEachObjectCmdletMethodInvocationNotAllowed",
+                        dropIntoDebugger: true);
                 }
             }
 

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1221,7 +1221,8 @@ namespace Microsoft.PowerShell.Commands
 
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "ForEach-Object Cmdlet",
-                        Message: $"Method invocation on type {objectType.FullName} would not be allowed when run in non-audit policy enforcement mode.");
+                        Message: $"Method invocation on type {objectType.FullName} would not be allowed when run in non-audit policy enforcement mode.",
+                        FQID:"ForEachObjectCmdletMethodInvocationNotAllowed");
                 }
             }
 

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1220,6 +1220,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
+                        context: Context,
                         title: InternalCommandStrings.WDACLogTitle,
                         message: StringUtil.Format(InternalCommandStrings.WDACLogMessage, objectType.FullName),
                         fqid: "ForEachObjectCmdletMethodInvocationNotAllowed",

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -11,6 +11,7 @@ using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
 using System.Management.Automation.PSTasks;
+using System.Management.Automation.Security;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -1202,17 +1203,25 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Cannot invoke certain methods in ConstrainedLanguage mode
-            if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
+            if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage || Context.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 object baseObject = PSObject.Base(inputObject);
+                var objectType = baseObject.GetType();
 
-                if (!CoreTypes.Contains(baseObject.GetType()))
+                if (!CoreTypes.Contains(objectType))
                 {
-                    PSInvalidOperationException exception =
-                        new PSInvalidOperationException(ParserStrings.InvokeMethodConstrainedLanguage);
+                    if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
+                    {
+                        PSInvalidOperationException exception =
+                            new PSInvalidOperationException(ParserStrings.InvokeMethodConstrainedLanguage);
 
-                    WriteError(new ErrorRecord(exception, "MethodInvocationNotSupportedInConstrainedLanguage", ErrorCategory.InvalidOperation, null));
-                    return true;
+                        WriteError(new ErrorRecord(exception, "MethodInvocationNotSupportedInConstrainedLanguage", ErrorCategory.InvalidOperation, null));
+                        return true;
+                    }
+
+                    SystemPolicy.LogWDACAuditMessage(
+                        Title: "ForEach-Object Cmdlet",
+                        Message: $"Method invocation on type {objectType.FullName} would not be allowed when run in non-audit policy enforcement mode.");
                 }
             }
 

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1220,9 +1220,9 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "ForEach-Object Cmdlet",
-                        Message: $"Method invocation on type {objectType.FullName} would not be allowed when run in non-audit policy enforcement mode.",
-                        FQID:"ForEachObjectCmdletMethodInvocationNotAllowed");
+                        title: "ForEach-Object Cmdlet",
+                        message: $"Method invocation on type {objectType.FullName} would not be allowed when run in non-audit policy enforcement mode.",
+                        fqid: "ForEachObjectCmdletMethodInvocationNotAllowed");
                 }
             }
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4001,9 +4001,9 @@ namespace System.Management.Automation
                         if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                title: "LanguagePrimitives Type Conversion",
-                                message: $"Type conversion from HashTable to {resultType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
-                                fqid: "LanguageTypeConversionNotAllowed");
+                                title: ExtendedTypeSystem.WDACHashTypeLogTitle,
+                                message: StringUtil.Format(ExtendedTypeSystem.WDACHashTypeLogMessage, resultType.FullName),
+                                fqid: "LanguageHashtableConversionNotAllowed");
                         }
                         else
                         {
@@ -5659,8 +5659,8 @@ namespace System.Management.Automation
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "LanguagePrimitives Type Conversion",
-                        message: $"Type conversion from {fromType.FullName} to {toType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
+                        title: ExtendedTypeSystem.WDACTypeConversionLogTitle,
+                        message: StringUtil.Format(ExtendedTypeSystem.WDACTypeConversionLogMessage, fromType.FullName, toType.FullName),
                         fqid: "LanguageTypeConversionNotAllowed");
                 }
             }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4001,6 +4001,7 @@ namespace System.Management.Automation
                         if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                         {
                             SystemPolicy.LogWDACAuditMessage(
+                                context: ecFromTLS,
                                 title: ExtendedTypeSystem.WDACHashTypeLogTitle,
                                 message: StringUtil.Format(ExtendedTypeSystem.WDACHashTypeLogMessage, resultType.FullName),
                                 fqid: "LanguageHashtableConversionNotAllowed",
@@ -5660,6 +5661,7 @@ namespace System.Management.Automation
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
+                        context: context,
                         title: ExtendedTypeSystem.WDACTypeConversionLogTitle,
                         message: StringUtil.Format(ExtendedTypeSystem.WDACTypeConversionLogMessage, fromType.FullName, toType.FullName),
                         fqid: "LanguageTypeConversionNotAllowed",

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4003,7 +4003,8 @@ namespace System.Management.Automation
                             SystemPolicy.LogWDACAuditMessage(
                                 title: ExtendedTypeSystem.WDACHashTypeLogTitle,
                                 message: StringUtil.Format(ExtendedTypeSystem.WDACHashTypeLogMessage, resultType.FullName),
-                                fqid: "LanguageHashtableConversionNotAllowed");
+                                fqid: "LanguageHashtableConversionNotAllowed",
+                                dropIntoDebugger: true);
                         }
                         else
                         {
@@ -5661,7 +5662,8 @@ namespace System.Management.Automation
                     SystemPolicy.LogWDACAuditMessage(
                         title: ExtendedTypeSystem.WDACTypeConversionLogTitle,
                         message: StringUtil.Format(ExtendedTypeSystem.WDACTypeConversionLogMessage, fromType.FullName, toType.FullName),
-                        fqid: "LanguageTypeConversionNotAllowed");
+                        fqid: "LanguageTypeConversionNotAllowed",
+                        dropIntoDebugger: true);
                 }
             }
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -3999,17 +3999,17 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        if (ecFromTLS.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
+                        if (ecFromTLS.LanguageMode != PSLanguageMode.ConstrainedLanguageAudit)
                         {
-                            SystemPolicy.LogWDACAuditMessage(
-                                Title: "LanguagePrimitives Type Conversion",
-                                Message: $"Type conversion from HashTable to {resultType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
-                                FQID:"LanguageTypeConversionNotAllowed");
+                            RuntimeException rte = InterpreterError.NewInterpreterException(valueToConvert, typeof(RuntimeException), null,
+                                "HashtableToObjectConversionNotSupportedInDataSection", ParserStrings.HashtableToObjectConversionNotSupportedInDataSection, resultType.ToString());
+                            throw rte;
                         }
-
-                        RuntimeException rte = InterpreterError.NewInterpreterException(valueToConvert, typeof(RuntimeException), null,
-                            "HashtableToObjectConversionNotSupportedInDataSection", ParserStrings.HashtableToObjectConversionNotSupportedInDataSection, resultType.ToString());
-                        throw rte;
+                        
+                        SystemPolicy.LogWDACAuditMessage(
+                            Title: "LanguagePrimitives Type Conversion",
+                            Message: $"Type conversion from HashTable to {resultType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
+                            FQID:"LanguageTypeConversionNotAllowed");
                     }
 
                     return result;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4000,9 +4000,9 @@ namespace System.Management.Automation
                         if (ecFromTLS?.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                Title: "LanguagePrimitives Type Conversion",
-                                Message: $"Type conversion from HashTable to {resultType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
-                                FQID:"LanguageTypeConversionNotAllowed");
+                                title: "LanguagePrimitives Type Conversion",
+                                message: $"Type conversion from HashTable to {resultType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
+                                fqid: "LanguageTypeConversionNotAllowed");
                         }
 
                         typeConversion.WriteLine("Constructor result: \"{0}\".", result);
@@ -5660,9 +5660,9 @@ namespace System.Management.Automation
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "LanguagePrimitives Type Conversion",
-                        Message: $"Type conversion from {fromType.FullName} to {toType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
-                        FQID:"LanguageTypeConversionNotAllowed");
+                        title: "LanguagePrimitives Type Conversion",
+                        message: $"Type conversion from {fromType.FullName} to {toType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
+                        fqid: "LanguageTypeConversionNotAllowed");
                 }
             }
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4003,7 +4003,8 @@ namespace System.Management.Automation
                         {
                             SystemPolicy.LogWDACAuditMessage(
                                 Title: "LanguagePrimitives Type Conversion",
-                                Message: $"Type conversion from HashTable to {resultType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.");
+                                Message: $"Type conversion from HashTable to {resultType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
+                                FQID:"LanguageTypeConversionNotAllowed");
                         }
 
                         RuntimeException rte = InterpreterError.NewInterpreterException(valueToConvert, typeof(RuntimeException), null,
@@ -5658,7 +5659,8 @@ namespace System.Management.Automation
 
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "LanguagePrimitives Type Conversion",
-                        Message: $"Type conversion from {fromType.FullName} to {toType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.");
+                        Message: $"Type conversion from {fromType.FullName} to {toType.FullName} would not be allowed in ConstrainedLanguage mode for untrusted script.",
+                        FQID:"LanguageTypeConversionNotAllowed");
                 }
             }
 

--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -177,9 +177,9 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
-                    Title: "Export-ModuleMember Cmdlet",
-                    Message: $"Export of module members would fail because module, {Context.EngineSessionState.Module.Name}, has a different language mode, {Context.EngineSessionState.Module.LanguageMode}, than the current session, {Context.LanguageMode}",
-                    FQID:"ExportModuleMemberCmdletNotAllowed");
+                    title: "Export-ModuleMember Cmdlet",
+                    message: $"Export of module members would fail because module, {Context.EngineSessionState.Module.Name}, has a different language mode, {Context.EngineSessionState.Module.LanguageMode}, than the current session, {Context.LanguageMode}",
+                    fqid: "ExportModuleMemberCmdletNotAllowed");
             }
 
             ModuleIntrinsics.ExportModuleMembers(this,

--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -177,6 +177,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
+                    context: Context,
                     title: Modules.WDACExportModuleCommandLogTitle,
                     message: StringUtil.Format(Modules.WDACExportModuleCommandLogMessage, Context.EngineSessionState.Module.Name, Context.EngineSessionState.Module.LanguageMode, Context.LanguageMode),
                     fqid: "ExportModuleMemberCmdletNotAllowed",

--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -179,7 +179,8 @@ namespace Microsoft.PowerShell.Commands
                 SystemPolicy.LogWDACAuditMessage(
                     title: Modules.WDACExportModuleCommandLogTitle,
                     message: StringUtil.Format(Modules.WDACExportModuleCommandLogMessage, Context.EngineSessionState.Module.Name, Context.EngineSessionState.Module.LanguageMode, Context.LanguageMode),
-                    fqid: "ExportModuleMemberCmdletNotAllowed");
+                    fqid: "ExportModuleMemberCmdletNotAllowed",
+                    dropIntoDebugger: true);
             }
 
             ModuleIntrinsics.ExportModuleMembers(this,

--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -178,7 +178,8 @@ namespace Microsoft.PowerShell.Commands
 
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Export-ModuleMember Cmdlet",
-                    Message: $"Export of module members would fail because module, {Context.EngineSessionState.Module.Name}, has a different language mode, {Context.EngineSessionState.Module.LanguageMode}, than the current session, {Context.LanguageMode}");
+                    Message: $"Export of module members would fail because module, {Context.EngineSessionState.Module.Name}, has a different language mode, {Context.EngineSessionState.Module.LanguageMode}, than the current session, {Context.LanguageMode}",
+                    FQID:"ExportModuleMemberCmdletNotAllowed");
             }
 
             ModuleIntrinsics.ExportModuleMembers(this,

--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -177,8 +177,8 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
-                    title: "Export-ModuleMember Cmdlet",
-                    message: $"Export of module members would fail because module, {Context.EngineSessionState.Module.Name}, has a different language mode, {Context.EngineSessionState.Module.LanguageMode}, than the current session, {Context.LanguageMode}",
+                    title: Modules.WDACExportModuleCommandLogTitle,
+                    message: StringUtil.Format(Modules.WDACExportModuleCommandLogMessage, Context.EngineSessionState.Module.Name, Context.EngineSessionState.Module.LanguageMode, Context.LanguageMode),
                     fqid: "ExportModuleMemberCmdletNotAllowed");
             }
 

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -890,11 +890,21 @@ namespace Microsoft.PowerShell.Commands
                     // Constrained Language session.
                     if (module.LanguageMode != manifestLanguageMode)
                     {
-                        var languageModeError = PSTraceSource.NewInvalidOperationException(
-                            Modules.MismatchedLanguageModes,
-                            module.Name, manifestLanguageMode, module.LanguageMode);
-                        languageModeError.SetErrorId("Modules_MismatchedLanguageModes");
-                        throw languageModeError;
+                        if (SystemPolicy.GetSystemLockdownPolicy() != SystemEnforcementMode.Audit)
+                        {
+                            var languageModeError = PSTraceSource.NewInvalidOperationException(
+                                Modules.MismatchedLanguageModes,
+                                module.Name, manifestLanguageMode, module.LanguageMode);
+                            languageModeError.SetErrorId("Modules_MismatchedLanguageModes");
+                            throw languageModeError;
+                        }
+
+                        SystemPolicy.LogWDACAuditMessage(
+                            context: Context,
+                            title: Modules.WDACMismatchedLanguageModesTitle,
+                            message: Modules.WDACMismatchedLanguageModesMessage,
+                            fqid: "ModulesMismatchedLanguageModes",
+                            dropIntoDebugger: true);
                     }
                 }
 

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3430,8 +3430,8 @@ namespace Microsoft.PowerShell.Commands
                         if (fnMatchPattern == null && SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                title: "Module Implicit Function Export",
-                                message: $"Implicit function export for module, {manifestScriptInfo.ModuleName}, would be denied in policy enforcement, because it is trusted but the session is in ConstrainedLanguage mode (not trusted).",
+                                title: Modules.WDACImplicitFunctionExportLogTitle,
+                                message: StringUtil.Format(Modules.WDACImplicitFunctionExportLogMessage, manifestScriptInfo.ModuleName),
                                 fqid: "ModuleImplicitFunctionExportNotAllowed");
                             fnMatchPattern = MatchAll;
                         }
@@ -5653,8 +5653,8 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
-                    title: "Module Importing of Script File",
-                    message: $"Script file, {fileName}, would not be imported as a module because session is in ConstrainedLanguage mode.",
+                    title: Modules.WDACScriptFileImportLogTitle,
+                    message: StringUtil.Format(Modules.WDACScriptFileImportLogMessage, fileName),
                     fqid: "ModuleImportScriptFilesNotAllowed");
             }
 
@@ -5756,8 +5756,8 @@ namespace Microsoft.PowerShell.Commands
                                     if (fnMatchPattern == null && systemLockdownPolicy == SystemEnforcementMode.Audit)
                                     {
                                         SystemPolicy.LogWDACAuditMessage(
-                                            title: "Module Implicit Function Export",
-                                            message: $"Implict function export for trusted module, {module.Name}, would be denied because the session is in ConstrainedLanguage mode.",
+                                            title: Modules.WDACImplicitFunctionExportLogTitle,
+                                            message: StringUtil.Format(Modules.WDACImplicitFunctionExportLogMessage2, module.Name),
                                             fqid: "ModuleImplicitFunctionExportNotAllowed");
                                         fnMatchPattern = MatchAll;
                                     }
@@ -6142,8 +6142,8 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "Module Contains Dot-Source Operator",
-                        message: $"Module, {moduleInfo.Name}, exports functions using wild card characters and also uses the dot-source operator, and import will fail when run in ConstrainedLanguage mode.",
+                        title: Modules.WDACModuleDotSourceLogTitle,
+                        message: StringUtil.Format(Modules.WDACModuleDotSourceLogMessage, moduleInfo.Name),
                         fqid: "ModuleImportDotSourceNotAllowed");
                 }
             }
@@ -6163,8 +6163,8 @@ namespace Microsoft.PowerShell.Commands
 
                 case SystemEnforcementMode.Audit:
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "Module Exporting Functions",
-                        message: $"Module, {module.Name}, exports functions using name wildcard characters, any nested module function names will be removed when running in ConstrainedLanguage mode.",
+                        title: Modules.WDACModuleFnExportWithNestedModulesLogTitle,
+                        message: StringUtil.Format(Modules.WDACModuleFnExportWithNestedModulesLogMessage, module.Name),
                         fqid: "ModuleExportWithWildcardCharactersNotAllowed");
                     break;
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3430,6 +3430,7 @@ namespace Microsoft.PowerShell.Commands
                         if (fnMatchPattern == null && SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                         {
                             SystemPolicy.LogWDACAuditMessage(
+                                context: Context,
                                 title: Modules.WDACImplicitFunctionExportLogTitle,
                                 message: StringUtil.Format(Modules.WDACImplicitFunctionExportLogMessage, manifestScriptInfo.ModuleName),
                                 fqid: "ModuleImplicitFunctionExportNotAllowed",
@@ -5654,6 +5655,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
+                    context: Context,
                     title: Modules.WDACScriptFileImportLogTitle,
                     message: StringUtil.Format(Modules.WDACScriptFileImportLogMessage, fileName),
                     fqid: "ModuleImportScriptFilesNotAllowed",
@@ -5758,6 +5760,7 @@ namespace Microsoft.PowerShell.Commands
                                     if (fnMatchPattern == null && systemLockdownPolicy == SystemEnforcementMode.Audit)
                                     {
                                         SystemPolicy.LogWDACAuditMessage(
+                                            context: Context,
                                             title: Modules.WDACImplicitFunctionExportLogTitle,
                                             message: StringUtil.Format(Modules.WDACImplicitFunctionExportLogMessage2, module.Name),
                                             fqid: "ModuleImplicitFunctionExportNotAllowed",
@@ -5783,7 +5786,7 @@ namespace Microsoft.PowerShell.Commands
                                     // exported functions only come from this module and not from any imported nested modules.
                                     // Unless there is a parent manifest that explicitly filters all exported functions (no wildcards).
                                     // This prevents unintended public exposure of imported functions running in FullLanguage.
-                                    RemoveNestedModuleFunctions(module, systemLockdownPolicy);
+                                    RemoveNestedModuleFunctions(Context, module, systemLockdownPolicy);
                                 }
 
                                 CheckForDisallowedDotSourcing(module, psm1ScriptInfo, options);
@@ -6145,6 +6148,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
+                        context: Context,
                         title: Modules.WDACModuleDotSourceLogTitle,
                         message: StringUtil.Format(Modules.WDACModuleDotSourceLogMessage, moduleInfo.Name),
                         fqid: "ModuleImportDotSourceNotAllowed",
@@ -6153,7 +6157,10 @@ namespace Microsoft.PowerShell.Commands
             }
         }
         
-        private static void RemoveNestedModuleFunctions(PSModuleInfo module, SystemEnforcementMode systemLockdownPolicy)
+        private static void RemoveNestedModuleFunctions(
+            ExecutionContext context,
+            PSModuleInfo module,
+            SystemEnforcementMode systemLockdownPolicy)
         {
             var input = module.SessionState?.Internal?.ExportedFunctions;
             if ((input == null) || (input.Count == 0))
@@ -6167,6 +6174,7 @@ namespace Microsoft.PowerShell.Commands
 
                 case SystemEnforcementMode.Audit:
                     SystemPolicy.LogWDACAuditMessage(
+                        context: context,
                         title: Modules.WDACModuleFnExportWithNestedModulesLogTitle,
                         message: StringUtil.Format(Modules.WDACModuleFnExportWithNestedModulesLogMessage, module.Name),
                         fqid: "ModuleExportWithWildcardCharactersNotAllowed",

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3432,7 +3432,8 @@ namespace Microsoft.PowerShell.Commands
                             SystemPolicy.LogWDACAuditMessage(
                                 title: Modules.WDACImplicitFunctionExportLogTitle,
                                 message: StringUtil.Format(Modules.WDACImplicitFunctionExportLogMessage, manifestScriptInfo.ModuleName),
-                                fqid: "ModuleImplicitFunctionExportNotAllowed");
+                                fqid: "ModuleImplicitFunctionExportNotAllowed",
+                                dropIntoDebugger: true);
                             fnMatchPattern = MatchAll;
                         }
 
@@ -5655,7 +5656,8 @@ namespace Microsoft.PowerShell.Commands
                 SystemPolicy.LogWDACAuditMessage(
                     title: Modules.WDACScriptFileImportLogTitle,
                     message: StringUtil.Format(Modules.WDACScriptFileImportLogMessage, fileName),
-                    fqid: "ModuleImportScriptFilesNotAllowed");
+                    fqid: "ModuleImportScriptFilesNotAllowed",
+                    dropIntoDebugger: true);
             }
 
             // If MinimumVersion/RequiredVersion/MaximumVersion has been specified, then only try to process manifest modules...
@@ -5758,7 +5760,8 @@ namespace Microsoft.PowerShell.Commands
                                         SystemPolicy.LogWDACAuditMessage(
                                             title: Modules.WDACImplicitFunctionExportLogTitle,
                                             message: StringUtil.Format(Modules.WDACImplicitFunctionExportLogMessage2, module.Name),
-                                            fqid: "ModuleImplicitFunctionExportNotAllowed");
+                                            fqid: "ModuleImplicitFunctionExportNotAllowed",
+                                            dropIntoDebugger: true);
                                         fnMatchPattern = MatchAll;
                                     }
 
@@ -6144,7 +6147,8 @@ namespace Microsoft.PowerShell.Commands
                     SystemPolicy.LogWDACAuditMessage(
                         title: Modules.WDACModuleDotSourceLogTitle,
                         message: StringUtil.Format(Modules.WDACModuleDotSourceLogMessage, moduleInfo.Name),
-                        fqid: "ModuleImportDotSourceNotAllowed");
+                        fqid: "ModuleImportDotSourceNotAllowed",
+                        dropIntoDebugger: true);
                 }
             }
         }
@@ -6165,7 +6169,8 @@ namespace Microsoft.PowerShell.Commands
                     SystemPolicy.LogWDACAuditMessage(
                         title: Modules.WDACModuleFnExportWithNestedModulesLogTitle,
                         message: StringUtil.Format(Modules.WDACModuleFnExportWithNestedModulesLogMessage, module.Name),
-                        fqid: "ModuleExportWithWildcardCharactersNotAllowed");
+                        fqid: "ModuleExportWithWildcardCharactersNotAllowed",
+                        dropIntoDebugger: true);
                     break;
             }
         }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3430,9 +3430,9 @@ namespace Microsoft.PowerShell.Commands
                         if (fnMatchPattern == null && SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                Title: "Module Implicit Function Export",
-                                Message: $"Implicit function export for module, {manifestScriptInfo.ModuleName}, would be denied in policy enforcement, because it is trusted but the session is in ConstrainedLanguage mode (not trusted).",
-                                FQID:"ModuleImplicitFunctionExportNotAllowed");
+                                title: "Module Implicit Function Export",
+                                message: $"Implicit function export for module, {manifestScriptInfo.ModuleName}, would be denied in policy enforcement, because it is trusted but the session is in ConstrainedLanguage mode (not trusted).",
+                                fqid: "ModuleImplicitFunctionExportNotAllowed");
                             fnMatchPattern = MatchAll;
                         }
 
@@ -5653,9 +5653,9 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 SystemPolicy.LogWDACAuditMessage(
-                    Title: "Module Importing of Script File",
-                    Message: $"Script file, {fileName}, would not be imported as a module because session is in ConstrainedLanguage mode.",
-                    FQID: "ModuleImportScriptFilesNotAllowed");
+                    title: "Module Importing of Script File",
+                    message: $"Script file, {fileName}, would not be imported as a module because session is in ConstrainedLanguage mode.",
+                    fqid: "ModuleImportScriptFilesNotAllowed");
             }
 
             // If MinimumVersion/RequiredVersion/MaximumVersion has been specified, then only try to process manifest modules...
@@ -5756,9 +5756,9 @@ namespace Microsoft.PowerShell.Commands
                                     if (fnMatchPattern == null && systemLockdownPolicy == SystemEnforcementMode.Audit)
                                     {
                                         SystemPolicy.LogWDACAuditMessage(
-                                            Title: "Module Implicit Function Export",
-                                            Message: $"Implict function export for trusted module, {module.Name}, would be denied because the session is in ConstrainedLanguage mode.",
-                                            FQID: "ModuleImplicitFunctionExportNotAllowed");
+                                            title: "Module Implicit Function Export",
+                                            message: $"Implict function export for trusted module, {module.Name}, would be denied because the session is in ConstrainedLanguage mode.",
+                                            fqid: "ModuleImplicitFunctionExportNotAllowed");
                                         fnMatchPattern = MatchAll;
                                     }
 
@@ -6142,9 +6142,9 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "Module Contains Dot-Source Operator",
-                        Message: $"Module, {moduleInfo.Name}, exports functions using wild card characters and also uses the dot-source operator, and import will fail when run in ConstrainedLanguage mode.",
-                        FQID: "ModuleImportDotSourceNotAllowed");
+                        title: "Module Contains Dot-Source Operator",
+                        message: $"Module, {moduleInfo.Name}, exports functions using wild card characters and also uses the dot-source operator, and import will fail when run in ConstrainedLanguage mode.",
+                        fqid: "ModuleImportDotSourceNotAllowed");
                 }
             }
         }
@@ -6163,9 +6163,9 @@ namespace Microsoft.PowerShell.Commands
 
                 case SystemEnforcementMode.Audit:
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "Module Exporting Functions",
-                        Message: $"Module, {module.Name}, exports functions using name wildcard characters, any nested module function names will be removed when running in ConstrainedLanguage mode.",
-                        FQID: "ModuleExportWithWildcardCharactersNotAllowed");
+                        title: "Module Exporting Functions",
+                        message: $"Module, {module.Name}, exports functions using name wildcard characters, any nested module function names will be removed when running in ConstrainedLanguage mode.",
+                        fqid: "ModuleExportWithWildcardCharactersNotAllowed");
                     break;
             }
         }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -3431,7 +3431,8 @@ namespace Microsoft.PowerShell.Commands
                         {
                             SystemPolicy.LogWDACAuditMessage(
                                 Title: "Module Implicit Function Export",
-                                Message: $"Implicit function export for module, {manifestScriptInfo.ModuleName}, would be denied in policy enforcement, because it is trusted but the session is in ConstrainedLanguage mode (not trusted).");
+                                Message: $"Implicit function export for module, {manifestScriptInfo.ModuleName}, would be denied in policy enforcement, because it is trusted but the session is in ConstrainedLanguage mode (not trusted).",
+                                FQID:"ModuleImplicitFunctionExportNotAllowed");
                             fnMatchPattern = MatchAll;
                         }
 
@@ -5653,7 +5654,8 @@ namespace Microsoft.PowerShell.Commands
 
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Module Importing of Script File",
-                    Message: $"Script file, {fileName}, would not be imported as a module because session is in ConstrainedLanguage mode.");
+                    Message: $"Script file, {fileName}, would not be imported as a module because session is in ConstrainedLanguage mode.",
+                    FQID: "ModuleImportScriptFilesNotAllowed");
             }
 
             // If MinimumVersion/RequiredVersion/MaximumVersion has been specified, then only try to process manifest modules...
@@ -5755,7 +5757,8 @@ namespace Microsoft.PowerShell.Commands
                                     {
                                         SystemPolicy.LogWDACAuditMessage(
                                             Title: "Module Implicit Function Export",
-                                            Message: $"Implict function export for trusted module, {module.Name}, would be denied because the session is in ConstrainedLanguage mode.");
+                                            Message: $"Implict function export for trusted module, {module.Name}, would be denied because the session is in ConstrainedLanguage mode.",
+                                            FQID: "ModuleImplicitFunctionExportNotAllowed");
                                         fnMatchPattern = MatchAll;
                                     }
 
@@ -6140,7 +6143,8 @@ namespace Microsoft.PowerShell.Commands
 
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Module Contains Dot-Source Operator",
-                        Message: $"Module, {moduleInfo.Name}, exports functions using wild card characters and also uses the dot-source operator, and import will fail when run in ConstrainedLanguage mode.");
+                        Message: $"Module, {moduleInfo.Name}, exports functions using wild card characters and also uses the dot-source operator, and import will fail when run in ConstrainedLanguage mode.",
+                        FQID: "ModuleImportDotSourceNotAllowed");
                 }
             }
         }
@@ -6160,7 +6164,8 @@ namespace Microsoft.PowerShell.Commands
                 case SystemEnforcementMode.Audit:
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Module Exporting Functions",
-                        Message: $"Module, {module.Name}, exports functions using name wildcard characters, any nested module function names will be removed when running in ConstrainedLanguage mode.");
+                        Message: $"Module, {module.Name}, exports functions using name wildcard characters, any nested module function names will be removed when running in ConstrainedLanguage mode.",
+                        FQID: "ModuleExportWithWildcardCharactersNotAllowed");
                     break;
             }
         }

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1443,19 +1443,6 @@ namespace System.Management.Automation
             return null;
         }
 
-        /// <summary>
-        /// Removes all functions not belonging to the parent module.
-        /// </summary>
-        /// <param name="module">Parent module.</param>
-        internal static void RemoveNestedModuleFunctions(PSModuleInfo module)
-        {
-            var input = module.SessionState?.Internal?.ExportedFunctions;
-            if ((input == null) || (input.Count == 0))
-            { return; }
-
-            input.RemoveAll(fnInfo => !module.Name.Equals(fnInfo.ModuleName, StringComparison.OrdinalIgnoreCase));
-        }
-
 #nullable enable
         private static void SortAndRemoveDuplicates<T>(List<T> input, Func<T, string> keyGetter)
         {

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -185,7 +185,8 @@ namespace Microsoft.PowerShell.Commands
                     SystemPolicy.LogWDACAuditMessage(
                         title: Modules.WDACNewModuleCommandLogTitle,
                         message: Modules.WDACNewModuleCommandLogMessage,
-                        fqid: "NewModuleCmdletWitFullLanguageScriptblockNotAllowed");
+                        fqid: "NewModuleCmdletWitFullLanguageScriptblockNotAllowed",
+                        dropIntoDebugger: true);
                 }
 
                 string gs = System.Guid.NewGuid().ToString();

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -184,7 +184,8 @@ namespace Microsoft.PowerShell.Commands
 
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "New-Module Cmdlet",
-                        Message: "A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.");
+                        Message: "A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.",
+                        FQID: "NewModuleCmdletWitFullLanguageScriptblockNotAllowed");
                 }
 
                 string gs = System.Guid.NewGuid().ToString();

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -169,7 +169,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // Check ScriptBlock language mode.  If it is different than the context language mode
                 // then throw error since private trusted script functions may be exposed.
-                if ((Context.LanguageMode == PSLanguageMode.ConstrainedLanguage) || (Context.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
+                if ((Context.LanguageMode == PSLanguageMode.ConstrainedLanguage || Context.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
                     _scriptBlock.LanguageMode == PSLanguageMode.FullLanguage)
                 {
                     if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
@@ -183,9 +183,9 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "New-Module Cmdlet",
-                        Message: "A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.",
-                        FQID: "NewModuleCmdletWitFullLanguageScriptblockNotAllowed");
+                        title: "New-Module Cmdlet",
+                        message: "A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.",
+                        fqid: "NewModuleCmdletWitFullLanguageScriptblockNotAllowed");
                 }
 
                 string gs = System.Guid.NewGuid().ToString();

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -183,6 +183,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
+                        context: Context,
                         title: Modules.WDACNewModuleCommandLogTitle,
                         message: Modules.WDACNewModuleCommandLogMessage,
                         fqid: "NewModuleCmdletWitFullLanguageScriptblockNotAllowed",

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -183,8 +183,8 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "New-Module Cmdlet",
-                        message: "A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.",
+                        title: Modules.WDACNewModuleCommandLogTitle,
+                        message: Modules.WDACNewModuleCommandLogMessage,
                         fqid: "NewModuleCmdletWitFullLanguageScriptblockNotAllowed");
                 }
 

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -184,7 +184,7 @@ namespace Microsoft.PowerShell.Commands
 
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "New-Module Cmdlet",
-                        Message: $"A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.");
+                        Message: "A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.");
                 }
 
                 string gs = System.Guid.NewGuid().ToString();

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -1246,7 +1246,7 @@ namespace System.Management.Automation
                         // setting 'Context.LanguageModeTransitionInParameterBinding' to true before the conversion.
                         var currentLanguageMode = Context.LanguageMode;
                         bool changeLanguageModeForTrustedCommand =
-                            currentLanguageMode == PSLanguageMode.ConstrainedLanguage &&
+                            (currentLanguageMode == PSLanguageMode.ConstrainedLanguage || currentLanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
                             this.Command.CommandInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage;
                         bool oldLangModeTransitionStatus = Context.LanguageModeTransitionInParameterBinding;
 

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -1246,7 +1246,7 @@ namespace System.Management.Automation
                         // setting 'Context.LanguageModeTransitionInParameterBinding' to true before the conversion.
                         var currentLanguageMode = Context.LanguageMode;
                         bool changeLanguageModeForTrustedCommand =
-                            (currentLanguageMode == PSLanguageMode.ConstrainedLanguage || currentLanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
+                            currentLanguageMode == PSLanguageMode.ConstrainedLanguage &&
                             this.Command.CommandInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage;
                         bool oldLangModeTransitionStatus = Context.LanguageModeTransitionInParameterBinding;
 

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -1244,8 +1244,9 @@ namespace System.Management.Automation
                         // However, we don't allow Hashtable-to-Object conversion (PSObject and IDictionary) because
                         // those can lead to property setters that probably aren't expected. This is enforced by
                         // setting 'Context.LanguageModeTransitionInParameterBinding' to true before the conversion.
+                        var currentLanguageMode = Context.LanguageMode;
                         bool changeLanguageModeForTrustedCommand =
-                            Context.LanguageMode == PSLanguageMode.ConstrainedLanguage &&
+                            (currentLanguageMode == PSLanguageMode.ConstrainedLanguage || currentLanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
                             this.Command.CommandInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage;
                         bool oldLangModeTransitionStatus = Context.LanguageModeTransitionInParameterBinding;
 
@@ -1263,7 +1264,7 @@ namespace System.Management.Automation
                         {
                             if (changeLanguageModeForTrustedCommand)
                             {
-                                Context.LanguageMode = PSLanguageMode.ConstrainedLanguage;
+                                Context.LanguageMode = currentLanguageMode;
                                 Context.LanguageModeTransitionInParameterBinding = oldLangModeTransitionStatus;
                             }
                         }

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -122,7 +122,7 @@ namespace System.Management.Automation
             // language modes (getting internal functions in the user's state) isn't a danger
             if ((!this.UseLocalScope) && (!this._rethrowExitException))
             {
-                ValidateCompatibleLanguageMode(_scriptBlock, context.LanguageMode, Command.MyInvocation);
+                ValidateCompatibleLanguageMode(_scriptBlock, context, Command.MyInvocation);
             }
         }
 

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -520,7 +520,8 @@ namespace System.Management.Automation
                     try
                     {
                         // If it's from ConstrainedLanguage to FullLanguage, indicate the transition before parameter binding takes place.
-                        if (oldLanguageMode == PSLanguageMode.ConstrainedLanguage && newLanguageMode == PSLanguageMode.FullLanguage)
+                        if ((oldLanguageMode == PSLanguageMode.ConstrainedLanguage || oldLanguageMode == PSLanguageMode.ConstrainedLanguageAudit) &&
+                            newLanguageMode == PSLanguageMode.FullLanguage)
                         {
                             oldLangModeTransitionStatus = Context.LanguageModeTransitionInParameterBinding;
                             Context.LanguageModeTransitionInParameterBinding = true;

--- a/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
@@ -185,7 +185,7 @@ namespace System.Management.Automation
 
             // Early out.
             // Always allow built-in functions needed for command line debugging.
-            if ((this.ExecutionContext.LanguageMode == PSLanguageMode.FullLanguage) ||
+            if ((this.ExecutionContext.LanguageMode == PSLanguageMode.FullLanguage || this.ExecutionContext.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit) ||
                 (fnInfo == null) ||
                 (fnInfo.Name.Equals("prompt", StringComparison.OrdinalIgnoreCase)) ||
                 (fnInfo.Name.Equals("TabExpansion2", StringComparison.OrdinalIgnoreCase)) ||

--- a/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
+using System.Management.Automation.Security;
 
 using Dbg = System.Management.Automation.Diagnostics;
 

--- a/src/System.Management.Automation/engine/SessionStatePublic.cs
+++ b/src/System.Management.Automation/engine/SessionStatePublic.cs
@@ -369,6 +369,16 @@ namespace System.Management.Automation
         /// types, does not support method invocation (except on those types), and does not
         /// support property setters (except on those types).
         /// </summary>
-        ConstrainedLanguage = 3
+        ConstrainedLanguage = 3,
+
+        /// <summary>
+        /// This language mode applies no language restrictions, but is set when a system is
+        /// in WDAC (Windows Defender Application Control) policy Audit mode.
+        /// When in ConstrainedLanguageAudit mode, PowerShell language and lock down restrictions
+        /// are logged instead of applied.
+        /// This allows users to discover what restrictions would apply to running scripts if
+        /// the WDAC policy was in enforcement mode.
+        /// </summary>
+        ConstrainedLanguageAudit = 4
     }
 }

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -2004,8 +2004,8 @@ namespace System.Management.Automation
                         if ((variable.Options & ScopedItemOptions.AllScope) == ScopedItemOptions.AllScope)
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                title: "Session State Variables",
-                                message: $"Changing or creating the variable {variable.Name} scope to AllScope will be prevented in ConstrainedLanguage mode for unstrusted script.",
+                                title: SessionStateStrings.WDACSessionStateVarLogTitle,
+                                message: StringUtil.Format(SessionStateStrings.WDACSessionStateVarLogMessage, variable.Name),
                                 fqid: "AllScopeVariableNotAllowed");
                         }
 

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -2005,7 +2005,8 @@ namespace System.Management.Automation
                         {
                             SystemPolicy.LogWDACAuditMessage(
                                 Title: "Session State Variables",
-                                Message: $"Changing or creating the variable {variable.Name} scope to AllScope will be prevented in ConstrainedLanguage mode for unstrusted script.");
+                                Message: $"Changing or creating the variable {variable.Name} scope to AllScope will be prevented in ConstrainedLanguage mode for unstrusted script.",
+                                FQID: "AllScopeVariableNotAllowed");
                         }
                         break;
                 }

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -2004,6 +2004,7 @@ namespace System.Management.Automation
                         if ((variable.Options & ScopedItemOptions.AllScope) == ScopedItemOptions.AllScope)
                         {
                             SystemPolicy.LogWDACAuditMessage(
+                                context: context,
                                 title: SessionStateStrings.WDACSessionStateVarLogTitle,
                                 message: StringUtil.Format(SessionStateStrings.WDACSessionStateVarLogMessage, variable.Name),
                                 fqid: "AllScopeVariableNotAllowed",

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -2004,10 +2004,11 @@ namespace System.Management.Automation
                         if ((variable.Options & ScopedItemOptions.AllScope) == ScopedItemOptions.AllScope)
                         {
                             SystemPolicy.LogWDACAuditMessage(
-                                Title: "Session State Variables",
-                                Message: $"Changing or creating the variable {variable.Name} scope to AllScope will be prevented in ConstrainedLanguage mode for unstrusted script.",
-                                FQID: "AllScopeVariableNotAllowed");
+                                title: "Session State Variables",
+                                message: $"Changing or creating the variable {variable.Name} scope to AllScope will be prevented in ConstrainedLanguage mode for unstrusted script.",
+                                fqid: "AllScopeVariableNotAllowed");
                         }
+
                         break;
                 }
             }

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -2006,7 +2006,8 @@ namespace System.Management.Automation
                             SystemPolicy.LogWDACAuditMessage(
                                 title: SessionStateStrings.WDACSessionStateVarLogTitle,
                                 message: StringUtil.Format(SessionStateStrings.WDACSessionStateVarLogMessage, variable.Name),
-                                fqid: "AllScopeVariableNotAllowed");
+                                fqid: "AllScopeVariableNotAllowed",
+                                dropIntoDebugger: true);
                         }
 
                         break;

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -4579,7 +4579,7 @@ namespace System.Management.Automation.Runspaces
                 ps1xmlInfo = new ExternalScriptInfo(fileToLoad, fileToLoad);
                 fileContents = ps1xmlInfo.ScriptContents;
 
-                if (ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage)
+                if (ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.FullLanguage || ps1xmlInfo.DefiningLanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
                 {
                     isFullyTrusted = true;
                 }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1460,27 +1460,39 @@ namespace System.Management.Automation
         /// <returns>The current ExecutionContext language mode.</returns>
         internal static PSLanguageMode EnforceSystemLockDownLanguageMode(ExecutionContext context)
         {
-            if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Enforce)
+            switch (SystemPolicy.GetSystemLockdownPolicy())
             {
-                switch (context.LanguageMode)
-                {
-                    case PSLanguageMode.FullLanguage:
-                        context.LanguageMode = PSLanguageMode.ConstrainedLanguage;
-                        break;
+                case SystemEnforcementMode.Enforce:
+                    switch (context.LanguageMode)
+                    {
+                        case PSLanguageMode.FullLanguage:
+                        case PSLanguageMode.ConstrainedLanguageAudit:
+                            context.LanguageMode = PSLanguageMode.ConstrainedLanguage;
+                            break;
 
-                    case PSLanguageMode.RestrictedLanguage:
-                        context.LanguageMode = PSLanguageMode.NoLanguage;
-                        break;
+                        case PSLanguageMode.RestrictedLanguage:
+                            context.LanguageMode = PSLanguageMode.NoLanguage;
+                            break;
 
-                    case PSLanguageMode.ConstrainedLanguage:
-                    case PSLanguageMode.NoLanguage:
-                        break;
+                        case PSLanguageMode.ConstrainedLanguage:
+                        case PSLanguageMode.NoLanguage:
+                            break;
 
-                    default:
-                        Diagnostics.Assert(false, "Unexpected PSLanguageMode");
-                        context.LanguageMode = PSLanguageMode.NoLanguage;
-                        break;
-                }
+                        default:
+                            Diagnostics.Assert(false, "Unexpected PSLanguageMode");
+                            context.LanguageMode = PSLanguageMode.NoLanguage;
+                            break;
+                    }
+                    break;
+
+                case SystemEnforcementMode.Audit:
+                    switch (context.LanguageMode)
+                    {
+                        case PSLanguageMode.FullLanguage:
+                            context.LanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
+                            break;
+                    }
+                    break;
             }
 
             return context.LanguageMode;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -2536,21 +2536,15 @@ namespace System.Management.Automation
         /// <returns>Script position message string.</returns>
         internal override string GetCurrentScriptPosition()
         {
-            if (_callStack.Count > 0)
+            using (IEnumerator<CallStackFrame> enumerator = GetCallStack().GetEnumerator())
             {
-                var fnContext = _callStack[0].FunctionContext;
-                if (fnContext is not null)
+                if (enumerator.MoveNext())
                 {
-                    var invocationInfo = new InvocationInfo(null, fnContext.CurrentPosition, _context);
-                    string scriptText = invocationInfo.GetFullScript();
-                    if (!string.IsNullOrEmpty(scriptText))
+                    var fnContext = enumerator.Current.FunctionContext;
+                    if (fnContext is not null)
                     {
-                        string[] scriptLines = scriptText.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-                        if (scriptLines.Length > invocationInfo.ScriptLineNumber)
-                        {
-                            string scriptLine = scriptLines[invocationInfo.ScriptLineNumber];
-                            return $"{invocationInfo.PositionMessage ?? string.Empty} : \n{scriptLine ?? string.Empty}";
-                        }
+                        var invocationInfo = new InvocationInfo(null, fnContext.CurrentPosition, _context);
+                        return $"\n{invocationInfo.PositionMessage}";
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -2540,10 +2540,10 @@ namespace System.Management.Automation
             {
                 if (enumerator.MoveNext())
                 {
-                    var fnContext = enumerator.Current.FunctionContext;
-                    if (fnContext is not null)
+                    var functionContext = enumerator.Current.FunctionContext;
+                    if (functionContext is not null)
                     {
-                        var invocationInfo = new InvocationInfo(null, fnContext.CurrentPosition, _context);
+                        var invocationInfo = new InvocationInfo(null, functionContext.CurrentPosition, _context);
                         return $"\n{invocationInfo.PositionMessage}";
                     }
                 }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -791,6 +791,16 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Returns script position message of current execution stack item.
+        /// This is used for WDAC audit mode logging for script information enhancement.
+        /// </summary>
+        /// <returns>Script position message string.</returns>
+        internal virtual string GetCurrentScriptPosition()
+        {
+            throw new PSNotImplementedException();
+        }
+
+        /// <summary>
         /// Passes the debugger command to the internal script debugger command processor.  This
         /// is used internally to handle debugger commands such as list, help, etc.
         /// </summary>
@@ -2517,6 +2527,35 @@ namespace System.Management.Automation
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns script position message of current execution stack item.
+        /// This is used for WDAC audit mode logging for script information enhancement.
+        /// </summary>
+        /// <returns>Script position message string.</returns>
+        internal override string GetCurrentScriptPosition()
+        {
+            if (_callStack.Count > 0)
+            {
+                var fnContext = _callStack[0].FunctionContext;
+                if (fnContext is not null)
+                {
+                    var invocationInfo = new InvocationInfo(null, fnContext.CurrentPosition, _context);
+                    string scriptText = invocationInfo.GetFullScript();
+                    if (!string.IsNullOrEmpty(scriptText))
+                    {
+                        string[] scriptLines = scriptText.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+                        if (scriptLines.Length > invocationInfo.ScriptLineNumber)
+                        {
+                            string scriptLine = scriptLines[invocationInfo.ScriptLineNumber];
+                            return $"{invocationInfo.PositionMessage ?? string.Empty} : \n{scriptLine ?? string.Empty}";
+                        }
+                    }
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -481,6 +481,7 @@ namespace System.Management.Automation.Runspaces
                         scriptBlock.CheckRestrictedLanguage(null, null, false);
                         break;
                     case PSLanguageMode.FullLanguage:
+                    case PSLanguageMode.ConstrainedLanguageAudit:
                         // Interactive script commands are permitted in this mode.
                         break;
                     case PSLanguageMode.ConstrainedLanguage:
@@ -522,6 +523,7 @@ namespace System.Management.Automation.Runspaces
                                 nameof(PSLanguageMode.NoLanguage));
                             throw new RuntimeException(message);
                         case PSLanguageMode.FullLanguage:
+                        case PSLanguageMode.ConstrainedLanguageAudit:
                             // Interactive script commands are permitted in this mode...
                             break;
                     }

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -936,8 +936,20 @@ namespace System.Management.Automation.PSTasks
 
             // Create and initialize a new Runspace
             var iss = InitialSessionState.CreateDefault2();
-            iss.LanguageMode = (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Enforce)
-                ? PSLanguageMode.ConstrainedLanguage : PSLanguageMode.FullLanguage;
+            switch (SystemPolicy.GetSystemLockdownPolicy())
+            {
+                case SystemEnforcementMode.Enforce:
+                    iss.LanguageMode = PSLanguageMode.ConstrainedLanguage;
+                    break;
+
+                case SystemEnforcementMode.Audit:
+                    iss.LanguageMode = PSLanguageMode.ConstrainedLanguageAudit;
+                    break;
+
+                case SystemEnforcementMode.None:
+                    iss.LanguageMode = PSLanguageMode.FullLanguage;
+                    break;
+            }
             runspace = RunspaceFactory.CreateRunspace(iss);
             runspace.Name = runspaceName;
             _activeRunspaces.TryAdd(runspace.Id, runspace);

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -950,6 +950,7 @@ namespace System.Management.Automation.PSTasks
                     iss.LanguageMode = PSLanguageMode.FullLanguage;
                     break;
             }
+            
             runspace = RunspaceFactory.CreateRunspace(iss);
             runspace.Name = runspaceName;
             _activeRunspaces.TryAdd(runspace.Id, runspace);

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2985,9 +2985,9 @@ namespace System.Management.Automation.Language
                 if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
                 {
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "Parser Configuration Keyword",
-                        Message: "The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
-                        FQID: "ConfigurationLanguageKeywordNotAllowed");
+                        title: "Parser Configuration Keyword",
+                        message: "The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
+                        fqid: "ConfigurationLanguageKeywordNotAllowed");
                 }
 
                 // Configuration is not supported on ARM or in ConstrainedLanguage
@@ -4211,9 +4211,9 @@ namespace System.Management.Automation.Language
             if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 SystemPolicy.LogWDACAuditMessage(
-                    Title: "Parser Class keyword",
-                    Message: "The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
-                    FQID: "ClassLanguageKeywordNotAllowed");
+                    title: "Parser Class keyword",
+                    message: "The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
+                    fqid: "ClassLanguageKeywordNotAllowed");
             }
             else if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguage)
             {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2986,7 +2986,7 @@ namespace System.Management.Automation.Language
                 {
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Parser Configuration Keyword",
-                        Message: $"The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.");
+                        Message: "The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.");
                 }
 
                 // Configuration is not supported on ARM or in ConstrainedLanguage
@@ -4211,7 +4211,7 @@ namespace System.Management.Automation.Language
             {
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Parser Class keyword",
-                    Message: $"The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.");
+                    Message: "The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.");
             }
             else if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguage)
             {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2985,8 +2985,8 @@ namespace System.Management.Automation.Language
                 if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
                 {
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "Parser Configuration Keyword",
-                        message: "The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
+                        title: ParserStrings.WDACParserConfigKeywordLogTitle,
+                        message: ParserStrings.WDACParserConfigKeywordLogMessage,
                         fqid: "ConfigurationLanguageKeywordNotAllowed");
                 }
 
@@ -4211,8 +4211,8 @@ namespace System.Management.Automation.Language
             if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 SystemPolicy.LogWDACAuditMessage(
-                    title: "Parser Class keyword",
-                    message: "The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
+                    title: ParserStrings.WDACParserClassKeywordLogTitle,
+                    message: ParserStrings.WDACParserClassKeywordLogMessage,
                     fqid: "ClassLanguageKeywordNotAllowed");
             }
             else if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguage)

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2986,7 +2986,8 @@ namespace System.Management.Automation.Language
                 {
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Parser Configuration Keyword",
-                        Message: "The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.");
+                        Message: "The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
+                        FQID: "ConfigurationLanguageKeywordNotAllowed");
                 }
 
                 // Configuration is not supported on ARM or in ConstrainedLanguage
@@ -4211,7 +4212,8 @@ namespace System.Management.Automation.Language
             {
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Parser Class keyword",
-                    Message: "The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.");
+                    Message: "The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.",
+                    FQID: "ClassLanguageKeywordNotAllowed");
             }
             else if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguage)
             {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2987,7 +2987,8 @@ namespace System.Management.Automation.Language
                     SystemPolicy.LogWDACAuditMessage(
                         title: ParserStrings.WDACParserConfigKeywordLogTitle,
                         message: ParserStrings.WDACParserConfigKeywordLogMessage,
-                        fqid: "ConfigurationLanguageKeywordNotAllowed");
+                        fqid: "ConfigurationLanguageKeywordNotAllowed",
+                        dropIntoDebugger: true);
                 }
 
                 // Configuration is not supported on ARM or in ConstrainedLanguage
@@ -4213,7 +4214,8 @@ namespace System.Management.Automation.Language
                 SystemPolicy.LogWDACAuditMessage(
                     title: ParserStrings.WDACParserClassKeywordLogTitle,
                     message: ParserStrings.WDACParserClassKeywordLogMessage,
-                    fqid: "ClassLanguageKeywordNotAllowed");
+                    fqid: "ClassLanguageKeywordNotAllowed",
+                    dropIntoDebugger: true);
             }
             else if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguage)
             {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2985,6 +2985,7 @@ namespace System.Management.Automation.Language
                 if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
                 {
                     SystemPolicy.LogWDACAuditMessage(
+                        context: Runspace.DefaultRunspace?.ExecutionContext,
                         title: ParserStrings.WDACParserConfigKeywordLogTitle,
                         message: ParserStrings.WDACParserConfigKeywordLogMessage,
                         fqid: "ConfigurationLanguageKeywordNotAllowed",
@@ -4212,6 +4213,7 @@ namespace System.Management.Automation.Language
             if (Runspace.DefaultRunspace?.ExecutionContext?.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 SystemPolicy.LogWDACAuditMessage(
+                    context: Runspace.DefaultRunspace?.ExecutionContext,
                     title: ParserStrings.WDACParserClassKeywordLogTitle,
                     message: ParserStrings.WDACParserClassKeywordLogMessage,
                     fqid: "ClassLanguageKeywordNotAllowed",

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1836,7 +1836,8 @@ namespace System.Management.Automation.Language
                     SystemPolicy.LogWDACAuditMessage(
                         title: ParserStrings.WDACParserDSSupportedCommandLogTitle,
                         message: ParserStrings.WDACParserDSSupportedCommandLogMessage,
-                        fqid: "SupportedCommandInDataSectionNotSupported");
+                        fqid: "SupportedCommandInDataSectionNotSupported",
+                        dropIntoDebugger: true);
                     break;
 
                 case PSLanguageMode.ConstrainedLanguage:

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1834,6 +1834,7 @@ namespace System.Management.Automation.Language
             {
                 case PSLanguageMode.ConstrainedLanguageAudit:
                     SystemPolicy.LogWDACAuditMessage(
+                        context: executionContext,
                         title: ParserStrings.WDACParserDSSupportedCommandLogTitle,
                         message: ParserStrings.WDACParserDSSupportedCommandLogMessage,
                         fqid: "SupportedCommandInDataSectionNotSupported",

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1834,8 +1834,8 @@ namespace System.Management.Automation.Language
             {
                 case PSLanguageMode.ConstrainedLanguageAudit:
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "Parser Data Section SupportedCommand",
-                        message: "The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.",
+                        title: ParserStrings.WDACParserDSSupportedCommandLogTitle,
+                        message: ParserStrings.WDACParserDSSupportedCommandLogMessage,
                         fqid: "SupportedCommandInDataSectionNotSupported");
                     break;
 

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1834,9 +1834,9 @@ namespace System.Management.Automation.Language
             {
                 case PSLanguageMode.ConstrainedLanguageAudit:
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "Parser Data Section SupportedCommand",
-                        Message: "The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.",
-                        FQID: "SupportedCommandInDataSectionNotSupported");
+                        title: "Parser Data Section SupportedCommand",
+                        message: "The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.",
+                        fqid: "SupportedCommandInDataSectionNotSupported");
                     break;
 
                 case PSLanguageMode.ConstrainedLanguage:

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1835,7 +1835,8 @@ namespace System.Management.Automation.Language
                 case PSLanguageMode.ConstrainedLanguageAudit:
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Parser Data Section SupportedCommand",
-                        Message: "The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.");
+                        Message: "The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.",
+                        FQID: "SupportedCommandInDataSectionNotSupported");
                     break;
 
                 case PSLanguageMode.ConstrainedLanguage:

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1835,7 +1835,7 @@ namespace System.Management.Automation.Language
                 case PSLanguageMode.ConstrainedLanguageAudit:
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Parser Data Section SupportedCommand",
-                        Message: $"The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.");
+                        Message: "The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.");
                     break;
 
                 case PSLanguageMode.ConstrainedLanguage:

--- a/src/System.Management.Automation/engine/remoting/client/RunspaceRef.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RunspaceRef.cs
@@ -88,13 +88,15 @@ namespace System.Management.Automation.Remoting
                 // Extract execution context from local runspace.
                 Runspace localRunspace = _runspaceRef.OldValue;
                 ExecutionContext context = localRunspace.ExecutionContext;
+                var localRunspaceLanguageMode = localRunspace.ExecutionContext.LanguageMode;
 
-                // This is trusted input as long as we're in FullLanguage mode
+                // This is trusted input as long as we're in FullLanguage or ConstrainedLanguageAudit mode.
                 // and if we are not in a loopback configuration mode, in which case we always force remote script commands
                 // to be parsed and evaluated on the remote session (not in the current local session).
                 RemoteRunspace remoteRunspace = _runspaceRef.Value as RemoteRunspace;
                 bool isConfiguredLoopback = remoteRunspace != null && remoteRunspace.IsConfiguredLoopBack;
-                bool isTrustedInput = !isConfiguredLoopback && (localRunspace.ExecutionContext.LanguageMode == PSLanguageMode.FullLanguage);
+                bool isTrustedInput = !isConfiguredLoopback && 
+                    (localRunspaceLanguageMode == PSLanguageMode.FullLanguage || localRunspaceLanguageMode == PSLanguageMode.ConstrainedLanguageAudit);
 
                 // Create PowerShell from ScriptBlock.
                 ScriptBlock scriptBlock = ScriptBlock.Create(context, line);

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2331,8 +2331,8 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                // This is trusted input as long as we're in FullLanguage mode
-                bool isTrustedInput = (Context.LanguageMode == PSLanguageMode.FullLanguage);
+                // This is trusted input as long as we're in FullLanguage or ConstrainedLanguageAudit mode
+                bool isTrustedInput = Context.LanguageMode == PSLanguageMode.FullLanguage || Context.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit;
                 powershell = _scriptBlock.GetPowerShell(isTrustedInput, _args);
             }
             catch (ScriptBlockToPowerShellNotSupportedException)

--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -646,7 +646,7 @@ namespace Microsoft.PowerShell.Commands
         {
             // If we're in ConstrainedLanguage mode and the system is in lockdown mode,
             // ensure that they haven't specified a ScriptBlock or InitScript - as
-            // we can't protect that boundary
+            // we can't protect that boundary.
             if ((Context.LanguageMode == PSLanguageMode.ConstrainedLanguage) &&
                 (SystemPolicy.GetSystemLockdownPolicy() != SystemEnforcementMode.Enforce) &&
                 ((ScriptBlock != null) || (InitializationScript != null)))

--- a/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
+++ b/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
@@ -160,6 +160,7 @@ namespace System.Management.Automation.Internal
         Engine_Trace = 0x1F06,
         Amsi_Init = 0x4001,
         WDAC_Query = 0x4002,
+        WDAC_Audit = 0x4003,
 
         // Experimental Features
         ExperimentalFeature_InvalidName = 0x3001,

--- a/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
+++ b/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
@@ -244,7 +244,8 @@ namespace System.Management.Automation.Internal
         NamedPipe = 0x6F,
         ISEOperation = 0x78,
         Amsi = 0X82,
-        WDAC = 0x83
+        WDAC = 0x83,
+        WDACAudit = 0x84
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -2760,7 +2760,7 @@ namespace System.Management.Automation.Remoting
             }
 
             SessionStateEntryVisibility visibility = SessionStateEntryVisibility.Private;
-            if (languageMode == PSLanguageMode.FullLanguage)
+            if (languageMode == PSLanguageMode.FullLanguage || languageMode == PSLanguageMode.ConstrainedLanguageAudit)
             {
                 visibility = SessionStateEntryVisibility.Public;
             }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5530,7 +5530,8 @@ namespace System.Management.Automation.Language
                     SystemPolicy.LogWDACAuditMessage(
                         title: ParameterBinderStrings.WDACBinderInvocationLogTitle,
                         message: StringUtil.Format(ParameterBinderStrings.WDACBinderInvocationLogMessage, name, targetName ?? string.Empty),
-                        fqid: "BinderMethodOrPropertyInvocationNotAllowed");
+                        fqid: "BinderMethodOrPropertyInvocationNotAllowed",
+                        dropIntoDebugger: true);
                 }
             }
 
@@ -7703,7 +7704,8 @@ namespace System.Management.Automation.Language
                 SystemPolicy.LogWDACAuditMessage(
                     title: ParameterBinderStrings.WDACBinderTypeCreationLogTitle,
                     message: StringUtil.Format(ParameterBinderStrings.WDACBinderTypeCreationLogMessage, targetName ?? string.Empty),
-                    fqid: "BinderTypeCreationNotAllowed");
+                    fqid: "BinderTypeCreationNotAllowed",
+                    dropIntoDebugger: true);
             }
 
             restrictions = args.Aggregate(restrictions, static (current, arg) => current.Merge(arg.PSGetMethodArgumentRestriction()));

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5528,9 +5528,9 @@ namespace System.Management.Automation.Language
 
                     string targetName = (targetValue as Type)?.FullName;
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "Parameter Binder",
-                        Message: $"Method or Property {name} on type {targetName ?? string.Empty} invocation will not be allowed with policy enforcement.",
-                        FQID:"MethodOrPropertyInvocationNotAllowed");
+                        title: "Parameter Binder",
+                        message: $"Method or Property {name} on type {targetName ?? string.Empty} invocation will not be allowed with policy enforcement.",
+                        fqid: "MethodOrPropertyInvocationNotAllowed");
                 }
             }
 
@@ -7701,9 +7701,9 @@ namespace System.Management.Automation.Language
 
                 string targetName = instanceType?.FullName;
                 SystemPolicy.LogWDACAuditMessage(
-                    Title: "Parameter Binder",
-                    Message: $"Will not be able to create type {targetName ?? string.Empty} during binding with policy enforcement.",
-                    FQID:"BinderTypeCreationNotAllowed");
+                    title: "Parameter Binder",
+                    message: $"Will not be able to create type {targetName ?? string.Empty} during binding with policy enforcement.",
+                    fqid: "BinderTypeCreationNotAllowed");
             }
 
             restrictions = args.Aggregate(restrictions, static (current, arg) => current.Merge(arg.PSGetMethodArgumentRestriction()));

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5528,9 +5528,9 @@ namespace System.Management.Automation.Language
 
                     string targetName = (targetValue as Type)?.FullName;
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "Parameter Binder",
-                        message: $"Method or Property {name} on type {targetName ?? string.Empty} invocation will not be allowed with policy enforcement.",
-                        fqid: "MethodOrPropertyInvocationNotAllowed");
+                        title: ParameterBinderStrings.WDACBinderInvocationLogTitle,
+                        message: StringUtil.Format(ParameterBinderStrings.WDACBinderInvocationLogMessage, name, targetName ?? string.Empty),
+                        fqid: "BinderMethodOrPropertyInvocationNotAllowed");
                 }
             }
 
@@ -7701,8 +7701,8 @@ namespace System.Management.Automation.Language
 
                 string targetName = instanceType?.FullName;
                 SystemPolicy.LogWDACAuditMessage(
-                    title: "Parameter Binder",
-                    message: $"Will not be able to create type {targetName ?? string.Empty} during binding with policy enforcement.",
+                    title: ParameterBinderStrings.WDACBinderTypeCreationLogTitle,
+                    message: StringUtil.Format(ParameterBinderStrings.WDACBinderTypeCreationLogMessage, targetName ?? string.Empty),
                     fqid: "BinderTypeCreationNotAllowed");
             }
 

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5526,7 +5526,7 @@ namespace System.Management.Automation.Language
                         return target.ThrowRuntimeError(args, moreTests, errorID, resourceString);
                     }
 
-                    string targetName = (targetValue as Type)?.GetType()?.FullName;
+                    string targetName = (targetValue as Type)?.FullName;
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Parameter Binder",
                         Message: $"Method or Property {name} on type {targetName ?? string.Empty} will not be accessible during binding with policy enforcement.");
@@ -7698,10 +7698,10 @@ namespace System.Management.Automation.Language
                     return target.ThrowRuntimeError(restrictions, "CannotCreateTypeConstrainedLanguage", ParserStrings.CannotCreateTypeConstrainedLanguage).WriteToDebugLog(this);
                 }
 
-                string targetName = instanceType?.GetType()?.FullName;
+                string targetName = instanceType?.FullName;
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Parameter Binder",
-                    Message: $"Will not be able to create type {targetName} during binding with policy enforcement.");
+                    Message: $"Will not be able to create type {targetName ?? string.Empty} during binding with policy enforcement.");
             }
 
             restrictions = args.Aggregate(restrictions, static (current, arg) => current.Merge(arg.PSGetMethodArgumentRestriction()));

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5528,6 +5528,7 @@ namespace System.Management.Automation.Language
 
                     string targetName = (targetValue as Type)?.FullName;
                     SystemPolicy.LogWDACAuditMessage(
+                        context: context,
                         title: ParameterBinderStrings.WDACBinderInvocationLogTitle,
                         message: StringUtil.Format(ParameterBinderStrings.WDACBinderInvocationLogMessage, name, targetName ?? string.Empty),
                         fqid: "BinderMethodOrPropertyInvocationNotAllowed",
@@ -7702,6 +7703,7 @@ namespace System.Management.Automation.Language
 
                 string targetName = instanceType?.FullName;
                 SystemPolicy.LogWDACAuditMessage(
+                    context: context,
                     title: ParameterBinderStrings.WDACBinderTypeCreationLogTitle,
                     message: StringUtil.Format(ParameterBinderStrings.WDACBinderTypeCreationLogMessage, targetName ?? string.Empty),
                     fqid: "BinderTypeCreationNotAllowed",

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5529,7 +5529,8 @@ namespace System.Management.Automation.Language
                     string targetName = (targetValue as Type)?.FullName;
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Parameter Binder",
-                        Message: $"Method or Property {name} on type {targetName ?? string.Empty} will not be accessible during binding with policy enforcement.");
+                        Message: $"Method or Property {name} on type {targetName ?? string.Empty} invocation will not be allowed with policy enforcement.",
+                        FQID:"MethodOrPropertyInvocationNotAllowed");
                 }
             }
 
@@ -7701,7 +7702,8 @@ namespace System.Management.Automation.Language
                 string targetName = instanceType?.FullName;
                 SystemPolicy.LogWDACAuditMessage(
                     Title: "Parameter Binder",
-                    Message: $"Will not be able to create type {targetName ?? string.Empty} during binding with policy enforcement.");
+                    Message: $"Will not be able to create type {targetName ?? string.Empty} during binding with policy enforcement.",
+                    FQID:"BinderTypeCreationNotAllowed");
             }
 
             restrictions = args.Aggregate(restrictions, static (current, arg) => current.Merge(arg.PSGetMethodArgumentRestriction()));

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5531,7 +5531,7 @@ namespace System.Management.Automation.Language
                         context: context,
                         title: ParameterBinderStrings.WDACBinderInvocationLogTitle,
                         message: StringUtil.Format(ParameterBinderStrings.WDACBinderInvocationLogMessage, name, targetName ?? string.Empty),
-                        fqid: "BinderMethodOrPropertyInvocationNotAllowed",
+                        fqid: "MethodOrPropertyInvocationNotAllowed",
                         dropIntoDebugger: true);
                 }
             }
@@ -7706,7 +7706,7 @@ namespace System.Management.Automation.Language
                     context: context,
                     title: ParameterBinderStrings.WDACBinderTypeCreationLogTitle,
                     message: StringUtil.Format(ParameterBinderStrings.WDACBinderTypeCreationLogMessage, targetName ?? string.Empty),
-                    fqid: "BinderTypeCreationNotAllowed",
+                    fqid: "TypeCreationNotAllowed",
                     dropIntoDebugger: true);
             }
 

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1070,9 +1070,9 @@ namespace System.Management.Automation
                 else if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                 {
                     SystemPolicy.LogWDACAuditMessage(
-                        Title: "Compiled Script Block Dot Source",
-                        Message: $"Script block invocation into current scope language transition would be disallowed when policiy is enforced.  Script language mode: {this.LanguageMode}, Context language mode: {context.LanguageMode}",
-                        FQID: "ScriptBlockDotSourceNotAllowed");
+                        title: "Compiled Script Block Dot Source",
+                        message: $"Script block invocation into current scope language transition would be disallowed when policiy is enforced.  Script language mode: {this.LanguageMode}, Context language mode: {context.LanguageMode}",
+                        fqid: "ScriptBlockDotSourceNotAllowed");
 
                     // Since we are in audit mode, go ahead and allow the language transition.
                     oldLanguageMode = context.LanguageMode;

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1070,8 +1070,8 @@ namespace System.Management.Automation
                 else if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                 {
                     SystemPolicy.LogWDACAuditMessage(
-                        title: "Compiled Script Block Dot Source",
-                        message: $"Script block invocation into current scope language transition would be disallowed when policiy is enforced.  Script language mode: {this.LanguageMode}, Context language mode: {context.LanguageMode}",
+                        title: AutomationExceptions.WDACCompiledScriptBlockLogTitle,
+                        message: StringUtil.Format(AutomationExceptions.WDACCompiledScriptBlockLogMessage, this.GetFileName() ?? string.Empty, this.LanguageMode, context.LanguageMode),
                         fqid: "ScriptBlockDotSourceNotAllowed");
 
                     // Since we are in audit mode, go ahead and allow the language transition.

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1073,7 +1073,8 @@ namespace System.Management.Automation
                     SystemPolicy.LogWDACAuditMessage(
                         title: AutomationExceptions.WDACCompiledScriptBlockLogTitle,
                         message: StringUtil.Format(AutomationExceptions.WDACCompiledScriptBlockLogMessage, scriptBlockId, this.LanguageMode, context.LanguageMode),
-                        fqid: "ScriptBlockDotSourceNotAllowed");
+                        fqid: "ScriptBlockDotSourceNotAllowed",
+                        dropIntoDebugger: true);
 
                     // Since we are in audit mode, go ahead and allow the language transition.
                     oldLanguageMode = context.LanguageMode;

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1071,7 +1071,8 @@ namespace System.Management.Automation
                 {
                     SystemPolicy.LogWDACAuditMessage(
                         Title: "Compiled Script Block Dot Source",
-                        Message: $"Script block invocation into current scope language transition would be disallowed when policiy is enforced.  Script language mode: {this.LanguageMode}, Context language mode: {context.LanguageMode}");
+                        Message: $"Script block invocation into current scope language transition would be disallowed when policiy is enforced.  Script language mode: {this.LanguageMode}, Context language mode: {context.LanguageMode}",
+                        FQID: "ScriptBlockDotSourceNotAllowed");
 
                     // Since we are in audit mode, go ahead and allow the language transition.
                     oldLanguageMode = context.LanguageMode;

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -10,6 +10,7 @@ using System.Management.Automation.Configuration;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
+using System.Management.Automation.Security;
 using System.Management.Automation.Tracing;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -1051,12 +1052,11 @@ namespace System.Management.Automation
             var oldScopeOrigin = context.EngineSessionState.CurrentScope.ScopeOrigin;
             var oldSessionState = context.EngineSessionState;
 
-            // If the script block has a different language mode than the current,
+            // If the script block has a different language mode than the current context,
             // change the language mode.
             PSLanguageMode? oldLanguageMode = null;
             PSLanguageMode? newLanguageMode = null;
-            if (this.LanguageMode.HasValue
-                && this.LanguageMode != context.LanguageMode)
+            if (this.LanguageMode.HasValue && this.LanguageMode != context.LanguageMode)
             {
                 // Don't allow context: ConstrainedLanguage -> FullLanguage transition if
                 // this is dot sourcing into the current scope, unless it is within a trusted module scope.
@@ -1064,6 +1064,16 @@ namespace System.Management.Automation
                     || createLocalScope
                     || context.EngineSessionState.Module?.LanguageMode == PSLanguageMode.FullLanguage)
                 {
+                    oldLanguageMode = context.LanguageMode;
+                    newLanguageMode = this.LanguageMode;
+                }
+                else if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
+                {
+                    SystemPolicy.LogWDACAuditMessage(
+                        Title: "Compiled Script Block Dot Source",
+                        Message: $"Script block invocation into current scope language transition would be disallowed when policiy is enforced.  Script language mode: {this.LanguageMode}, Context language mode: {context.LanguageMode}");
+
+                    // Since we are in audit mode, go ahead and allow the language transition.
                     oldLanguageMode = context.LanguageMode;
                     newLanguageMode = this.LanguageMode;
                 }
@@ -2360,8 +2370,8 @@ namespace System.Management.Automation
             // change the language mode.
             PSLanguageMode? oldLanguageMode = null;
             PSLanguageMode? newLanguageMode = null;
-            if (_scriptBlock.LanguageMode.HasValue
-                && _scriptBlock.LanguageMode != Context.LanguageMode)
+            if (_scriptBlock.LanguageMode.HasValue &&
+                _scriptBlock.LanguageMode != Context.LanguageMode)
             {
                 oldLanguageMode = Context.LanguageMode;
                 newLanguageMode = _scriptBlock.LanguageMode;

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1069,9 +1069,10 @@ namespace System.Management.Automation
                 }
                 else if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                 {
+                    string scriptBlockId = $"{this.Id}+{this.GetFileName() ?? string.Empty}";
                     SystemPolicy.LogWDACAuditMessage(
                         title: AutomationExceptions.WDACCompiledScriptBlockLogTitle,
-                        message: StringUtil.Format(AutomationExceptions.WDACCompiledScriptBlockLogMessage, this.GetFileName() ?? string.Empty, this.LanguageMode, context.LanguageMode),
+                        message: StringUtil.Format(AutomationExceptions.WDACCompiledScriptBlockLogMessage, scriptBlockId, this.LanguageMode, context.LanguageMode),
                         fqid: "ScriptBlockDotSourceNotAllowed");
 
                     // Since we are in audit mode, go ahead and allow the language transition.

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1071,6 +1071,7 @@ namespace System.Management.Automation
                 {
                     string scriptBlockId = $"{this.Id}+{this.GetFileName() ?? string.Empty}";
                     SystemPolicy.LogWDACAuditMessage(
+                        context: context,
                         title: AutomationExceptions.WDACCompiledScriptBlockLogTitle,
                         message: StringUtil.Format(AutomationExceptions.WDACCompiledScriptBlockLogMessage, scriptBlockId, this.LanguageMode, context.LanguageMode),
                         fqid: "ScriptBlockDotSourceNotAllowed",

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -63,7 +63,8 @@ namespace System.Management.Automation
                         SystemPolicy.LogWDACAuditMessage(
                             title: ParserStrings.WDACParserModuleScopeCallOperatorLogTitle,
                             message: ParserStrings.WDACParserModuleScopeCallOperatorLogMessage,
-                            fqid: "ModuleScopeCallOperatorNotAllowed");
+                            fqid: "ModuleScopeCallOperatorNotAllowed",
+                            dropIntoDebugger: true);
                     }
                     else
                     {
@@ -3015,7 +3016,8 @@ namespace System.Management.Automation
                                         SystemPolicy.LogWDACAuditMessage(
                                             title: ParserStrings.WDACParserForEachOperatorLogTitle,
                                             message: StringUtil.Format(ParserStrings.WDACParserForEachOperatorLogMessage, method.Name ?? string.Empty),
-                                            fqid: "ForEachOperatorMethodInvocationNotAllowed");
+                                            fqid: "ForEachOperatorMethodInvocationNotAllowed",
+                                            dropIntoDebugger: true);
                                     }
                                 }
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -61,9 +61,9 @@ namespace System.Management.Automation
                     {
                         // In audit mode, report but don't enforce.
                         SystemPolicy.LogWDACAuditMessage(
-                            Title: "Module Scope Call Operator",
-                            Message: "The module scope call operator, & (Get-Module MyModule) MyFunction, would be denied when run in policy enforcement.",
-                            FQID: "ModuleScopeCallOperatorNotAllowed");
+                            title: "Module Scope Call Operator",
+                            message: "The module scope call operator, & (Get-Module MyModule) MyFunction, would be denied when run in policy enforcement.",
+                            fqid: "ModuleScopeCallOperatorNotAllowed");
                     }
                     else
                     {
@@ -3013,9 +3013,9 @@ namespace System.Management.Automation
                                         }
 
                                         SystemPolicy.LogWDACAuditMessage(
-                                            Title: "ForEach Operator",
-                                            Message: $"The ForEach operator would fail method invocation, {method.Name ?? string.Empty}, when run in Constrained Language mode.",
-                                            FQID: "ForEachOperatorMethodInvocationNotAllowed");
+                                            title: "ForEach Operator",
+                                            message: $"The ForEach operator would fail method invocation, {method.Name ?? string.Empty}, when run in Constrained Language mode.",
+                                            fqid: "ForEachOperatorMethodInvocationNotAllowed");
                                     }
                                 }
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -62,7 +62,8 @@ namespace System.Management.Automation
                         // In audit mode, report but don't enforce.
                         SystemPolicy.LogWDACAuditMessage(
                             Title: "Module Scope Call Operator",
-                            Message: "The module scope call operator, & (Get-Module MyModule) MyFunction, would be denied when run in policy enforcement.");
+                            Message: "The module scope call operator, & (Get-Module MyModule) MyFunction, would be denied when run in policy enforcement.",
+                            FQID: "ModuleScopeCallOperatorNotAllowed");
                     }
                     else
                     {
@@ -3013,7 +3014,8 @@ namespace System.Management.Automation
 
                                         SystemPolicy.LogWDACAuditMessage(
                                             Title: "ForEach Operator",
-                                            Message: $"The ForEach operator would fail method call, {method.Name ?? string.Empty}, when run in Constrained Language mode.");
+                                            Message: $"The ForEach operator would fail method invocation, {method.Name ?? string.Empty}, when run in Constrained Language mode.",
+                                            FQID: "ForEachOperatorMethodInvocationNotAllowed");
                                     }
                                 }
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -61,8 +61,8 @@ namespace System.Management.Automation
                     {
                         // In audit mode, report but don't enforce.
                         SystemPolicy.LogWDACAuditMessage(
-                            title: "Module Scope Call Operator",
-                            message: "The module scope call operator, & (Get-Module MyModule) MyFunction, would be denied when run in policy enforcement.",
+                            title: ParserStrings.WDACParserModuleScopeCallOperatorLogTitle,
+                            message: ParserStrings.WDACParserModuleScopeCallOperatorLogMessage,
                             fqid: "ModuleScopeCallOperatorNotAllowed");
                     }
                     else
@@ -3013,8 +3013,8 @@ namespace System.Management.Automation
                                         }
 
                                         SystemPolicy.LogWDACAuditMessage(
-                                            title: "ForEach Operator",
-                                            message: $"The ForEach operator would fail method invocation, {method.Name ?? string.Empty}, when run in Constrained Language mode.",
+                                            title: ParserStrings.WDACParserForEachOperatorLogTitle,
+                                            message: StringUtil.Format(ParserStrings.WDACParserForEachOperatorLogMessage, method.Name ?? string.Empty),
                                             fqid: "ForEachOperatorMethodInvocationNotAllowed");
                                     }
                                 }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -696,7 +696,7 @@ namespace System.Management.Automation
                 // GetSteppablePipeline() is called on an arbitrary script block with the intention
                 // of invoking it. So the trustworthiness is defined by the trustworthiness of the
                 // script block's language mode.
-                bool isTrusted = scriptBlock.LanguageMode == PSLanguageMode.FullLanguage;
+                bool isTrusted = scriptBlock.LanguageMode == PSLanguageMode.FullLanguage || scriptBlock.LanguageMode == PSLanguageMode.ConstrainedLanguageAudit;
 
                 foreach (var commandAst in pipelineAst.PipelineElements.Cast<CommandAst>())
                 {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -61,6 +61,7 @@ namespace System.Management.Automation
                     {
                         // In audit mode, report but don't enforce.
                         SystemPolicy.LogWDACAuditMessage(
+                            context: context,
                             title: ParserStrings.WDACParserModuleScopeCallOperatorLogTitle,
                             message: ParserStrings.WDACParserModuleScopeCallOperatorLogMessage,
                             fqid: "ModuleScopeCallOperatorNotAllowed",
@@ -3014,6 +3015,7 @@ namespace System.Management.Automation
                                         }
 
                                         SystemPolicy.LogWDACAuditMessage(
+                                            context: context,
                                             title: ParserStrings.WDACParserForEachOperatorLogTitle,
                                             message: StringUtil.Format(ParserStrings.WDACParserForEachOperatorLogMessage, method.Name ?? string.Empty),
                                             fqid: "ForEachOperatorMethodInvocationNotAllowed",

--- a/src/System.Management.Automation/logging/LogProvider.cs
+++ b/src/System.Management.Automation/logging/LogProvider.cs
@@ -123,6 +123,17 @@ namespace System.Management.Automation
             int queryResult);
 
         /// <summary>
+        /// Provider interface function for logging WDAC audit event.
+        /// </summary>
+        /// <param name="title">Title of WDAC audit event.</param>
+        /// <param name="message">WDAC audit event message.</param>
+        /// <param name="fqid">FullyQualifiedId of WDAC audit event.</param>
+        internal abstract void LogWDACAuditEvent(
+            string title,
+            string message,
+            string fqid);
+
+        /// <summary>
         /// True if the log provider needs to use logging variables.
         /// </summary>
         /// <returns></returns>
@@ -411,6 +422,19 @@ namespace System.Management.Automation
             string fileName,
             int querySuccess,
             int queryResult)
+        {
+        }
+
+        /// <summary>
+        /// Provider interface function for logging WDAC audit event.
+        /// </summary>
+        /// <param name="title">Title of WDAC audit event.</param>
+        /// <param name="message">WDAC audit event message.</param>
+        /// <param name="fqid">FullyQualifiedId of WDAC audit event.</param>
+        internal override void LogWDACAuditEvent(
+            string title,
+            string message,
+            string fqid)
         {
         }
 

--- a/src/System.Management.Automation/resources/AutomationExceptions.resx
+++ b/src/System.Management.Automation/resources/AutomationExceptions.resx
@@ -201,4 +201,10 @@
   <data name="CantGetUsingExpressionValueWithSpecifiedVariableDictionary" xml:space="preserve">
     <value>Cannot get the value of the Using expression '{0}' in the specified variable dictionary. When creating a PowerShell instance from a script block, the Using expression cannot contain an indexing operation or member-accessing operation.</value>
   </data>
+  <data name="WDACCompiledScriptBlockLogTitle" xml:space="preserve">
+    <value>Compiled Script Block Dot Source</value>
+  </data>
+  <data name="WDACCompiledScriptBlockLogMessage" xml:space="preserve">
+    <value>Script block '{0}' invocation into current scope will be disallowed when policy is enforced. Script language mode: {1}, Context language mode: {2}.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -228,4 +228,10 @@ Reviewed by TArcher on 2010-07-20
   <data name="NativeCommandNotFound" xml:space="preserve">
     <value>Command '{0}' was not found. The specified command must be an executable.</value>
   </data>
+  <data name="WDACLogTitle" xml:space="preserve">
+    <value>Script Block Processing Dot-Source Check</value>
+  </data>
+  <data name="WDACLogMessage" xml:space="preserve">
+    <value>Dot-Source processing for script block '{0}' will fail in Constrained Language mode because its language mode '{1}' does not match the current language mode '{2}'.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -234,4 +234,10 @@ Reviewed by TArcher on 2010-07-20
   <data name="WDACLogMessage" xml:space="preserve">
     <value>Dot-Source processing for script block '{0}' will fail in Constrained Language mode because its language mode '{1}' does not match the current language mode '{2}'.</value>
   </data>
+  <data name="SearcherWDACLogTitle" xml:space="preserve">
+    <value>Command Searcher</value>
+  </data>
+  <data name="SearcherWDACLogMessage" xml:space="preserve">
+    <value>Command '{0}' in module '{1}' is untrusted and will not be accessible in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
+++ b/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
@@ -388,4 +388,16 @@ PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
     <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
   </data>
+  <data name="WDACHashTypeLogTitle" xml:space="preserve">
+    <value>Extended Type System Hashtable Conversion</value>
+  </data>
+  <data name="WDACHashTypeLogMessage" xml:space="preserve">
+    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+  </data>
+  <data name="WDACTypeConversionLogTitle" xml:space="preserve">
+    <value>Extended Type System Hashtable Conversion</value>
+  </data>
+  <data name="WDACTypeConversionLogMessage" xml:space="preserve">
+    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/InternalCommandStrings.resx
+++ b/src/System.Management.Automation/resources/InternalCommandStrings.resx
@@ -184,4 +184,10 @@ ErrorAction, WarningAction, InformationAction, PipelineVariable</value>
   <data name="ParallelPipedInputProcessingError" xml:space="preserve">
     <value>An unexpected error has occurred while processing ForEach-Object -Parallel input. This may mean that some of the piped input did not get processed. Error: {0}.</value>
   </data>
+  <data name="WDACLogTitle" xml:space="preserve">
+    <value>ForEach-Object Cmdlet</value>
+  </data>
+  <data name="WDACLogMessage" xml:space="preserve">
+    <value>Method invocation on type '{0}' would not be allowed when run in non-audit policy enforcement mode.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -627,4 +627,10 @@
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
     <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
   </data>
+  <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
+    <value>Export-ModuleMember Cmdlet</value>
+  </data>
+  <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
+    <value>Export of module members will fail because module '{0}', has a different language mode '{1}' than the current session '{2}'.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -633,4 +633,37 @@
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
     <value>Export of module members will fail because module '{0}', has a different language mode '{1}' than the current session '{2}'.</value>
   </data>
+  <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
+    <value>Module Implicit Function Export</value>
+  </data>
+  <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
+    <value>Implicit function export for module '{0}' will be denied, because it is trusted but the session is in ConstrainedLanguage mode (not trusted).</value>
+  </data>
+  <data name="WDACImplicitFunctionExportLogMessage2" xml:space="preserve">
+    <value>Implict function export for trusted module '{0}' will be denied because the session is in ConstrainedLanguage mode.</value>
+  </data>
+  <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
+    <value>Importing Script File as Module</value>
+  </data>
+  <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
+    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+  </data>
+  <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
+    <value>Module Contains Dot-Source Operator</value>
+  </data>
+  <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
+    <value>Module '{0}' import will fail because it exports functions using wild card characters while also uses the dot-source operator.</value>
+  </data>
+  <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
+    <value>"Module Exporting Functions</value>
+  </data>
+  <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
+    <value>Module '{0}' exports functions using name wildcard characters, any nested module function names will be removed when running in ConstrainedLanguage mode.</value>
+  </data>
+  <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
+    <value>"New-Module Cmdlet</value>
+  </data>
+  <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
+    <value>A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -666,4 +666,10 @@
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
     <value>A new module from an untrusted ConstrainedLanguage session would be blocked from providing the FullLanguage script block.</value>
   </data>
+  <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
+    <value>"Module Mismatched Language Modes</value>
+  </data>
+  <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
+    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when the policy is enforced.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/ParameterBinderStrings.resx
+++ b/src/System.Management.Automation/resources/ParameterBinderStrings.resx
@@ -247,15 +247,15 @@
     <value>The key '{0}' has already been added to the dictionary.</value>
   </data>
   <data name="WDACBinderInvocationLogTitle" xml:space="preserve">
-    <value>Parameter Binder Invocation</value>
+    <value>Method or Property Invocation Not Allowed</value>
   </data>
   <data name="WDACBinderInvocationLogMessage" xml:space="preserve">
     <value>Method or Property '{0}' on type '{1}' invocation will not be allowed in ConstrainedLanguage mode.</value>
   </data>
   <data name="WDACBinderTypeCreationLogTitle" xml:space="preserve">
-    <value>Parameter Binder Type Creation</value>
+    <value>Type Creation Not Allowed</value>
   </data>
   <data name="WDACBinderTypeCreationLogMessage" xml:space="preserve">
-    <value>Will not be able to create type '{0}' during binding in ConstrainedLanguage mode.</value>
+    <value>Will not be able to create type '{0}' during parameter binding in ConstrainedLanguage mode.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ParameterBinderStrings.resx
+++ b/src/System.Management.Automation/resources/ParameterBinderStrings.resx
@@ -246,4 +246,16 @@
   <data name="KeyAlreadyAdded" xml:space="preserve">
     <value>The key '{0}' has already been added to the dictionary.</value>
   </data>
+  <data name="WDACBinderInvocationLogTitle" xml:space="preserve">
+    <value>Parameter Binder Invocation</value>
+  </data>
+  <data name="WDACBinderInvocationLogMessage" xml:space="preserve">
+    <value>Method or Property '{0}' on type '{1}' invocation will not be allowed in ConstrainedLanguage mode.</value>
+  </data>
+  <data name="WDACBinderTypeCreationLogTitle" xml:space="preserve">
+    <value>Parameter Binder Type Creation</value>
+  </data>
+  <data name="WDACBinderTypeCreationLogMessage" xml:space="preserve">
+    <value>Will not be able to create type '{0}' during binding in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1328,4 +1328,34 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="InvokingCleanBlockNotSupported" xml:space="preserve">
     <value>Directly invoking the 'clean' block of a script block is not supported.</value>
   </data>
+  <data name="WDACParserConfigKeywordLogTitle" xml:space="preserve">
+    <value>Parser Configuration Keyword</value>
+  </data>
+  <data name="WDACParserConfigKeywordLogMessage" xml:space="preserve">
+    <value>The Configuration keyword would not allowed in ConstrainedLanguage mode for untrusted script.</value>
+  </data>
+  <data name="WDACParserClassKeywordLogTitle" xml:space="preserve">
+    <value>Parser Class Keyword</value>
+  </data>
+  <data name="WDACParserClassKeywordLogMessage" xml:space="preserve">
+    <value>The Class keyword would not allowed in ConstrainedLanguage mode for untrusted script.</value>
+  </data>
+  <data name="WDACParserDSSupportedCommandLogTitle" xml:space="preserve">
+    <value>Parser Data Section SupportedCommand</value>
+  </data>
+  <data name="WDACParserDSSupportedCommandLogMessage" xml:space="preserve">
+    <value>The Data Section that includes the SupportedCommand parameter would be disallowed in ConstrainedLanguage mode for untrusted script.</value>
+  </data>
+  <data name="WDACParserModuleScopeCallOperatorLogTitle" xml:space="preserve">
+    <value>Module Scope Call Operator</value>
+  </data>
+  <data name="WDACParserModuleScopeCallOperatorLogMessage" xml:space="preserve">
+    <value>The module scope call operator will be denied in policy enforcement.</value>
+  </data>
+  <data name="WDACParserForEachOperatorLogTitle" xml:space="preserve">
+    <value>ForEach Operator Method Invocation</value>
+  </data>
+  <data name="WDACParserForEachOperatorLogMessage" xml:space="preserve">
+    <value>The ForEach operator will fail '{0}' method invocation when run in Constrained Language mode.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/SecuritySupportStrings.resx
+++ b/src/System.Management.Automation/resources/SecuritySupportStrings.resx
@@ -163,6 +163,6 @@
     <value>Script File Read</value>
   </data>
   <data name="ExternalScriptWDACLogMessage" xml:space="preserve">
-    <value>Script file '{0}' is not trusted by policy and weill run in ConstrainedLanguage mode.</value>
+    <value>Script file '{0}' is not trusted by policy and will run in ConstrainedLanguage mode.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/SecuritySupportStrings.resx
+++ b/src/System.Management.Automation/resources/SecuritySupportStrings.resx
@@ -159,4 +159,10 @@
   <data name="UnknownSystemScriptFileEnforcement" xml:space="preserve">
     <value>An unknown script file policy enforcement value was returned: {0}.</value>
   </data>
+  <data name="ExternalScriptWDACLogTitle" xml:space="preserve">
+    <value>Script File Read</value>
+  </data>
+  <data name="ExternalScriptWDACLogMessage" xml:space="preserve">
+    <value>Script file '{0}' is not trusted by policy and weill run in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/SecuritySupportStrings.resx
+++ b/src/System.Management.Automation/resources/SecuritySupportStrings.resx
@@ -163,6 +163,6 @@
     <value>Script File Read</value>
   </data>
   <data name="ExternalScriptWDACLogMessage" xml:space="preserve">
-    <value>Script file '{0}' with scriptblock '{1}' is not trusted by policy and will run in ConstrainedLanguage mode.</value>
+    <value>Script file '{0}' is not trusted by policy and will run in ConstrainedLanguage mode.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/SecuritySupportStrings.resx
+++ b/src/System.Management.Automation/resources/SecuritySupportStrings.resx
@@ -163,6 +163,6 @@
     <value>Script File Read</value>
   </data>
   <data name="ExternalScriptWDACLogMessage" xml:space="preserve">
-    <value>Script file '{0}' is not trusted by policy and will run in ConstrainedLanguage mode.</value>
+    <value>Script file '{0}' with scriptblock '{1}' is not trusted by policy and will run in ConstrainedLanguage mode.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/SessionStateStrings.resx
+++ b/src/System.Management.Automation/resources/SessionStateStrings.resx
@@ -648,4 +648,10 @@
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
     <value>'{0}' parameter cannot be null or empty.</value>
   </data>
+  <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
+    <value>Session State Variables</value>
+  </data>
+  <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
+    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -78,11 +78,13 @@ namespace System.Management.Automation.Security
         /// </summary>
         /// <param name="Title">Audit message title.</param>
         /// <param name="Message">Audit message message.</param>
+        /// <param name="FQID">Fully Qualified ID.</param>
         internal static void LogWDACAuditMessage(
             string Title,
-            string Message)
+            string Message,
+            string FQID )
         {
-            var auditMessage = $"WDAC Audit mode - {Title} - {Message}";
+            var auditMessage = $"WDAC Audit mode - {Title} - {Message} - {FQID}";
 
             // TODO:  Add ETW call
             // PSEtwLog.LogWDACAuditEvent("message");

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -133,7 +133,7 @@ namespace System.Management.Automation.Security
             // First check latest WDAC APIs if available.
             // Revert to legacy APIs if system policy is in AUDIT mode or debug hook is in effect.
             Exception errorException = null;
-            if (s_wldpCanExecuteAvailable && systemLockdownPolicy != SystemEnforcementMode.Audit && !s_allowDebugOverridePolicy)
+            if (s_wldpCanExecuteAvailable && systemLockdownPolicy == SystemEnforcementMode.Enforce)
             {
                 try
                 {
@@ -196,6 +196,7 @@ namespace System.Management.Automation.Security
                 return SystemScriptFileEnforcement.None;
             }
 
+            // Check policy for file.
             switch (SystemPolicy.GetLockdownPolicy(filePath, fileHandle))
             {
                 case SystemEnforcementMode.Enforce:

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -76,11 +76,13 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Writes to PowerShell WDAC Audit mode ETW log.
         /// </summary>
+        /// <param name="context">Current execution context.</param>
         /// <param name="title">Audit message title.</param>
         /// <param name="message">Audit message message.</param>
         /// <param name="fqid">Fully Qualified ID.</param>
         /// <param name="dropIntoDebugger">Stops code execution and goes into debugger mode.</param>
         internal static void LogWDACAuditMessage(
+            ExecutionContext context,
             string title,
             string message,
             string fqid,
@@ -89,7 +91,7 @@ namespace System.Management.Automation.Security
             string messageToWrite = message;
 
             // Augment the log message with current script information from the script debugger, if available.
-            var context = System.Management.Automation.Runspaces.LocalPipeline.GetExecutionContextFromTLS();
+            context ??= System.Management.Automation.Runspaces.LocalPipeline.GetExecutionContextFromTLS();
             bool debuggerAvailable = context is not null &&
                                      context._debugger is not null &&
                                      context._debugger is ScriptDebugger;

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -111,7 +111,7 @@ namespace System.Management.Automation.Security
                 System.Console.WriteLine("Stopping script execution in debugger...");
                 System.Console.WriteLine(string.Empty);
 
-                context?._debugger?.SetDebuggerStepMode(true);
+                context._debugger.Break();
             }
         }
 

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -100,7 +100,7 @@ namespace System.Management.Automation.Security
                 var scriptPosMessage = context._debugger.GetCurrentScriptPosition();
                 if (!string.IsNullOrEmpty(scriptPosMessage))
                 {
-                    messageToWrite = message + "scriptPosMessage";
+                    messageToWrite = message + scriptPosMessage;
                 }
             }
 

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -84,19 +84,7 @@ namespace System.Management.Automation.Security
             string Message,
             string FQID )
         {
-            var auditMessage = $"WDAC Audit mode - {Title} - {Message} - {FQID}";
-
-            // TODO:  Add ETW call
-            // PSEtwLog.LogWDACAuditEvent("message");
-
-            // TODO: Debug only
-            try
-            {
-                System.Console.WriteLine(string.Empty);
-                System.Console.WriteLine(auditMessage);
-                System.Console.WriteLine(string.Empty);
-            }
-            catch { }
+            PSEtwLog.LogWDACAuditEvent(Title, Message, FQID);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -76,15 +76,15 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Writes to PowerShell WDAC Audit mode ETW log.
         /// </summary>
-        /// <param name="Title">Audit message title.</param>
-        /// <param name="Message">Audit message message.</param>
-        /// <param name="FQID">Fully Qualified ID.</param>
+        /// <param name="title">Audit message title.</param>
+        /// <param name="message">Audit message message.</param>
+        /// <param name="fqid">Fully Qualified ID.</param>
         internal static void LogWDACAuditMessage(
-            string Title,
-            string Message,
-            string FQID )
+            string title,
+            string message,
+            string fqid)
         {
-            PSEtwLog.LogWDACAuditEvent(Title, Message, FQID);
+            PSEtwLog.LogWDACAuditEvent(title, message, fqid);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -41,7 +41,7 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Script file is allowed to run in FullLanguage mode but will emit ConstrainedLanguage restriction audit logs.
         /// </summary>
-        AllowConstrainedAudit
+        AllowConstrainedAudit = 4
     }
 
     /// <summary>

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -92,8 +92,7 @@ namespace System.Management.Automation.Security
             var context = System.Management.Automation.Runspaces.LocalPipeline.GetExecutionContextFromTLS();
             bool debuggerAvailable = context is not null &&
                                      context._debugger is not null &&
-                                     context._debugger.DebugMode.HasFlag(DebugModes.LocalScript) &&
-                                     !context._debugger.IsRemote;
+                                     context._debugger is ScriptDebugger;
 
             if (debuggerAvailable)
             {
@@ -109,6 +108,7 @@ namespace System.Management.Automation.Security
             // We drop into the debugger only if requested and we are running in the interactive host session runspace (Id == 1).
             if (debuggerAvailable &&
                 dropIntoDebugger is true && 
+                context._debugger.DebugMode.HasFlag(DebugModes.LocalScript) &&
                 System.Management.Automation.Runspaces.Runspace.DefaultRunspace.Id == 1 &&
                 context.DebugPreferenceVariable.HasFlag(ActionPreference.Break))
             {

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -288,16 +288,6 @@ namespace System.Management.Automation.Security
                 }
             }
 
-            // TODO: !!Debug only!!
-            if (string.IsNullOrEmpty(path))
-            {
-                var debuggerAttached = false;
-                while (!debuggerAttached)
-                {
-                    System.Threading.Thread.Sleep(500);
-                }
-            }
-
             try
             {
                 WLDP_HOST_INFORMATION hostInformation = new WLDP_HOST_INFORMATION();

--- a/src/System.Management.Automation/utils/tracing/PSEtwLog.cs
+++ b/src/System.Management.Automation/utils/tracing/PSEtwLog.cs
@@ -145,6 +145,20 @@ namespace System.Management.Automation.Tracing
         }
 
         /// <summary>
+        /// Provider interface function for logging WDAC audit event.
+        /// </summary>
+        /// <param name="title">Title of WDAC audit event.</param>
+        /// <param name="message">WDAC audit event message.</param>
+        /// <param name="fqid">FullyQualifiedId of WDAC audit event.</param>
+        internal static void LogWDACAuditEvent(
+            string title,
+            string message,
+            string fqid)
+        {
+            provider.LogWDACAuditEvent(title, message, fqid);
+        }
+
+        /// <summary>
         /// Provider interface function for logging settings event.
         /// </summary>
         /// <param name="logContext"></param>

--- a/src/System.Management.Automation/utils/tracing/PSEtwLogProvider.cs
+++ b/src/System.Management.Automation/utils/tracing/PSEtwLogProvider.cs
@@ -229,7 +229,7 @@ namespace System.Management.Automation.Tracing
             string message,
             string fqid)
         {
-            WriteEvent(PSEventId.WDAC_Audit, PSChannel.Operational, PSOpcode.Method, PSLevel.Informational, PSTask.WDAC, (PSKeyword)0x0, title, message, fqid);
+            WriteEvent(PSEventId.WDAC_Audit, PSChannel.Operational, PSOpcode.Method, PSLevel.Informational, PSTask.WDACAudit, (PSKeyword)0x0, title, message, fqid);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/utils/tracing/PSEtwLogProvider.cs
+++ b/src/System.Management.Automation/utils/tracing/PSEtwLogProvider.cs
@@ -219,6 +219,20 @@ namespace System.Management.Automation.Tracing
         }
 
         /// <summary>
+        /// Provider interface function for logging WDAC audit event.
+        /// </summary>
+        /// <param name="title">Title of WDAC audit event.</param>
+        /// <param name="message">WDAC audit event message.</param>
+        /// <param name="fqid">FullyQualifiedId of WDAC audit event.</param>
+        internal override void LogWDACAuditEvent(
+            string title,
+            string message,
+            string fqid)
+        {
+            WriteEvent(PSEventId.WDAC_Audit, PSChannel.Operational, PSOpcode.Method, PSLevel.Informational, PSTask.WDAC, (PSKeyword)0x0, title, message, fqid);
+        }
+
+        /// <summary>
         /// Provider interface function for logging provider lifecycle event.
         /// </summary>
         /// <param name="logContext"></param>

--- a/src/System.Management.Automation/utils/tracing/PSSysLogProvider.cs
+++ b/src/System.Management.Automation/utils/tracing/PSSysLogProvider.cs
@@ -119,6 +119,20 @@ namespace System.Management.Automation.Tracing
         }
 
         /// <summary>
+        /// Provider interface function for logging WDAC audit event.
+        /// </summary>
+        /// <param name="title">Title of WDAC audit event.</param>
+        /// <param name="message">WDAC audit event message.</param>
+        /// <param name="fqid">FullyQualifiedId of WDAC audit event.</param>
+        internal override void LogWDACAuditEvent(
+            string title,
+            string message,
+            string fqid)
+        {
+            WriteEvent(PSEventId.WDAC_Audit, PSChannel.Operational, PSOpcode.Method, PSLevel.Informational, PSTask.WDAC, (PSKeyword)0x0, title, message, fqid);
+        }
+
+        /// <summary>
         /// Provider interface function for logging engine lifecycle event.
         /// </summary>
         /// <param name="logContext"></param>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds a new language mode and logging messages to PowerShell restrictions when run under Windows WDAC (Windows Defender Application Control) policy.

This addresses Issue #18628 

## PR Context

PowerShell enforces language mode and other restrictions when it detects it is running under a WDAC (or deprecated AppLocker) system polices (Windows platform only).  The enforced restrictions can cause existing script (written without the restrictions in mind) to break in unpredictable ways.  

WDAC can run in Audit mode where policy restriction instances are not enforced but logged.  These changes updates PowerShell so that when WDAC is in Audit mode, it too logs when restrictions would apply if the policy was being enforced.  This will help users to understand what restrictions will apply when their script runs in policy enforcement mode.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): PSWDACAuditLogging
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
