### PR TITLE
Fix `-Be null` to `-Be $null` in the certificate provider tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -48,7 +48,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path
-            $result | Should -Not -Be null
+            $result | Should -Not -Be $null
             $result | ForEach-Object {
                 $resolvedPath = Resolve-Path $_.PSPath
                 $resolvedPath.Provider | Should -Be $expectedResolvedPath.Provider
@@ -165,7 +165,7 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
             $cert | Should -Not -Be $null
-            $cert.EnhancedKeyUsageList | Should -Not -Be null
+            $cert.EnhancedKeyUsageList | Should -Not -Be $null
             $cert.EnhancedKeyUsageList.Count | Should -Be 3
             $cert.EnhancedKeyUsageList[0].ObjectId.Length | Should -Not -Be 0
             $cert.EnhancedKeyUsageList[0].ObjectId | Should -Be $expectedOid
@@ -178,8 +178,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
 
             $allCerts = Get-Item cert:\CurrentUser\My\*
             $codeSignCerts = Get-Item cert:\CurrentUser\My\* -CodeSigningCert
-            $codeSignCerts | Should -Not -Be null
-            $allCerts | Should -Not -Be null
+            $codeSignCerts | Should -Not -Be $null
+            $allCerts | Should -Not -Be $null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }
@@ -192,8 +192,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $allCerts = Get-Item cert:\CurrentUser\My\*
             $testThumbprint = (Get-GoodCertificateObject).Thumbprint
             $allCertsExceptOne = (Get-Item "cert:\currentuser\my\*" -Exclude $testThumbprint)
-            $allCerts | Should -Not -Be null
-            $allCertsExceptOne | Should -Not -Be null
+            $allCerts | Should -Not -Be $null
+            $allCertsExceptOne | Should -Not -Be $null
             $countDifference = $allCerts.Count - $allCertsExceptOne.Count
             $countDifference | Should -Be 1
         }
@@ -210,8 +210,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
 
             $allCerts = get-ChildItem cert:\CurrentUser\My
             $codeSignCerts = get-ChildItem cert:\CurrentUser\My -CodeSigningCert
-            $codeSignCerts | Should -Not -Be null
-            $allCerts | Should -Not -Be null
+            $codeSignCerts | Should -Not -Be $null
+            $allCerts | Should -Not -Be $null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix `-Be null` to `-Be $null` in the certificate provider tests

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
