### PR TITLE
Fix wildcard globbing in root of device paths

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1251,6 +1251,15 @@ namespace System.Management.Automation
 #endif
         }
 
+        internal static bool PathIsDevicePath(string path)
+        {
+#if UNIX
+            return false;
+#else
+            return path.StartsWith(@"\\.\") || path.StartsWith(@"\\?\");
+#endif
+        }
+
         internal static readonly string PowerShellAssemblyStrongNameFormat =
             "{0}, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1241,7 +1241,7 @@ namespace System.Management.Automation
             }
 
             // handle special cases like '\\wsl$\ubuntu', '\\?\', and '\\.\pipe\' which aren't a UNC path, but we can say it is so the filesystemprovider can use it
-            if (!networkOnly && (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || path.StartsWith("\\\\?\\") || path.StartsWith("\\\\.\\")))
+            if (!networkOnly && (path.StartsWith(WslRootPath, StringComparison.OrdinalIgnoreCase) || PathIsDevicePath(path)))
             {
                 return true;
             }
@@ -1251,12 +1251,12 @@ namespace System.Management.Automation
 #endif
         }
 
-        internal static bool PathIsDevicePath(string path, bool pathIsUnescaped)
+        internal static bool PathIsDevicePath(string path)
         {
 #if UNIX
             return false;
 #else
-            return path.StartsWith(@"\\.\") || path.StartsWith(@"\\?\") || (pathIsUnescaped && path.StartsWith(@"\\`?\"));
+            return path.StartsWith(@"\\.\") || path.StartsWith(@"\\?\");
 #endif
         }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1251,12 +1251,12 @@ namespace System.Management.Automation
 #endif
         }
 
-        internal static bool PathIsDevicePath(string path)
+        internal static bool PathIsDevicePath(string path, bool pathIsUnescaped)
         {
 #if UNIX
             return false;
 #else
-            return path.StartsWith(@"\\.\") || path.StartsWith(@"\\?\");
+            return path.StartsWith(@"\\.\") || path.StartsWith(@"\\?\") || (pathIsUnescaped && path.StartsWith(@"\\`?\"));
 #endif
         }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4915,7 +4915,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             if (!parentPath.EndsWith(StringLiterals.DefaultPathSeparator)
-                && Utils.PathIsDevicePath(parentPath)
+                && Utils.PathIsDevicePath(parentPath, pathIsUnescaped: true)
                 && parentPath.Length - parentPath.Replace(StringLiterals.DefaultPathSeparatorString, string.Empty).Length == 3)
             {
                 // Device paths start with either "\\.\" or "\\?\"

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4913,6 +4913,15 @@ namespace Microsoft.PowerShell.Commands
                 // make sure we return two backslashes so it still results in a UNC path
                 parentPath = "\\\\";
             }
+
+            if (!parentPath.EndsWith(StringLiterals.DefaultPathSeparator)
+                && Utils.PathIsDevicePath(parentPath)
+                && parentPath.Length - parentPath.Replace(StringLiterals.DefaultPathSeparatorString, string.Empty).Length == 3)
+            {
+                // Device paths start with either "\\.\" or "\\?\"
+                // When referring to the root, like: "\\.\CDROM0\" then it needs the trailing separator to be valid.
+                parentPath += StringLiterals.DefaultPathSeparator;
+            }
 #endif
             return parentPath;
         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4923,6 +4923,7 @@ namespace Microsoft.PowerShell.Commands
                 parentPath += StringLiterals.DefaultPathSeparator;
             }
 #endif
+            s_tracer.WriteLine("GetParentPath returning '{0}'", parentPath);
             return parentPath;
         }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4915,7 +4915,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             if (!parentPath.EndsWith(StringLiterals.DefaultPathSeparator)
-                && Utils.PathIsDevicePath(parentPath, pathIsUnescaped: true)
+                && Utils.PathIsDevicePath(parentPath)
                 && parentPath.Length - parentPath.Replace(StringLiterals.DefaultPathSeparatorString, string.Empty).Length == 3)
             {
                 // Device paths start with either "\\.\" or "\\?\"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -534,6 +534,13 @@ Describe "Handling of globbing patterns" -Tags "CI" {
         $Res = Get-ChildItem -Path '\\.\C:\*'
         $Res.Count | Should -BeGreaterThan 0
     }
+
+    It "Handle wildcards in root of device path with '?'" -Skip:(!$IsWindows) {
+        $DeviceId = Get-CimInstance -ClassName Win32_Volume | Select-Object -First 1 -ExpandProperty DeviceId
+        $EscapedDeviceId = [WildcardPattern]::Escape($DeviceId)
+        $Res = Get-ChildItem -Path "$EscapedDeviceId*"
+        $Res.Count | Should -BeGreaterThan 0
+    }
 }
 
 Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -536,9 +536,7 @@ Describe "Handling of globbing patterns" -Tags "CI" {
     }
 
     It "Handle wildcards in root of device path with '?'" -Skip:(!$IsWindows) {
-        $DeviceId = Get-CimInstance -ClassName Win32_Volume | Select-Object -First 1 -ExpandProperty DeviceId
-        $EscapedDeviceId = [WildcardPattern]::Escape($DeviceId)
-        $Res = Get-ChildItem -Path "$EscapedDeviceId*"
+        $Res = Get-ChildItem -Path '\\`?\C:\*'
         $Res.Count | Should -BeGreaterThan 0
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -529,6 +529,11 @@ Describe "Handling of globbing patterns" -Tags "CI" {
             Test-Path -LiteralPath $testPath2 | Should -BeTrue
         }
     }
+
+    It "Handle wildcards in root of device path" -Skip:(!$IsWindows) {
+        $Res = Get-ChildItem -Path '\\.\C:\*'
+        $Res.Count | Should -BeGreaterThan 0
+    }
 }
 
 Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -531,7 +531,7 @@ Describe "Handling of globbing patterns" -Tags "CI" {
     }
 
     Context "Device paths" {
-        # The globber is overly greedy somewhere so you need to escape the escape backtick to preserve the question mark
+        # The globber is overly greedy somewhere so you need to escape the escape backtick to preserve the question mark issue https://github.com/PowerShell/PowerShell/issues/19627
         It "Handle device paths: <path>" -Skip:(!$IsWindows) -TestCases @(
             @{ path = "\\.\${env:SystemDrive}\" }
             @{ path = "\\.\${env:SystemDrive}\*" }
@@ -559,7 +559,7 @@ Describe "Handling of globbing patterns" -Tags "CI" {
         It "Fails for invalid device path: <path>" -Skip:(!$IsWindows) -TestCases @(
             @{ path = "\\.\INVALID0\" }
             @{ path = "\\``?\INVALID0\" }
-            # @{ path = "\\.\INVALID0\*" }  // problem in globber where this fails but is ignored
+            # @{ path = "\\.\INVALID0\*" }  // problem in globber where this fails but is ignored issue https://github.com/PowerShell/PowerShell/issues/19626
             # @{ path = "\\``?\INVALID0\*" }
         ) {
             param($path)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes scenarios like: `Get-ChildItem -Path '\\.\C:\*'` so it properly handles wildcards at the root.  
The code would find the parent of the wildcard (in this case `\\.\C:\`) but it would leave out the trailing separator (so it would end up like this: `\\.\C:`) which is not valid for device path roots.
This PR adds a check for root device paths and adds back the missing backslash if needed.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/19439
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
