### PR TITLE
Make the vPack PAT library more obvious

### DIFF
--- a/tools/releaseBuild/azureDevOps/vpackRelease.yml
+++ b/tools/releaseBuild/azureDevOps/vpackRelease.yml
@@ -16,6 +16,10 @@ variables:
   - name: POWERSHELL_TELEMETRY_OPTOUT
     value: 1
   - group: Azure Blob variable group
+  # adds the pat to publish the vPack
+  # instructions to create are in the description of the library
+  - group: vPack
+
 
 stages:
 - stage: prep


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make the vPack PAT library more obvious

## PR Context

PAT was added in a template, moving it out to the pipeline makes it easier to find when it needs to be update.
