### PR TITLE
Fix the regex used for package name check

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/vpackReleaseJob.yml
+++ b/tools/releaseBuild/azureDevOps/templates/vpackReleaseJob.yml
@@ -55,7 +55,7 @@ jobs:
   - pwsh: |
       $message = @()
       Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -include *.zip, *.msi | ForEach-Object {
-          if($_.Name -notmatch 'PowerShell-\d\.\d\.\d\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm32|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
+          if($_.Name -notmatch 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm32|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
           {
                 $messageInstance = "$($_.Name) is not a valid package name"
                 $message += $messageInstance


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix the regex used for package name check when building/releasing vPack package.
