### PR TITLE
Skip VT100 tests on Windows Server 2012R2 as console does not support it

### DIFF
--- a/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
+++ b/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
@@ -6,7 +6,7 @@ Describe '$env:__SuppressAnsiEscapeSequences tests' -Tag CI {
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
 
         if (-not $host.ui.SupportsVirtualTerminal) {
-            $PSDefaultParameterValues["it:skip"] = $true
+            $global:PSDefaultParameterValues["it:skip"] = $true
         }
 
         $originalSuppressPref = $env:__SuppressAnsiEscapeSequences

--- a/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
+++ b/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
@@ -3,12 +3,24 @@
 
 Describe '$env:__SuppressAnsiEscapeSequences tests' -Tag CI {
     BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+
+        if ($IsWindows) {
+            $osInfo = [System.Environment]::OSVersion.Version
+            $isSrv2k12R2 = $osInfo.Major -eq 6 -and $osInfo.Minor -le 3
+
+            if ($isSrv2k12R2) {
+                $PSDefaultParameterValues["it:skip"] = $true
+            }
+        }
+
         $originalSuppressPref = $env:__SuppressAnsiEscapeSequences
         $originalRendering = $PSStyle.OutputRendering
         $PSStyle.OutputRendering = 'Ansi'
     }
 
     AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
         $env:__SuppressAnsiEscapeSequences = $originalSuppressPref
         $PSStyle.OutputRendering = $originalRendering
     }

--- a/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
+++ b/test/powershell/Language/Scripting/SuppressAnsiEscapeSequence.Tests.ps1
@@ -5,13 +5,8 @@ Describe '$env:__SuppressAnsiEscapeSequences tests' -Tag CI {
     BeforeAll {
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
 
-        if ($IsWindows) {
-            $osInfo = [System.Environment]::OSVersion.Version
-            $isSrv2k12R2 = $osInfo.Major -eq 6 -and $osInfo.Minor -le 3
-
-            if ($isSrv2k12R2) {
-                $PSDefaultParameterValues["it:skip"] = $true
-            }
+        if (-not $host.ui.SupportsVirtualTerminal) {
+            $PSDefaultParameterValues["it:skip"] = $true
         }
 
         $originalSuppressPref = $env:__SuppressAnsiEscapeSequences

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -119,6 +119,16 @@ Describe 'Get-Error tests' -Tag CI {
     }
 
     It 'Get-Error uses Error color for Message and PositionMessage members' {
+
+        if ($IsWindows) {
+            $osInfo = [System.Environment]::OSVersion.Version
+            $isSrv2k12R2 = $osInfo.Major -eq 6 -and $osInfo.Minor -le 3
+
+            if ($isSrv2k12R2) {
+                Set-ItResult -Skipped -Because 'Windows Server 2012 R2 does not support VT100 escape sequences'
+            }
+        }
+
         $suppressVT = $false
         if (Test-Path env:/__SuppressAnsiEscapeSequences) {
             $suppressVT = $true

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -120,13 +120,8 @@ Describe 'Get-Error tests' -Tag CI {
 
     It 'Get-Error uses Error color for Message and PositionMessage members' {
 
-        if ($IsWindows) {
-            $osInfo = [System.Environment]::OSVersion.Version
-            $isSrv2k12R2 = $osInfo.Major -eq 6 -and $osInfo.Minor -le 3
-
-            if ($isSrv2k12R2) {
-                Set-ItResult -Skipped -Because 'Windows Server 2012 R2 does not support VT100 escape sequences'
-            }
+        if (-not $host.ui.SupportsVirtualTerminal) {
+            Set-ItResult -Skipped -Because 'Windows Server 2012 R2 does not support VT100 escape sequences'
         }
 
         $suppressVT = $false

--- a/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
+++ b/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
@@ -6,13 +6,8 @@ Describe 'OutputRendering tests' -Tag 'CI' {
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
         # Console host does not support VT100 escape sequences on Windows 2012R2 or earlier
 
-        if ($IsWindows) {
-            $osInfo = [System.Environment]::OSVersion.Version
-            $isSrv2k12R2 = $osInfo.Major -eq 6 -and $osInfo.Minor -le 3
-
-            if ($isSrv2k12R2) {
-                $PSDefaultParameterValues["it:skip"] = $true
-            }
+        if (-not $host.ui.SupportsVirtualTerminal) {
+            $PSDefaultParameterValues["it:skip"] = $true
         }
     }
 

--- a/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
+++ b/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
@@ -5,8 +5,14 @@ Describe 'OutputRendering tests' -Tag 'CI' {
     BeforeAll {
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
         # Console host does not support VT100 escape sequences on Windows 2012R2 or earlier
-        if ($IsWindows -and [System.Environment]::OSVersion.Version -le [version]::new(6, 3)) {
-            $PSDefaultParameterValues["it:skip"] = $true
+
+        if ($IsWindows) {
+            $osInfo = [System.Environment]::OSVersion.Version
+            $isSrv2k12R2 = $osInfo.Major -eq 6 -and $osInfo.Minor -le 3
+
+            if ($isSrv2k12R2) {
+                $PSDefaultParameterValues["it:skip"] = $true
+            }
         }
     }
 

--- a/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
+++ b/test/powershell/engine/Formatting/OutputRendering.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'OutputRendering tests' -Tag 'CI' {
         # Console host does not support VT100 escape sequences on Windows 2012R2 or earlier
 
         if (-not $host.ui.SupportsVirtualTerminal) {
-            $PSDefaultParameterValues["it:skip"] = $true
+            $global:PSDefaultParameterValues["it:skip"] = $true
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Skip tests on Windows Server 2012R2 which require VT100 console support

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
