### PR TITLE
Remove unused string completion code

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -387,7 +387,7 @@ namespace System.Management.Automation
                     completionContext.ExecutionContext.LanguageMode = PSLanguageMode.ConstrainedLanguage;
                 }
 
-                return GetResultHelper(completionContext, out replacementIndex, out replacementLength, false);
+                return GetResultHelper(completionContext, out replacementIndex, out replacementLength);
             }
             finally
             {
@@ -398,7 +398,7 @@ namespace System.Management.Automation
             }
         }
 
-        internal List<CompletionResult> GetResultHelper(CompletionContext completionContext, out int replacementIndex, out int replacementLength, bool isQuotedString)
+        internal List<CompletionResult> GetResultHelper(CompletionContext completionContext, out int replacementIndex, out int replacementLength)
         {
             replacementIndex = -1;
             replacementLength = -1;
@@ -434,16 +434,12 @@ namespace System.Management.Automation
                                 return result;
                             }
 
-                            result = GetResultForIdentifier(completionContext, ref replacementIndex, ref replacementLength, isQuotedString);
+                            result = GetResultForIdentifier(completionContext, ref replacementIndex, ref replacementLength);
                         }
 
                         break;
 
                     case TokenKind.Parameter:
-                        // When it's the content of a quoted string, we only handle variable/member completion
-                        if (isQuotedString)
-                            break;
-
                         completionContext.WordToComplete = tokenAtCursor.Text;
                         var cmdAst = lastAst.Parent as CommandAst;
                         if (lastAst is StringConstantExpressionAst && cmdAst != null && cmdAst.CommandElements.Count == 1)
@@ -491,10 +487,6 @@ namespace System.Management.Automation
                         break;
 
                     case TokenKind.Comment:
-                        // When it's the content of a quoted string, we only handle variable/member completion
-                        if (isQuotedString)
-                            break;
-
                         completionContext.WordToComplete = tokenAtCursor.Text;
                         result = CompletionCompleters.CompleteComment(completionContext, ref replacementIndex, ref replacementLength);
                         break;
@@ -527,7 +519,7 @@ namespace System.Management.Automation
                             return CompletionCompleters.CompleteIndexExpression(completionContext, indexExpressionAst.Target);
                         }
 
-                        result = GetResultForString(completionContext, ref replacementIndex, ref replacementLength, isQuotedString);
+                        result = GetResultForString(completionContext, ref replacementIndex, ref replacementLength);
                         break;
 
                     case TokenKind.RBracket:
@@ -839,8 +831,7 @@ namespace System.Management.Automation
 
                 bool skipAutoCompleteForCommandCall = isCursorLineEmpty && !isLineContinuationBeforeCursor;
                 bool lastAstIsExpressionAst = lastAst is ExpressionAst;
