### PR TITLE
Invoke-WebRequest and Invoke-RestMethod: Rename TimeoutSec to ConnectionTimeoutSeconds (with alias) and add OperationTimeoutSeconds

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -26,8 +27,9 @@ namespace Microsoft.PowerShell.Commands
         /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class.
         /// </summary>
         /// <param name="response">The response.</param>
+        /// <param name="perReadTimeout">Time permitted between reads or Timeout.InfiniteTimeSpan for no timeout.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        public BasicHtmlWebResponseObject(HttpResponseMessage response, CancellationToken cancellationToken) : this(response, null, cancellationToken) { }
+        public BasicHtmlWebResponseObject(HttpResponseMessage response, TimeSpan perReadTimeout, CancellationToken cancellationToken) : this(response, null, perReadTimeout, cancellationToken) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BasicHtmlWebResponseObject"/> class
@@ -35,8 +37,9 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="response">The response.</param>
         /// <param name="contentStream">The content stream associated with the response.</param>
+        /// <param name="perReadTimeout">Time permitted between reads or Timeout.InfiniteTimeSpan for no timeout.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        public BasicHtmlWebResponseObject(HttpResponseMessage response, Stream? contentStream, CancellationToken cancellationToken) : base(response, contentStream, cancellationToken)
+        public BasicHtmlWebResponseObject(HttpResponseMessage response, Stream? contentStream, TimeSpan perReadTimeout, CancellationToken cancellationToken) : base(response, contentStream, perReadTimeout, cancellationToken)
         {
             InitializeContent(cancellationToken);
             InitializeRawContent(response);
@@ -157,7 +160,7 @@ namespace Microsoft.PowerShell.Commands
                 // Fill the Content buffer
                 string? characterSet = WebResponseHelper.GetCharacterSet(BaseResponse);
 
-                Content = StreamHelper.DecodeStream(RawContentStream, characterSet, out Encoding encoding, cancellationToken);
+                Content = StreamHelper.DecodeStream(RawContentStream, characterSet, out Encoding encoding, perReadTimeout, cancellationToken);
                 Encoding = encoding;
             }
             else

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -266,11 +266,25 @@ namespace Microsoft.PowerShell.Commands
         public virtual SwitchParameter DisableKeepAlive { get; set; }
 
         /// <summary>
-        /// Gets or sets the TimeOut property.
+        /// Gets or sets the ConnectionTimeoutSeconds property.
         /// </summary>
+        /// <remarks>
+        /// This property applies to sending the request and receiving the response headers only.
+        /// </remarks>
+        [Alias("TimeoutSec")]
         [Parameter]
         [ValidateRange(0, int.MaxValue)]
-        public virtual int TimeoutSec { get; set; }
+        public virtual int ConnectionTimeoutSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OperationTimeoutSeconds property.
+        /// </summary>
+        /// <remarks>
+        /// This property applies to each read operation when receiving the response body.
+        /// </remarks>
+        [Parameter]
+        [ValidateRange(0, int.MaxValue)]
+        public virtual int OperationTimeoutSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets the Headers property.
@@ -570,7 +584,7 @@ namespace Microsoft.PowerShell.Commands
                             string respVerboseMsg = contentLength is null
                                 ? string.Format(CultureInfo.CurrentCulture, WebCmdletStrings.WebResponseNoSizeVerboseMsg, response.Version, contentType)
                                 : string.Format(CultureInfo.CurrentCulture, WebCmdletStrings.WebResponseVerboseMsg, response.Version, contentLength, contentType);
-                            
+
                             WriteVerbose(respVerboseMsg);
 
                             bool _isSuccess = response.IsSuccessStatusCode;
