### PR TITLE
Update ComputerUnix.cs to fix Restart- and Stop-Computer on Linux/Mac

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.Commands
             var args = "-P now";
             if (Platform.IsMacOS)
             {
-                args = "now";
+                args = "-h now";
             }
             if (InternalTestHooks.TestStopComputer)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; } = false;
+        public SwitchParameter Force { get; set; };
 
 #endregion "Parameters"
 
@@ -39,14 +39,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            string const unixRestartCommand = "/sbin/shutdown";
-            string const unixRestartArgs = "-r now";
+            const string unixRestartCommand = "/sbin/shutdown";
+            const string unixRestartArgs = "-r now";
             
-            string const macOSRestartCommand = "osascript";
-            string const macOSRestartArgs = @"-e 'tell application ""System Events"" to restart'";
+            const string macOSRestartCommand = "osascript";
+            const string macOSRestartArgs = @"-e 'tell application ""System Events"" to restart'";
 
-            string const macOSForceRestartCommand = "/sbin/shutdown";
-            string const macOSForceRestartArgs = "-r now";            
+            const string macOSForceRestartCommand = "/sbin/shutdown";
+            const string macOSForceRestartArgs = "-r now";            
 
             string command;
             string args;
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; } = false;
+        public SwitchParameter Force { get; set; };
 
 #endregion "Parameters"
         
@@ -117,14 +117,14 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
 
-            string const unixStopCommand = "/sbin/shutdown";
-            string const unixStopArgs = "-P now";
+            const string unixStopCommand = "/sbin/shutdown";
+            const string unixStopArgs = "-P now";
             
-            string const macOSStopCommand = "osascript";
-            string const macOSStopArgs = @"-e 'tell application ""System Events"" to shut down'";
+            const string macOSStopCommand = "osascript";
+            const string macOSStopArgs = @"-e 'tell application ""System Events"" to shut down'";
 
-            string const macOSForceStopCommand = "/sbin/shutdown";
-            string const macOSForceStopArgs = "-h now";            
+            const string macOSForceStopCommand = "/sbin/shutdown";
+            const string macOSForceStopArgs = "-h now";            
 
             string command;
             string args;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Run a command.
         /// </summary>
