### PR TITLE
Apply IDE0019: InlineAsTypeCheck in Management.Automation.FormatAndOutput

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -176,15 +176,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             // need to check the type:
             // it can be a string or a script block
-            ScriptBlock sb = val as ScriptBlock;
-            if (sb != null)
+            if (val is ScriptBlock sb)
             {
                 PSPropertyExpression ex = new PSPropertyExpression(sb);
                 return ex;
             }
 
-            string s = val as string;
-            if (s != null)
+            if (val is string s)
             {
                 if (string.IsNullOrEmpty(s))
                 {

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -131,9 +131,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _cache ??= new FormattedObjectsCache(this.LineOutput.RequiresBuffering);
 
             // no need for formatting, just process the object
-            FormatStartData formatStart = o as FormatStartData;
-
-            if (formatStart != null)
+            if (o is FormatStartData formatStart)
             {
                 // get autosize flag from object
                 // turn on group caching
@@ -145,8 +143,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 else
                 {
                     // If the format info doesn't define column widths, then auto-size based on the first ten elements
-                    TableHeaderInfo headerInfo = formatStart.shapeInfo as TableHeaderInfo;
-                    if ((headerInfo != null) &&
+                    if ((formatStart.shapeInfo is TableHeaderInfo headerInfo) &&
                         (headerInfo.tableColumnInfoList.Count > 0) &&
                         (headerInfo.tableColumnInfoList[0].width == 0))
                     {
@@ -258,8 +255,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <returns>Whether the object needs to be shunted to preprocessing.</returns>
         private bool NeedsPreprocessing(object o)
         {
-            FormatEntryData fed = o as FormatEntryData;
-            if (fed != null)
+            if (o is FormatEntryData fed)
             {
                 // we got an already pre-processed object
                 if (!fed.outOfBand)
@@ -322,8 +318,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // need to abort the command
 
                 string violatingCommand = "format-*";
-                StartData sdObj = obj as StartData;
-                if (sdObj != null)
+                if (obj is StartData sdObj)
                 {
                     if (sdObj.shapeInfo is WideViewHeaderInfo)
                     {
@@ -383,18 +378,16 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                                         FormatMessagesContextManager.OutputContext parentContext,
                                         FormatInfoData formatInfoData)
         {
-            FormatStartData formatStartData = formatInfoData as FormatStartData;
             // initialize the format context
-            if (formatStartData != null)
+            if (formatInfoData is FormatStartData formatStartData)
             {
                 FormatOutputContext foc = new FormatOutputContext(parentContext, formatStartData);
 
                 return foc;
             }
 
-            GroupStartData gsd = formatInfoData as GroupStartData;
             // we are starting a group, initialize the group context
-            if (gsd != null)
+            if (formatInfoData is GroupStartData gsd)
             {
                 GroupOutputContext goc = null;
 
@@ -544,8 +537,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private void ProcessOutOfBandPayload(FormatEntryData fed)
         {
             // try if it is raw text
-            RawTextFormatEntry rte = fed.formatEntryInfo as RawTextFormatEntry;
-            if (rte != null)
+            if (fed.formatEntryInfo is RawTextFormatEntry rte)
             {
                 if (fed.isHelpObject)
                 {
@@ -564,8 +556,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             // try if it is a complex entry
-            ComplexViewEntry cve = fed.formatEntryInfo as ComplexViewEntry;
-            if (cve != null && cve.formatValueList != null)
+            if (fed.formatEntryInfo is ComplexViewEntry cve && cve.formatValueList != null)
             {
                 ComplexWriter complexWriter = new ComplexWriter();
 
@@ -575,8 +566,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return;
             }
             // try if it is a list view
-            ListViewEntry lve = fed.formatEntryInfo as ListViewEntry;
-            if (lve != null && lve.listViewFieldList != null)
+            if (fed.formatEntryInfo is ListViewEntry lve && lve.listViewFieldList != null)
             {
                 ListWriter listWriter = new ListWriter();
 
@@ -628,9 +618,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 for (FormatMessagesContextManager.OutputContext oc = _ctxManager.ActiveOutputContext; oc != null; oc = oc.ParentContext)
                 {
-                    FormatOutputContext foc = oc as FormatOutputContext;
-
-                    if (foc != null)
+                    if (oc is FormatOutputContext foc)
                         return foc;
                 }
 
@@ -655,17 +643,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             _formattingHint = null;
 
-            TableHeaderInfo thi = formatStartData.shapeInfo as TableHeaderInfo;
-
-            if (thi != null)
+            if (formatStartData.shapeInfo is TableHeaderInfo thi)
             {
                 ProcessCachedGroupOnTable(thi, objects);
                 return;
             }
 
-            WideViewHeaderInfo wvhi = formatStartData.shapeInfo as WideViewHeaderInfo;
-
-            if (wvhi != null)
+            if (formatStartData.shapeInfo is WideViewHeaderInfo wvhi)
             {
                 ProcessCachedGroupOnWide(wvhi, objects);
                 return;
@@ -982,11 +966,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// </summary>
             internal override void Initialize()
             {
-                TableFormattingHint tableHint = this.InnerCommand.RetrieveFormattingHint() as TableFormattingHint;
                 int[] columnWidthsHint = null;
-                // We expect that console width is less then 120.
+                // We expect that console width is less than 120.
 
-                if (tableHint != null)
+                if (this.InnerCommand.RetrieveFormattingHint() is TableFormattingHint tableHint)
                 {
                     columnWidthsHint = tableHint.columnWidths;
                 }
@@ -1215,13 +1198,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // set the hard wider default, to be used if no other info is available
                 int itemsPerRow = 2;
 
-                // get the header info and the view hint
-                WideFormattingHint hint = this.InnerCommand.RetrieveFormattingHint() as WideFormattingHint;
-
+                // get the header info
                 int columnsOnTheScreen = GetConsoleWindowWidth(this.InnerCommand._lo.ColumnNumber);
 
                 // give a preference to the hint, if there
-                if (hint != null && hint.maxWidth > 0)
+                if (this.InnerCommand.RetrieveFormattingHint() is WideFormattingHint hint && hint.maxWidth > 0)
                 {
                     itemsPerRow = TableWriter.ComputeWideViewBestItemsPerRowFit(hint.maxWidth, columnsOnTheScreen);
                 }
@@ -1402,8 +1383,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <param name="fed">FormatEntryData to process.</param>
             internal override void ProcessPayload(FormatEntryData fed)
             {
-                ComplexViewEntry cve = fed.formatEntryInfo as ComplexViewEntry;
-                if (cve == null || cve.formatValueList == null)
+                if (fed.formatEntryInfo is not ComplexViewEntry cve || cve.formatValueList == null)
                     return;
                 _writer.WriteObject(cve.formatValueList);
             }

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -1383,9 +1383,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// <param name="fed">FormatEntryData to process.</param>
             internal override void ProcessPayload(FormatEntryData fed)
             {
-                if (fed.formatEntryInfo is not ComplexViewEntry cve || cve.formatValueList == null)
-                    return;
-                _writer.WriteObject(cve.formatValueList);
+                if (fed.formatEntryInfo is ComplexViewEntry cve && cve.formatValueList is not null)
+                {
+                    _writer.WriteObject(cve.formatValueList);
+                }
             }
 
             private readonly ComplexWriter _writer = new ComplexWriter();

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -70,8 +70,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             foreach (object obj in fe.formatValueList)
             {
-                FormatEntry feChild = obj as FormatEntry;
-                if (feChild != null)
+                if (obj is FormatEntry feChild)
                 {
                     if (currentDepth < maxRecursionDepth)
                     {
@@ -100,15 +99,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     continue;
                 }
 
-                FormatTextField ftf = obj as FormatTextField;
-                if (ftf != null)
+                if (obj is FormatTextField ftf)
                 {
                     this.AddToBuffer(ftf.text);
                     continue;
                 }
 
-                FormatPropertyField fpf = obj as FormatPropertyField;
-                if (fpf != null)
+                if (obj is FormatPropertyField fpf)
                 {
                     this.AddToBuffer(fpf.propertyValue);
                 }

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
@@ -384,14 +384,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 match = true;
             }
 
-            if (match && !allowAttributes)
+            if (match && !allowAttributes && n is XmlElement e && e.Attributes.Count > 0)
             {
-                XmlElement e = n as XmlElement;
-                if (e != null && e.Attributes.Count > 0)
-                {
-                    // Error at XPath {0} in file {1}: The XML Element {2} does not allow attributes.
-                    ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.AttributesNotAllowed, ComputeCurrentXPath(), FilePath, n.Name));
-                }
+                // Error at XPath {0} in file {1}: The XML Element {2} does not allow attributes.
+                ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.AttributesNotAllowed, ComputeCurrentXPath(), FilePath, n.Name));
             }
 
             return match;

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Complex.cs
@@ -179,14 +179,12 @@ namespace System.Management.Automation
                 return new CustomItemNewline();
             }
 
-            var textToken = token as TextToken;
-            if (textToken != null)
+            if (token is TextToken textToken)
             {
                 return new CustomItemText { Text = textToken.text };
             }
 
-            var frameToken = token as FrameToken;
-            if (frameToken != null)
+            if (token is FrameToken frameToken)
             {
                 var frame = new CustomItemFrame
                 {
@@ -211,8 +209,7 @@ namespace System.Management.Automation
                 return frame;
             }
 
-            var cpt = token as CompoundPropertyToken;
-            if (cpt != null)
+            if (token is CompoundPropertyToken cpt)
             {
                 var cie = new CustomItemExpression { EnumerateCollection = cpt.enumerateCollection };
 
@@ -234,8 +231,7 @@ namespace System.Management.Automation
                 return cie;
             }
 
-            var fpt = token as FieldPropertyToken;
-            if (fpt != null)
+            if (token is FieldPropertyToken fpt)
             {
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Complex.cs
@@ -231,10 +231,6 @@ namespace System.Management.Automation
                 return cie;
             }
 
-            if (token is FieldPropertyToken fpt)
-            {
-            }
-
             Diagnostics.Assert(false, "Unexpected formatting token kind");
 
             return null;

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
@@ -318,8 +318,7 @@ namespace System.Management.Automation
                 Label = definition.label.text;
             }
 
-            FieldPropertyToken fpt = definition.formatTokenList[0] as FieldPropertyToken;
-            if (fpt != null)
+            if (definition.formatTokenList[0] is FieldPropertyToken fpt)
             {
                 if (fpt.fieldFormattingDirective.formatString != null)
                 {

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Table.cs
@@ -446,10 +446,9 @@ namespace System.Management.Automation
 
             foreach (TableRowItemDefinition itemdef in rowdefinition.rowItemDefinitionList)
             {
-                FieldPropertyToken fpt = itemdef.formatTokenList[0] as FieldPropertyToken;
                 TableControlColumn column;
 
-                if (fpt != null)
+                if (itemdef.formatTokenList[0] is FieldPropertyToken fpt)
                 {
                     column = new TableControlColumn(fpt.expression.expressionValue, itemdef.alignment,
                                     fpt.expression.isScriptBlock, fpt.fieldFormattingDirective.formatString);

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Wide.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Wide.cs
@@ -204,8 +204,7 @@ namespace System.Management.Automation
 
         internal WideControlEntryItem(WideControlEntryDefinition definition) : this()
         {
-            FieldPropertyToken fpt = definition.formatTokenList[0] as FieldPropertyToken;
-            if (fpt != null)
+            if (definition.formatTokenList[0] is FieldPropertyToken fpt)
             {
                 DisplayEntry = new DisplayEntry(fpt.expression);
                 FormatString = fpt.fieldFormattingDirective.formatString;

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
@@ -143,9 +143,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 int currentMatch = BestMatchIndexUndefined;
-                TypeReference tr = r as TypeReference;
 
-                if (tr != null)
+                if (r is TypeReference tr)
                 {
                     // we have a type
                     currentMatch = MatchTypeIndex(tr.name, currentObject, ex);
@@ -486,9 +485,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 foreach (TypeOrGroupReference togr in vd.appliesTo.referenceList)
                 {
                     StringBuilder sb = new StringBuilder();
-                    TypeReference tr = togr as TypeReference;
                     sb.Append(isMatched ? "MATCH FOUND" : "NOT MATCH");
-                    if (tr != null)
+                    if (togr is TypeReference tr)
                     {
                         sb.AppendFormat(
                             CultureInfo.InvariantCulture,
@@ -601,8 +599,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             foreach (TypeOrGroupReference r in appliesTo.referenceList)
             {
                 // if it is a type reference, just add the type name
-                TypeReference tr = r as TypeReference;
-                if (tr != null)
+                if (r is TypeReference tr)
                 {
                     if (!allTypes.Contains(tr.name))
                         allTypes.Add(tr.name);

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -1085,20 +1085,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private FormatToken LoadFormatTokenFromObjectModel(CustomItemBase item, int viewIndex, string typeName)
         {
-            var newline = item as CustomItemNewline;
-            if (newline != null)
+            if (item is CustomItemNewline newline)
             {
                 return new NewLineToken { count = newline.Count };
             }
 
-            var text = item as CustomItemText;
-            if (text != null)
+            if (item is CustomItemText text)
             {
                 return new TextToken { text = text.Text };
             }
 
-            var expr = item as CustomItemExpression;
-            if (expr != null)
+            if (item is CustomItemExpression expr)
             {
                 var cpt = new CompoundPropertyToken { enumerateCollection = expr.EnumerateCollection };
 
@@ -1766,9 +1763,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private bool LoadStringResourceReference(XmlNode n, out StringResourceReference resource)
         {
             resource = null;
-            XmlElement e = n as XmlElement;
 
-            if (e == null)
+            if (n is not XmlElement e)
             {
                 // Error at XPath {0} in file {1}: Node should be an XmlElement.
                 this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.NonXmlElementNode, ComputeCurrentXPath(), FilePath));

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatMsgCtxManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatMsgCtxManager.cs
@@ -68,8 +68,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal void Process(object o)
         {
             PacketInfoData formatData = o as PacketInfoData;
-            FormatEntryData fed = formatData as FormatEntryData;
-            if (fed != null)
+            if (formatData is FormatEntryData fed)
             {
                 OutputContext ctx = null;
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -141,13 +141,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return;
             }
             // check if we have a view with autosize checked
-            if (this.dataBaseInfo.view != null && this.dataBaseInfo.view.mainControl != null)
+            if (this.dataBaseInfo.view != null && this.dataBaseInfo.view.mainControl != null
+                && this.dataBaseInfo.view.mainControl is ControlBody controlBody && controlBody.autosize.HasValue)
             {
-                ControlBody controlBody = this.dataBaseInfo.view.mainControl as ControlBody;
-                if (controlBody != null && controlBody.autosize.HasValue)
-                {
-                    _autosize = controlBody.autosize.Value;
-                }
+                _autosize = controlBody.autosize.Value;
             }
         }
 
@@ -439,17 +436,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (formatTokenList.Count != 0)
             {
                 FormatToken token = formatTokenList[0];
-                FieldPropertyToken fpt = token as FieldPropertyToken;
-                if (fpt != null)
+                if (token is FieldPropertyToken fpt)
                 {
                     PSPropertyExpression ex = this.expressionFactory.CreateFromExpressionToken(fpt.expression, this.dataBaseInfo.view.loadingInfo);
                     fpf.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, ex, fpt.fieldFormattingDirective, out result);
                 }
-                else
+                else if (token is TextToken tt)
                 {
-                    TextToken tt = token as TextToken;
-                    if (tt != null)
-                        fpf.propertyValue = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
+                    fpf.propertyValue = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
                 }
             }
             else

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -107,8 +107,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             ComplexControlBody complexBody = null;
 
             // we might have a reference
-            ControlReference controlReference = control as ControlReference;
-            if (controlReference != null && controlReference.controlType == typeof(ComplexControlBody))
+            if (control is ControlReference controlReference && controlReference.controlType == typeof(ComplexControlBody))
             {
                 // retrieve the reference
                 complexBody = DisplayDataQuery.ResolveControlReference(
@@ -205,8 +204,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             #region foreach loop
             foreach (FormatToken t in formatTokenList)
             {
-                TextToken tt = t as TextToken;
-                if (tt != null)
+                if (t is TextToken tt)
                 {
                     FormatTextField ftf = new FormatTextField();
                     ftf.text = _db.displayResourceManagerCache.GetTextTokenString(tt);
@@ -214,8 +212,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     continue;
                 }
 
-                var newline = t as NewLineToken;
-                if (newline != null)
+                if (t is NewLineToken newline)
                 {
                     for (int i = 0; i < newline.count; i++)
                     {
@@ -225,8 +222,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     continue;
                 }
 
-                FrameToken ft = t as FrameToken;
-                if (ft != null)
+                if (t is FrameToken ft)
                 {
                     // instantiate a new entry and attach a frame info object
                     FormatEntry feFrame = new FormatEntry();
@@ -245,8 +241,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     continue;
                 }
                 #region CompoundPropertyToken
-                CompoundPropertyToken cpt = t as CompoundPropertyToken;
-                if (cpt != null)
+                if (t is CompoundPropertyToken cpt)
                 {
                     if (!EvaluateDisplayCondition(so, cpt.conditionToken))
                     {

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
@@ -114,20 +114,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                     // we try to fall back and see if we have an un-resolved PSPropertyExpression
                     FormatToken token = listItem.formatTokenList[0];
-                    FieldPropertyToken fpt = token as FieldPropertyToken;
-                    if (fpt != null)
+                    if (token is FieldPropertyToken fpt)
                     {
                         PSPropertyExpression ex = this.expressionFactory.CreateFromExpressionToken(fpt.expression, this.dataBaseInfo.view.loadingInfo);
 
                         // use the un-resolved PSPropertyExpression string as a label
                         lvf.label = ex.ToString();
                     }
-                    else
+                    else if (token is TextToken tt)
                     {
-                        TextToken tt = token as TextToken;
-                        if (tt != null)
-                            // we had a text token, use it as a label (last resort...)
-                            lvf.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
+                        // we had a text token, use it as a label (last resort...)
+                        lvf.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
                     }
                 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -191,18 +191,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         token = rowItem.formatTokenList[0];
                     if (token != null)
                     {
-                        FieldPropertyToken fpt = token as FieldPropertyToken;
-                        if (fpt != null)
+                        if (token is FieldPropertyToken fpt)
                         {
                             ci.label = fpt.expression.expressionValue;
                         }
-                        else
+                        else if (token is TextToken tt)
                         {
-                            TextToken tt = token as TextToken;
-                            if (tt != null)
-                            {
-                                ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
-                            }
+                            ci.label = this.dataBaseInfo.db.displayResourceManagerCache.GetTextTokenString(tt);
                         }
                     }
                     else

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -646,8 +646,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             ErrorRecord errorRecord = null;
             string msg = null;
-            PSPropertyExpressionError psPropertyExpressionError = error as PSPropertyExpressionError;
-            if (psPropertyExpressionError != null)
+            if (error is PSPropertyExpressionError psPropertyExpressionError)
             {
                 errorRecord = new ErrorRecord(
                                 psPropertyExpressionError.result.Exception,
@@ -660,8 +659,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 errorRecord.ErrorDetails = new ErrorDetails(msg);
             }
 
-            StringFormatError formattingError = error as StringFormatError;
-            if (formattingError != null)
+            if (error is StringFormatError formattingError)
             {
                 errorRecord = new ErrorRecord(
                                 formattingError.exception,

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatXMLWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatXMLWriter.cs
@@ -385,8 +385,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal void WriteCustomItem(CustomItemBase item)
         {
-            var newline = item as CustomItemNewline;
-            if (newline != null)
+            if (item is CustomItemNewline newline)
             {
                 for (int i = 0; i < newline.Count; i++)
                 {
@@ -396,15 +395,13 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            var text = item as CustomItemText;
-            if (text != null)
+            if (item is CustomItemText text)
             {
                 _writer.WriteElementString("Text", text.Text);
                 return;
             }
 
-            var expr = item as CustomItemExpression;
-            if (expr != null)
+            if (item is CustomItemExpression expr)
             {
                 _writer.WriteStartElement("ExpressionBinding");
                 if (expr.EnumerateCollection)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
@@ -30,8 +30,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         internal bool IsFormatInfoData(PSObject so)
         {
-            var fid = PSObject.Base(so) as FormatInfoData;
-            if (fid != null)
+            if (PSObject.Base(so) is FormatInfoData fid)
             {
                 if (fid is FormatStartData ||
                     fid is FormatEndData ||
@@ -86,8 +85,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <returns>Deserialized object or null.</returns>
         internal object Deserialize(PSObject so)
         {
-            var fid = PSObject.Base(so) as FormatInfoData;
-            if (fid != null)
+            if (PSObject.Base(so) is FormatInfoData fid)
             {
                 if (fid is FormatStartData ||
                     fid is FormatEndData ||

--- a/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
@@ -43,8 +43,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <returns>Objects the cache needs to return. It can be null.</returns>
         internal List<PacketInfoData> Add(PacketInfoData o)
         {
-            FormatStartData fsd = o as FormatStartData;
-            if (fsd != null)
+            if (o is FormatStartData fsd)
             {
                 // just cache the reference (used during the notification call)
                 _formatStartData = fsd;
@@ -120,9 +119,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             // add only of it's not a control message
             // and it's not out of band
-            FormatEntryData fed = o as FormatEntryData;
-
-            if (fed == null || fed.outOfBand)
+            if (o is not FormatEntryData fed || fed.outOfBand)
                 return;
 
             _currentObjectCount++;
@@ -139,8 +136,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             foreach (PacketInfoData x in _queue)
             {
-                FormatEntryData fed = x as FormatEntryData;
-                if (fed != null && fed.outOfBand)
+                if (x is FormatEntryData fed && fed.outOfBand)
                     continue;
 
                 validObjects.Add(x);

--- a/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/OutputQueue.cs
@@ -119,10 +119,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             // add only of it's not a control message
             // and it's not out of band
-            if (o is not FormatEntryData fed || fed.outOfBand)
-                return;
-
-            _currentObjectCount++;
+            if (o is FormatEntryData fed && !fed.outOfBand)
+            {
+                _currentObjectCount++;
+            }
         }
 
         private void Notify()

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -121,8 +121,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="obj">Object to extract the IEnumerable from.</param>
         internal static IEnumerable GetEnumerable(object obj)
         {
-            PSObject mshObj = obj as PSObject;
-            if (mshObj != null)
+            if (obj is PSObject mshObj)
             {
                 obj = mshObj.BaseObject;
             }
@@ -228,8 +227,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     IEnumerator enumerator = e.GetEnumerator();
                     if (enumerator != null)
                     {
-                        IBlockingEnumerator<object> be = enumerator as IBlockingEnumerator<object>;
-                        if (be != null)
+                        if (enumerator is IBlockingEnumerator<object> be)
                         {
                             while (be.MoveNext(false))
                             {
@@ -418,22 +416,18 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private static List<PSPropertyExpression> GetDefaultPropertySet(PSMemberSet standardMembersSet)
         {
-            if (standardMembersSet != null)
+            if (standardMembersSet != null && standardMembersSet.Members[TypeTable.DefaultDisplayPropertySet] is PSPropertySet defaultDisplayPropertySet)
             {
-                PSPropertySet defaultDisplayPropertySet = standardMembersSet.Members[TypeTable.DefaultDisplayPropertySet] as PSPropertySet;
-                if (defaultDisplayPropertySet != null)
+                List<PSPropertyExpression> retVal = new List<PSPropertyExpression>();
+                foreach (string prop in defaultDisplayPropertySet.ReferencedPropertyNames)
                 {
-                    List<PSPropertyExpression> retVal = new List<PSPropertyExpression>();
-                    foreach (string prop in defaultDisplayPropertySet.ReferencedPropertyNames)
+                    if (!string.IsNullOrEmpty(prop))
                     {
-                        if (!string.IsNullOrEmpty(prop))
-                        {
-                            retVal.Add(new PSPropertyExpression(prop));
-                        }
+                        retVal.Add(new PSPropertyExpression(prop));
                     }
-
-                    return retVal;
                 }
+
+                return retVal;
             }
 
             return new List<PSPropertyExpression>();
@@ -457,21 +451,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private static PSPropertyExpression GetDefaultNameExpression(PSMemberSet standardMembersSet)
         {
-            if (standardMembersSet != null)
+            if (standardMembersSet != null && standardMembersSet.Members[TypeTable.DefaultDisplayProperty] is PSNoteProperty defaultDisplayProperty)
             {
-                PSNoteProperty defaultDisplayProperty = standardMembersSet.Members[TypeTable.DefaultDisplayProperty] as PSNoteProperty;
-                if (defaultDisplayProperty != null)
+                string expressionString = defaultDisplayProperty.Value.ToString();
+                if (string.IsNullOrEmpty(expressionString))
                 {
-                    string expressionString = defaultDisplayProperty.Value.ToString();
-                    if (string.IsNullOrEmpty(expressionString))
-                    {
-                        // invalid data, the PSObject is empty
-                        return null;
-                    }
-                    else
-                    {
-                        return new PSPropertyExpression(expressionString);
-                    }
+                    // invalid data, the PSObject is empty
+                    return null;
+                }
+                else
+                {
+                    return new PSPropertyExpression(expressionString);
                 }
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -215,8 +215,7 @@ namespace Microsoft.PowerShell.Commands
             foreach (PSMemberInfo member in members)
             {
                 // it can be a property set
-                PSPropertySet propertySet = member as PSPropertySet;
-                if (propertySet != null)
+                if (member is PSPropertySet propertySet)
                 {
                     if (expand)
                     {

--- a/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/OutConsole.cs
@@ -69,9 +69,7 @@ namespace Microsoft.PowerShell.Commands
 
             ((OutputManagerInner)this.implementation).LineOutput = lineOutput;
 
-            MshCommandRuntime mrt = this.CommandRuntime as MshCommandRuntime;
-
-            if (mrt != null)
+            if (this.CommandRuntime is MshCommandRuntime mrt)
             {
                 mrt.MergeUnclaimedPreviousErrorResults = true;
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Fix IDE0019 in Management.Automation.FormatAndOutput folder.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
https://github.com/PowerShell/PowerShell/issues/18399
https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
Microsoft.CodeAnalysis.CSharp version [4.6.0-1.final](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp/4.6.0-1.final).
There might have been some manual fixes in this PR but they all fall into 3 categories:
1. Newly created double newlines that trigger other diagnostics.
2. Code that previously looked like this
    ```c#
    if (condition)
    {
        Type type = var as Type;
        if (type != null)
        ...
    ```
    was fixed to this:
    ```c#
    if (condition)
    {
        if (var is Type type)
        ...
    ```
    and I have additionally changed it to this:
    ```c#
    if (condition && var is Type type)
    {
        ...
    ```
3. Once or twice autofix "ate" comments but it might have been in another PR. You can see all similar PRs in the linked issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