@@ -621,12 +635,19 @@ namespace Microsoft.PowerShell.Commands
                                 string detailMsg = string.Empty;
                                 try
                                 {
-                                    string error = StreamHelper.GetResponseString(response, _cancelToken.Token);
+                                    // We can't use ReadAsStringAsync because it doesn't have per read timeouts
+                                    TimeSpan perReadTimeout = ConvertTimeoutSecondsToTimeSpan(OperationTimeoutSeconds);
+                                    string characterSet = WebResponseHelper.GetCharacterSet(response);
+                                    var responseStream = StreamHelper.GetResponseStream(response, _cancelToken.Token);
+                                    int initialCapacity = (int)Math.Min(contentLength ?? StreamHelper.DefaultReadBuffer, StreamHelper.DefaultReadBuffer);
+                                    var bufferedStream = new WebResponseContentMemoryStream(responseStream, initialCapacity, this, contentLength, perReadTimeout, _cancelToken.Token);
+                                    string error = StreamHelper.DecodeStream(bufferedStream, characterSet, out Encoding encoding, perReadTimeout, _cancelToken.Token);
                                     detailMsg = FormatErrorMessage(error, contentType);
                                 }
-                                catch
+                                catch (Exception ex)
                                 {
                                     // Catch all
+                                    er.ErrorDetails = new ErrorDetails(ex.ToString());
                                 }
 
                                 if (!string.IsNullOrEmpty(detailMsg))
@@ -666,7 +687,7 @@ namespace Microsoft.PowerShell.Commands
 
                             ThrowTerminatingError(er);
                         }
-                        finally 
+                        finally
                         {
                             _cancelToken?.Dispose();
                             _cancelToken = null;
@@ -970,7 +991,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        webProxy.UseDefaultCredentials =  ProxyUseDefaultCredentials;
+                        webProxy.UseDefaultCredentials = ProxyUseDefaultCredentials;
                     }
 
                     // We don't want to update the WebSession unless the proxies are different
@@ -1020,7 +1041,7 @@ namespace Microsoft.PowerShell.Commands
                 WebSession.RetryIntervalInSeconds = RetryIntervalSec;
             }
 
-            WebSession.TimeoutSec = TimeoutSec;
+            WebSession.ConnectionTimeout = ConvertTimeoutSecondsToTimeSpan(ConnectionTimeoutSeconds);
         }
 
         internal virtual HttpClient GetHttpClient(bool handleRedirect)
@@ -1388,6 +1409,9 @@ namespace Microsoft.PowerShell.Commands
         #endregion Virtual Methods
 
         #region Helper Methods
