### PR TITLE
Add exponential backoff to the retry algorithm of WebCmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1375,11 +1375,10 @@ namespace Microsoft.PowerShell.Commands
                     float retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
                     int exponent = WebSession.MaximumRetryCount - totalRequests + 1;
 
-                    Random random = new();
                     retryIntervalInSeconds = RetryMode switch
                     {
                         WebRequestRetryMode.Exponential => MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent), _maximumRetryIntervalInSeconds),
-                        WebRequestRetryMode.ExponentialJitter => MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent) * random.NextSingle(), _maximumRetryIntervalInSeconds),
+                        WebRequestRetryMode.ExponentialJitter => MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent) * Random.Shared.NextSingle(), _maximumRetryIntervalInSeconds),
                         WebRequestRetryMode.Fixed or _ => WebSession.RetryIntervalInSeconds
                     };
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1357,13 +1357,13 @@ namespace Microsoft.PowerShell.Commands
                     if (string.Equals(RetryMode, "Exponential", StringComparison.OrdinalIgnoreCase))
                     {
                         // If RetryMode is specified as "Exponential", use the exponential backoff algorithm to determine the retry interval.
-                        retryIntervalInSeconds = MathF.Min(retryIntervalInSeconds * MathF.Pow(2, exponent), _maximumRetryIntervalInSeconds);
+                        retryIntervalInSeconds = MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent), _maximumRetryIntervalInSeconds);
                     }
                     else if (string.Equals(RetryMode, "ExponentialJitter", StringComparison.OrdinalIgnoreCase))
                     {
                         // If RetryMode is specified as "ExponentialJitter", use the exponential backoff with jitter algorithm to determine the retry interval.
                         Random random = new();
-                        retryIntervalInSeconds = MathF.Min(retryIntervalInSeconds * MathF.Pow(2, exponent) * random.NextSingle(), _maximumRetryIntervalInSeconds);
+                        retryIntervalInSeconds = MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent) * random.NextSingle(), _maximumRetryIntervalInSeconds);
                     }
 
                     // If the status code is 429 get the retry interval from the Headers.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -123,6 +123,11 @@ namespace Microsoft.PowerShell.Commands
         internal Dictionary<string, string> _relationLink = null;
 
         /// <summary>
+        /// Maximum retry interval for exponential backoff strategy.
+        /// </summary>
+        private const int _maximumRetryIntervalInSeconds = 600;
+
+        /// <summary>
         /// The current size of the local file being resumed.
         /// </summary>
         private long _resumeFileSize = 0;
@@ -306,13 +311,6 @@ namespace Microsoft.PowerShell.Commands
         public virtual int MaximumRedirection { get; set; } = -1;
 
         /// <summary>
-        /// Gets or sets the MaximumRetryCount property, which determines the number of retries of a failed web request.
-        /// </summary>
-        [Parameter]
-        [ValidateRange(0, int.MaxValue)]
-        public virtual int MaximumRetryCount { get; set; }
-
-        /// <summary>
         /// Gets or sets the PreserveAuthorizationOnRedirect property.
         /// </summary>
         /// <remarks>
@@ -327,6 +325,24 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public virtual SwitchParameter PreserveAuthorizationOnRedirect { get; set; }
 
+        #endregion Redirect
+
+        #region Retry
+
+        /// <summary>
+        /// Gets or sets the RetryMode property.
+        /// </summary>
+        [Parameter]
+        [ValidateSet("Fixed", "Exponential", "ExponentialJitter", IgnoreCase = true)]
+        public virtual string RetryMode { get; set; } = "Fixed";
+
+        /// <summary>
+        /// Gets or sets the MaximumRetryCount property, which determines the number of retries of a failed web request.
+        /// </summary>
+        [Parameter]
+        [ValidateRange(0, int.MaxValue)]
+        public virtual int MaximumRetryCount { get; set; }
+
         /// <summary>
         /// Gets or sets the RetryIntervalSec property, which determines the number seconds between retries.
         /// </summary>
@@ -334,7 +350,7 @@ namespace Microsoft.PowerShell.Commands
         [ValidateRange(1, int.MaxValue)]
         public virtual int RetryIntervalSec { get; set; } = 5;
 
