### PR TITLE
Added `-CaseInsensitive` switch parameter to `Select-Object` & `Get-Unique` cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
@@ -50,6 +50,13 @@ namespace Microsoft.PowerShell.Commands
         }
 
         private bool _onType = false;
+
+        /// <summary>
+        /// Gets or sets case insensitive switch for string comparison.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter CaseInsensitive { get; set; }
+
         #endregion Parameters
 
         #region Overrides
@@ -77,7 +84,9 @@ namespace Microsoft.PowerShell.Commands
                 if (string.Equals(
                     inputString,
                     _lastObjectAsString,
-                    StringComparison.CurrentCulture))
+                    CaseInsensitive.IsPresent
+                        ? StringComparison.CurrentCultureIgnoreCase
+                        : StringComparison.CurrentCulture))
                 {
                     isUnique = false;
                 }
@@ -91,7 +100,7 @@ namespace Microsoft.PowerShell.Commands
                 _comparer ??= new ObjectCommandComparer(
                     true, // ascending (doesn't matter)
                     CultureInfo.CurrentCulture,
-                    true); // case-sensitive
+                    !CaseInsensitive.IsPresent); // case-sensitive
 
                 isUnique = (_comparer.Compare(InputObject, _lastObject) != 0);
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
@@ -96,9 +96,9 @@ namespace Microsoft.PowerShell.Commands
             else // compare as objects
             {
                 _comparer ??= new ObjectCommandComparer(
-                    true, // ascending (doesn't matter)
+                    ascending: true, // ascending (doesn't matter)
                     CultureInfo.CurrentCulture,
-                    !CaseInsensitive.IsPresent); // case-sensitive
+                    caseSensitive: !CaseInsensitive.IsPresent); // case-sensitive
 
                 isUnique = (_comparer.Compare(InputObject, _lastObject) != 0);
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
@@ -96,9 +96,9 @@ namespace Microsoft.PowerShell.Commands
             else // compare as objects
             {
                 _comparer ??= new ObjectCommandComparer(
-                    ascending: true, // ascending (doesn't matter)
+                    ascending: true,
                     CultureInfo.CurrentCulture,
-                    caseSensitive: !CaseInsensitive.IsPresent); // case-sensitive
+                    caseSensitive: !CaseInsensitive.IsPresent);
 
                 isUnique = (_comparer.Compare(InputObject, _lastObject) != 0);
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
@@ -84,9 +84,7 @@ namespace Microsoft.PowerShell.Commands
                 if (string.Equals(
                     inputString,
                     _lastObjectAsString,
-                    CaseInsensitive.IsPresent
-                        ? StringComparison.CurrentCultureIgnoreCase
-                        : StringComparison.CurrentCulture))
+                    CaseInsensitive.IsPresent ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture))
                 {
                     isUnique = false;
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -111,6 +111,13 @@ namespace Microsoft.PowerShell.Commands
         private bool _unique;
 
         /// <summary>
+        /// Gets or sets case insensitive switch for string comparison.
+        /// Used in combination with Unique switch parameter.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter CaseInsensitive { get; set; }
+
+        /// <summary>
         /// </summary>
         /// <value></value>
         [Parameter(ParameterSetName = "DefaultParameter")]
@@ -632,7 +639,7 @@ namespace Microsoft.PowerShell.Commands
                 bool isObjUnique = true;
                 foreach (UniquePSObjectHelper uniqueObj in _uniques)
                 {
-                    ObjectCommandComparer comparer = new(true, CultureInfo.CurrentCulture, true);
+                    ObjectCommandComparer comparer = new(true, CultureInfo.CurrentCulture, !CaseInsensitive.IsPresent);
                     if ((comparer.Compare(obj.BaseObject, uniqueObj.WrittenObject.BaseObject) == 0) &&
                         (uniqueObj.NotePropertyCount == addedNoteProperties.Count))
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -639,7 +639,11 @@ namespace Microsoft.PowerShell.Commands
                 bool isObjUnique = true;
                 foreach (UniquePSObjectHelper uniqueObj in _uniques)
                 {
-                    ObjectCommandComparer comparer = new(true, CultureInfo.CurrentCulture, !CaseInsensitive.IsPresent);
+                    ObjectCommandComparer comparer = new(
+                        ascending: true,
+                        CultureInfo.CurrentCulture,
+                        caseSensitive: !CaseInsensitive.IsPresent);
+
                     if ((comparer.Compare(obj.BaseObject, uniqueObj.WrittenObject.BaseObject) == 0) &&
                         (uniqueObj.NotePropertyCount == addedNoteProperties.Count))
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Unique.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Unique.Tests.ps1
@@ -1,8 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Get-Unique DRT Unit Tests" -Tags "CI" {
-    It "Command get-unique works with AsString switch" {
+
+    BeforeAll {
         $inputArray = "aa","aa","Aa","ba","BA","BA"
+    }
+
+    It "Command get-unique works with AsString switch" {
         $results = $inputArray | Get-Unique -AsString
 
         $results.Length | Should -Be 4
@@ -17,6 +21,18 @@ Describe "Get-Unique DRT Unit Tests" -Tags "CI" {
         $results[2] | Should -BeOfType System.String
         $results[3] | Should -BeOfType System.String
     }
+
+    It "Command get-unique works with AsString and CaseInsensitive switches" {
+        $results = $inputArray | Get-Unique -AsString -CaseInsensitive
+
+        $results.Length | Should -Be 2
+
+        $results[0] | Should -BeExactly "aa"
+        $results[1] | Should -BeExactly "ba"
+
+        $results[0] | Should -BeOfType System.String
+        $results[1] | Should -BeOfType System.String
+    }
 }
 
 Describe "Get-Unique" -Tags "CI" {
@@ -26,6 +42,8 @@ Describe "Get-Unique" -Tags "CI" {
         $expectedOutput1 = 1,2,3,4,5
         $collection     = "a", "b", "b", "d"
         $expectedOutput2 = "a", "b", "d"
+        $collection2 = "a","A", "b", "B"
+        $expectedOutput3 = "a", "b"
     }
 
     It "Should be able to use the Get-Unique cmdlet without error with inputObject switch" {
@@ -60,5 +78,10 @@ Describe "Get-Unique" -Tags "CI" {
     It "Should get the unique items when piped collection input is used" {
         $actual = $collection | Get-Unique
         $(Compare-Object $actual $expectedOutput2 -SyncWindow 0).Length | Should -Be 0
+    }
+
+    It "Should get the unique strings when CaseInsensitive switch is used" {
+        $actual = $collection2 | Get-Unique -CaseInsensitive
+        $(Compare-Object $actual $expectedOutput3 -SyncWindow 0).Length | Should -Be 0
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -58,6 +58,13 @@ Describe "Select-Object" -Tags "CI" {
         $result | Should -Be $expected
     }
 
+    It "Should work work correctly with Unique and CaseInsensitive parameter" {
+        $result = "abc", "Abc" | Select-Object -Unique -CaseInsensitive
+
+        $result.Count | Should -Be 1
+        $result | Should -Be "abc"
+    }
+
     It "Should return correct object with Skip parameter" {
         $result = $dirObject | Select-Object -Skip $TestLength
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #12059

Added `-CaseInsensitive` switch parameter to `Select-Object` & `Get-Unique` cmdlets.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

The `Select-Object` and `Get-Unique` cmdlets currently do case-sensitive string comparison when filtering unique items, and don't allow the user to override this behaviour and use case-insensitive comparison.

To make sure no breaking change is introduced, the most ideal solution is to introduce a `-CaseInsensitive` parameter.

### Examples

#### Select-Object -Unique

```powershell
> "derp", "Derp" | Select-Object -Unique
derp
Derp

> "derp", "Derp" | Select-Object -Unique -CaseInsensitive
derp
```

#### Get-Unique

```powershell
> "aa", "Aa", "bb", "Bb" | Get-Unique
aa
Aa
bb
Bb

> "aa", "Aa", "bb", "Bb" | Get-Unique -AsString -CaseInsensitive
aa
bb

> "aa", "Aa", "bb", "Bb" | Get-Unique -CaseInsensitive
aa
bb
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/10097
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
