### PR TITLE
Add even more debugging to try to determine why these test fail in release build.

### DIFF
--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -45,7 +45,11 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
             else {
                 Write-Verbose "LocalSourceCheck is null"
             }
-            Get-ChildItem "$HOME/.config" -Recurse -File | out-string -str | Write-Verbose -Verbose
+
+            if (-not $IsWindows) {
+                Get-ChildItem "$HOME/.config" -Recurse -File | out-string -str | Write-Verbose -Verbose
+            }
+
             $skipPackageTests = $true
         }
 

--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -22,12 +22,30 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
         # register the asset directory
         $localSourceName = [Guid]::NewGuid().ToString("n")
         $localSourceLocation = Join-Path $PSScriptRoot assets
-        $newSourceResult = Register-PackageSource -Name $localSourceName -provider NuGet -Location $localSourceLocation -Force -Trusted
+        $newSourceResult = Register-PackageSource -Name $localSourceName -provider NuGet -Location $localSourceLocation -Force -Trusted -Verbose
         Write-Verbose -Verbose -Message "Register-PackageSource -Name $localSourceName -provider NuGet -Location $localSourceLocation -Force -Trusted"
         $newSourceResult | Out-String -Stream | Write-Verbose -Verbose
+        $localSourceCheck = Get-PackageSource -Name $localSourceName -ErrorAction Ignore
 
         $skipPackageTests = $false
-        if ($newSourceResult.Location -ne $localSourceLocation) {
+        # It is possible that Register-PackageSource appears to succeed but the source is not actually registered
+        # collect as much information as possible to help diagnose the problem
+        if (($newSourceResult.Location -ne $localSourceLocation) -or ($localSourceCheck.Location -ne $localSourceLocation)) {
+            Write-Verbose -Verbose "Skipping tests because local source could not be correctly created"
+            if ( $newSourceResult ) {
+                $newSourceResult | out-string -str | Write-Verbose -Verbose
+            }
+            else {
+                Write-Verbose "newSourceResult is null"
+            }
+
+            if ( $localSourceCheck ) {
+                $localSourceCheck | out-string -str | Write-Verbose -Verbose
+            }
+            else {
+                Write-Verbose "LocalSourceCheck is null"
+            }
+            Get-ChildItem "$HOME/.config" -Recurse -File | out-string -str | Write-Verbose -Verbose
             $skipPackageTests = $true
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

During release build a set of tests are failing on Ubuntu18 (and Ubuntu18Tar).
This adds additional checks and data gathering code as well as marks tests pending if the local
PackageSource cannot be created.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
