### PR TITLE
For Preview releases, add `pwsh-preview.exe` alias to MSIX package

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3658,7 +3658,14 @@ function New-MSIXPackage
 
     $appxManifest = Get-Content "$RepoRoot\assets\AppxManifest.xml" -Raw
     $appxManifest = $appxManifest.Replace('$VERSION$', $ProductVersion).Replace('$ARCH$', $Architecture).Replace('$PRODUCTNAME$', $productName).Replace('$DISPLAYNAME$', $displayName).Replace('$PUBLISHER$', $releasePublisher)
-    Set-Content -Path "$ProductSourcePath\AppxManifest.xml" -Value $appxManifest -Force
+    $xml = [xml]$appxManifest
+    if ($isPreview) {
+        $aliasNode = $xml.Package.Applications.Application.Extensions.Extension.AppExecutionAlias.ExecutionAlias.Clone()
+        $aliasNode.alias = "pwsh-preview.exe"
+        $xml.Package.Applications.Application.Extensions.Extension.AppExecutionAlias.AppendChild($aliasNode) | Out-Null
+    }
+    $xml.Save("$ProductSourcePath\AppxManifest.xml")
+
     # Necessary image assets need to be in source assets folder
     $assets = @(
         'Square150x150Logo'

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -61,6 +61,8 @@ function Start-PSPackage {
         [ValidateScript({$Environment.IsMacOS})]
         [string] $MacOSRuntime,
 
+        [switch] $Private,
+
         [Switch] $Force,
 
         [Switch] $SkipReleaseChecks,
@@ -473,6 +475,7 @@ function Start-PSPackage {
                     ProductVersion = $Version
                     Architecture = $WindowsRuntime.Split('-')[1]
                     Force = $Force
+                    Private = $Private
                 }
 
                 if ($PSCmdlet.ShouldProcess("Create MSIX Package")) {
@@ -3602,6 +3605,9 @@ function New-MSIXPackage
         [ValidateSet('x64','x86','arm','arm64')]
         [string] $Architecture,
 
+        # Produce private package for testing in Store
+        [Switch] $Private,
+
         # Force overwrite of package
         [Switch] $Force,
 
@@ -3630,13 +3636,20 @@ function New-MSIXPackage
     $ProductSemanticVersion = Get-PackageSemanticVersion -Version $ProductVersion
     $productSemanticVersionWithName = $ProductName + '-' + $ProductSemanticVersion
     $packageName = $productSemanticVersionWithName
+    if ($Private) {
+        $ProductNameSuffix = 'Private'
+    }
+
     if ($ProductNameSuffix) {
         $packageName += "-$ProductNameSuffix"
     }
 
     $displayName = $productName
 
-    if ($ProductSemanticVersion.Contains('-')) {
+    if ($Private) {
+        $ProductName = 'PowerShell-Private'
+        $displayName = 'PowerShell-Private'
+    } elseif ($ProductSemanticVersion.Contains('-')) {
         $ProductName += 'Preview'
         $displayName += ' Preview'
     }
@@ -3660,6 +3673,7 @@ function New-MSIXPackage
     $appxManifest = $appxManifest.Replace('$VERSION$', $ProductVersion).Replace('$ARCH$', $Architecture).Replace('$PRODUCTNAME$', $productName).Replace('$DISPLAYNAME$', $displayName).Replace('$PUBLISHER$', $releasePublisher)
     $xml = [xml]$appxManifest
     if ($isPreview) {
+        Write-Verbose -Verbose "Adding pwsh-preview.exe alias"
         $aliasNode = $xml.Package.Applications.Application.Extensions.Extension.AppExecutionAlias.ExecutionAlias.Clone()
         $aliasNode.alias = "pwsh-preview.exe"
         $xml.Package.Applications.Application.Extensions.Extension.AppExecutionAlias.AppendChild($aliasNode) | Out-Null


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The changes are in packaging such that if it's a preview release, we modify the appx manifest XML to add another alias `pwsh-preview.exe`.  This results in a reparse point called `pwsh-preview.exe` created at install time that points to `pwsh.exe` so that users can use `pwsh-preview` to launch the preview Store app if they have it side-by-side installed with the stable release.

Verified manually using the new `-private` switch to produce a new pkg I could publish privately to the store.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/19576

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
