### PR TITLE
Add an explicit manual stage for changelog update

### DIFF
--- a/tools/releaseBuild/azureDevOps/releasePipeline.yml
+++ b/tools/releaseBuild/azureDevOps/releasePipeline.yml
@@ -248,8 +248,8 @@ stages:
         $azDoBuild | Remove-AzDOBuildTag -tag 'InProgress' -Pass | Add-AzDOBuildTag -tag 'SignedOff'
       displayName: Signoff Release-Automation run
 
-- stage: GitHubDraftRelease
-  displayName: Create GitHub draft release
+- stage: UpdateChangeLog
+  displayName: Update the changelog
   # do not include stages that are likely to fail in dependency as there is no way to force deploy.
   dependsOn:
   - MSIXBundle
@@ -261,7 +261,21 @@ stages:
   - ValidateFxdPackage
   - ValidateGlobalTool
 
-# The environment here is used for approval.
+  jobs:
+  - template: templates/release/approvalJob.yml
+    parameters:
+      displayName: Make sure the changelog is updated
+      jobName: MergeChangeLog
+      instructions: |
+        Update and merge the changelog for the release.
+        This step is required for creating GitHub draft release.
+
+- stage: GitHubDraftRelease
+  displayName: Create GitHub draft release
+  # do not include stages that are likely to fail in dependency as there is no way to force deploy.
+  dependsOn: UpdateChangeLog
+
+  # The environment here is used for approval.
   jobs:
   - deployment: AzureBlobPublic
     displayName: Make Azure Blob Public


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix https://github.com/PowerShell/PowerShell/issues/19545

Add an explicit manual stage for changelog update.
The step "create GitHub Draft release" requires the corresponding changelog file gets updated for the release. So, add an explicit manual step before the "Create GitHub draft release" stage in the release pipeline to make the dependency clear.

I have run a release pipeline to validate this change:

![image](https://user-images.githubusercontent.com/127450/233489102-e5c579b0-e52b-4dba-a596-39c94e08e056.png)
