### PR TITLE
Skip file signature tests on 2012R2 where PKI cmdlets do not work

### DIFF
--- a/test/powershell/engine/Security/FileSignature.Tests.ps1
+++ b/test/powershell/engine/Security/FileSignature.Tests.ps1
@@ -22,9 +22,15 @@ Describe "Windows platform file signatures" -Tags 'Feature' {
 }
 
 Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWindows') {
-    $PSDefaultParameterValues = @{ "It:Skip" = (-not $IsWindows) }
+    $shouldSkip = (-not $IsWindows) -or (Test-IsWinServer2012R2)
+
+    $PSDefaultParameterValues = @{ "It:Skip" = $shouldSkip }
 
     BeforeAll {
+        if ($shouldSkip) {
+            return
+        }
+
         $session = New-PSSession -UseWindowsPowerShell
         try {
             # New-SelfSignedCertificate runs in implicit remoting so do all the
@@ -83,6 +89,11 @@ Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWin
     }
 
     AfterAll {
+
+        if ($shouldSkip) {
+            return
+        }
+
         Remove-Item -Path Cert:\LocalMachine\Root\$caRootThumbprint -Force
         Remove-Item -Path Cert:\LocalMachine\TrustedPublisher\$signingThumbprint -Force
         Remove-Item -Path Cert:\CurrentUser\My\$signingThumbprint -Force


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The PKI module cmdlet New-SelfSignedCertificate does not support the parameters used in the BeforeAll on Windows Server 2012 R2. Hence, skipping those tests.

Also skipping BeforeAll on unsupported platform.

## PR Context

Related change: #18774

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