+
+        internal static TimeSpan ConvertTimeoutSecondsToTimeSpan(int timeout) => timeout > 0 ? TimeSpan.FromSeconds(timeout) : Timeout.InfiniteTimeSpan;
+
         private Uri PrepareUri(Uri uri)
         {
             uri = CheckProtocol(uri);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -72,14 +72,24 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion Properties
 
+        #region Protected Fields
+
+        /// <summary>
+        /// Time permitted between reads or Timeout.InfiniteTimeSpan for no timeout.
+        /// </summary>
+        protected TimeSpan perReadTimeout;
+
+        #endregion Protected Fields
+
         #region Constructors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebResponseObject"/> class.
         /// </summary>
         /// <param name="response">The Http response.</param>
+        /// <param name="perReadTimeout">Time permitted between reads or Timeout.InfiniteTimeSpan for no timeout.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        public WebResponseObject(HttpResponseMessage response, CancellationToken cancellationToken) : this(response, null, cancellationToken) { }
+        public WebResponseObject(HttpResponseMessage response, TimeSpan perReadTimeout, CancellationToken cancellationToken) : this(response, null, perReadTimeout, cancellationToken) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebResponseObject"/> class
@@ -87,9 +97,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="response">Http response.</param>
         /// <param name="contentStream">The http content stream.</param>
+        /// <param name="perReadTimeout">Time permitted between reads or Timeout.InfiniteTimeSpan for no timeout.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        public WebResponseObject(HttpResponseMessage response, Stream? contentStream, CancellationToken cancellationToken)
+        public WebResponseObject(HttpResponseMessage response, Stream? contentStream, TimeSpan perReadTimeout, CancellationToken cancellationToken)
         {
+            this.perReadTimeout = perReadTimeout;
             SetResponse(response, contentStream, cancellationToken);
             InitializeContent();
             InitializeRawContent(response);
@@ -149,7 +161,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 int initialCapacity = (int)Math.Min(contentLength, StreamHelper.DefaultReadBuffer);
-                RawContentStream = new WebResponseContentMemoryStream(st, initialCapacity, cmdlet: null, response.Content.Headers.ContentLength.GetValueOrDefault(), cancellationToken);
+                RawContentStream = new WebResponseContentMemoryStream(st, initialCapacity, cmdlet: null, response.Content.Headers.ContentLength.GetValueOrDefault(), perReadTimeout, cancellationToken);
             }
 
             // Set the position of the content stream to the beginning

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
@@ -29,6 +30,7 @@ namespace Microsoft.PowerShell.Commands
         private readonly Stream _originalStreamToProxy;
         private readonly Cmdlet? _ownerCmdlet;
         private readonly CancellationToken _cancellationToken;
+        private readonly TimeSpan _perReadTimeout;
         private bool _isInitialized = false;
 
         #endregion Data
@@ -41,13 +43,15 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="initialCapacity">Presize the memory stream.</param>
         /// <param name="cmdlet">Owner cmdlet if any.</param>
         /// <param name="contentLength">Expected download size in Bytes.</param>
+        /// <param name="perReadTimeout">Time permitted between reads or Timeout.InfiniteTimeSpan for no timeout.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        internal WebResponseContentMemoryStream(Stream stream, int initialCapacity, Cmdlet? cmdlet, long? contentLength, CancellationToken cancellationToken) : base(initialCapacity)
+        internal WebResponseContentMemoryStream(Stream stream, int initialCapacity, Cmdlet? cmdlet, long? contentLength, TimeSpan perReadTimeout, CancellationToken cancellationToken) : base(initialCapacity)
         {
             this._contentLength = contentLength;
             _originalStreamToProxy = stream;
             _ownerCmdlet = cmdlet;
             _cancellationToken = cancellationToken;
+            _perReadTimeout = perReadTimeout;
         }
         #endregion Constructors
 
@@ -228,7 +232,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
 
-                    read = _originalStreamToProxy.ReadAsync(buffer, 0, buffer.Length, cancellationToken).GetAwaiter().GetResult();
+                    read = _originalStreamToProxy.ReadAsync(buffer.AsMemory(), _perReadTimeout, cancellationToken).GetAwaiter().GetResult();
 
                     if (read > 0)
                     {
@@ -255,6 +259,59 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
+    internal static class StreamTimeoutExtensions
+    {
+        internal static async Task<int> ReadAsync(this Stream stream, Memory<byte> buffer, TimeSpan readTimeout, CancellationToken cancellationToken)
+        {
+            if (readTimeout == Timeout.InfiniteTimeSpan)
+            {
+                return await stream.ReadAsync(buffer, cancellationToken);
+            }
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(readTimeout);
+            return await stream.ReadAsync(buffer, cts.Token).ConfigureAwait(false);
+        }
+
+        internal static async Task CopyToAsync(this Stream source, Stream destination, TimeSpan perReadTimeout, CancellationToken cancellationToken)
+        {
+            if (perReadTimeout == Timeout.InfiniteTimeSpan)
+            {
+                // No timeout - use fast path
+                await source.CopyToAsync(destination, cancellationToken);
+                return;
+            }
+
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(StreamHelper.ChunkSize);
+            CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            try
+            {
+                while (true)
+                {
+                    if (!cts.TryReset())
+                    {
+                        cts.Dispose();
+                        cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    }
+
+                    cts.CancelAfter(perReadTimeout);
+                    int bytesRead = await source.ReadAsync(buffer, cts.Token).ConfigureAwait(false);
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    await destination.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                cts.Dispose();
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+    }
+
     internal static class StreamHelper
     {
         #region Constants
@@ -270,11 +327,11 @@ namespace Microsoft.PowerShell.Commands
 
         #region Static Methods
 
-        internal static void WriteToStream(Stream input, Stream output, PSCmdlet cmdlet, long? contentLength, CancellationToken cancellationToken)
+        internal static void WriteToStream(Stream input, Stream output, PSCmdlet cmdlet, long? contentLength, TimeSpan perReadTimeout, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(cmdlet);
 
-            Task copyTask = input.CopyToAsync(output, cancellationToken);
+            Task copyTask = input.CopyToAsync(output, perReadTimeout, cancellationToken);
 
             bool wroteProgress = false;
             ProgressRecord record = new(
@@ -328,16 +385,17 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="filePath">Output file name.</param>
         /// <param name="cmdlet">Current cmdlet (Invoke-WebRequest or Invoke-RestMethod).</param>
         /// <param name="contentLength">Expected download size in Bytes.</param>
+        /// <param name="perReadTimeout">Time permitted between reads or Timeout.InfiniteTimeSpan for no timeout.</param>
         /// <param name="cancellationToken">CancellationToken to track the cmdlet cancellation.</param>
-        internal static void SaveStreamToFile(Stream stream, string filePath, PSCmdlet cmdlet, long? contentLength, CancellationToken cancellationToken)
+        internal static void SaveStreamToFile(Stream stream, string filePath, PSCmdlet cmdlet, long? contentLength, TimeSpan perReadTimeout, CancellationToken cancellationToken)
         {
             // If the web cmdlet should resume, append the file instead of overwriting.
             FileMode fileMode = cmdlet is WebRequestPSCmdlet webCmdlet && webCmdlet.ShouldResume ? FileMode.Append : FileMode.Create;
             using FileStream output = new(filePath, fileMode, FileAccess.Write, FileShare.Read);
-            WriteToStream(stream, output, cmdlet, contentLength, cancellationToken);
+            WriteToStream(stream, output, cmdlet, contentLength, perReadTimeout, cancellationToken);
         }
 
-        private static string StreamToString(Stream stream, Encoding encoding, CancellationToken cancellationToken)
+        private static string StreamToString(Stream stream, Encoding encoding, TimeSpan perReadTimeout, CancellationToken cancellationToken)
         {
             StringBuilder result = new(capacity: ChunkSize);
             Decoder decoder = encoding.GetDecoder();
@@ -348,51 +406,59 @@ namespace Microsoft.PowerShell.Commands
                 useBufferSize = encoding.GetMaxCharCount(10);
             }
 
-            char[] chars = new char[useBufferSize];
-            byte[] bytes = new byte[useBufferSize * 4];
-            int bytesRead = 0;
-            do
+            char[] chars = ArrayPool<char>.Shared.Rent(useBufferSize);
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(useBufferSize * 4);
+            try
             {
-                // Read at most the number of bytes that will fit in the input buffer. The
-                // return value is the actual number of bytes read, or zero if no bytes remain.
-                bytesRead = stream.ReadAsync(bytes, 0, useBufferSize * 4, cancellationToken).GetAwaiter().GetResult();
-
-                bool completed = false;
-                int byteIndex = 0;
-
-                while (!completed)
+                int bytesRead = 0;
+                do
                 {
-                    // If this is the last input data, flush the decoder's internal buffer and state.
-                    bool flush = bytesRead is 0;
-                    decoder.Convert(bytes, byteIndex, bytesRead - byteIndex, chars, 0, useBufferSize, flush, out int bytesUsed, out int charsUsed, out completed);
+                    // Read at most the number of bytes that will fit in the input buffer. The
+                    // return value is the actual number of bytes read, or zero if no bytes remain.
+                    bytesRead = stream.ReadAsync(bytes.AsMemory(), perReadTimeout, cancellationToken).GetAwaiter().GetResult();
 
-                    // The conversion produced the number of characters indicated by charsUsed. Write that number
-                    // of characters to our result buffer
-                    result.Append(chars, 0, charsUsed);
+                    bool completed = false;
+                    int byteIndex = 0;
 
-                    // Increment byteIndex to the next block of bytes in the input buffer, if any, to convert.
-                    byteIndex += bytesUsed;
-
-                    // The behavior of decoder.Convert changed start .NET 3.1-preview2.
-                    // The change was made in https://github.com/dotnet/coreclr/pull/27229
-                    // The recommendation from .NET team is to not check for 'completed' if 'flush' is false.
-                    // Break out of the loop if all bytes have been read.
-                    if (!flush && bytesRead == byteIndex)
+                    while (!completed)
                     {
-                        break;
+                        // If this is the last input data, flush the decoder's internal buffer and state.
+                        bool flush = bytesRead is 0;
+                        decoder.Convert(bytes, byteIndex, bytesRead - byteIndex, chars, 0, useBufferSize, flush, out int bytesUsed, out int charsUsed, out completed);
+
+                        // The conversion produced the number of characters indicated by charsUsed. Write that number
+                        // of characters to our result buffer
+                        result.Append(chars, 0, charsUsed);
+
+                        // Increment byteIndex to the next block of bytes in the input buffer, if any, to convert.
+                        byteIndex += bytesUsed;
+
+                        // The behavior of decoder.Convert changed start .NET 3.1-preview2.
+                        // The change was made in https://github.com/dotnet/coreclr/pull/27229
+                        // The recommendation from .NET team is to not check for 'completed' if 'flush' is false.
+                        // Break out of the loop if all bytes have been read.
+                        if (!flush && bytesRead == byteIndex)
+                        {
+                            break;
+                        }
                     }
                 }
-            }
-            while (bytesRead != 0);
+                while (bytesRead != 0);
 
-            return result.ToString();
+                return result.ToString();
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(chars);
+                ArrayPool<byte>.Shared.Return(bytes);
+            }
         }
 
-        internal static string DecodeStream(Stream stream, string? characterSet, out Encoding encoding, CancellationToken cancellationToken)
+        internal static string DecodeStream(Stream stream, string? characterSet, out Encoding encoding, TimeSpan perReadTimeout, CancellationToken cancellationToken)
         {
             bool isDefaultEncoding = !TryGetEncoding(characterSet, out encoding);
 
-            string content = StreamToString(stream, encoding, cancellationToken);
+            string content = StreamToString(stream, encoding, perReadTimeout, cancellationToken);
             if (isDefaultEncoding)
             {
                 // We only look within the first 1k characters as the meta element and
@@ -415,7 +481,7 @@ namespace Microsoft.PowerShell.Commands
                     if (TryGetEncoding(characterSet, out Encoding localEncoding))
                     {
                         stream.Seek(0, SeekOrigin.Begin);
-                        content = StreamToString(stream, localEncoding, cancellationToken);
+                        content = StreamToString(stream, localEncoding, perReadTimeout, cancellationToken);
                         encoding = localEncoding;
                     }
                 }
@@ -458,8 +524,6 @@ namespace Microsoft.PowerShell.Commands
 
             return encoding.GetBytes(str);
         }
-
-        internal static string GetResponseString(HttpResponseMessage response, CancellationToken cancellationToken) => response.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
 
         internal static Stream GetResponseStream(HttpResponseMessage response, CancellationToken cancellationToken) => response.Content.ReadAsStreamAsync(cancellationToken).GetAwaiter().GetResult();
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.Commands
         private bool _skipCertificateCheck;
         private bool _noProxy;
         private bool _disposed;
-        private int _timeoutSec;
+        private TimeSpan _connectionTimeout;
 
         /// <summary>
         /// Contains true if an existing HttpClient had to be disposed and recreated since the WebSession was last used.
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal bool SkipCertificateCheck { set => SetStructVar(ref _skipCertificateCheck, value); }
 
-        internal int TimeoutSec { set => SetStructVar(ref _timeoutSec, value); }
+        internal TimeSpan ConnectionTimeout { set => SetStructVar(ref _connectionTimeout, value); }
 
         internal bool NoProxy
         {
@@ -240,7 +240,7 @@ namespace Microsoft.PowerShell.Commands
             // Check timeout setting (in seconds instead of milliseconds as in HttpWebRequest)
             return new HttpClient(handler)
             {
-                Timeout = _timeoutSec is 0 ? TimeSpan.FromMilliseconds(Timeout.Infinite) : TimeSpan.FromSeconds(_timeoutSec)
+                Timeout = _connectionTimeout
             };
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -613,7 +613,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $command = "Invoke-WebRequest -Uri '$uri' -ConnectionTimeoutSeconds 2"
 
         $result = ExecuteWebCommand -command $command
-        $result.Error.FullyQualifiedErrorId | Should -Be "System.Threading.Tasks.TaskCanceledException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+        $result.Error.FullyQualifiedErrorId | Should -Be "ConnectionTimeoutReached,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
     }
 
     It "Invoke-WebRequest validate TimeoutSec alias" {
@@ -621,7 +621,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $command = "Invoke-WebRequest -Uri '$uri' -TimeoutSec 2"
 
         $result = ExecuteWebCommand -command $command
-        $result.Error.FullyQualifiedErrorId | Should -Be "System.Threading.Tasks.TaskCanceledException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+        $result.Error.FullyQualifiedErrorId | Should -Be "ConnectionTimeoutReached,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
     }
 
     It "Validate Invoke-WebRequest error with -Proxy and -NoProxy option" {
@@ -2663,7 +2663,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $command = "Invoke-RestMethod -Uri '$uri' -ConnectionTimeoutSeconds 2"
 
         $result = ExecuteWebCommand -command $command
-        $result.Error.FullyQualifiedErrorId | Should -Be "System.Threading.Tasks.TaskCanceledException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+        $result.Error.FullyQualifiedErrorId | Should -Be "ConnectionTimeoutReached,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
 
     It "Invoke-RestMethod validate TimeoutSec alias" {
@@ -2671,7 +2671,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $command = "Invoke-RestMethod -Uri '$uri' -TimeoutSec 2"
 
         $result = ExecuteWebCommand -command $command
-        $result.Error.FullyQualifiedErrorId | Should -Be "System.Threading.Tasks.TaskCanceledException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+        $result.Error.FullyQualifiedErrorId | Should -Be "ConnectionTimeoutReached,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
 
     It "Validate Invoke-RestMethod error with -Proxy and -NoProxy option" {
@@ -4409,7 +4409,7 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
         RunWithCancellation -Uri $uri -Arguments '-SkipCertificateCheck'
     }
 
-    It 'Invoke-WebRequest: HTTPS with Defalte compression CTRL-C Cancels request after request headers' {
+    It 'Invoke-WebRequest: HTTPS with Deflate compression CTRL-C Cancels request after request headers' {
         $uri = Get-WebListenerUrl -Https -Test StallDeflate -TestValue '30/application%2fjson'
         RunWithCancellation -Uri $uri -Arguments '-SkipCertificateCheck'
     }
@@ -4494,6 +4494,8 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support OperationTimeoutSecond
         $result = ExecuteWebCommand -command $invoke
         if ($WillTimeout) {
             $result.Error | Should -Not -BeNullOrEmpty
+            $fqErrorClass = if ($Command -eq 'Invoke-WebRequest') { 'InvokeWebRequestCommand'} else { 'InvokeRestMethodCommand'}
+            $result.Error.FullyQualifiedErrorId | Should -Be "OperationTimeoutReached,Microsoft.PowerShell.Commands.$fqErrorClass"
             $result.Output | Should -BeNullOrEmpty
         } else {
             $result.Error | Should -BeNullOrEmpty


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This renames `-TimeoutSec` parameter (with alias to old parameter name) to `-ConnectionTimeoutSeconds` and adds `-OperationTimeoutSeconds` parameter to both `Invoke-WebRequest` and `Invoke-RestMethod` commands.

* `-TimeoutSec` becomes `-ConnectionTimeoutSeconds` and is aliased with `-TimeoutSec` and has same behaviour as before. That is, it is the timeout that applies from just prior to sending a web request to receiving the response headers.
*  `-OperationTimeoutSeconds` specifies the maximum allowed time between reads from the network when streaming http response content.

The default for both items is to have no timeout.

close #12249
close #16122 
close #19519

## PR Context

There are reports that when a network stream goes away and the OS doesn't or is unable to notify PowerShell that the network stream has been lost that PowerShell hangs forever in `Invoke-WebRequest` / `Invoke-RestMethod` on stalled response streams.

A previous PR made it possible to use CTRL-C to terminate this, but there was no way to have PowerShell timeout after a period of network inactivity in batch scenarios. This PR adds the timeout. The timeout applies to inter-stream reads, and not to the stream time as a whole. Therefore setting the `-OperationTimeoutSeconds` to 30 seconds means that any delay of longer than 30 seconds between reading data from the stream will terminate the request. However a large file that takes several minutes to download will not terminate unless the stream stalls for more than 30 seconds.

The default of 0 for `-ConnectionTimeoutSeconds` and `-OperationTimeoutSeconds` means no timeout applies as per request by WG noted in #19519. Any value less than 0 for `-OperationTimeoutSeconds` is also treated as no timeout.

### Performance Comparison

The following benchmark was used to assess performance implications of this PR over 7.3.4 vanilla using a local dotnet minimal API with a static array of bytes being returned by the website (source below).

All tests were run on a HP laptop with 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz   2.70 GHz and 16 GB memory. Note the dotnet web server and the client application were tested over HTTP on the same laptop over localhost interface.

Note: testing was done on an earlier iteration before renaming and minor refactoring of timeout handling.

```csharp
var builder = WebApplication.CreateBuilder(args);
var app = builder.Build();

var bytes = new byte[200*1024*1024]; // ~200 MB array
Random.Shared.NextBytes(bytes);
Console.WriteLine("Byte stream initialized");
app.MapGet("/", () => Results.Bytes(bytes));

app.Run();
```
The benchmark web server was built in Release configuration and run as an executable.

```powershell
# Curl from 7.3.4 vanilla
1 .. 10 | %{(Measure-Command { curl http://localhost:5000/ --output curl_data.bin }).TotalMilliseconds} | Measure-Object -Average -Minimum -Maximum -StandardDeviation
# Command run twice, and second summary taken
Count             : 10
Average           : 733.3488
Maximum           : 879.6177
Minimum           : 632.9115
StandardDeviation : 69.7117181472224

# PowerShell 7.3.4 vanilla
1 .. 10 | %{(Measure-Command { iwr http://localhost:5000/ -OutFile iwr_7.3.4_data.bin }).TotalMilliseconds} | Measure-Object -Average -Minimum -Maximum -StandardDeviation

# Command run twice and second summary taken
Count             : 10
Average           : 1115.43297
Sum               :
Maximum           : 1132.2394
Minimum           : 1102.5451
StandardDeviation : 11.4286089899233

# Powershell 7.4.0-preview.3
1 .. 10 | %{(Measure-Command { iwr http://localhost:5000/ -OutFile iwr_7.4.0-preview-3_data.bin }).TotalMilliseconds} | Measure-Object -Average -Minimum -Maximum -StandardDeviation

# Command run twice and second summary taken 
Count             : 10
Average           : 415.06509
Sum               :
Maximum           : 474.9918
Minimum           : 388.273
StandardDeviation : 33.2625053366048
Property          :

# Powershell 7.4.0-preview.3-81-g6b80bf03b74dff76816740fbb3549b87f190f518
1 .. 10 | %{(Measure-Command { iwr http://localhost:5000/ -OutFile iwr_7.4.0-preview.3-with-19558_data.bin }).TotalMilliseconds} | Measure-Object -Average -Minimum -Maximum -StandardDeviation

# Command run twice and second summary taken
Count             : 10
Average           : 410.43762
Sum               :
Maximum           : 479.3415
Minimum           : 378.843
StandardDeviation : 27.3532692743502
Property          :
# Powershell 7.4.0-preview.3-81-g6b80bf03b74dff76816740fbb3549b87f190f518 - Adding OperationTimeoutSeconds parameter
1 .. 10 | %{(Measure-Command { iwr http://localhost:5000/ -OperationTimeoutSeconds 10 -OutFile iwr_7.4.0-preview.3-with-19558-OperationTimeoutSeconds-data.bin }).TotalMilliseconds} | Measure-Object -Average -Minimum -Maximum -StandardDeviation

# Command run twice and second summary taken
Count             : 10
Average           : 646.04633
Sum               :
Maximum           : 663.085
Minimum           : 607.9275
StandardDeviation : 16.2551572417324
Property          :
```

My conclusions from these results are:

*  the patch does not have any material impact on performance on downloading a file from the last preview release when the `-OperationTimeoutSeconds` parameter isn't used
* the patch has a 30% increase on download performance over release 3 when the `-OperationTimeoutSeconds` parameter is used but is still favourable when compared to curl performance. This is likely attributable to the work spent resetting the timeout on the cancellation token before each network read.
* the last preview release is significantly faster than 7.3.4 for this use case as it is now faster than using `curl` when it was significantly slower in the 7.3.4 release.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
