### PR TITLE
Add support of respecting `$PSStyle.OutputRendering` on the remote host

### DIFF
--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHostUserInterface.cs
@@ -122,6 +122,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void Write(string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.Write1, new object[] { message });
         }
 
@@ -130,6 +131,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.Write2, new object[] { foregroundColor, backgroundColor, message });
         }
 
@@ -146,6 +148,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void WriteLine(string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.WriteLine2, new object[] { message });
         }
 
@@ -154,6 +157,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void WriteLine(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.WriteLine3, new object[] { foregroundColor, backgroundColor, message });
         }
 
@@ -162,6 +166,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void WriteErrorLine(string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.WriteErrorLine, new object[] { message });
         }
 
@@ -170,6 +175,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void WriteDebugLine(string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.WriteDebugLine, new object[] { message });
         }
 
@@ -186,6 +192,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void WriteVerboseLine(string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.WriteVerboseLine, new object[] { message });
         }
 
@@ -194,6 +201,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void WriteWarningLine(string message)
         {
+            message = GetOutputString(message, supportsVirtualTerminal: true);
             _serverMethodExecutor.ExecuteVoidMethod(RemoteHostMethodId.WriteWarningLine, new object[] { message });
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Using PowerShell remoting, if you set `$PSStyle.OutputRendering = 'plaintext'` on the remote side, ANSI escape sequences are still being sent over the wire.  Change is in the RemoteHostUserInterface using the `GetOutputString()` method to determine and strip ANSI escape sequences if required.  Since this interface doesn't detect or support indicating if VirtualTerminal is supported, we always assume so so that ANSI can still be sent.

Tested manually using `Enter-PSHostProcess`.

## PR Context

Reported by Microsoft partner that ANSI is still being sent over the wire via PSRP even if `$PSStyle.OutputRendering = 'plaintext'` is set in the remote server side.  This is because only the local host was checking if ANSI should be removed.  This change uses the same method.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
