### PR TITLE
Computer cmdlets should fail with error when not run via sudo on Unix

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -175,7 +175,6 @@ namespace Microsoft.PowerShell.Commands
                     ErrorRecord error = new ErrorRecord(
                         new InvalidOperationException(ComputerResources.ShutdownCommandNotFound), "CommandNotFound", ErrorCategory.ObjectNotFound, targetObject: null);
                     ThrowTerminatingError(error);
-                    return;
                 }
             }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -161,11 +161,21 @@ namespace Microsoft.PowerShell.Commands
                     FileName = "/sbin/shutdown",
                     Arguments = string.Empty,
                     RedirectStandardOutput = false,
+                    RedirectStandardError = true,
                     UseShellExecute = false,
                     CreateNoWindow = true,
                 }
             };
             _process.Start();
+            _process.WaitForExit();
+            if (_process.ExitCode != 0)
+            {
+                string stderr = _process.StandardError.ReadToEnd();
+                string errMsg = StringUtil.Format("Command returned 0x{0:X}: {1}", _process.ExitCode, stderr);
+                ErrorRecord error = new ErrorRecord(
+                    new InvalidOperationException(errMsg), "CommandFailed", ErrorCategory.OperationStopped, null);
+                WriteError(error);
+            }
         }
 #endregion
     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     ErrorRecord error = new ErrorRecord(
                         new InvalidOperationException(ComputerResources.ShutdownCommandNotFound), "CommandNotFound", ErrorCategory.ObjectNotFound, targetObject: null);
-                    WriteError(error);
+                    ThrowTerminatingError(error);
                     return;
                 }
             }
@@ -196,10 +196,9 @@ namespace Microsoft.PowerShell.Commands
             if (_process.ExitCode != 0)
             {
                 string stderr = _process.StandardError.ReadToEnd();
-                string errMsg = StringUtil.Format(ComputerResources.CommandFailed, _process.ExitCode, stderr);
                 ErrorRecord error = new ErrorRecord(
-                    new InvalidOperationException(errMsg), "CommandFailed", ErrorCategory.OperationStopped, null);
-                WriteError(error);
+                    new InvalidOperationException(stderr), "CommandFailed", ErrorCategory.OperationStopped, null);
+                ThrowTerminatingError(error);
             }
         }
 #endregion

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -158,7 +158,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Run shutdown command.
         /// </summary>