-                if (!isQuotedString &&
-                    !skipAutoCompleteForCommandCall &&
+                if (!skipAutoCompleteForCommandCall &&
                     (lastAst is CommandParameterAst || lastAst is CommandAst ||
                     (lastAstIsExpressionAst && lastAst.Parent is CommandAst) ||
                     (lastAstIsExpressionAst && lastAst.Parent is CommandParameterAst) ||
@@ -879,7 +870,7 @@ namespace System.Management.Automation
                         replacementLength = completionContext.ReplacementLength;
                     }
                 }
-                else if (!isQuotedString)
+                else
                 {
                     //
                     // Handle completion of empty line within configuration statement
@@ -1778,111 +1769,50 @@ namespace System.Management.Automation
             return result;
         }
 
-        private List<CompletionResult> GetResultForString(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
+        private static List<CompletionResult> GetResultForString(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength)
         {
-            // When it's the content of a quoted string, we only handle variable/member completion
-            if (isQuotedString) { return null; }
-
-            var tokenAtCursor = completionContext.TokenAtCursor;
             var lastAst = completionContext.RelatedAsts.Last();
-
-            List<CompletionResult> result = null;
             var expandableString = lastAst as ExpandableStringExpressionAst;
             var constantString = lastAst as StringConstantExpressionAst;
             if (constantString == null && expandableString == null) { return null; }
 
             string strValue = constantString != null ? constantString.Value : expandableString.Value;
-            StringConstantType strType = constantString != null ? constantString.StringConstantType : expandableString.StringConstantType;
-            string subInput = null;
 
             bool shouldContinue;
-            result = GetResultForEnumPropertyValueOfDSCResource(completionContext, strValue, ref replacementIndex, ref replacementLength, out shouldContinue);
+            List<CompletionResult> result = GetResultForEnumPropertyValueOfDSCResource(completionContext, strValue, ref replacementIndex, ref replacementLength, out shouldContinue);
             if (!shouldContinue || (result != null && result.Count > 0))
             {
                 return result;
             }
 
-            if (strType == StringConstantType.DoubleQuoted)
+            var commandElementAst = lastAst as CommandElementAst;
+            string wordToComplete =
+                CompletionCompleters.ConcatenateStringPathArguments(commandElementAst, string.Empty, completionContext);
+
+            if (wordToComplete != null)
             {
-                var match = Regex.Match(strValue, @"(\$[\w\d]+\.[\w\d\*]*)$");
-                if (match.Success)
+                completionContext.WordToComplete = wordToComplete;
+
+                // Handle scenarios like this: cd 'c:\windows\win'<tab>
+                if (lastAst.Parent is CommandAst || lastAst.Parent is CommandParameterAst)
                 {
-                    subInput = match.Groups[1].Value;
+                    result = CompletionCompleters.CompleteCommandArgument(completionContext);
+                    replacementIndex = completionContext.ReplacementIndex;
+                    replacementLength = completionContext.ReplacementLength;
                 }
-                else if ((match = Regex.Match(strValue, @"(\[[\w\d\.]+\]::[\w\d\*]*)$")).Success)
+                // Handle scenarios like this: "c:\wind"<tab>. Treat the StringLiteral/StringExpandable as path/command
+                else
                 {
-                    subInput = match.Groups[1].Value;
-                }
-            }
+                    // Handle path/commandname completion for quoted string
+                    result = new List<CompletionResult>(CompletionCompleters.CompleteFilename(completionContext));
 
-            // Handle variable/member completion
-            if (subInput != null)
-            {
-                int stringStartIndex = tokenAtCursor.Extent.StartScriptPosition.Offset;
-                int cursorIndexInString = _cursorPosition.Offset - stringStartIndex - 1;
-                if (cursorIndexInString >= strValue.Length)
-                    cursorIndexInString = strValue.Length;
-
-                var analysis = new CompletionAnalysis(_ast, _tokens, _cursorPosition, _options);
-                var subContext = analysis.CreateCompletionContext(completionContext.TypeInferenceContext);
-
-                var subResult = analysis.GetResultHelper(subContext, out int subReplaceIndex, out _, true);
-
-                if (subResult != null && subResult.Count > 0)
-                {
-                    result = new List<CompletionResult>();
-                    replacementIndex = stringStartIndex + 1 + (cursorIndexInString - subInput.Length);
-                    replacementLength = subInput.Length;
-                    ReadOnlySpan<char> prefix = subInput.AsSpan(0, subReplaceIndex);
-
-                    foreach (CompletionResult entry in subResult)
+                    // Try command name completion only if the text contains '-'
+                    if (wordToComplete.Contains('-'))
                     {
-                        string completionText = string.Concat(prefix, entry.CompletionText.AsSpan());
-                        if (entry.ResultType == CompletionResultType.Property)
+                        var commandNameResult = CompletionCompleters.CompleteCommand(completionContext);
+                        if (commandNameResult != null && commandNameResult.Count > 0)
                         {
-                            completionText = TokenKind.DollarParen.Text() + completionText + TokenKind.RParen.Text();
-                        }
-                        else if (entry.ResultType == CompletionResultType.Method)
-                        {
-                            completionText = TokenKind.DollarParen.Text() + completionText;
-                        }
-
-                        completionText += "\"";
-                        result.Add(new CompletionResult(completionText, entry.ListItemText, entry.ResultType, entry.ToolTip));
-                    }
-                }
-            }
-            else
-            {
-                var commandElementAst = lastAst as CommandElementAst;
-                string wordToComplete =
-                    CompletionCompleters.ConcatenateStringPathArguments(commandElementAst, string.Empty, completionContext);
-
-                if (wordToComplete != null)
-                {
-                    completionContext.WordToComplete = wordToComplete;
-
-                    // Handle scenarios like this: cd 'c:\windows\win'<tab>
-                    if (lastAst.Parent is CommandAst || lastAst.Parent is CommandParameterAst)
-                    {
-                        result = CompletionCompleters.CompleteCommandArgument(completionContext);
-                        replacementIndex = completionContext.ReplacementIndex;
-                        replacementLength = completionContext.ReplacementLength;
-                    }
-                    // Handle scenarios like this: "c:\wind"<tab>. Treat the StringLiteral/StringExpandable as path/command
-                    else
-                    {
-                        // Handle path/commandname completion for quoted string
-                        result = new List<CompletionResult>(CompletionCompleters.CompleteFilename(completionContext));
-
-                        // Try command name completion only if the text contains '-'
-                        if (wordToComplete.Contains('-'))
-                        {
-                            var commandNameResult = CompletionCompleters.CompleteCommand(completionContext);
-                            if (commandNameResult != null && commandNameResult.Count > 0)
-                            {
-                                result.AddRange(commandNameResult);
-                            }
+                            result.AddRange(commandNameResult);
                         }
                     }
                 }
@@ -2000,7 +1930,7 @@ namespace System.Management.Automation
             return results;
         }
 
-        private static List<CompletionResult> GetResultForIdentifier(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength, bool isQuotedString)
+        private static List<CompletionResult> GetResultForIdentifier(CompletionContext completionContext, ref int replacementIndex, ref int replacementLength)
         {
             List<CompletionResult> result = null;
             var tokenAtCursor = completionContext.TokenAtCursor;
@@ -2148,9 +2078,6 @@ namespace System.Management.Automation
                     }
                 }
 
-                // When it's the content of a quoted string, we only handle variable/member completion
-                if (isQuotedString) { return result; }
-
                 // Handle the StringExpandableToken;
                 var strToken = tokenAtCursor as StringExpandableToken;
                 if (strToken != null && strToken.NestedTokens != null && strConst != null)
@@ -2220,8 +2147,6 @@ namespace System.Management.Automation
                 // When it's the content of a quoted string, we only handle variable/member completion
                 if (isSingleDash)
                 {
-                    if (isQuotedString) { return result; }
-
                     var res = CompletionCompleters.CompleteCommandParameter(completionContext);
                     if (res.Count != 0)
                     {
@@ -2326,9 +2251,6 @@ namespace System.Management.Automation
                     return result;
                 }
             }
-
-            // When it's the content of a quoted string, we only handle variable/member completion
-            if (isQuotedString) { return result; }
 
             bool needFileCompletion = false;
             if (lastAst.Parent is FileRedirectionAst || CompleteAgainstSwitchFile(lastAst, completionContext.TokenBeforeCursor))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Removes unused code for completing members in double quoted strings.
The idea seems to have been that users would have been able to enter a variable, or literal type in a double quoted string and tab complete the member to auto convert it into a subexpression like this:
```
"Hello$MyVar.<Tab> -> "Hello$($MyVar.MyMember)
"Hello[string]::<Tab> -> "Hello$([string]::Empty)
```
But the actual code isn't working.  
An obvious alternative to removing the code would be to fix it but I've never seen anyone request this and it doesn't seem very useful to me.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [X] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
