### PR TITLE
Improve path completion

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4435,6 +4435,7 @@ namespace System.Management.Automation
                 int lastSeparatorIndex = wordToComplete.LastIndexOfAny(Utils.Separators.DirectoryOrDrive);
                 if (lastSeparatorIndex == -1)
                 {
+                    // provider path is always absolute
                     if (providerSeparatorIndex == -1)
                     {
                         filter = $"{wordToComplete}*";

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4432,6 +4432,8 @@ namespace System.Management.Automation
                     && wordToComplete[pathStartOffset] is '~'
                     && wordToComplete[pathStartOffset + 1] is '/' or '\\';
 
+                // This simple analysis is quick but doesn't handle scenarios where a separator character is not actually a separator
+                // For example "\" or ":" in *nix filenames. This is only a problem if it appears to be the last separator though.
                 int lastSeparatorIndex = wordToComplete.LastIndexOfAny(Utils.Separators.DirectoryOrDrive);
                 if (lastSeparatorIndex == -1)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4463,17 +4463,19 @@ namespace System.Management.Automation
             }
 
             StringConstantType stringType;
-            if (quote.Equals(string.Empty, StringComparison.Ordinal))
+            switch (quote)
             {
-                stringType = StringConstantType.BareWord;
-            }
-            else if (quote.Equals("\"", StringComparison.Ordinal))
-            {
-                stringType = StringConstantType.DoubleQuoted;
-            }
-            else
-            {
-                stringType = StringConstantType.SingleQuoted;
+                case "":
+                    stringType = StringConstantType.BareWord;
+                    break;
+
+                case "\"":
+                    stringType = StringConstantType.DoubleQuoted;
+                    break;
+
+                default:
+                    stringType = StringConstantType.SingleQuoted;
+                    break;
             }
 
             var useLiteralPath = context.GetOption("LiteralPaths", @default: false);
@@ -4704,15 +4706,9 @@ namespace System.Management.Automation
             string providerPrefix,
             StringConstantType stringType)
         {
-            string homePath;
-            if (inputUsedHome && !string.IsNullOrEmpty(provider.Home))
-            {
-                homePath = provider.Home;
-            }
-            else
-            {
-                homePath = null;
-            }
+            string homePath = inputUsedHome && !string.IsNullOrEmpty(provider.Home)
+                ? provider.Home
+                : null;
 
             var pattern = WildcardPattern.Get(filterText, WildcardOptions.IgnoreCase);
             var results = new List<CompletionResult>();

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4583,15 +4583,7 @@ namespace System.Management.Automation
 #endif
             var enumerationOptions = _enumerationOptions;
             var results = new List<CompletionResult>();
-            string homePath;
-            if (inputUsedHome && !string.IsNullOrEmpty(provider.Home))
-            {
-                homePath = provider.Home;
-            }
-            else
-            {
-                homePath = null;
-            }
+            string homePath = inputUsedHome && !string.IsNullOrEmpty(provider.Home) ? provider.Home : null;
 
             WildcardPattern wildcardFilter;
             if (WildcardPattern.ContainsRangeWildcard(filterText))
@@ -4622,15 +4614,10 @@ namespace System.Management.Automation
                 {
                     basePath = null;
                 }
-                IEnumerable <FileSystemInfo> fileSystemObjects;
-                if (containersOnly)
-                {
-                    fileSystemObjects = dirInfo.EnumerateDirectories(filterText, enumerationOptions);
-                }
-                else
-                {
-                    fileSystemObjects = dirInfo.EnumerateFileSystemInfos(filterText, enumerationOptions);
-                }
+                IEnumerable <FileSystemInfo> fileSystemObjects = containersOnly
+                    ? dirInfo.EnumerateDirectories(filterText, enumerationOptions)
+                    : dirInfo.EnumerateFileSystemInfos(filterText, enumerationOptions);
+
                 foreach (var entry in fileSystemObjects)
                 {
                     bool isContainer = entry.Attributes.HasFlag(FileAttributes.Directory);

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4418,7 +4418,7 @@ namespace System.Management.Automation
             bool defaultRelativePath = false;
             bool inputUsedHomeChar = false;
 
-            if (wordToComplete == string.Empty)
+            if (string.IsNullOrEmpty(wordToComplete))
             {
                 filter = "*";
                 basePath = ".";
@@ -4840,7 +4840,7 @@ namespace System.Management.Automation
             // The obvious solution would be to use the "PSChildName" property
             // but some providers don't have it (like the Variable provider)
             // So we use a substring of "PSPath" instead.
-            string childName = psObject.PSPath;
+            string childName = psObject.PSPath ?? string.Empty;
             int ProviderSeparatorIndex = childName.IndexOf("::", StringComparison.Ordinal);
             childName = childName.Substring(ProviderSeparatorIndex + 2);
             int indexOfName = childName.LastIndexOf(separator);

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -318,7 +318,7 @@ namespace System.Management.Automation
         /// Checks if the string contains a left bracket "[" followed by a right bracket "]" after any number of characters.
         /// </summary>
         /// <param name="pattern"> The string to check.</param>
-        /// <returns>Returns true if the string contains both a left and right bracket "[" "]" and if the right bracket comes after the left bracket</returns>
+        /// <returns>Returns true if the string contains both a left and right bracket "[" "]" and if the right bracket comes after the left bracket.</returns>
         internal static bool ContainsRangeWildcard(string pattern)
         {
             if (string.IsNullOrEmpty(pattern))

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -314,6 +314,11 @@ namespace System.Management.Automation
             return result;
         }
 
+        /// <summary>
+        /// Checks if the string contains a left bracket "[" followed by a right bracket "]" after any number of characters.
+        /// </summary>
+        /// <param name="pattern"> The string to check.</param>
+        /// <returns></returns>
         internal static bool ContainsRangeWildcard(string pattern)
         {
             if (string.IsNullOrEmpty(pattern))

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -318,7 +318,7 @@ namespace System.Management.Automation
         /// Checks if the string contains a left bracket "[" followed by a right bracket "]" after any number of characters.
         /// </summary>
         /// <param name="pattern"> The string to check.</param>
-        /// <returns></returns>
+        /// <returns>Returns true if the string contains both a left and right bracket "[" "]" and if the right bracket comes after the left bracket</returns>
         internal static bool ContainsRangeWildcard(string pattern)
         {
             if (string.IsNullOrEmpty(pattern))

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -314,6 +314,38 @@ namespace System.Management.Automation
             return result;
         }
 
+        internal static bool ContainsRangeWildcard(string pattern)
+        {
+            if (string.IsNullOrEmpty(pattern))
+            {
+                return false;
+            }
+
+            bool foundStart = false;
+            bool result = false;
+            for (int index = 0; index < pattern.Length; ++index)
+            {
+                if (pattern[index] is '[')
+                {
+                    foundStart = true;
+                    continue;
+                }
+                
+                if (foundStart && pattern[index] is ']')
+                {
+                    result = true;
+                    break;
+                }
+
+                if (pattern[index] == escapeChar)
+                {
+                    ++index;
+                }
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Unescapes any escaped characters in the input string.
         /// </summary>

--- a/src/System.Management.Automation/utils/PowerShellExecutionHelper.cs
+++ b/src/System.Management.Automation/utils/PowerShellExecutionHelper.cs
@@ -62,11 +62,17 @@ namespace System.Management.Automation
 
         internal Collection<PSObject> ExecuteCurrentPowerShell(out Exception exceptionThrown, IEnumerable input = null)
         {
+            return ExecuteCurrentPowerShell(out exceptionThrown, out _, input);
+        }
+
+        internal Collection<PSObject> ExecuteCurrentPowerShell(out Exception exceptionThrown, out bool hadErrors, IEnumerable input = null)
+        {
             exceptionThrown = null;
 
             // This flag indicates a previous call to this method had its pipeline cancelled
             if (CancelTabCompletion)
             {
+                hadErrors = false;
                 return new Collection<PSObject>();
             }
 
@@ -89,6 +95,7 @@ namespace System.Management.Automation
             }
             finally
             {
+                hadErrors = CurrentPowerShell.HadErrors;
                 CurrentPowerShell.Commands.Clear();
             }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1105,17 +1105,43 @@ class InheritedClassTest : System.Attribute
         }
 
         It "Should use '~' as relative filter text when not followed by separator" {
-            try
-            {
-                $TempDirPath = ".$separator~TempDir"
-                $TempDir = New-Item -Path $TempDirPath -ItemType Directory -Force
-                $res = TabExpansion2 -inputScript ~
-                $res.CompletionMatches[0].CompletionText | Should -Be $TempDirPath
-            }
-            finally
-            {
-                Remove-Item -Path $TempDirPath -Force
-            }
+            $TempDirName = "~TempDir"
+            $TempDirPath = Join-Path -Path $TestDrive -ChildPath "~TempDir"
+            $TempDir = New-Item -Path $TempDirPath -ItemType Directory -Force
+            Push-Location -Path $TestDrive
+            $res = TabExpansion2 -inputScript ~
+            $res.CompletionMatches[0].CompletionText | Should -Be ".${separator}${TempDirName}"
+        }
+
+        It 'Escapes backtick properly for path: <LiteralPath>' -TestCases @(
+            @{LiteralPath = 'BacktickTest[';   BacktickSingle = 1; BacktickDouble = 2;  LiteralBacktickSingle = 0; LiteralBacktickDouble = 0}
+            @{LiteralPath = 'BacktickTest`[';  BacktickSingle = 3; BacktickDouble = 6;  LiteralBacktickSingle = 1; LiteralBacktickDouble = 2}
+            @{LiteralPath = 'BacktickTest``['; BacktickSingle = 5; BacktickDouble = 10; LiteralBacktickSingle = 2; LiteralBacktickDouble = 4}
+            @{LiteralPath = 'BacktickTest$';   BacktickSingle = 0; BacktickDouble = 1;  LiteralBacktickSingle = 0; LiteralBacktickDouble = 1}
+            @{LiteralPath = 'BacktickTest`$';  BacktickSingle = 2; BacktickDouble = 3;  LiteralBacktickSingle = 1; LiteralBacktickDouble = 3}
+            @{LiteralPath = 'BacktickTest``$'; BacktickSingle = 4; BacktickDouble = 7;  LiteralBacktickSingle = 2; LiteralBacktickDouble = 5}
+        ) {
+            param($LiteralPath, $BacktickSingle, $BacktickDouble, $LiteralBacktickSingle, $LiteralBacktickDouble)
+            $NewPath = Join-Path -Path $TestDrive -ChildPath $LiteralPath
+            $null = New-Item -Path $NewPath -Force
+            Push-Location $TestDrive
+            
+            $InputText = "Get-ChildItem -Path {0}.${separator}BacktickTest"
+            $InputTextLiteral = "Get-ChildItem -LiteralPath {0}.${separator}BacktickTest"
+
+            $Text = (TabExpansion2 -inputScript ($InputText -f "'")).CompletionMatches[0].CompletionText
+            $Text.Length - $Text.Replace('`','').Length | Should -Be $BacktickSingle
+
+            $Text = (TabExpansion2 -inputScript ($InputText -f '"')).CompletionMatches[0].CompletionText
+            $Text.Length - $Text.Replace('`','').Length | Should -Be $BacktickDouble
+
+            $Text = (TabExpansion2 -inputScript ($InputTextLiteral -f "'")).CompletionMatches[0].CompletionText
+            $Text.Length - $Text.Replace('`','').Length | Should -Be $LiteralBacktickSingle
+
+            $Text = (TabExpansion2 -inputScript ($InputTextLiteral -f '"')).CompletionMatches[0].CompletionText
+            $Text.Length - $Text.Replace('`','').Length | Should -Be $LiteralBacktickDouble
+
+            Remove-Item -LiteralPath $LiteralPath
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Refactor of the file path completion code to make it faster and prepare it for some future improvements I have planned (Not replacing variables in input text, user options for controlling sorting behavior and more).

Speed improvements for relative paths are pretty big:
```
cd C:\windows\System32\
Measure-Command -Expression {TabExpansion2 -inputScript .\}
```
old: 1.99 seconds
new: 199 ms

Similar improvements are seen in other providers:
```
cd HKCU:\SOFTWARE\Classes\
Measure-Command -Expression {TabExpansion2 -inputScript .\}
```
Old: 1.60 seconds
new: 139 ms

Also stopped it from replacing `~` when referring to home so this: `~\Downloads<Tab>` no longer turns into: `C:\Users\Martin\Downloads\`


<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/4797
Contributes to: https://github.com/PowerShell/PowerShell/issues/5350

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