-        protected void RunShutdown(String args) {
+        protected void RunShutdown(String args)
+        {
             if (shutdownPath is null)
             {
                 CommandInfo cmdinfo = CommandDiscovery.LookupCommandInfo(

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -152,7 +152,7 @@ namespace Microsoft.PowerShell.Commands
 #region "Internals"
 
         /// <summary>
-        /// Run shutdown command
+        /// Run shutdown command.
         /// </summary>
         protected void RunShutdown(String args) {
             string shutdownPath = "/sbin/shutdown";

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -151,12 +151,13 @@ namespace Microsoft.PowerShell.Commands
 
 #region "Internals"
 
+        private static string shutdownPath = "/usr/sbin/shutdown";
+
         /// <summary>
         /// Run shutdown command.
         /// </summary>
         protected void RunShutdown(String args) {
-            string shutdownPath = "/sbin/shutdown";
-            const string altShutdownPath = "/usr/sbin/shutdown";
+            const string altShutdownPath = "/sbin/shutdown";
 
             if (!File.Exists(shutdownPath) && File.Exists(altShutdownPath))
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            RunCommand("/sbin/shutdown", "-r now");
+            RunShutdown("-r now");
         }
 #endregion "Overrides"
     }
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            RunCommand("/sbin/shutdown", args);
+            RunShutdown(args);
         }
 #endregion "Overrides"
     }
@@ -152,9 +152,9 @@ namespace Microsoft.PowerShell.Commands
 #region "Internals"
 
         /// <summary>
-        /// Run a command.
+        /// Run shutdown command
         /// </summary>
-        protected void RunCommand(String command, String args) {
+        protected void RunShutdown(String args) {
             string shutdownPath = "/sbin/shutdown";
             const string altShutdownPath = "/usr/sbin/shutdown";
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.Commands
             else
             {
                 ErrorRecord error = new ErrorRecord(
-                    new InvalidOperationException(ComputerResources.ShutdownCommandNotFound), "CommandNotFound", ErrorCategory.ObjectNotFound, null);
+                    new InvalidOperationException(ComputerResources.ShutdownCommandNotFound), "CommandNotFound", ErrorCategory.ObjectNotFound, targetObject: null);
                 WriteError(error);
                 return;
             }

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
@@ -391,6 +391,6 @@
     <value>Command failed with exit code {0}: {1}</value>
   </data>
   <data name="ShutdownCommandNotFound" xml:space="preserve">
-    <value>'shutdown' command was not found and required.</value>
+    <value>Required 'shutdown' command was not found.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
@@ -387,9 +387,6 @@
   <data name="InvalidParameterForCoreClr" xml:space="preserve">
     <value>The {0} parameter is not supported for CoreCLR.</value>
   </data>
-  <data name="CommandFailed" xml:space="preserve">
-    <value>Command failed with exit code {0}: {1}</value>
-  </data>
   <data name="ShutdownCommandNotFound" xml:space="preserve">
     <value>The required native command 'shutdown' was not found.</value>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
@@ -391,6 +391,6 @@
     <value>Command failed with exit code {0}: {1}</value>
   </data>
   <data name="ShutdownCommandNotFound" xml:space="preserve">
-    <value>Required 'shutdown' command was not found.</value>
+    <value>The required native command 'shutdown' was not found.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
@@ -387,4 +387,10 @@
   <data name="InvalidParameterForCoreClr" xml:space="preserve">
     <value>The {0} parameter is not supported for CoreCLR.</value>
   </data>
+  <data name="CommandFailed" xml:space="preserve">
+    <value>Command failed with exit code {0}: {1}</value>
+  </data>
+  <data name="ShutdownCommandNotFound" xml:space="preserve">
+    <value>'shutdown' command was not found and required.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -164,9 +164,6 @@ End time: {0:yyyyMMddHHmmss}
   <data name="DebuggerSourceCodeFormat" xml:space="preserve">
     <value>{0}:{1,-3} {2}</value>
   </data>
-  <data name="CommandFailed" xml:space="preserve">
-    <value>An error occurred while running '{0}': {1}</value>
-  </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
 The current session does not support debugging; execution will continue.

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -124,6 +124,6 @@ Describe 'Non-admin on Unix' {
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
         $error.Clear()
-        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand" -Because (Get-Error)
+        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand" -Because (Get-Error | Out-String)
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -110,6 +110,6 @@ finally
 
 Describe 'Non-admin on Unix' {
     It 'Reports error if not run under sudo' -Skip:($IsWindows) {
-        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand"
+        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand" -Because (Get-Error | Out-String)
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -116,13 +116,9 @@ Describe 'Non-admin on Unix' {
         else {
             $IsWindowsOrSudo = $false
         }
-
-        $shutdown = Get-Command shutdown -ErrorAction Ignore
-        Write-Verbose "shutdown: $($shutdown.path)" -Verbose
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
-        $error.Clear()
-        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand" -Because (Get-Error | Out-String)
+        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -109,7 +109,16 @@ finally
 }
 
 Describe 'Non-admin on Unix' {
-    It 'Reports error if not run under sudo' -Skip:($IsWindows) {
-        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand" -Because (Get-Error | Out-String)
+    BeforeAll {
+        if ($IsWindows -or (id -u) -eq 0) {
+            $IsWindowsOrSudo = $true
+        }
+        else {
+            $IsWindowsOrSudo = $false
+        }
+    }
+
+    It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
+        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -107,3 +107,9 @@ finally
     Disable-Testhook -testhookName $restartTesthookName
     Set-TesthookResult -testhookName $restartTesthookResultName -value 0
 }
+
+Describe 'Non-admin on Unix' {
+    It 'Reports error if not run under sudo' -Skip:($IsWindows) {
+        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand"
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -116,6 +116,9 @@ Describe 'Non-admin on Unix' {
         else {
             $IsWindowsOrSudo = $false
         }
+
+        $shutdown = Get-Command shutdown -ErrorAction Ignore
+        Write-Verbose "shutdown: $shutdown" -Verbose
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -116,6 +116,8 @@ Describe 'Non-admin on Unix' {
         else {
             $IsWindowsOrSudo = $false
         }
+
+        Write-Verbose -Verbose "IsWindowsOrSudo: $IsWindowsOrSudo"
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -123,6 +123,7 @@ Describe 'Non-admin on Unix' {
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
+        $error.Clear()
         { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand" -Because (Get-Error)
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -123,6 +123,6 @@ Describe 'Non-admin on Unix' {
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
-        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand"
+        { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand" -Because (Get-Error)
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -110,7 +110,7 @@ finally
 
 Describe 'Non-admin on Unix' {
     BeforeAll {
-        if ($IsWindows -or (id -g) -eq 0) {
+        if ([environment]::IsPrivilegedProcess) {
             $IsWindowsOrSudo = $true
         }
         else {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -110,13 +110,15 @@ finally
 
 Describe 'Non-admin on Unix' {
     BeforeAll {
-        if ($IsWindows -or (id -u) -eq 0) {
+        if ($IsWindows -or (id -g) -eq 0) {
             $IsWindowsOrSudo = $true
         }
         else {
             $IsWindowsOrSudo = $false
         }
 
+        Write-Verbose -Verbose "user id: $(id -u)"
+        Write-Verbose -Verbose "group id: $(id -g)"
         Write-Verbose -Verbose "IsWindowsOrSudo: $IsWindowsOrSudo"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -118,7 +118,7 @@ Describe 'Non-admin on Unix' {
         }
 
         $shutdown = Get-Command shutdown -ErrorAction Ignore
-        Write-Verbose "shutdown: $shutdown" -Verbose
+        Write-Verbose "shutdown: $($shutdown.path)" -Verbose
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -116,10 +116,6 @@ Describe 'Non-admin on Unix' {
         else {
             $IsWindowsOrSudo = $false
         }
-
-        Write-Verbose -Verbose "user id: $(id -u)"
-        Write-Verbose -Verbose "group id: $(id -g)"
-        Write-Verbose -Verbose "IsWindowsOrSudo: $IsWindowsOrSudo"
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -116,6 +116,8 @@ Describe 'Non-admin on Unix' {
         else {
             $IsWindowsOrSudo = $false
         }
+
+        Write-Verbose -Verbose (Get-Command shutdown | Format-List | Out-String)
     }
 
     It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -110,17 +110,13 @@ finally
 
 Describe 'Non-admin on Unix' {
     BeforeAll {
-        if ([environment]::IsPrivilegedProcess) {
-            $IsWindowsOrSudo = $true
+        $skip = $false
+        if ($IsWindows -or [environment]::IsPrivilegedProcess -or ($null -eq (Get-Command shutdown -CommandType Application -ErrorAction Ignore))) {
+            $skip = $true
         }
-        else {
-            $IsWindowsOrSudo = $false
-        }
-
-        Write-Verbose -Verbose (Get-Command shutdown | Format-List | Out-String)
     }
 
-    It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
+    It 'Reports error if not run under sudo' -Skip:($skip) {
         { Restart-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.RestartComputerCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -60,7 +60,16 @@ finally
 }
 
 Describe 'Non-admin on Unix' {
-    It 'Reports error if not run under sudo' -Skip:($IsWindows) {
+    BeforeAll {
+        if ($IsWindows -or (id -g) -eq 0) {
+            $IsWindowsOrSudo = $true
+        }
+        else {
+            $IsWindowsOrSudo = $false
+        }
+    }
+
+    It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
         { Stop-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.StopComputerCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -61,12 +61,11 @@ finally
 
 Describe 'Non-admin on Unix' {
     BeforeAll {
-        BeforeAll {
-            $skip = $false
-            if ($IsWindows -or [environment]::IsPrivilegedProcess -or ($null -eq (Get-Command shutdown -CommandType Application -ErrorAction Ignore))) {
-                $skip = $true
-            }
+        $skip = $false
+        if ($IsWindows -or [environment]::IsPrivilegedProcess -or ($null -eq (Get-Command shutdown -CommandType Application -ErrorAction Ignore))) {
+            $skip = $true
         }
+    }
 
     It 'Reports error if not run under sudo' -Skip:($skip) {
         { Stop-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.StopComputerCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -61,15 +61,14 @@ finally
 
 Describe 'Non-admin on Unix' {
     BeforeAll {
-        if ([environment]::IsPrivilegedProcess) {
-            $IsWindowsOrSudo = $true
+        BeforeAll {
+            $skip = $false
+            if ($IsWindows -or [environment]::IsPrivilegedProcess -or ($null -eq (Get-Command shutdown -CommandType Application -ErrorAction Ignore))) {
+                $skip = $true
+            }
         }
-        else {
-            $IsWindowsOrSudo = $false
-        }
-    }
 
-    It 'Reports error if not run under sudo' -Skip:($IsWindowsOrSudo) {
+    It 'Reports error if not run under sudo' -Skip:($skip) {
         { Stop-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.StopComputerCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -61,7 +61,7 @@ finally
 
 Describe 'Non-admin on Unix' {
     BeforeAll {
-        if ($IsWindows -or (id -g) -eq 0) {
+        if ([environment]::IsPrivilegedProcess) {
             $IsWindowsOrSudo = $true
         }
         else {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -58,3 +58,9 @@ finally
     Disable-Testhook -testhookName $stopTesthook
     Set-TesthookResult -testhookName $stopTesthookResultName -Value $DefaultResultValue
 }
+
+Describe 'Non-admin on Unix' {
+    It 'Reports error if not run under sudo' -Skip:($IsWindows) {
+        { Stop-Computer -ErrorAction Stop } | Should -Throw -ErrorId "CommandFailed,Microsoft.PowerShell.Commands.StopComputerCommand"
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Computer cmdlets rely on `shutdown` command to work and doesn't have error handling when it fails so when run without root permissions it silently fails.  Change is to check the exit code and emit the stderr message.  Also changed to use CommandDiscovery to find `shutdown` instead of a hardcoded path.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/19802

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
