### PR TITLE
Add some debugging to the transcript test for SilentlyContinue.

### DIFF
--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -269,6 +269,9 @@ Describe 'Basic os_log tests on MacOS' -Tag @('CI','RequireSudoOnUnix') {
         [bool] $IsSupportedEnvironment = $IsMacOS
         [bool] $persistenceEnabled = $false
 
+        $currentWarningPreference = $WarningPreference
+        $WarningPreference = "SilentlyContinue"
+
         if ($IsSupportedEnvironment)
         {
             # Check the current state.
@@ -306,6 +309,7 @@ Path:.*
     }
 
     AfterAll {
+        $WarningPreference = $currentWarningPreference
         if ($IsSupportedEnvironment -and !$persistenceEnabled)
         {
             # disable persistence if it wasn't enabled
@@ -444,6 +448,10 @@ Describe 'Basic EventLog tests on Windows' -Tag @('CI','RequireAdminOnWindows') 
     BeforeAll {
         [bool] $IsSupportedEnvironment = $IsWindows
         [string] $powershell = Join-Path -Path $PSHOME -ChildPath 'pwsh'
+
+        $currentWarningPreference = $WarningPreference
+        $WarningPreference = "SilentlyContinue"
+
         $scriptBlockLoggingCases = @(
             @{
                 name = 'normal script block'
@@ -461,6 +469,10 @@ Describe 'Basic EventLog tests on Windows' -Tag @('CI','RequireAdminOnWindows') 
         {
             & "$PSHOME\RegisterManifest.ps1"
         }
+    }
+
+    AfterAll {
+        $WarningPreference = $currentWarningPreference
     }
 
     BeforeEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -173,7 +173,7 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             $counterData = Get-Counter -Counter $counterPath -SampleInterval $sampleInterval -MaxSamples $counterCount
             $endTime = Get-Date
             $counterData.Length | Should -Be $counterCount
-            ($endTime - $startTime).TotalSeconds | Should -Not -BeLessThan ($counterCount * $sampleInterval)
+            ($endTime - $startTime).TotalSeconds -as [int] | Should -Not -BeLessThan ($counterCount * $sampleInterval)
         }
 
         It "Can process array of counter names" -Skip:$(SkipCounterTests) {

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -197,7 +197,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -Not -FileContentMatch "INFO: "
-        $transcriptFilePath | Should -Not -FileContentMatch $message
+        $transcriptFilePath | Should -Not -FileContentMatch $message -Because (get-content $transcriptFilePath)
     }
 
     It "Transcription should not record Write-Information output when InformationAction is set to Ignore" {

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -187,9 +187,10 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
     It "Transcription should not record Write-Information output when InformationAction is set to SilentlyContinue" {
         [String]$message = New-Guid
+        $traceData = Join-Path $TESTDRIVE tracedata.txt
         $script = {
             Start-Transcript -Path $transcriptFilePath
-            Write-Information -Message $message -InformationAction SilentlyContinue
+            Trace-Command -File $traceData -Name param* { -Write-Information -Message $message -InformationAction SilentlyContinue }
             Stop-Transcript
         }
 
@@ -197,7 +198,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -Not -FileContentMatch "INFO: "
-        $transcriptFilePath | Should -Not -FileContentMatch $message -Because (get-content $transcriptFilePath)
+        $transcriptFilePath | Should -Not -FileContentMatch $message -Because (get-content $transcriptFilePath,$traceData)
     }
 
     It "Transcription should not record Write-Information output when InformationAction is set to Ignore" {

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -190,7 +190,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $traceData = Join-Path $TESTDRIVE tracedata.txt
         $script = {
             Start-Transcript -Path $transcriptFilePath
-            Trace-Command -File $traceData -Name param* { -Write-Information -Message $message -InformationAction SilentlyContinue }
+            Trace-Command -File $traceData -Name param* { Write-Information -Message $message -InformationAction SilentlyContinue }
             Stop-Transcript
         }
 

--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -31,6 +31,8 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
 
         $SavedProgressPreference = $ProgressPreference
         $ProgressPreference = "SilentlyContinue"
+
+        Get-PackageSource | Out-String -Stream | Write-Verbose -Verbose
         }
 
     AfterAll {
@@ -66,12 +68,12 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
 
     It "Find-package"  {
         $f = Find-Package -ProviderName NuGet -Name $packageName -Source $localSourceName
-        $f.Name | Should -Contain "$packageName"
+        $f.Name | Should -Contain "$packageName" -Because ((Get-PackageSource $localSourceName).Location | Get-ChildItem)
 	}
 
     It "Install-package"  {
         $i = Install-Package -ProviderName NuGet -Name $packageName -Force -Source $localSourceName -Scope CurrentUser
-        $i.Name | Should -Contain "$packageName"
+        $i.Name | Should -Contain "$packageName" -Because ((Get-PackageSource $localSourceName).Location | Get-ChildItem)
 	}
 
     It "Get-package"  {
@@ -81,7 +83,7 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
 
     It "save-package"  {
         $s = Save-Package -ProviderName NuGet -Name $packageName -Path $TestDrive -Force -Source $localSourceName
-        $s.Name | Should -Contain "$packageName"
+        $s.Name | Should -Contain "$packageName" -Because (Get-ChildItem $TestDrive)
 	}
 
     It "uninstall-package"  {

--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -22,11 +22,19 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
         # register the asset directory
         $localSourceName = [Guid]::NewGuid().ToString("n")
         $localSourceLocation = Join-Path $PSScriptRoot assets
-        Register-PackageSource -Name $localSourceName -provider NuGet -Location $localSourceLocation -Force -Trusted
+        $newSourceResult = Register-PackageSource -Name $localSourceName -provider NuGet -Location $localSourceLocation -Force -Trusted
+        Write-Verbose -Verbose -Message "Register-PackageSource -Name $localSourceName -provider NuGet -Location $localSourceLocation -Force -Trusted"
+        $newSourceResult | Out-String -Stream | Write-Verbose -Verbose
+
+        $skipPackageTests = $false
+        if ($newSourceResult.Location -ne $localSourceLocation) {
+            $skipPackageTests = $true
+        }
 
         # register the gallery location
         $galleryLocation = "https://www.powershellgallery.com/api/v2"
         $gallerySourceName = [Guid]::newGuid().ToString("n")
+        # this is expected to fail as there should already be a source pointing to the gallery url
         Register-PackageSource -Name $gallerySourceName -Location $galleryLocation -ProviderName 'PowerShellGet' -Trusted -ErrorAction SilentlyContinue
 
         $SavedProgressPreference = $ProgressPreference
@@ -66,27 +74,27 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
         $ipp | Should -Contain "NanoServerPackage"
     }
 
-    It "Find-package"  {
+    It "Find-package" -skip:$skipPackageTests {
         $f = Find-Package -ProviderName NuGet -Name $packageName -Source $localSourceName
-        $f.Name | Should -Contain "$packageName" -Because ((Get-PackageSource $localSourceName).Location | Get-ChildItem)
+        $f.Name | Should -Contain "$packageName" -Because "PackageSource $localSourceLocation not created"
 	}
 
-    It "Install-package"  {
+    It "Install-package" -skip:$skipPackageTests {
         $i = Install-Package -ProviderName NuGet -Name $packageName -Force -Source $localSourceName -Scope CurrentUser
-        $i.Name | Should -Contain "$packageName" -Because ((Get-PackageSource $localSourceName).Location | Get-ChildItem)
+        $i.Name | Should -Contain "$packageName" -Because "PackageSource $localSourceLocation not created"
 	}
 
-    It "Get-package"  {
+    It "Get-package" -skip:$skipPackageTests {
         $g = Get-Package -ProviderName NuGet -Name $packageName
         $g.Name | Should -Contain "$packageName"
 	}
 
-    It "save-package"  {
+    It "save-package" -skip:$skipPackageTests {
         $s = Save-Package -ProviderName NuGet -Name $packageName -Path $TestDrive -Force -Source $localSourceName
         $s.Name | Should -Contain "$packageName" -Because (Get-ChildItem $TestDrive)
 	}
 
-    It "uninstall-package"  {
+    It "uninstall-package" -skip:$skipPackageTests {
         $u = Uninstall-Package -ProviderName NuGet -Name $packageName
         $u.Name | Should -Contain "$packageName"
 	}

--- a/test/tools/Modules/PSSysLog/PSSysLog.psm1
+++ b/test/tools/Modules/PSSysLog/PSSysLog.psm1
@@ -182,6 +182,7 @@ class PSLogItem
     [string] $EventId = [string]::Empty
     [string] $Message = [string]::Empty
     [int] $Count = 1
+    [System.Collections.Generic.List[String]]$ParseErrors = [System.Collections.Generic.List[string]]::new()
 
     hidden static $monthNames = @('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun','Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec')
 
@@ -316,7 +317,7 @@ class PSLogItem
         }
         else
         {
-            Write-Warning -Message "Could not split EventId $($item.EventId) on '[] ' Count:$($subparts.Count) -> $content"
+            $item.ParseErrors.Add("Could not split EventId $($item.EventId) on '[] ' Count:$($subparts.Count) -> $content")
         }
 
         # (commitid:TID:ChannelID)
@@ -331,7 +332,7 @@ class PSLogItem
         }
         else
         {
-            Write-Warning -Message "Could not split CommitId $($item.CommitId) on '(): ' Count:$($subparts.Count) -> $content"
+            $item.ParseErrors.Add("Could not split CommitId $($item.CommitId) on '(): ' Count:$($subparts.Count) -> $content")
         }
 
         # nameid[PID]
@@ -345,7 +346,7 @@ class PSLogItem
         }
         else
         {
-            Write-Warning -Message "Could not split LogId $($item.LogId) on '[]:' Count:$($subparts.Count) -> $content"
+            $item.ParseErrors.Add("Could not split LogId $($item.LogId) on '[]:' Count:$($subparts.Count) -> $content")
         }
 
         return $item
@@ -465,7 +466,7 @@ class PSLogItem
             }
             else
             {
-                Write-Warning -Message "Could not split CommitId $($item.CommitId) on '(): ' Count:$($subparts.Count)"
+                $item.ParseErrors.Add("Could not split CommitId $($item.CommitId) on '(): ' Count:$($subparts.Count)")
             }
 
             # [EventId]
@@ -478,7 +479,7 @@ class PSLogItem
             }
             else
             {
-                Write-Warning -Message "Could not split EventId $($item.EventId) on '[] ' Count:$($subparts.Count)"
+                $item.ParseErrors.Add("Could not split EventId $($item.EventId) on '[] ' Count:$($subparts.Count)")
             }
 
             $result = $item


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
tests are failing in release tests but not in CI.
Adding a `-Because` to get the content of the file for transcript test misbehavior
Adding debugging data for package management tests
suppress warnings in syslog tests
round to int for get-counter test

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
