### PR TITLE
Change logic for testing missing or extra cmdlets.

### DIFF
--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -617,8 +617,8 @@ Describe "Verify aliases and cmdlets" -Tags "CI" {
         $expectedCmdletNames = $commandHashTableList.ForEach({"{0}" -f $_.Name})
         $extraCmds = $observedCmdletNames.Where({$expectedCmdletNames -notcontains $_})
         $missedCmds = $expectedCmdletNames.Where({$observedCmdletNames -notcontains $_})
-        $extraCmds.Count | Should -Be 0 -Because "Extra cmdlets $($extraCmds -join ',')"
-        $missedCmds.Count | Should -Be 0 -Because "Missed cmdlets $($missedCmds -join ',')"
+        $extraCmds | Should -HaveCount 0 -Because "Extra cmdlets $($extraCmds -join ',')"
+        $missedCmds | Should -HaveCount 0 -Because "Missed cmdlets $($missedCmds -join ',')"
     }
 
     It "'<Name>' Cmdlet should have the correct ConfirmImpact '<ConfirmImpact>'" -TestCases $commandHashtableList {

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -613,9 +613,12 @@ Describe "Verify aliases and cmdlets" -Tags "CI" {
     }
 
     It "All approved Cmdlets present (no new Cmdlets added, no Cmdlets removed)" {
-        $observedCmdletNames = $currentCmdletList.ForEach({"{0}" -f $_.Name}) | Sort-Object
-        $expectedCmdletNames = $commandHashTableList.ForEach({"{0}" -f $_.Name}) | Sort-Object
-        $observedCmdletNames | Should -Be $expectedCmdletNames
+        $observedCmdletNames = $currentCmdletList.ForEach({"{0}" -f $_.Name})
+        $expectedCmdletNames = $commandHashTableList.ForEach({"{0}" -f $_.Name})
+        $extraCmds = $observedCmdletNames.Where({$expectedCmdletNames -notcontains $_})
+        $missedCmds = $expectedCmdletNames.Where({$observedCmdletNames -notcontains $_})
+        $extraCmds.Count | Should -Be 0 -Because "Extra cmdlets $($extraCmds -join ',')"
+        $missedCmds.Count | Should -Be 0 -Because "Missed cmdlets $($missedCmds -join ',')"
     }
 
     It "'<Name>' Cmdlet should have the correct ConfirmImpact '<ConfirmImpact>'" -TestCases $commandHashtableList {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This change is for the test 'All approved Cmdlets present (no new Cmdlets added, no Cmdlets removed)'.
extra/missing cmdlet tests executed during release testing will sometime fail. The error message indicates that the cmdlet is not actually extra or missing. I'm changing the way we check.
 
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
