### PR TITLE
Support trigger registration in Feedback Provider

### DIFF
--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/FeedbackHub.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/FeedbackHub.cs
@@ -144,11 +144,11 @@ namespace System.Management.Automation.Subsystem.Feedback
             List<FeedbackResult>? resultList = null;
             if (generalFeedback is not null)
             {
-                FeedbackResult? builtinResult = GetBuiltinFeedback(generalFeedback, localRunspace, feedbackContext, questionMarkValue);
-                if (builtinResult is not null)
+                FeedbackResult? builtInResult = GetBuiltInFeedback(generalFeedback, localRunspace, feedbackContext, questionMarkValue);
+                if (builtInResult is not null)
                 {
                     resultList ??= new List<FeedbackResult>(count);
-                    resultList.Add(builtinResult);
+                    resultList.Add(builtInResult);
                 }
             }
 
@@ -198,8 +198,8 @@ namespace System.Management.Automation.Subsystem.Feedback
             return canSkip;
         }
 
-        private static FeedbackResult? GetBuiltinFeedback(
-            IFeedbackProvider builtinFeedback,
+        private static FeedbackResult? GetBuiltInFeedback(
+            IFeedbackProvider builtInFeedback,
             LocalRunspace localRunspace,
             FeedbackContext feedbackContext,
             bool questionMarkValue)
@@ -215,10 +215,10 @@ namespace System.Management.Automation.Subsystem.Feedback
                     Runspace.DefaultRunspace = localRunspace;
                 }
 
-                FeedbackItem? item = builtinFeedback.GetFeedback(feedbackContext, CancellationToken.None);
+                FeedbackItem? item = builtInFeedback.GetFeedback(feedbackContext, CancellationToken.None);
                 if (item is not null)
                 {
-                    return new FeedbackResult(builtinFeedback.Id, builtinFeedback.Name, item);
+                    return new FeedbackResult(builtInFeedback.Id, builtInFeedback.Name, item);
                 }
             }
             finally

--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
@@ -63,7 +63,7 @@ namespace System.Management.Automation.Subsystem.Feedback
     }
 
     /// <summary>
-    /// 
+    /// Context information about the last command line.
     /// </summary>
     public sealed class FeedbackContext
     {

--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
@@ -4,15 +4,36 @@
 #nullable enable
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Management.Automation.Internal;
+using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
-using System.Management.Automation.Subsystem.Prediction;
 using System.Threading;
 
 namespace System.Management.Automation.Subsystem.Feedback
 {
+    /// <summary>
+    /// 
+    /// </summary>
+    [Flags]
+    public enum FeedbackTrigger
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Success = 1,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Error = 2,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Comment = 4,
+    }
+
     /// <summary>
     /// Layout for displaying the recommended actions.
     /// </summary>
@@ -27,6 +48,67 @@ namespace System.Management.Automation.Subsystem.Feedback
         /// Display all recommended actions in the same row.
         /// </summary>
         Landscape,
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed class FeedbackContext
+    {
+        /// <summary>
+        /// Gets the last command line that was just executed.
+        /// </summary>
+        public string CommandLine => CommandLineAst.Extent.Text;
+
+        /// <summary>
+        /// Gets the abstract syntax tree (AST) generated from parsing the last command line.
+        /// </summary>
+        public Ast CommandLineAst { get; }
+
+        /// <summary>
+        /// Gets the tokens generated from parsing the user input.
+        /// </summary>
+        public IReadOnlyList<Token> CommandLineTokens { get; }
+
+        /// <summary>
+        /// Gets the last error record generated from executing the last command line.
+        /// </summary>
+        public ErrorRecord? LastError { get; }
+
+        /// <summary>
+        /// Gets the current location of the default session.
+        /// It returns null if there is no default Runspace or if the default is a remote Runspace.
+        /// </summary>
+        public PathInfo? CurrentLocation { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="commandLine"></param>
+        /// <param name="lastError"></param>
+        /// <param name="cwd"></param>
+        public FeedbackContext(string commandLine, ErrorRecord? lastError, PathInfo? cwd)
+        {
+            CommandLineAst = Parser.ParseInput(commandLine, out Token[] tokens, out _);
+            CommandLineTokens = tokens;
+            LastError = lastError;
+            CurrentLocation = cwd;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="ast"></param>
+        /// <param name="tokens"></param>
+        /// <param name="lastError"></param>
+        /// <param name="cwd"></param>
+        internal FeedbackContext(Ast ast, Token[] tokens, ErrorRecord? lastError, PathInfo? cwd)
+        {
+            CommandLineAst = ast;
+            CommandLineTokens = tokens;
+            LastError = lastError;
+            CurrentLocation = cwd;
+        }
     }
 
     /// <summary>

--- a/test/xUnit/csharp/test_Feedback.cs
+++ b/test/xUnit/csharp/test_Feedback.cs
@@ -43,7 +43,7 @@ namespace PSTests.Sequential
 
         public string Description => _description;
 
-        public FeedbackItem GetFeedback(string commandLine, ErrorRecord errorRecord, CancellationToken token)
+        public FeedbackItem GetFeedback(FeedbackContext context, CancellationToken token)
         {
             if (_delay)
             {
@@ -54,7 +54,7 @@ namespace PSTests.Sequential
 
             return new FeedbackItem(
                 "slow-feedback-caption",
-                new List<string> { $"{commandLine}+{errorRecord.FullyQualifiedErrorId}" });
+                new List<string> { $"{context.CommandLine}+{context.LastError.FullyQualifiedErrorId}" });
         }
     }
 

--- a/test/xUnit/csharp/test_Subsystem.cs
+++ b/test/xUnit/csharp/test_Subsystem.cs
@@ -65,7 +65,7 @@ namespace PSTests.Sequential
 
         #region IFeedbackProvider
 
-        public FeedbackItem GetFeedback(string commandLine, ErrorRecord errorRecord, CancellationToken token) => new FeedbackItem("nothing", null);
+        public FeedbackItem GetFeedback(FeedbackContext context, CancellationToken token) => new FeedbackItem("nothing", null);
 
         #endregion
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Address #19372 and address #19364

1. Allow a feedback provider to register the trigger for it to be called. The triggers are: `Comment`, `Success`, `CommandNotFound`, `Error`, and `All`. By default, a feedback provider will be triggered by `CommandNotFound` only.
2. Some refactoring:
    - update the interface method to pass in more context information.
    - split the `FeedbackHub.GetFeedback` methods into multiple helper methods to reduce its complexity.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): **PSFeedbackProvider**
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
