### PR TITLE
Add additional platform check for Windows before launching native app.

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1691,8 +1691,11 @@ namespace System.Management.Automation
 
             if (_runStandAlone)
             {
-                if (s_supportScreenScrape == null && Platform.IsWindows)
+                if (s_supportScreenScrape == null)
                 {
+#if UNIX
+                    s_supportScreenScrape = false;
+#else
                     try
                     {
                         _startPosition = this.Command.Context.EngineHostInterface.UI.RawUI.CursorPosition;
@@ -1704,6 +1707,7 @@ namespace System.Management.Automation
                     {
                         s_supportScreenScrape = false;
                     }
+#endif
                 }
 
                 // if screen scraping isn't supported, we enable redirection so that the output is still transcribed

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1691,7 +1691,7 @@ namespace System.Management.Automation
 
             if (_runStandAlone)
             {
-                if (s_supportScreenScrape == null)
+                if (s_supportScreenScrape == null && Platform.IsWindows)
                 {
                     try
                     {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -366,3 +366,28 @@ Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "
         $result | Should -BeExactly $expected
     }
 }
+
+Describe "Native application invocation and getting cursor position" -Tags 'CI' {
+    It "Invoking a native application should not collect the cursor position" -Skip:($IsWindows) {
+        $expectCmd = Get-Command expect -Type Application -ErrorAction Ignore
+        $dateCmd = Get-Command date -Type Application -ErrorAction Ignore
+        # if date or expect are missing mark the test as pending
+        # test setup will need to ensure that these programs are present.
+        $missing = @()
+        if ($null -eq $expectCmd) {
+            $missing += "expect"
+        }
+        if ($null -eq $dateCmd) {
+            $missing += "date"
+        }
+        if ($missing.count -ne 0) {
+            $message = "missing command(s) {0}" -f ($missing -join ", ")
+            Set-ItResult -Pending $message
+        }
+
+        $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
+        $commandString = "spawn $powershell -nopro -c /bin/date; expect eof"
+        [string]$result = expect -c $commandString
+        $result.IndexOf("`e[6n") | Should -Be -1 -Because $result.replace("`e","``e").replace("`u{7}","<BELL>")
+    }
+}

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -382,7 +382,7 @@ Describe "Native application invocation and getting cursor position" -Tags 'CI' 
         }
         if ($missing.count -ne 0) {
             $message = "missing command(s) {0}" -f ($missing -join ", ")
-            Set-ItResult -Pending $message
+            Set-ItResult -Pending -Because $message
         }
 
         $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"


### PR DESCRIPTION
## PR Summary

Fix #18874

This change ensures that we do not get the cursor position in preparation for the BufferCell call since it is only supported on Windows. On non-Windows machines this might also cause problems for applications such as `expect` in which pwsh runs in a session connected by a pty. This change should address the misbehavior described in issue #18874.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
