### PR TITLE
Invoke-WebRequest/RestMethod: Improve reliability of CTRL-C tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4226,13 +4226,14 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
         $invoke = "`$result = $Command -Uri `"$Uri`" $Arguments"
         $task = $pwsh.AddScript($invoke).InvokeAsync()
         $delay = [System.Threading.Tasks.Task]::Delay($DelayMs)
+
+        # Stop sleeping as soon as the main task ends or vice versa
         $null = [System.Threading.Tasks.Task]::WhenAny($task, $delay).GetAwaiter().GetResult()
         $task.IsCompleted | Should -Be $WillComplete.ToBool()
         $pwsh.Stop()
         Wait-UntilTrue { [bool]($Task.IsCompleted) } | Should -BeTrue
         $result = $pwsh.Runspace.SessionStateProxy.GetVariable('result')
         $pwsh.Dispose()
-
         return $result
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4218,14 +4218,14 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
             [string]$Command = 'Invoke-WebRequest',
             [string]$Arguments = '',
             [uri]$Uri,
-            [int]$TimeoutMS = 5000,
+            [int]$DelayBeforeStopSimulationMs = 5000,
             [switch]$WillComplete
         )
 
         $pwsh = [PowerShell]::Create()
         $invoke = "`$result = $Command -Uri `"$Uri`" $Arguments"
         $task = $pwsh.AddScript($invoke).InvokeAsync()
-        $delay = [System.Threading.Tasks.Task]::Delay($TimeoutMS)
+        $delay = [System.Threading.Tasks.Task]::Delay($DelayBeforeStopSimulationMs)
 
         # Simulate CTRL-C as soon as the timeout expires or the main task ends
         $null = [System.Threading.Tasks.Task]::WaitAny($task, $delay)
@@ -4239,7 +4239,7 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
 
     It 'Invoke-WebRequest: CTRL-C Cancels request before request headers received' {
         $uri = Get-WebListenerUrl -test Delay -TestValue 30
-        RunWithCancellation -Uri $uri
+        RunWithCancellation -Uri $uri -DelayBeforeStopSimulationMs 1000
     }
 
     It 'Invoke-WebRequest: CTRL-C Cancels request after request headers received' {
@@ -4302,7 +4302,7 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
 
     It 'Invoke-RestMethod: CTRL-C Cancels request before request headers received' {
         $uri = Get-WebListenerUrl -test Delay -TestValue 30
-        RunWithCancellation -Command 'Invoke-RestMethod' -Uri $uri
+        RunWithCancellation -Command 'Invoke-RestMethod' -Uri $uri -DelayBeforeStopSimulationMs 1000
     }
 
     It 'Invoke-RestMethod: CTRL-C Cancels request after JSON request headers received' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4218,7 +4218,7 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
             [string]$Command = 'Invoke-WebRequest',
             [string]$Arguments = '',
             [uri]$Uri,
-            [int]$TimeoutMS = 10000,
+            [int]$TimeoutMS = 5000,
             [switch]$WillComplete
         )
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4231,6 +4231,10 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
         $null = [System.Threading.Tasks.Task]::WaitAny($task, $delay)
         $task.IsCompleted | Should -Be $WillComplete.ToBool()
         $pwsh.Stop()
+
+        # The download stall is normally 30 seconds from the web listener based
+        # on the first slash separated parameter in the -TestValue provided to
+        # Get-WebListenerUrl -test Stall -TestValue duration/content-type.
         Wait-UntilTrue { [bool]($Task.IsCompleted) } | Should -BeTrue
         $result = $pwsh.Runspace.SessionStateProxy.GetVariable('result')
         $pwsh.Dispose()


### PR DESCRIPTION
Closes #19531 

* Lengthen the race window from milliseconds to seconds.
*  Don't sleep any longer than necessary if a task has already completed.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Addresses request by @daxian-dbw in https://github.com/PowerShell/PowerShell/pull/19330

Raised as #19531 


<!-- Summarize your PR between here and the checklist. -->

## PR Context

CTRL C tests rely races on timeouts that had time-frames in 100s of milliseconds. These may be too tight when running in CI where resources are stretched. Increased the timeouts and changed logic so it only waits as long as necessary if possible.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