-        #endregion Redirect
+        #endregion Retry
 
         #region Method
 
@@ -1335,7 +1351,20 @@ namespace Microsoft.PowerShell.Commands
                 // When MaximumRetryCount is not specified, the totalRequests is 1.
                 if (totalRequests > 1 && ShouldRetry(response.StatusCode))
                 {
-                    int retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
+                    double retryIntervalInSeconds = (double)WebSession.RetryIntervalInSeconds;
+                    int exponent = WebSession.MaximumRetryCount - totalRequests + 1;
+
+                    if (String.Equals(RetryMode, "Exponential", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // If RetryMode is specified as "Exponential", use the exponential backoff algorithm to determine the retry interval.
+                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * Math.Pow(2.0, exponent), _maximumRetryIntervalInSeconds);
+                    }
+                    else if (String.Equals(RetryMode, "ExponentialJitter", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // If RetryMode is specified as "ExponentialJitter", use the exponential backoff with jitter algorithm to determine the retry interval.
+                        Random random = new Random();
+                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * Math.Pow(2.0, exponent) * random.NextDouble(), _maximumRetryIntervalInSeconds);
+                    }
 
                     // If the status code is 429 get the retry interval from the Headers.
                     // Ignore broken header and its value.
@@ -1346,7 +1375,7 @@ namespace Microsoft.PowerShell.Commands
                             IEnumerator<string> enumerator = retryAfter.GetEnumerator();
                             if (enumerator.MoveNext())
                             {
-                                retryIntervalInSeconds = Convert.ToInt32(enumerator.Current);
+                                retryIntervalInSeconds = (double)Convert.ToInt32(enumerator.Current);
                             }
                         }
                         catch
@@ -1358,13 +1387,13 @@ namespace Microsoft.PowerShell.Commands
                     string retryMessage = string.Format(
                         CultureInfo.CurrentCulture,
                         WebCmdletStrings.RetryVerboseMsg,
-                        retryIntervalInSeconds,
+                        retryIntervalInSeconds.ToString("G3"),
                         response.StatusCode);
 
                     WriteVerbose(retryMessage);
 
                     _cancelToken = new CancellationTokenSource();
-                    Task.Delay(retryIntervalInSeconds * 1000, _cancelToken.Token).GetAwaiter().GetResult();
+                    Task.Delay((int)(retryIntervalInSeconds * 1000), _cancelToken.Token).GetAwaiter().GetResult();
                     _cancelToken.Cancel();
                     _cancelToken = null;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1375,22 +1375,13 @@ namespace Microsoft.PowerShell.Commands
                     float retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
                     int exponent = WebSession.MaximumRetryCount - totalRequests + 1;
 
