### PR TITLE
Apply IDE0019: InlineAsTypeCheck in Microsoft.PowerShell.Commands

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -1187,8 +1187,7 @@ namespace Microsoft.PowerShell.Commands
                 //
                 // Build xpath for <Suppress>
                 //
-                Hashtable suppresshash = hash[hashkey_supress_lc] as Hashtable;
-                if (suppresshash != null)
+                if (hash[hashkey_supress_lc] is Hashtable suppresshash)
                 {
                     xpathStringSuppress = BuildXPathFromHashTable(suppresshash);
                 }
@@ -1255,8 +1254,7 @@ namespace Microsoft.PowerShell.Commands
         private static string HandleEventIdHashValue(object value)
         {
             StringBuilder ret = new();
-            Array idsArray = value as Array;
-            if (idsArray != null)
+            if (value is Array idsArray)
             {
                 ret.Append('(');
                 for (int i = 0; i < idsArray.Length; i++)
@@ -1285,8 +1283,7 @@ namespace Microsoft.PowerShell.Commands
         private static string HandleLevelHashValue(object value)
         {
             StringBuilder ret = new();
-            Array levelsArray = value as Array;
-            if (levelsArray != null)
+            if (value is Array levelsArray)
             {
                 ret.Append('(');
                 for (int i = 0; i < levelsArray.Length; i++)
@@ -1317,8 +1314,7 @@ namespace Microsoft.PowerShell.Commands
             long keywordsMask = 0;
             long keywordLong = 0;
 
-            Array keywordArray = value as Array;
-            if (keywordArray != null)
+            if (value is Array keywordArray)
             {
                 foreach (object keyword in keywordArray)
                 {
@@ -1473,8 +1469,7 @@ namespace Microsoft.PowerShell.Commands
         private static string HandleDataHashValue(object value)
         {
             StringBuilder ret = new();
-            Array dataArray = value as Array;
-            if (dataArray != null)
+            if (value is Array dataArray)
             {
                 ret.Append('(');
                 for (int i = 0; i < dataArray.Length; i++)
@@ -1504,8 +1499,7 @@ namespace Microsoft.PowerShell.Commands
         private static string HandleNamedDataHashValue(string key, object value)
         {
             StringBuilder ret = new();
-            Array dataArray = value as Array;
-            if (dataArray != null)
+            if (value is Array dataArray)
             {
                 ret.Append('(');
                 for (int i = 0; i < dataArray.Length; i++)
@@ -1752,8 +1746,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        Array eltArray = value as Array;
-                        if (eltArray != null)
+                        if (value is Array eltArray)
                         {
                             foreach (object elt in eltArray)
                             {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
@@ -491,8 +491,7 @@ namespace Microsoft.PowerShell.Cmdletization
                 return this.Session;
             }
 
-            var sessionBoundQueryBuilder = queryBuilder as ISessionBoundQueryBuilder<TSession>;
-            if (sessionBoundQueryBuilder != null)
+            if (queryBuilder is ISessionBoundQueryBuilder<TSession> sessionBoundQueryBuilder)
             {
                 TSession sessionOfTheQueryBuilder = sessionBoundQueryBuilder.GetTargetSession();
                 if (sessionOfTheQueryBuilder != null)

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/CimJobException.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/CimJobException.cs
@@ -98,16 +98,14 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             Dbg.Assert(jobContext != null, "Caller should verify jobContext != null");
             Dbg.Assert(inner != null, "Caller should verify inner != null");
 
-            CimException cimException = inner as CimException;
-            if (cimException != null)
+            if (inner is CimException cimException)
             {
                 return CreateFromCimException(jobDescription, jobContext, cimException);
             }
 
             string message = BuildErrorMessage(jobDescription, jobContext, inner.Message);
             CimJobException cimJobException = new(message, inner);
-            var containsErrorRecord = inner as IContainsErrorRecord;
-            if (containsErrorRecord != null)
+            if (inner is IContainsErrorRecord containsErrorRecord)
             {
                 cimJobException.InitializeErrorRecord(
                     jobContext,
@@ -356,8 +354,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
         {
             get
             {
-                var cimException = this.InnerException as CimException;
-                if ((cimException == null) || (cimException.ErrorData == null))
+                if ((this.InnerException is not CimException cimException) || (cimException.ErrorData == null))
                 {
                     return false;
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/ExtrinsicMethodInvocationJob.cs
@@ -66,8 +66,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
                 methodParameter.Value = dotNetValue;
                 cmdletOutput.Add(methodParameter.Name, methodParameter);
 
-                var cimInstances = dotNetValue as CimInstance[];
-                if (cimInstances != null)
+                if (dotNetValue is CimInstance[] cimInstances)
                 {
                     foreach (var instance in cimInstances)
                     {
@@ -75,8 +74,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
                     }
                 }
 
-                var cimInstance = dotNetValue as CimInstance;
-                if (cimInstance != null)
+                if (dotNetValue is CimInstance cimInstance)
                 {
                     CimCmdletAdapter.AssociateSessionOfOriginWithInstance(cimInstance, this.JobContext.Session);
                 }
@@ -191,15 +189,13 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             this.ExceptionSafeWrapper(
                     delegate
                     {
-                        var methodResult = item as CimMethodResult;
-                        if (methodResult != null)
+                        if (item is CimMethodResult methodResult)
                         {
                             this.OnNext(methodResult);
                             return;
                         }
 
-                        var streamedResult = item as CimMethodStreamedResult;
-                        if (streamedResult != null)
+                        if (item is CimMethodStreamedResult streamedResult)
                         {
                             this.OnNext(streamedResult);
                             return;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/TerminatingErrorTracker.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/TerminatingErrorTracker.cs
@@ -53,8 +53,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             int maxNumberOfSessionsIndicatedByCimInstanceArguments = 1;
             foreach (object cmdletArgument in invocationInfo.BoundParameters.Values)
             {
-                CimInstance[] array = cmdletArgument as CimInstance[];
-                if (array != null)
+                if (cmdletArgument is CimInstance[] array)
                 {
                     int numberOfSessionsAssociatedWithArgument = array
                         .Select(CimCmdletAdapter.GetSessionOfOriginFromCimInstance)

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimChildJobBase.cs
@@ -623,8 +623,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             }
             else
             {
-                CimJobException cje = exception as CimJobException;
-                if ((cje != null) && (cje.IsTerminatingError))
+                if ((exception is CimJobException cje) && (cje.IsTerminatingError))
                 {
                     terminatingErrorTracker.MarkSessionAsTerminated(this.JobContext.Session, out sessionWasAlreadyTerminated);
                     isThisTerminatingError = true;
@@ -1013,8 +1012,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
 
         internal static void AddShowComputerNameMarker(PSObject pso)
         {
-            PSPropertyInfo psShowComputerNameProperty = pso.InstanceMembers[RemotingConstants.ShowComputerNameNoteProperty] as PSPropertyInfo;
-            if (psShowComputerNameProperty != null)
+            if (pso.InstanceMembers[RemotingConstants.ShowComputerNameNoteProperty] is PSPropertyInfo psShowComputerNameProperty)
             {
                 psShowComputerNameProperty.Value = true;
             }

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/clientSideQuery.cs
@@ -36,8 +36,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
 
                 if (wildcardsEnabled)
                 {
-                    var propertyValueAsString = propertyValue as string;
-                    if ((propertyValueAsString != null) && (WildcardPattern.ContainsWildcardCharacters(propertyValueAsString)))
+                    if ((propertyValue is string propertyValueAsString) && (WildcardPattern.ContainsWildcardCharacters(propertyValueAsString)))
                     {
                         this.ErrorMessageGenerator =
                             (queryDescription, className) => GetErrorMessageForNotFound_ForWildcard(this.PropertyName, this.PropertyValue, className);
@@ -466,8 +465,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
                 }
                 else
                 {
-                    string expectedPropertyValueAsString = cimTypedExpectedPropertyValue as string;
-                    if (expectedPropertyValueAsString != null && WildcardPattern.ContainsWildcardCharacters(expectedPropertyValueAsString))
+                    if (cimTypedExpectedPropertyValue is string expectedPropertyValueAsString && WildcardPattern.ContainsWildcardCharacters(expectedPropertyValueAsString))
                     {
                         return BehaviorOnNoMatch.SilentlyContinue;
                     }
@@ -504,8 +502,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
                     actualPropertyValue = actualPropertyValue.ToString();
                 }
 
-                var expectedPropertyValueAsString = expectedPropertyValue as string;
-                if (expectedPropertyValueAsString != null)
+                if (expectedPropertyValue is string expectedPropertyValueAsString)
                 {
                     var actualPropertyValueAsString = (string)actualPropertyValue;
                     return actualPropertyValueAsString.Equals(expectedPropertyValueAsString, StringComparison.OrdinalIgnoreCase);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -903,8 +903,7 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (InvalidOperationException e)
             {
-                Win32Exception eInner = e.InnerException as Win32Exception;
-                if (eInner == null
+                if (e.InnerException is not Win32Exception eInner
                     || eInner.NativeErrorCode != NativeMethods.ERROR_SERVICE_ALREADY_RUNNING)
                 {
                     exception = e;
@@ -1020,9 +1019,7 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (InvalidOperationException e)
             {
-                Win32Exception eInner =
-                    e.InnerException as Win32Exception;
-                if (eInner == null
+                if (e.InnerException is not Win32Exception eInner
                     || eInner.NativeErrorCode != NativeMethods.ERROR_SERVICE_NOT_ACTIVE)
                 {
                     exception = e;
@@ -1117,8 +1114,7 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (InvalidOperationException e)
             {
-                Win32Exception eInner = e.InnerException as Win32Exception;
-                if (eInner != null
+                if (e.InnerException is Win32Exception eInner
                     && eInner.NativeErrorCode == NativeMethods.ERROR_SERVICE_NOT_ACTIVE)
                 {
                     serviceNotRunning = true;
@@ -1198,8 +1194,7 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (InvalidOperationException e)
             {
-                Win32Exception eInner = e.InnerException as Win32Exception;
-                if (eInner != null
+                if (e.InnerException is Win32Exception eInner
                     && eInner.NativeErrorCode == NativeMethods.ERROR_SERVICE_NOT_ACTIVE)
                 {
                     serviceNotRunning = true;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
@@ -560,9 +560,8 @@ namespace Microsoft.PowerShell.Commands
         {
             protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
             {
-                string notePropertyName = arguments as string;
                 PSMemberTypes memberType;
-                if (notePropertyName != null && LanguagePrimitives.TryConvertTo<PSMemberTypes>(notePropertyName, out memberType))
+                if (arguments is string notePropertyName && LanguagePrimitives.TryConvertTo<PSMemberTypes>(notePropertyName, out memberType))
                 {
                     switch (memberType)
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
@@ -502,9 +502,8 @@ namespace Microsoft.PowerShell.Commands
                                     MshCommandRuntime mshCommandRuntime = this.CommandRuntime as MshCommandRuntime;
                                     string Message = StringUtil.Format(ConvertHTMLStrings.MetaPropertyNotFound, s, _meta[s]);
                                     WarningRecord record = new(Message);
-                                    InvocationInfo invocationInfo = GetVariableValue(SpecialVariables.MyInvocation) as InvocationInfo;
 
-                                    if (invocationInfo != null)
+                                    if (GetVariableValue(SpecialVariables.MyInvocation) is InvocationInfo invocationInfo)
                                     {
                                         record.SetInvocationInfo(invocationInfo);
                                     }
@@ -553,16 +552,14 @@ namespace Microsoft.PowerShell.Commands
             foreach (MshParameter p in mshParams)
             {
                 COLTag.Append("<col");
-                string width = p.GetEntry(ConvertHTMLParameterDefinitionKeys.WidthEntryKey) as string;
-                if (width != null)
+                if (p.GetEntry(ConvertHTMLParameterDefinitionKeys.WidthEntryKey) is string width)
                 {
                     COLTag.Append(" width = \"");
                     COLTag.Append(width);
                     COLTag.Append('"');
                 }
 
-                string alignment = p.GetEntry(ConvertHTMLParameterDefinitionKeys.AlignmentEntryKey) as string;
-                if (alignment != null)
+                if (p.GetEntry(ConvertHTMLParameterDefinitionKeys.AlignmentEntryKey) is string alignment)
                 {
                     COLTag.Append(" align = \"");
                     COLTag.Append(alignment);
@@ -608,8 +605,7 @@ namespace Microsoft.PowerShell.Commands
         private static void WritePropertyName(StringBuilder Listtag, MshParameter p)
         {
             // for writing the property name
-            string label = p.GetEntry(ConvertHTMLParameterDefinitionKeys.LabelEntryKey) as string;
-            if (label != null)
+            if (p.GetEntry(ConvertHTMLParameterDefinitionKeys.LabelEntryKey) is string label)
             {
                 Listtag.Append(label);
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -338,8 +338,7 @@ namespace System.Management.Automation
             Dbg.Assert(source != null, "caller should validate the parameter");
 
             bool sourceHandled = false;
-            PSObject moSource = source as PSObject;
-            if (moSource != null && !moSource.ImmediateBaseObjectIsEmpty)
+            if (source is PSObject moSource && !moSource.ImmediateBaseObjectIsEmpty)
             {
                 // Check if baseObject is primitive known type
                 object baseObject = moSource.ImmediateBaseObject;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
@@ -407,8 +407,7 @@ namespace Microsoft.PowerShell.Commands
         private void HandleRunspaceAvailabilityChanged(object sender, RunspaceAvailabilityEventArgs e)
         {
             // Ignore nested commands.
-            LocalRunspace localRunspace = sender as LocalRunspace;
-            if (localRunspace != null)
+            if (sender is LocalRunspace localRunspace)
             {
                 var basePowerShell = localRunspace.GetCurrentBasePowerShell();
                 if ((basePowerShell != null) && (basePowerShell.IsNested))
@@ -438,8 +437,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void HandlePipelineOutputDataReady(object sender, EventArgs e)
         {
-            PipelineReader<PSObject> reader = sender as PipelineReader<PSObject>;
-            if (reader != null && reader.IsOpen)
+            if (sender is PipelineReader<PSObject> reader && reader.IsOpen)
             {
                 WritePipelineCollection(reader.NonBlockingRead(), PSStreamObjectType.Output);
             }
@@ -447,8 +445,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void HandlePipelineErrorDataReady(object sender, EventArgs e)
         {
-            PipelineReader<object> reader = sender as PipelineReader<object>;
-            if (reader != null && reader.IsOpen)
+            if (sender is PipelineReader<object> reader && reader.IsOpen)
             {
                 WritePipelineCollection(reader.NonBlockingRead(), PSStreamObjectType.Error);
             }
@@ -538,8 +535,7 @@ namespace Microsoft.PowerShell.Commands
             // Only enable and disable the host's runspace if we are in process attach mode.
             if (_debugger is ServerRemoteDebugger)
             {
-                LocalRunspace localRunspace = runspace as LocalRunspace;
-                if ((localRunspace != null) && (localRunspace.ExecutionContext != null) && (localRunspace.ExecutionContext.EngineHostInterface != null))
+                if ((runspace is LocalRunspace localRunspace) && (localRunspace.ExecutionContext != null) && (localRunspace.ExecutionContext.EngineHostInterface != null))
                 {
                     try
                     {
@@ -552,8 +548,7 @@ namespace Microsoft.PowerShell.Commands
 
         private static void SetLocalMode(System.Management.Automation.Debugger debugger, bool localMode)
         {
-            ServerRemoteDebugger remoteDebugger = debugger as ServerRemoteDebugger;
-            if (remoteDebugger != null)
+            if (debugger is ServerRemoteDebugger remoteDebugger)
             {
                 remoteDebugger.LocalDebugMode = localMode;
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OriginalColumnInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OriginalColumnInfo.cs
@@ -33,15 +33,13 @@ namespace Microsoft.PowerShell.Commands
 
                 // The live object has the liveObjectPropertyName property.
                 object liveObjectValue = propertyInfo.Value;
-                ICollection collectionValue = liveObjectValue as ICollection;
-                if (collectionValue != null)
+                if (liveObjectValue is ICollection collectionValue)
                 {
                     liveObjectValue = _parentCmdlet.ConvertToString(PSObjectHelper.AsPSObject(propertyInfo.Value));
                 }
                 else
                 {
-                    PSObject psObjectValue = liveObjectValue as PSObject;
-                    if (psObjectValue != null)
+                    if (liveObjectValue is PSObject psObjectValue)
                     {
                         // Since PSObject implements IComparable there is a need to verify if its BaseObject actually implements IComparable.
                         if (psObjectValue.BaseObject is IComparable)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -180,8 +180,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            IDictionary dictionary = InputObject.BaseObject as IDictionary;
-            if (dictionary != null)
+            if (InputObject.BaseObject is IDictionary dictionary)
             {
                 // Dictionaries should be enumerated through because the pipeline does not enumerate through them.
                 foreach (DictionaryEntry entry in dictionary)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
@@ -71,8 +71,7 @@ namespace Microsoft.PowerShell.Commands
             catch (TargetInvocationException ex)
             {
                 // Verify if this is an error loading the System.Core dll.
-                FileNotFoundException fileNotFoundEx = ex.InnerException as FileNotFoundException;
-                if (fileNotFoundEx != null && fileNotFoundEx.FileName.Contains("System.Core"))
+                if (ex.InnerException is FileNotFoundException fileNotFoundEx && fileNotFoundEx.FileName.Contains("System.Core"))
                 {
                     _parentCmdlet.ThrowTerminatingError(
                         new ErrorRecord(new InvalidOperationException(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
@@ -69,8 +69,7 @@ namespace Microsoft.PowerShell.Commands
 
                     if (token != null)
                     {
-                        FieldPropertyToken fpt = token as FieldPropertyToken;
-                        if (fpt != null)
+                        if (token is FieldPropertyToken fpt)
                         {
                             // If Database does not provide a label(DisplayName) for the current property, use the expression value instead.
                             displayName ??= fpt.expression.expressionValue;
@@ -98,8 +97,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                         else
                         {
-                            TextToken tt = token as TextToken;
-                            if (tt != null)
+                            if (token is TextToken tt)
                             {
                                 displayName = _typeInfoDatabase.displayResourceManagerCache.GetTextTokenString(tt);
                                 columnInfo = new OriginalColumnInfo(tt.text, displayName, tt.text, parentCmdlet);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -139,22 +139,19 @@ namespace Microsoft.PowerShell.Commands
 
                 PSControl control;
 
-                var tableControlBody = definition.mainControl as TableControlBody;
-                if (tableControlBody != null)
+                if (definition.mainControl is TableControlBody tableControlBody)
                 {
                     control = new TableControl(tableControlBody, definition);
                 }
                 else
                 {
-                    var listControlBody = definition.mainControl as ListControlBody;
-                    if (listControlBody != null)
+                    if (definition.mainControl is ListControlBody listControlBody)
                     {
                         control = new ListControl(listControlBody, definition);
                     }
                     else
                     {
-                        var wideControlBody = definition.mainControl as WideControlBody;
-                        if (wideControlBody != null)
+                        if (definition.mainControl is WideControlBody wideControlBody)
                         {
                             control = new WideControl(wideControlBody, definition);
                             if (writeOldWay)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
@@ -230,8 +230,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (!Force)
                     {
-                        PSMethod memberAsPSMethod = member as PSMethod;
-                        if ((memberAsPSMethod != null) && (memberAsPSMethod.IsSpecial))
+                        if ((member is PSMethod memberAsPSMethod) && (memberAsPSMethod.IsSpecial))
                         {
                             continue;
                         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -726,8 +726,7 @@ namespace Microsoft.PowerShell.Commands
             //
             // handle recognized types of exceptions first
             //
-            RemoteException remoteException = runtimeException as RemoteException;
-            if ((remoteException != null) && (remoteException.SerializedRemoteException != null))
+            if ((runtimeException is RemoteException remoteException) && (remoteException.SerializedRemoteException != null))
             {
                 if (Deserializer.IsInstanceOfType(remoteException.SerializedRemoteException, typeof(CommandNotFoundException)))
                 {
@@ -1575,8 +1574,7 @@ namespace Microsoft.PowerShell.Commands
             powerShell.AddParameter("TypeName", this.FormatTypeName);
 
             // For remote PS version 5.1 and greater, we need to include the new -PowerShellVersion parameter
-            RemoteRunspace remoteRunspace = Session.Runspace as RemoteRunspace;
-            if ((remoteRunspace != null) && (remoteRunspace.ServerVersion != null) &&
+            if ((Session.Runspace is RemoteRunspace remoteRunspace) && (remoteRunspace.ServerVersion != null) &&
                 (remoteRunspace.ServerVersion >= new Version(5, 1)))
             {
                 powerShell.AddParameter("PowerShellVersion", PSVersionInfo.PSVersion);
@@ -1942,20 +1940,17 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Connection URI associated with the remote runspace.</returns>
         private string GetConnectionString()
         {
-            WSManConnectionInfo connectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as WSManConnectionInfo;
-            if (connectionInfo != null)
+            if (_remoteRunspaceInfo.Runspace.ConnectionInfo is WSManConnectionInfo connectionInfo)
             {
                 return connectionInfo.ConnectionUri.ToString();
             }
 
-            VMConnectionInfo vmConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as VMConnectionInfo;
-            if (vmConnectionInfo != null)
+            if (_remoteRunspaceInfo.Runspace.ConnectionInfo is VMConnectionInfo vmConnectionInfo)
             {
                 return vmConnectionInfo.ComputerName;
             }
 
-            ContainerConnectionInfo containerConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as ContainerConnectionInfo;
-            if (containerConnectionInfo != null)
+            if (_remoteRunspaceInfo.Runspace.ConnectionInfo is ContainerConnectionInfo containerConnectionInfo)
             {
                 return containerConnectionInfo.ComputerName;
             }
@@ -2244,8 +2239,7 @@ function Get-PSImplicitRemotingSessionOption
         {
             StringBuilder result = new("& $script:NewPSSessionOption ");
 
-            RunspaceConnectionInfo runspaceConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as RunspaceConnectionInfo;
-            if (runspaceConnectionInfo != null)
+            if (_remoteRunspaceInfo.Runspace.ConnectionInfo is RunspaceConnectionInfo runspaceConnectionInfo)
             {
                 result.Append(null, $"-Culture '{CodeGeneration.EscapeSingleQuotedStringContent(runspaceConnectionInfo.Culture.ToString())}' ");
                 result.Append(null, $"-UICulture '{CodeGeneration.EscapeSingleQuotedStringContent(runspaceConnectionInfo.UICulture.ToString())}' ");
@@ -2256,8 +2250,7 @@ function Get-PSImplicitRemotingSessionOption
                 result.Append(null, $"-OperationTimeOut {runspaceConnectionInfo.OperationTimeout} ");
             }
 
-            WSManConnectionInfo wsmanConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as WSManConnectionInfo;
-            if (wsmanConnectionInfo != null)
+            if (_remoteRunspaceInfo.Runspace.ConnectionInfo is WSManConnectionInfo wsmanConnectionInfo)
             {
                 if (!wsmanConnectionInfo.UseCompression)
                 {
@@ -2522,8 +2515,7 @@ function Get-PSImplicitRemotingSession
 
         private string GenerateNewRunspaceExpression()
         {
-            VMConnectionInfo vmConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as VMConnectionInfo;
-            if (vmConnectionInfo != null)
+            if (_remoteRunspaceInfo.Runspace.ConnectionInfo is VMConnectionInfo vmConnectionInfo)
             {
                 string vmConfigurationName = vmConnectionInfo.ConfigurationName;
                 return string.Format(
@@ -2535,8 +2527,7 @@ function Get-PSImplicitRemotingSession
             }
             else
             {
-                ContainerConnectionInfo containerConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as ContainerConnectionInfo;
-                if (containerConnectionInfo != null)
+                if (_remoteRunspaceInfo.Runspace.ConnectionInfo is ContainerConnectionInfo containerConnectionInfo)
                 {
                     string containerConfigurationName = containerConnectionInfo.ContainerProc.ConfigurationName;
                     return string.Format(
@@ -2578,19 +2569,16 @@ function Get-PSImplicitRemotingSession
         /// <returns></returns>
         private string GenerateConnectionStringForNewRunspace()
         {
-            WSManConnectionInfo connectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as WSManConnectionInfo;
-            if (connectionInfo == null)
+            if (_remoteRunspaceInfo.Runspace.ConnectionInfo is not WSManConnectionInfo connectionInfo)
             {
-                VMConnectionInfo vmConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as VMConnectionInfo;
-                if (vmConnectionInfo != null)
+                if (_remoteRunspaceInfo.Runspace.ConnectionInfo is VMConnectionInfo vmConnectionInfo)
                 {
                     return string.Format(CultureInfo.InvariantCulture,
                         VMIdParameterTemplate,
                         CodeGeneration.EscapeSingleQuotedStringContent(vmConnectionInfo.VMGuid.ToString()));
                 }
 
-                ContainerConnectionInfo containerConnectionInfo = _remoteRunspaceInfo.Runspace.ConnectionInfo as ContainerConnectionInfo;
-                if (containerConnectionInfo != null)
+                if (_remoteRunspaceInfo.Runspace.ConnectionInfo is ContainerConnectionInfo containerConnectionInfo)
                 {
                     return string.Format(CultureInfo.InvariantCulture,
                         ContainerIdParameterTemplate,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -571,15 +571,13 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        IDictionary dict = obj as IDictionary;
-                        if (dict != null)
+                        if (obj is IDictionary dict)
                         {
                             rv = ProcessDictionary(dict, currentDepth, in context);
                         }
                         else
                         {
-                            IEnumerable enumerable = obj as IEnumerable;
-                            if (enumerable != null)
+                            if (obj is IEnumerable enumerable)
                             {
                                 rv = ProcessEnumerable(enumerable, currentDepth, in context);
                             }
@@ -626,9 +624,8 @@ namespace Microsoft.PowerShell.Commands
             }
 
             bool wasDictionary = true;
-            IDictionary dict = obj as IDictionary;
 
-            if (dict == null)
+            if (obj is not IDictionary dict)
             {
                 wasDictionary = false;
                 dict = new Dictionary<string, object>();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
@@ -33,7 +33,6 @@ namespace Microsoft.PowerShell.Commands
             // so we create the DebugRecord here and fill it up with the appropriate InvocationInfo;
             // then, we call the command runtime directly and pass this record to WriteDebug().
             //
-
             if (this.CommandRuntime is MshCommandRuntime mshCommandRuntime)
             {
                 DebugRecord record = new(Message);
@@ -78,7 +77,6 @@ namespace Microsoft.PowerShell.Commands
             // so we create the VerboseRecord here and fill it up with the appropriate InvocationInfo;
             // then, we call the command runtime directly and pass this record to WriteVerbose().
             //
-
             if (this.CommandRuntime is MshCommandRuntime mshCommandRuntime)
             {
                 VerboseRecord record = new(Message);
@@ -123,7 +121,6 @@ namespace Microsoft.PowerShell.Commands
             // so we create the WarningRecord here and fill it up with the appropriate InvocationInfo;
             // then, we call the command runtime directly and pass this record to WriteWarning().
             //
-
             if (this.CommandRuntime is MshCommandRuntime mshCommandRuntime)
             {
                 WarningRecord record = new(Message);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write.cs
@@ -33,15 +33,12 @@ namespace Microsoft.PowerShell.Commands
             // so we create the DebugRecord here and fill it up with the appropriate InvocationInfo;
             // then, we call the command runtime directly and pass this record to WriteDebug().
             //
-            MshCommandRuntime mshCommandRuntime = this.CommandRuntime as MshCommandRuntime;
 
-            if (mshCommandRuntime != null)
+            if (this.CommandRuntime is MshCommandRuntime mshCommandRuntime)
             {
                 DebugRecord record = new(Message);
 
-                InvocationInfo invocationInfo = GetVariableValue(SpecialVariables.MyInvocation) as InvocationInfo;
-
-                if (invocationInfo != null)
+                if (GetVariableValue(SpecialVariables.MyInvocation) is InvocationInfo invocationInfo)
                 {
                     record.SetInvocationInfo(invocationInfo);
                 }
@@ -81,15 +78,12 @@ namespace Microsoft.PowerShell.Commands
             // so we create the VerboseRecord here and fill it up with the appropriate InvocationInfo;
             // then, we call the command runtime directly and pass this record to WriteVerbose().
             //
-            MshCommandRuntime mshCommandRuntime = this.CommandRuntime as MshCommandRuntime;
 
-            if (mshCommandRuntime != null)
+            if (this.CommandRuntime is MshCommandRuntime mshCommandRuntime)
             {
                 VerboseRecord record = new(Message);
 
-                InvocationInfo invocationInfo = GetVariableValue(SpecialVariables.MyInvocation) as InvocationInfo;
-
-                if (invocationInfo != null)
+                if (GetVariableValue(SpecialVariables.MyInvocation) is InvocationInfo invocationInfo)
                 {
                     record.SetInvocationInfo(invocationInfo);
                 }
@@ -129,15 +123,12 @@ namespace Microsoft.PowerShell.Commands
             // so we create the WarningRecord here and fill it up with the appropriate InvocationInfo;
             // then, we call the command runtime directly and pass this record to WriteWarning().
             //
-            MshCommandRuntime mshCommandRuntime = this.CommandRuntime as MshCommandRuntime;
 
-            if (mshCommandRuntime != null)
+            if (this.CommandRuntime is MshCommandRuntime mshCommandRuntime)
             {
                 WarningRecord record = new(Message);
 
-                InvocationInfo invocationInfo = GetVariableValue(SpecialVariables.MyInvocation) as InvocationInfo;
-
-                if (invocationInfo != null)
+                if (GetVariableValue(SpecialVariables.MyInvocation) is InvocationInfo invocationInfo)
                 {
                     record.SetInvocationInfo(invocationInfo);
                 }
@@ -361,8 +352,7 @@ namespace Microsoft.PowerShell.Commands
 
             // 2005/07/14-913791 "write-error output is confusing and misleading"
             // set InvocationInfo to the script not the command
-            InvocationInfo myInvocation = GetVariableValue(SpecialVariables.MyInvocation) as InvocationInfo;
-            if (myInvocation != null)
+            if (GetVariableValue(SpecialVariables.MyInvocation) is InvocationInfo myInvocation)
             {
                 errorRecord.SetInvocationInfo(myInvocation);
                 errorRecord.PreserveInvocationInfoOnce = true;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
@@ -51,9 +51,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (o != null)
             {
-                string s = o as string;
-                IEnumerable enumerable = null;
-                if (s != null)
+                if (o is string s)
                 {
                     // strings are IEnumerable, so we special case them
                     if (s.Length > 0)
@@ -61,7 +59,7 @@ namespace Microsoft.PowerShell.Commands
                         return s;
                     }
                 }
-                else if ((enumerable = o as IEnumerable) != null)
+                else if (o is IEnumerable enumerable)
                 {
                     // unroll enumerables, including arrays.
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -764,12 +764,10 @@ namespace Microsoft.PowerShell.Commands
                 while (!_deserializer.Done() && count < first)
                 {
                     object result = _deserializer.Deserialize();
-                    PSObject psObject = result as PSObject;
 
-                    if (psObject != null)
+                    if (result is PSObject psObject)
                     {
-                        ICollection c = psObject.BaseObject as ICollection;
-                        if (c != null)
+                        if (psObject.BaseObject is ICollection c)
                         {
                             foreach (object o in c)
                             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
@@ -512,8 +512,7 @@ namespace Microsoft.PowerShell.Commands
         private static ErrorRecord ConvertToErrorRecord(object obj)
         {
             ErrorRecord result = null;
-            PSObject mshobj = obj as PSObject;
-            if (mshobj != null)
+            if (obj is PSObject mshobj)
             {
                 object baseObject = mshobj.BaseObject;
                 if (baseObject is not PSCustomObject)
@@ -522,8 +521,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            ErrorRecord errorRecordResult = obj as ErrorRecord;
-            if (errorRecordResult != null)
+            if (obj is ErrorRecord errorRecordResult)
             {
                 result = errorRecordResult;
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Fix IDE0019 in Microsoft.PowerShell.Commands folder.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
https://github.com/PowerShell/PowerShell/issues/18399
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
Microsoft.CodeAnalysis.CSharp version [4.6.0-1.final](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp/4.6.0-1.final).
There might have been some manual fixes in this PR but they all fall into 3 categories:
1. Newly created double newlines that trigger other diagnostics.
2. Code that previously looked like this
    ```c#
    if (condition)
    {
        Type type = var as Type;
        if (type != null)
        ...
    ```
    was fixed to this:
    ```c#
    if (condition)
    {
        if (var is Type type)
        ...
    ```
    and I have additionally changed it to this:
    ```c#
    if (condition && var is Type type)
    {
        ...
    ```
3. Once or twice autofix "ate" comments but it might have been in another PR. You can see all similar PRs in the linked issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