-        protected void RunCommand(String command = "/sbin/shutdown", String args = "") {
+        protected void RunCommand(string command, string args) {
             _process = new Process()
             {
                 StartInfo = new ProcessStartInfo

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; } = false;
+        public SwitchParameter Force { get; set; };
 
 #endregion "Parameters"
 
@@ -39,14 +39,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            string unixRestartCommand = "/sbin/shutdown";
-            string unixRestartArgs = "-r now";
+            string const unixRestartCommand = "/sbin/shutdown";
+            string const unixRestartArgs = "-r now";
             
-            string macOSRestartCommand = "osascript";
-            string macOSRestartArgs = @"-e 'tell application ""System Events"" to restart'";
+            string const macOSRestartCommand = "osascript";
+            string const macOSRestartArgs = @"-e 'tell application ""System Events"" to restart'";
 
-            string macOSForceRestartCommand = "/sbin/shutdown";
-            string macOSForceRestartArgs = "-r now";            
+            string const macOSForceRestartCommand = "/sbin/shutdown";
+            string const macOSForceRestartArgs = "-r now";            
 
             string command;
             string args;
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; } = false;
+        public SwitchParameter Force { get; set; };
 
 #endregion "Parameters"
         
@@ -117,14 +117,14 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
 
-            string unixStopCommand = "/sbin/shutdown";
-            string unixStopArgs = "-P now";
+            string const unixStopCommand = "/sbin/shutdown";
+            string const unixStopArgs = "-P now";
             
-            string macOSStopCommand = "osascript";
-            string macOSStopArgs = @"-e 'tell application ""System Events"" to shut down'";
+            string const macOSStopCommand = "osascript";
+            string const macOSStopArgs = @"-e 'tell application ""System Events"" to shut down'";
 
-            string macOSForceStopCommand = "/sbin/shutdown";
-            string macOSForceStopArgs = "-h now";            
+            string const macOSForceStopCommand = "/sbin/shutdown";
+            string const macOSForceStopArgs = "-h now";            
 
             string command;
             string args;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -21,6 +21,16 @@ namespace Microsoft.PowerShell.Commands
     public sealed class RestartComputerCommand : CommandLineCmdletBase
     {
         // TODO: Support remote computers?
+        
+#region "Parameters"
+
+        /// <summary>
+        /// Force the operation to take place if possible.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Force { get; set; } = false;
+
+#endregion "Parameters"
 
 #region "Overrides"
 
@@ -29,6 +39,36 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
+            string unixRestartCommand = "/sbin/shutdown";
+            string unixRestartArgs = "-r now";
+            
+            string macOSRestartCommand = "osascript";
+            string macOSRestartArgs = @"-e 'tell application ""System Events"" to restart'";
+
+            string macOSForceRestartCommand = "/sbin/shutdown";
+            string macOSForceRestartArgs = "-r now";            
+
+            string command;
+            string args;
+
+            if (Platform.IsMacOS)
+            {
+                if (Force.IsPresent)
+                {
+                    command = macOSForceRestartCommand;
+                    args = macOSForceRestartArgs;
+                } 
+                else 
+                {
+                    command = macOSRestartCommand;
+                    args = macOSRestartArgs;  
+                }
+            } 
+            else {
+                command = unixRestartCommand;
+                args = unixRestartArgs;
+            }
+            
             if (InternalTestHooks.TestStopComputer)
             {
                 var retVal = InternalTestHooks.TestStopComputerResults;
@@ -42,7 +82,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            RunCommand("/sbin/shutdown", "-r now");
+            RunCommand(command, args);
         }
 #endregion "Overrides"
     }
@@ -58,7 +98,17 @@ namespace Microsoft.PowerShell.Commands
     public sealed class StopComputerCommand : CommandLineCmdletBase
     {
         // TODO: Support remote computers?
+        
+#region "Parameters"
 
+        /// <summary>
+        /// Force the operation to take place if possible.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Force { get; set; } = false;
+
+#endregion "Parameters"
+        
 #region "Overrides"
 
         /// <summary>
@@ -66,11 +116,38 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            var args = "-P now";
+
+            string unixStopCommand = "/sbin/shutdown";
+            string unixStopArgs = "-P now";
+            
+            string macOSStopCommand = "osascript";
+            string macOSStopArgs = @"-e 'tell application ""System Events"" to shut down'";
+
+            string macOSForceStopCommand = "/sbin/shutdown";
+            string macOSForceStopArgs = "-h now";            
+
+            string command;
+            string args;
+            
             if (Platform.IsMacOS)
             {
-                args = "-h now";
+                if (Force.IsPresent)
+                {
+                    command = macOSForceStopCommand;
+                    args = macOSForceStopArgs;
+                } 
+                else
+                {
+                    command = macOSStopCommand;
+                    args = macOSStopArgs;
+                }
             }
+            else
+            {
+                command = unixStopCommand;
+                args = unixStopArgs;
+            }
+            
             if (InternalTestHooks.TestStopComputer)
             {
                 var retVal = InternalTestHooks.TestStopComputerResults;
@@ -84,7 +161,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            RunCommand("/sbin/shutdown", args);
+            RunCommand(command, args);
         }
 #endregion "Overrides"
     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -153,13 +153,13 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Run a command.
         /// </summary>
-        protected void RunCommand(String command, String args) {
+        protected void RunCommand(String command = "/sbin/shutdown", String args = string.Empty) {
             _process = new Process()
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "/sbin/shutdown",
-                    Arguments = string.Empty,
+                    FileName = command,
+                    Arguments = args,
                     RedirectStandardOutput = false,
                     UseShellExecute = false,
                     CreateNoWindow = true,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; };
+        public SwitchParameter Force { get; set; } = false;
 
 #endregion "Parameters"
 
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; };
+        public SwitchParameter Force { get; set; } = false;
 
 #endregion "Parameters"
         

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Run a command.
         /// </summary>
-        protected void RunCommand(String command = "/sbin/shutdown", String args = string.Empty) {
+        protected void RunCommand(String command = "/sbin/shutdown", String args = "") {
             _process = new Process()
             {
                 StartInfo = new ProcessStartInfo

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; };
+        public SwitchParameter Force { get; set; }
 
 #endregion "Parameters"
 
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
         /// Force the operation to take place if possible.
         /// </summary>
         [Parameter]
-        public SwitchParameter Force { get; set; };
+        public SwitchParameter Force { get; set; }
 
 #endregion "Parameters"
         


### PR DESCRIPTION
Fix `Restart-Computer` on Linux and `Stop-Computer` on MacOS by modifying `RunCommand` to respect `command` and `args` inputs.

# PR Summary

Fix `Restart-Computer` on Linux systems and `Stop-Computer` on MacOS systems.  

See issues [#14684](https://github.com/PowerShell/PowerShell/issues/14684) and [#19738](https://github.com/PowerShell/PowerShell/issues/19738)

Made minimal changes necessary to correct behavior.

I am new at contributing to projects and have not done a build or testing.  Perhaps someone in the Community or on the PowerShell team can validate functionality.

## PR Context

`Restart-Computer` on Linux has been shutting down systems instead of restarting them.. 
`Stop-Computer` on MacOS has been incorrectly throwing errors due to missing arguments.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