-                    switch (RetryMode)
+                    Random random = new();
+                    retryIntervalInSeconds = RetryMode switch
                     {
-                        case WebRequestRetryMode.Fixed:
-                            retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
-                            break;
-                        case WebRequestRetryMode.Exponential:
-                            retryIntervalInSeconds = MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent), _maximumRetryIntervalInSeconds);
-                            break;
-                        case WebRequestRetryMode.ExponentialJitter:
-                            Random random = new();
-                            retryIntervalInSeconds = MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent) * random.NextSingle(), _maximumRetryIntervalInSeconds);
-                            break;
-                        default:
-                            retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
-                            break;
-                    }
+                        WebRequestRetryMode.Exponential => MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent), _maximumRetryIntervalInSeconds),
+                        WebRequestRetryMode.ExponentialJitter => MathF.Min(MathF.ScaleB(retryIntervalInSeconds, exponent) * random.NextSingle(), _maximumRetryIntervalInSeconds),
+                        WebRequestRetryMode.Fixed or _ => WebSession.RetryIntervalInSeconds
+                    };
 
                     // If the status code is 429 get the retry interval from the Headers.
                     // Ignore broken header and its value.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1357,13 +1357,13 @@ namespace Microsoft.PowerShell.Commands
                     if (string.Equals(RetryMode, "Exponential", StringComparison.OrdinalIgnoreCase))
                     {
                         // If RetryMode is specified as "Exponential", use the exponential backoff algorithm to determine the retry interval.
-                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * MathF.Pow(2, exponent), _maximumRetryIntervalInSeconds);
+                        retryIntervalInSeconds = MathF.Min(retryIntervalInSeconds * MathF.Pow(2, exponent), _maximumRetryIntervalInSeconds);
                     }
                     else if (string.Equals(RetryMode, "ExponentialJitter", StringComparison.OrdinalIgnoreCase))
                     {
                         // If RetryMode is specified as "ExponentialJitter", use the exponential backoff with jitter algorithm to determine the retry interval.
                         Random random = new();
-                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * MathF.Pow(2, exponent) * random.NextDouble(), _maximumRetryIntervalInSeconds);
+                        retryIntervalInSeconds = MathF.Min(retryIntervalInSeconds * MathF.Pow(2, exponent) * random.NextSingle(), _maximumRetryIntervalInSeconds);
                     }
 
                     // If the status code is 429 get the retry interval from the Headers.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1351,19 +1351,19 @@ namespace Microsoft.PowerShell.Commands
                 // When MaximumRetryCount is not specified, the totalRequests is 1.
                 if (totalRequests > 1 && ShouldRetry(response.StatusCode))
                 {
-                    double retryIntervalInSeconds = (double)WebSession.RetryIntervalInSeconds;
+                    float retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
                     int exponent = WebSession.MaximumRetryCount - totalRequests + 1;
 
-                    if (String.Equals(RetryMode, "Exponential", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(RetryMode, "Exponential", StringComparison.OrdinalIgnoreCase))
                     {
                         // If RetryMode is specified as "Exponential", use the exponential backoff algorithm to determine the retry interval.
-                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * Math.Pow(2.0, exponent), _maximumRetryIntervalInSeconds);
+                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * MathF.Pow(2, exponent), _maximumRetryIntervalInSeconds);
                     }
-                    else if (String.Equals(RetryMode, "ExponentialJitter", StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals(RetryMode, "ExponentialJitter", StringComparison.OrdinalIgnoreCase))
                     {
                         // If RetryMode is specified as "ExponentialJitter", use the exponential backoff with jitter algorithm to determine the retry interval.
-                        Random random = new Random();
-                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * Math.Pow(2.0, exponent) * random.NextDouble(), _maximumRetryIntervalInSeconds);
+                        Random random = new();
+                        retryIntervalInSeconds = Math.Min(retryIntervalInSeconds * MathF.Pow(2, exponent) * random.NextDouble(), _maximumRetryIntervalInSeconds);
                     }
 
                     // If the status code is 429 get the retry interval from the Headers.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1375,7 +1375,7 @@ namespace Microsoft.PowerShell.Commands
                             IEnumerator<string> enumerator = retryAfter.GetEnumerator();
                             if (enumerator.MoveNext())
                             {
-                                retryIntervalInSeconds = (double)Convert.ToInt32(enumerator.Current);
+                                retryIntervalInSeconds = Convert.ToInt32(enumerator.Current);
                             }
                         }
                         catch

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2189,6 +2189,43 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
 
             $verboseFile | Should -FileContentMatch 'Retrying after interval of 3 seconds. Status code for previous attempt: Conflict'
         }
