### PR TITLE
Apply IDE0019: InlineAsTypeCheck in Management.Automation folders

### DIFF
--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -1935,8 +1935,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 object evalResultObject;
                 if (IsConstantValueVisitor.IsConstant(pair.Item1, out evalResultObject, forAttribute: false, forRequires: false))
                 {
-                    var presentName = evalResultObject as string;
-                    if (presentName != null)
+                    if (evalResultObject is string presentName)
                     {
                         if (mandatoryPropertiesNames.Remove(presentName) && mandatoryPropertiesNames.Count == 0)
                         {
@@ -2298,8 +2297,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
         internal static string MapTypeNameToMofType(ITypeName typeName, string memberName, string className, out bool isArrayType, out string embeddedInstanceType, List<object> embeddedInstanceTypes, ref string[] enumNames)
         {
             TypeName propTypeName;
-            var arrayTypeName = typeName as ArrayTypeName;
-            if (arrayTypeName != null)
+            if (typeName is ArrayTypeName arrayTypeName)
             {
                 isArrayType = true;
                 propTypeName = arrayTypeName.ElementType as TypeName;
@@ -2362,15 +2360,13 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             while (bases.Count > 0)
             {
                 var b = bases.Dequeue();
-                var tc = b as TypeConstraintAst;
 
-                if (tc != null)
+                if (b is TypeConstraintAst tc)
                 {
                     b = tc.TypeName.GetReflectionType();
                     if (b == null)
                     {
-                        var td = tc.TypeName as TypeName;
-                        if (td != null && td._typeDefinitionAst != null)
+                        if (tc.TypeName is TypeName td && td._typeDefinitionAst != null)
                         {
                             ProcessMembers(sb, embeddedInstanceTypes, td._typeDefinitionAst, className);
                             foreach (var b1 in td._typeDefinitionAst.BaseTypes)
@@ -2412,8 +2408,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             methodsLinePosition = new Dictionary<string, int>();
             foreach (var member in typeDefinitionAst.Members)
             {
-                var functionMemberAst = member as FunctionMemberAst;
-                if (functionMemberAst != null)
+                if (member is FunctionMemberAst functionMemberAst)
                 {
                     if (functionMemberAst.Name.Equals(getMethodName, StringComparison.OrdinalIgnoreCase))
                     {
@@ -2493,9 +2488,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
         {
             foreach (var member in typeDefinitionAst.Members)
             {
-                var property = member as PropertyMemberAst;
-
-                if (property == null || property.IsStatic ||
+                if (member is not PropertyMemberAst property || property.IsStatic ||
                     property.Attributes.All(a => a.TypeName.GetReflectionAttributeType() != typeof(DscPropertyAttribute)))
                 {
                     continue;
@@ -2598,8 +2591,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
 
             resourceDefinitions = ast.FindAll(n =>
             {
-                var typeAst = n as TypeDefinitionAst;
-                if (typeAst != null)
+                if (n is TypeDefinitionAst typeAst)
                 {
                     for (int i = 0; i < typeAst.Attributes.Count; i++)
                     {
@@ -2674,13 +2666,9 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                     {
                         foreach (var na in attr.NamedArguments)
                         {
-                            if (na.ArgumentName.Equals("RunAsCredential", StringComparison.OrdinalIgnoreCase))
+                            if (na.ArgumentName.Equals("RunAsCredential", StringComparison.OrdinalIgnoreCase) && attr.GetAttribute() is DscResourceAttribute dscResourceAttribute)
                             {
-                                var dscResourceAttribute = attr.GetAttribute() as DscResourceAttribute;
-                                if (dscResourceAttribute != null)
-                                {
-                                    runAsBehavior = dscResourceAttribute.RunAsCredential;
-                                }
+                                runAsBehavior = dscResourceAttribute.RunAsCredential;
                             }
                         }
                     }
@@ -2914,8 +2902,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             bool needComma = false;
             foreach (var attr in customAttributes)
             {
-                var dscProperty = attr as DscPropertyAttribute;
-                if (dscProperty != null)
+                if (attr is DscPropertyAttribute dscProperty)
                 {
                     if (dscProperty.Key)
                     {
@@ -2938,8 +2925,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                     continue;
                 }
 
-                var validateSet = attr as ValidateSetAttribute;
-                if (validateSet != null)
+                if (attr is ValidateSetAttribute validateSet)
                 {
                     bool valueMapComma = false;
                     StringBuilder sbValues = new(", Values{");

--- a/src/System.Management.Automation/cimSupport/cmdletization/MethodInvocationInfo.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/MethodInvocationInfo.cs
@@ -62,20 +62,17 @@ namespace Microsoft.PowerShell.Cmdletization
                     continue;
                 }
 
-                var objectInstance = methodParameter.Value as T;
-                if (objectInstance != null)
+                if (methodParameter.Value is T objectInstance)
                 {
                     result.Add(objectInstance);
                     continue;
                 }
 
-                var objectInstanceArray = methodParameter.Value as IEnumerable;
-                if (objectInstanceArray != null)
+                if (methodParameter.Value is IEnumerable objectInstanceArray)
                 {
                     foreach (object element in objectInstanceArray)
                     {
-                        var objectInstance2 = element as T;
-                        if (objectInstance2 != null)
+                        if (element is T objectInstance2)
                         {
                             result.Add(objectInstance2);
                         }

--- a/src/System.Management.Automation/cimSupport/cmdletization/ObjectModelWrapper.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ObjectModelWrapper.cs
@@ -29,8 +29,7 @@ namespace Microsoft.PowerShell.Cmdletization
             _classVersion = classVersion;
             _privateData = privateData;
 
-            var compiledScript = this.Cmdlet as PSScriptCmdlet;
-            if (compiledScript != null)
+            if (this.Cmdlet is PSScriptCmdlet compiledScript)
             {
                 compiledScript.StoppingEvent += delegate { this.StopProcessing(); };
                 compiledScript.DisposingEvent +=

--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -100,14 +100,12 @@ namespace Microsoft.PowerShell.Cmdletization
             }
             catch (InvalidOperationException e)
             {
-                XmlSchemaException schemaException = e.InnerException as XmlSchemaException;
-                if (schemaException != null)
+                if (e.InnerException is XmlSchemaException schemaException)
                 {
                     throw new XmlException(schemaException.Message, schemaException, schemaException.LineNumber, schemaException.LinePosition);
                 }
 
-                XmlException xmlException = e.InnerException as XmlException;
-                if (xmlException != null)
+                if (e.InnerException is XmlException xmlException)
                 {
                     throw xmlException;
                 }
@@ -828,8 +826,7 @@ function __cmdletization_BindCommonParameters
         private CommandMetadata GetCommandMetadata(CommonCmdletMetadata cmdletMetadata)
         {
             string defaultParameterSetName = null;
-            StaticCmdletMetadataCmdletMetadata staticCmdletMetadata = cmdletMetadata as StaticCmdletMetadataCmdletMetadata;
-            if (staticCmdletMetadata != null)
+            if (cmdletMetadata is StaticCmdletMetadataCmdletMetadata staticCmdletMetadata)
             {
                 if (!string.IsNullOrEmpty(staticCmdletMetadata.DefaultCmdletParameterSet))
                 {

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -61,8 +61,7 @@ namespace Microsoft.PowerShell.Cim
         public override System.Collections.ObjectModel.Collection<PSAdaptedProperty> GetProperties(object baseObject)
         {
             // baseObject should never be null
-            CimInstance cimInstance = baseObject as CimInstance;
-            if (cimInstance == null)
+            if (baseObject is not CimInstance cimInstance)
             {
                 string msg = string.Format(CultureInfo.InvariantCulture,
                     CimInstanceTypeAdapterResources.BaseObjectNotCimInstance,
@@ -107,8 +106,7 @@ namespace Microsoft.PowerShell.Cim
             }
 
             // baseObject should never be null
-            CimInstance cimInstance = baseObject as CimInstance;
-            if (cimInstance == null)
+            if (baseObject is not CimInstance cimInstance)
             {
                 string msg = string.Format(CultureInfo.InvariantCulture,
                     CimInstanceTypeAdapterResources.BaseObjectNotCimInstance,
@@ -142,8 +140,7 @@ namespace Microsoft.PowerShell.Cim
             }
 
             // baseObject should never be null
-            CimInstance cimInstance = baseObject as CimInstance;
-            if (cimInstance == null)
+            if (baseObject is not CimInstance cimInstance)
             {
                 string msg = string.Format(
                     CultureInfo.InvariantCulture,
@@ -197,8 +194,7 @@ namespace Microsoft.PowerShell.Cim
         {
             ArgumentNullException.ThrowIfNull(adaptedProperty);
 
-            CimProperty cimProperty = adaptedProperty.Tag as CimProperty;
-            if (cimProperty != null)
+            if (adaptedProperty.Tag is CimProperty cimProperty)
             {
                 return CimTypeToTypeNameDisplayString(cimProperty.CimType);
             }
@@ -219,8 +215,7 @@ namespace Microsoft.PowerShell.Cim
         {
             ArgumentNullException.ThrowIfNull(adaptedProperty);
 
-            CimProperty cimProperty = adaptedProperty.Tag as CimProperty;
-            if (cimProperty != null)
+            if (adaptedProperty.Tag is CimProperty cimProperty)
             {
                 return cimProperty.Value;
             }

--- a/src/System.Management.Automation/logging/LogProvider.cs
+++ b/src/System.Management.Automation/logging/LogProvider.cs
@@ -189,9 +189,7 @@ namespace System.Management.Automation
         {
             sb.AppendLine(StringUtil.Format(EtwLoggingStrings.ErrorRecordMessage, except.Message));
 
-            IContainsErrorRecord ier = except as IContainsErrorRecord;
-
-            if (ier != null)
+            if (except is IContainsErrorRecord ier)
             {
                 ErrorRecord er = ier.ErrorRecord;
 

--- a/src/System.Management.Automation/logging/MshLog.cs
+++ b/src/System.Management.Automation/logging/MshLog.cs
@@ -211,8 +211,7 @@ namespace System.Management.Automation
             }
 
             InvocationInfo invocationInfo = null;
-            IContainsErrorRecord icer = exception as IContainsErrorRecord;
-            if (icer != null && icer.ErrorRecord != null)
+            if (exception is IContainsErrorRecord icer && icer.ErrorRecord != null)
                 invocationInfo = icer.ErrorRecord.InvocationInfo;
             foreach (LogProvider provider in GetLogProvider(executionContext))
             {
@@ -413,8 +412,7 @@ namespace System.Management.Automation
             }
 
             InvocationInfo invocationInfo = null;
-            IContainsErrorRecord icer = exception as IContainsErrorRecord;
-            if (icer != null && icer.ErrorRecord != null)
+            if (exception is IContainsErrorRecord icer && icer.ErrorRecord != null)
                 invocationInfo = icer.ErrorRecord.InvocationInfo;
             foreach (LogProvider provider in GetLogProvider(executionContext))
             {
@@ -605,8 +603,7 @@ namespace System.Management.Automation
             }
 
             InvocationInfo invocationInfo = null;
-            IContainsErrorRecord icer = exception as IContainsErrorRecord;
-            if (icer != null && icer.ErrorRecord != null)
+            if (exception is IContainsErrorRecord icer && icer.ErrorRecord != null)
                 invocationInfo = icer.ErrorRecord.InvocationInfo;
             foreach (LogProvider provider in GetLogProvider(executionContext))
             {
@@ -804,9 +801,7 @@ namespace System.Management.Automation
                 logContext.User = Logging.UnknownUserName;
             }
 
-            System.Management.Automation.Remoting.PSSenderInfo psSenderInfo =
-                    executionContext.SessionState.PSVariable.GetValue("PSSenderInfo") as System.Management.Automation.Remoting.PSSenderInfo;
-            if (psSenderInfo != null)
+            if (executionContext.SessionState.PSVariable.GetValue("PSSenderInfo") is System.Management.Automation.Remoting.PSSenderInfo psSenderInfo)
             {
                 logContext.ConnectedUser = psSenderInfo.UserInfo.Identity.Name;
             }

--- a/src/System.Management.Automation/logging/MshLog.cs
+++ b/src/System.Management.Automation/logging/MshLog.cs
@@ -610,7 +610,10 @@ namespace System.Management.Automation
 
             InvocationInfo invocationInfo = null;
             if (exception is IContainsErrorRecord icer && icer.ErrorRecord != null)
+            {
                 invocationInfo = icer.ErrorRecord.InvocationInfo;
+            }
+
             foreach (LogProvider provider in GetLogProvider(executionContext))
             {
                 if (NeedToLogProviderHealthEvent(provider, executionContext))

--- a/src/System.Management.Automation/logging/MshLog.cs
+++ b/src/System.Management.Automation/logging/MshLog.cs
@@ -416,7 +416,10 @@ namespace System.Management.Automation
 
             InvocationInfo invocationInfo = null;
             if (exception is IContainsErrorRecord icer && icer.ErrorRecord != null)
+            {
                 invocationInfo = icer.ErrorRecord.InvocationInfo;
+            }
+
             foreach (LogProvider provider in GetLogProvider(executionContext))
             {
                 if (NeedToLogCommandHealthEvent(provider, executionContext))

--- a/src/System.Management.Automation/logging/MshLog.cs
+++ b/src/System.Management.Automation/logging/MshLog.cs
@@ -212,7 +212,10 @@ namespace System.Management.Automation
 
             InvocationInfo invocationInfo = null;
             if (exception is IContainsErrorRecord icer && icer.ErrorRecord != null)
+            {
                 invocationInfo = icer.ErrorRecord.InvocationInfo;
+            }
+
             foreach (LogProvider provider in GetLogProvider(executionContext))
             {
                 if (NeedToLogEngineHealthEvent(provider, executionContext))

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -651,8 +651,7 @@ namespace Microsoft.PowerShell
                     break;
 
                 case CommandTypes.ExternalScript:
-                    ExternalScriptInfo si = commandInfo as ExternalScriptInfo;
-                    if (si == null)
+                    if (commandInfo is not ExternalScriptInfo si)
                     {
                         reason = PSTraceSource.NewArgumentException("scriptInfo");
                     }

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -663,8 +663,7 @@ namespace System.Management.Automation.Internal
         {
             foreach (X509Extension extension in c.Extensions)
             {
-                X509KeyUsageExtension keyUsageExtension = extension as X509KeyUsageExtension;
-                if (keyUsageExtension != null)
+                if (extension is X509KeyUsageExtension keyUsageExtension)
                 {
                     if ((keyUsageExtension.KeyUsages & keyUsage) == keyUsage)
                     {

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -761,8 +761,7 @@ namespace System.Management.Automation
             if (msv == null)
             {
                 // Check if the value is in string format
-                string singleValue = value as string;
-                if (singleValue != null)
+                if (value is string singleValue)
                 {
                     msv = new string[1];
                     msv[0] = singleValue;

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -883,7 +883,7 @@ namespace System.Management.Automation.Internal
             // session!=null check required for DRTs TestEncryptSecureString* entries in CryptoUtilsTest/UTUtils.dll
             // for newer clients, server will never initiate key exchange.
             // for server, just the session key is required to encrypt/decrypt anything
-            if ((Session is ServerRemoteSession session) && (session.Context.ClientCapability.ProtocolVersion >= RemotingConstants.ProtocolVersionWin8RTM))
+            if (Session is ServerRemoteSession session && session.Context.ClientCapability.ProtocolVersion >= RemotingConstants.ProtocolVersionWin8RTM)
             {
                 _rsaCryptoProvider.GenerateSessionKey();
             }

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -235,9 +235,9 @@ namespace System.Management.Automation.Internal
             // [2], [3]                         // RESERVED - Always 0
             blob[4] = (byte)CALG_AES_256;       // AES-256 algo id (0x10)
             blob[5] = 0x66;                     // ??
-            // [6], [7], [8]                    // 0x00 
+            // [6], [7], [8]                    // 0x00
             blob[9] = (byte)CALG_RSA_KEYX;      // 0xa4
-            // [10], [11]                       // 0x00 
+            // [10], [11]                       // 0x00
 
             // create a reversed copy and add the encrypted key
             byte[] reversedKey = CreateReverseByteArray(encryptedKey);
@@ -365,7 +365,7 @@ namespace System.Management.Automation.Internal
         // handle to the AES provider object (houses session key and iv)
         private readonly Aes _aes;
 
-        // this flag indicates that this class has a key imported from the 
+        // this flag indicates that this class has a key imported from the
         // remote end and so can be used for encryption
         private bool _canEncrypt;
 
@@ -423,7 +423,7 @@ namespace System.Management.Automation.Internal
             {
                 if (!_sessionKeyGenerated)
                 {
-                    // Aes object gens key automatically on construction, so this is somewhat redundant, 
+                    // Aes object gens key automatically on construction, so this is somewhat redundant,
                     // but at least the actionable key will not be in-memory until it's requested fwiw.
                     _aes.GenerateKey();
                     _sessionKeyGenerated = true;
@@ -880,12 +880,10 @@ namespace System.Management.Automation.Internal
 
         internal override string EncryptSecureString(SecureString secureString)
         {
-            ServerRemoteSession session = Session as ServerRemoteSession;
-
             // session!=null check required for DRTs TestEncryptSecureString* entries in CryptoUtilsTest/UTUtils.dll
             // for newer clients, server will never initiate key exchange.
             // for server, just the session key is required to encrypt/decrypt anything
-            if ((session != null) && (session.Context.ClientCapability.ProtocolVersion >= RemotingConstants.ProtocolVersionWin8RTM))
+            if ((Session is ServerRemoteSession session) && (session.Context.ClientCapability.ProtocolVersion >= RemotingConstants.ProtocolVersionWin8RTM))
             {
                 _rsaCryptoProvider.GenerateSessionKey();
             }

--- a/src/System.Management.Automation/utils/ExecutionExceptions.cs
+++ b/src/System.Management.Automation/utils/ExecutionExceptions.cs
@@ -55,8 +55,7 @@ namespace System.Management.Automation
             ArgumentNullException.ThrowIfNull(innerException);
             // invocationInfo may be null
 
-            IContainsErrorRecord icer = innerException as IContainsErrorRecord;
-            if (icer != null && icer.ErrorRecord != null)
+            if (innerException is IContainsErrorRecord icer && icer.ErrorRecord != null)
             {
                 _errorRecord = new ErrorRecord(icer.ErrorRecord, innerException);
             }

--- a/src/System.Management.Automation/utils/ParameterBinderExceptions.cs
+++ b/src/System.Management.Automation/utils/ParameterBinderExceptions.cs
@@ -665,8 +665,7 @@ namespace System.Management.Automation
                 errorId,
                 args)
         {
-            ValidationMetadataException validationException = innerException as ValidationMetadataException;
-            if (validationException != null && validationException.SwallowException)
+            if (innerException is ValidationMetadataException validationException && validationException.SwallowException)
             {
                 _swallowException = true;
             }

--- a/src/System.Management.Automation/utils/PowerShellExecutionHelper.cs
+++ b/src/System.Management.Automation/utils/PowerShellExecutionHelper.cs
@@ -113,9 +113,8 @@ namespace System.Management.Automation
 
             try
             {
-                PSObject pso = obj as PSObject;
                 string result;
-                if (pso != null)
+                if (obj is PSObject pso)
                 {
                     object baseObject = pso.BaseObject;
                     if (baseObject != null && baseObject is not PSCustomObject)

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -354,33 +354,28 @@ namespace System.Management.Automation
             }
 
             var pipeline = ast.GetSimplePipeline(false, out _, out _);
-            if (pipeline != null)
+            if (pipeline != null && pipeline.GetPureExpression() is HashtableAst hashtableAst)
             {
-                var hashtableAst = pipeline.GetPureExpression() as HashtableAst;
-                if (hashtableAst != null)
+                var result = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                foreach (var pair in hashtableAst.KeyValuePairs)
                 {
-                    var result = new Hashtable(StringComparer.OrdinalIgnoreCase);
-                    foreach (var pair in hashtableAst.KeyValuePairs)
+                    if (pair.Item1 is StringConstantExpressionAst key && keys.Contains(key.Value, StringComparer.OrdinalIgnoreCase))
                     {
-                        var key = pair.Item1 as StringConstantExpressionAst;
-                        if (key != null && keys.Contains(key.Value, StringComparer.OrdinalIgnoreCase))
+                        try
                         {
-                            try
-                            {
-                                var val = pair.Item2.SafeGetValue();
-                                result[key.Value] = val;
-                            }
-                            catch
-                            {
-                                throw PSTraceSource.NewInvalidOperationException(
-                                         ParserStrings.InvalidPowerShellDataFile,
-                                         psDataFilePath);
-                            }
+                            var val = pair.Item2.SafeGetValue();
+                            result[key.Value] = val;
+                        }
+                        catch
+                        {
+                            throw PSTraceSource.NewInvalidOperationException(
+                                        ParserStrings.InvalidPowerShellDataFile,
+                                        psDataFilePath);
                         }
                     }
-
-                    return result;
                 }
+
+                return result;
             }
 
             throw PSTraceSource.NewInvalidOperationException(

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -354,7 +354,7 @@ namespace System.Management.Automation
             }
 
             var pipeline = ast.GetSimplePipeline(false, out _, out _);
-            if (pipeline != null && pipeline.GetPureExpression() is HashtableAst hashtableAst)
+            if (pipeline?.GetPureExpression() is HashtableAst hashtableAst)
             {
                 var result = new Hashtable(StringComparer.OrdinalIgnoreCase);
                 foreach (var pair in hashtableAst.KeyValuePairs)

--- a/src/System.Management.Automation/utils/RuntimeException.cs
+++ b/src/System.Management.Automation/utils/RuntimeException.cs
@@ -271,7 +271,7 @@ namespace System.Management.Automation
             set
             {
                 _thrownByThrowStatement = value;
-                if (_errorRecord != null && _errorRecord.Exception is RuntimeException exception)
+                if (_errorRecord?.Exception is RuntimeException exception)
                 {
                     exception.WasThrownFromThrowStatement = value;
                 }

--- a/src/System.Management.Automation/utils/RuntimeException.cs
+++ b/src/System.Management.Automation/utils/RuntimeException.cs
@@ -271,13 +271,9 @@ namespace System.Management.Automation
             set
             {
                 _thrownByThrowStatement = value;
-                if (_errorRecord != null)
+                if (_errorRecord != null && _errorRecord.Exception is RuntimeException exception)
                 {
-                    RuntimeException exception = _errorRecord.Exception as RuntimeException;
-                    if (exception != null)
-                    {
-                        exception.WasThrownFromThrowStatement = value;
-                    }
+                    exception.WasThrownFromThrowStatement = value;
                 }
             }
         }

--- a/src/System.Management.Automation/utils/SessionStateExceptions.cs
+++ b/src/System.Management.Automation/utils/SessionStateExceptions.cs
@@ -66,8 +66,7 @@ namespace System.Management.Automation
             _message = base.Message;
             _providerInfo = provider;
 
-            IContainsErrorRecord icer = innerException as IContainsErrorRecord;
-            if (icer != null && icer.ErrorRecord != null)
+            if (innerException is IContainsErrorRecord icer && icer.ErrorRecord != null)
             {
                 _errorRecord = new ErrorRecord(icer.ErrorRecord, innerException);
             }
@@ -199,8 +198,7 @@ namespace System.Management.Automation
                 errorRecordException = new ParentContainsErrorRecordException(this);
             }
 
-            IContainsErrorRecord icer = innerException as IContainsErrorRecord;
-            if (icer != null && icer.ErrorRecord != null)
+            if (innerException is IContainsErrorRecord icer && icer.ErrorRecord != null)
             {
                 _errorRecord = new ErrorRecord(icer.ErrorRecord, errorRecordException);
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Fix IDE0019 in Management.Automation folders, including cimSupport, DscSupport, logging, security, singleshell, utils.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
https://github.com/PowerShell/PowerShell/issues/18399
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
Microsoft.CodeAnalysis.CSharp version [4.6.0-1.final](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp/4.6.0-1.final).
There might have been some manual fixes in this PR but they all fall into 3 categories:
1. Newly created double newlines that trigger other diagnostics.
2. Code that previously looked like this
    ```c#
    if (condition)
    {
        Type type = var as Type;
        if (type != null)
        ...
    ```
    was fixed to this:
    ```c#
    if (condition)
    {
        if (var is Type type)
        ...
    ```
    and I have additionally changed it to this:
    ```c#
    if (condition && var is Type type)
    {
        ...
    ```
3. Once or twice autofix "ate" comments but it might have been in another PR. You can see all similar PRs in the linked issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
