### PR TITLE
Fix HTTP status from 409 to 429 for WebCmdlets to get retry interval from Retry-After header.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1339,7 +1339,7 @@ namespace Microsoft.PowerShell.Commands
 
                     // If the status code is 429 get the retry interval from the Headers.
                     // Ignore broken header and its value.
-                    if (response.StatusCode is HttpStatusCode.Conflict && response.Headers.TryGetValues(HttpKnownHeaderNames.RetryAfter, out IEnumerable<string> retryAfter))
+                    if (response.StatusCode is HttpStatusCode.TooManyRequests && response.Headers.TryGetValues(HttpKnownHeaderNames.RetryAfter, out IEnumerable<string> retryAfter))
                     {
                         try
                         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2168,15 +2168,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
                 headers        = '{"Retry-After":"1"}'
             }
             $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
-            # Measure processing time
-            $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
-            $commandStr = "Invoke-WebRequest -Uri '$uri' -MaximumRetryCount 2 -RetryIntervalSec 3 -SkipHttpErrorCheck"
-            $result = ExecuteWebCommand -command $commandStr
-            $stopWatch.Stop()
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-WebRequest -Uri $uri -MaximumRetryCount 1 -RetryIntervalSec 3 -SkipHttpErrorCheck -Verbose 4>$verbosefile
 
-            # If it is working correctly, the process takes about 2.x seconds to complete (Retry-After:1 * MaximumRetryCount:2)
-            # otherwise it takes >6 seconds (RetryIntervalSec:3 * MaximumRetryCount:2)
-            $stopWatch.Elapsed.TotalSeconds | Should -BeLessThan 2.9
+            $verboseFile | Should -FileContentMatch 'Retrying after interval of 1 seconds. Status code for previous attempt: TooManyRequests'
         }
 
         It "Invoke-WebRequest ignores the Retry-After header value NOT in 429 status" {
@@ -2186,18 +2181,13 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
                 reposnsephrase = 'Conflict'
                 contenttype    = 'application/json'
                 body           = '{"message":"oops"}'
-                headers        = '{"Retry-After":"4"}'
+                headers        = '{"Retry-After":"1"}'
             }
             $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
-            # Measure processing time
-            $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
-            $commandStr = "Invoke-WebRequest -Uri '$uri' -MaximumRetryCount 2 -RetryIntervalSec 1 -SkipHttpErrorCheck"
-            $result = ExecuteWebCommand -command $commandStr
-            $stopWatch.Stop()
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-WebRequest -Uri $uri -MaximumRetryCount 1 -RetryIntervalSec 3 -SkipHttpErrorCheck -Verbose 4>$verbosefile
 
-            # If it is working correctly, the process takes about 2.x seconds to complete (RetryIntervalSec:1 * MaximumRetryCount:2)
-            # otherwise it takes >8 seconds (Retry-After:4 * MaximumRetryCount:2)
-            $stopWatch.Elapsed.TotalSeconds | Should -BeLessThan 2.9
+            $verboseFile | Should -FileContentMatch 'Retrying after interval of 3 seconds. Status code for previous attempt: Conflict'
         }
     }
 
@@ -4100,15 +4090,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
                 headers        = '{"Retry-After":"1"}'
             }
             $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
-            # Measure processing time
-            $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
-            $commandStr = "Invoke-RestMethod -Uri '$uri' -MaximumRetryCount 2 -RetryIntervalSec 3 -SkipHttpErrorCheck"
-            $result = ExecuteWebCommand -command $commandStr
-            $stopWatch.Stop()
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-RestMethod -Uri $uri -MaximumRetryCount 1 -RetryIntervalSec 3 -SkipHttpErrorCheck -Verbose 4>$verbosefile
 
-            # If it is working correctly, the process takes about 2.x seconds to complete (Retry-After:1 * MaximumRetryCount:2)
-            # otherwise it takes >6 seconds (RetryIntervalSec:3 * MaximumRetryCount:2)
-            $stopWatch.Elapsed.TotalSeconds | Should -BeLessThan 2.9
+            $verboseFile | Should -FileContentMatch 'Retrying after interval of 1 seconds. Status code for previous attempt: TooManyRequests'
         }
 
         It "Invoke-RestMethod ignores the Retry-After header value NOT in 429 status" {
@@ -4118,18 +4103,13 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
                 reposnsephrase = 'Conflict'
                 contenttype    = 'application/json'
                 body           = '{"message":"oops"}'
-                headers        = '{"Retry-After":"4"}'
+                headers        = '{"Retry-After":"1"}'
             }
             $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
-            # Measure processing time
-            $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
-            $commandStr = "Invoke-RestMethod -Uri '$uri' -MaximumRetryCount 2 -RetryIntervalSec 1 -SkipHttpErrorCheck"
-            $result = ExecuteWebCommand -command $commandStr
-            $stopWatch.Stop()
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-RestMethod -Uri $uri -MaximumRetryCount 1 -RetryIntervalSec 3 -SkipHttpErrorCheck -Verbose 4>$verbosefile
 
-            # If it is working correctly, the process takes about 2.x seconds to complete (RetryIntervalSec:1 * MaximumRetryCount:2)
-            # otherwise it takes >8 seconds (Retry-After:4 * MaximumRetryCount:2)
-            $stopWatch.Elapsed.TotalSeconds | Should -BeLessThan 2.9
+            $verboseFile | Should -FileContentMatch 'Retrying after interval of 3 seconds. Status code for previous attempt: Conflict'
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The code that gets the appropriate retry interval from the Retry-After response header is incorrect and is executing with status code 409 when it should be executing with status code 429. This PR will correct that.

The original code was implemented in PR #18717.  
This PR will fix #19621 and also correctly resolves #13188 again.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