+
+        It "Invoke-WebRequest -RetryMode Exponential should use the exponential backoff stratefy for retrying." {
+
+            $Query = @{
+                statusCode     = 404
+                reposnsephrase = 'NotFound'
+                contenttype    = 'application/json'
+                body           = '{"message":"oops"}'
+            }
+            $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-WebRequest -Uri $uri -RetryMode Exponential -MaximumRetryCount 3 -RetryIntervalSec 1 -SkipHttpErrorCheck -Verbose 4>$verbosefile
+
+            $exepectMessage = @(
+                'Retrying after interval of 1 seconds. Status code for previous attempt: NotFound'
+                'Retrying after interval of 2 seconds. Status code for previous attempt: NotFound'
+                'Retrying after interval of 4 seconds. Status code for previous attempt: NotFound'
+            ) -join [System.Environment]::NewLine
+            $verboseFile | Should -FileContentMatchMultiline $exepectMessage
+        }
+
+        It "Invoke-WebRequest -RetryMode ExponentialJitter should use the exponential backoff stratefy with jitter for retrying." {
+
+            $Query = @{
+                statusCode     = 404
+                reposnsephrase = 'NotFound'
+                contenttype    = 'application/json'
+                body           = '{"message":"oops"}'
+            }
+            $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-WebRequest -Uri $uri -RetryMode ExponentialJitter -MaximumRetryCount 3 -RetryIntervalSec 1 -SkipHttpErrorCheck -Verbose 4>$verbosefile
+
+            # In the exponential backoff stratefy with jitter, retry interval could not be estimated.
+            $exepectMessageRegex = 'Retrying after interval of [\.\d]+ seconds. Status code for previous attempt: NotFound'
+            Select-String -Path $verboseFile -Pattern $exepectMessageRegex -Raw | Should -HaveCount 3
+        }
     }
 
     Context "Regex Parsing" {
@@ -4110,6 +4147,43 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             $result = Invoke-RestMethod -Uri $uri -MaximumRetryCount 1 -RetryIntervalSec 3 -SkipHttpErrorCheck -Verbose 4>$verbosefile
 
             $verboseFile | Should -FileContentMatch 'Retrying after interval of 3 seconds. Status code for previous attempt: Conflict'
+        }
+
+        It "Invoke-RestMethod -RetryMode Exponential should use the exponential backoff stratefy for retrying." {
+
+            $Query = @{
+                statusCode     = 404
+                reposnsephrase = 'NotFound'
+                contenttype    = 'application/json'
+                body           = '{"message":"oops"}'
+            }
+            $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-RestMethod -Uri $uri -RetryMode Exponential -MaximumRetryCount 3 -RetryIntervalSec 1 -SkipHttpErrorCheck -Verbose 4>$verbosefile
+
+            $exepectMessage = @(
+                'Retrying after interval of 1 seconds. Status code for previous attempt: NotFound'
+                'Retrying after interval of 2 seconds. Status code for previous attempt: NotFound'
+                'Retrying after interval of 4 seconds. Status code for previous attempt: NotFound'
+            ) -join [System.Environment]::NewLine
+            $verboseFile | Should -FileContentMatchMultiline $exepectMessage
+        }
+
+        It "Invoke-RestMethod -RetryMode ExponentialJitter should use the exponential backoff stratefy with jitter for retrying." {
+
+            $Query = @{
+                statusCode     = 404
+                reposnsephrase = 'NotFound'
+                contenttype    = 'application/json'
+                body           = '{"message":"oops"}'
+            }
+            $uri = Get-WebListenerUrl -Test 'Response' -Query $Query
+            $verboseFile = Join-Path $TestDrive -ChildPath verbose.txt
+            $result = Invoke-RestMethod -Uri $uri -RetryMode ExponentialJitter -MaximumRetryCount 3 -RetryIntervalSec 1 -SkipHttpErrorCheck -Verbose 4>$verbosefile
+
+            # In the exponential backoff stratefy with jitter, retry interval could not be estimated.
+            $exepectMessageRegex = 'Retrying after interval of [\.\d]+ seconds. Status code for previous attempt: NotFound'
+            Select-String -Path $verboseFile -Pattern $exepectMessageRegex -Raw | Should -HaveCount 3
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a new parameter `-RetryMode` to `Invoke-WebRequest` and `Invoke-RestMethod` to add the ability to retry with exponential backoff strategy and exponential backoff with jitter strategy.

The type of `-RetryMode` is `[WebRequestRetryMode]` enum and users can select one from three modes.

- `Fixed`: Use fixed retry interval. The interval follows the value of `-RetryIntervalSec`. This is the default mode.

- `Exponential`: Use exponential backoff strategy. The retry interval is expressed as `RetryIntervalSec * (2 ^ retryCount)`.

- `ExponentialJitter`: Use exponential backoff with jitter strategy. The retry interval is expressed as `RetryIntervalSec * (2 ^ retryCount) * jitter`. `jitter` is a random value betweem `0.0` and `1.0`.

Note 1:
If we select `Exponential` or `ExponentialJitter`, the interval will never exceed 600 seconds. This prevents the interval from becoming excessively long. 600 seconds is used by `curl`.

Note 2:
This is not a breaking change, since the default mode is `Fixed`. It does not change the behavior of existing scripts.

## PR Context

This PR resolves #19632

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
