### PR TITLE
Make TypeAccelerators a public API

### DIFF
--- a/test/powershell/engine/TypeAccelerators.Tests.ps1
+++ b/test/powershell/engine/TypeAccelerators.Tests.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Tests for TypeAccelerators' -Tag 'CI' {
+    AfterEach {
+        $null = [TypeAccelerators]::Remove('DummyType')
+    }
+
+    It 'Creates accelerator' {
+        [TypeAccelerators]::Add('DummyType', [int])
+        [DummyType].FullName | Should -Be System.Int32
+    }
+
+    It 'Creates accelerator for generic type' {
+        [TypeAccelerators]::Add('DummyType', [System.Collections.Generic.List`1])
+        [DummyType].FullName | Should -Be 'System.Collections.Generic.List`1'
+
+        $list = [DummyType[int]]::new()
+        $list.Add('1')
+        $list[0] | Should -BeOfType ([int])
+        $list[0] | Should -Be 1
+    }
+
+    It 'Removes accelerators' {
+        # Run twice to check that it doesn't throw
+        [TypeAccelerators]::Remove('DummyType') | Should -BeTrue
+        [TypeAccelerators]::Remove('DummyType') | Should -BeTrue
+    }
+
+    It 'Gets accelerators' {
+        [TypeAccelerators]::Add('DummyType', [int])
+        $actual = [TypeAccelerators]::Get
+        $actual.ContainsKey('DummyType') | Should -BeTrue
+    }
+}


### PR DESCRIPTION
# PR Summary

Make the TypeAccelerators class public and also add an accelerator for the type. Fixes an issue where a TypeAccelerator type was cached after being used for the first time stopping a user from redefining the accelerator with a different type.

## PR Context

There are numerous blog posts out there that document how to make a type accelerator using reflection to get the class. This effectively has made the class a public API in PowerShell. This PR makes the class public as well as adding an accelerator `[TypeAccelerators]` that make it easy to define custom accelerators.

This also fixes a bug where once an accelerator type was used it is cached even when it would be removed using `[TypeAccelerators]::Remove('TypeName')`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
