### PR TITLE
Enable type conversion of AutomationNull to $null for assignment

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4691,6 +4691,11 @@ namespace System.Management.Automation
                                     }
                                 }
 
+                                // treat AutomationNull.Value as null for consistency
+                                if (propValue == AutomationNull.Value) {
+                                    propValue = null;
+                                }
+
                                 property.Value = propValue;
                             }
                             else

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4692,7 +4692,8 @@ namespace System.Management.Automation
                                 }
 
                                 // treat AutomationNull.Value as null for consistency
-                                if (propValue == AutomationNull.Value) {
+                                if (propValue == AutomationNull.Value)
+                                {
                                     propValue = null;
                                 }
 

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -36,7 +36,7 @@ Describe "Scripting.Followup.Tests" -Tags "CI" {
                 [string[]]$LogMessage
             }
 
-            [Example] @{ 'LogMessage' = [System.Management.Automation.Internal.AutomationNull]::Value }
+            [Example] @{ LogMessage = [System.Management.Automation.Internal.AutomationNull]::Value }
         }
 
         $result.LogMessage | Should -BeNullOrEmpty

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -30,6 +30,18 @@ Describe "Scripting.Followup.Tests" -Tags "CI" {
         $arraylist.Count | Should -Be 0
     }
 
+    It 'AutomationNull should be same as null for type conversion' {
+        $result = pwsh -noprofile -command {
+            class Example {
+                [string[]]$LogMessage
+            }
+
+            [Example] @{ 'LogMessage' = [System.Management.Automation.Internal.AutomationNull]::Value }
+        }
+
+        $result.LogMessage | Should -BeNullOrEmpty
+    }
+
     ## fix https://github.com/PowerShell/PowerShell/issues/17165
     It "([bool] `$var = 42) should return the varaible value" {
         ([bool]$var = 42).GetType().FullName | Should -Be "System.Boolean"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9175168</samp>

### Summary
🐛🛠️🧪

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🛠️ - This emoji represents a tool or improvement, which is the secondary purpose of the change, as it adds a check for `AutomationNull.Value`.
3.  🧪 - This emoji represents a test or experiment, which is the tertiary purpose of the change, as it adds a test case to verify the bug fix.
-->
Fix a bug in type conversion when setting a property to `AutomationNull.Value`. Add a test case to verify the fix.

> _`AutomationNull`_
> _A bug in type conversion_
> _Fixed with a check_

### Walkthrough
* Fix a bug where setting a property to `AutomationNull.Value` would not be equivalent to setting it to `null` in type conversion ([link](https://github.com/PowerShell/PowerShell/pull/19415/files?diff=unified&w=0#diff-cab208708785228b7a0ea80689110fc4715ec4b5d5cedb96fb36b419b77972f8R4694-R4699) in `src/System.Management.Automation/engine/LanguagePrimitives.cs`)



We've made the call previously that AutomationNull.Value should be treated as $null in most cases.  The change here detects that the value is AutomationNull and uses null instead.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/19402

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
