### PR TITLE
Fix deadlock when piping to shell associated file extension

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -70,7 +70,6 @@ namespace System.Management.Automation
         internal static MinishellStream ToMinishellStream(string stream)
         {
             Dbg.Assert(stream != null, "caller should validate the parameter");
-
             MinishellStream ms = MinishellStream.Unknown;
             if (OutputStream.Equals(stream, StringComparison.OrdinalIgnoreCase))
             {
@@ -134,7 +133,7 @@ namespace System.Management.Automation
         }
     }
 
-    #nullable enable
+#nullable enable
     /// <summary>
     /// This exception is used by the NativeCommandProcessor to indicate an error
     /// when a native command returns a non-zero exit code.
@@ -188,7 +187,7 @@ namespace System.Management.Automation
         public int ProcessId { get; }
 
     }
-    #nullable restore
+#nullable restore
 
     /// <summary>
     /// Provides way to create and execute native commands.
@@ -605,19 +604,6 @@ namespace System.Management.Automation
                     {
                         _nativeProcess = new Process() { StartInfo = startInfo };
                         _nativeProcess.Start();
-                        if (UpstreamIsNativeCommand)
-                        {
-                            SemaphoreSlim processInitialized = _processInitialized;
-                            if (processInitialized is null)
-                            {
-                                lock (_sync)
-                                {
-                                    processInitialized = _processInitialized ??= new SemaphoreSlim(0, 1);
-                                }
-                            }
-
-                            processInitialized?.Release();
-                        }
                     }
                     catch (Win32Exception)
                     {
@@ -696,6 +682,20 @@ namespace System.Management.Automation
                         }
 #endif
                     }
+                }
+
+                if (UpstreamIsNativeCommand)
+                {
+                    SemaphoreSlim processInitialized = _processInitialized;
+                    if (processInitialized is null)
+                    {
+                        lock (_sync)
+                        {
+                            processInitialized = _processInitialized ??= new SemaphoreSlim(0, 1);
+                        }
+                    }
+
+                    processInitialized?.Release();
                 }
 
                 if (this.Command.MyInvocation.PipelinePosition < this.Command.MyInvocation.PipelineLength)
@@ -1720,6 +1720,7 @@ namespace System.Management.Automation
                 ? (stackalloc Range[0x20]).Slice(0, extensionCount)
                 : new Range[extensionCount];
 
+            extensions.Clear();
             extensions = extensions.Slice(0, extensionList.Split(extensions, ';'));
             foreach (Range extension in extensions)
             {

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -682,20 +682,12 @@ namespace System.Management.Automation
                         }
 #endif
                     }
-                }
 
-                if (UpstreamIsNativeCommand)
-                {
-                    SemaphoreSlim processInitialized = _processInitialized;
-                    if (processInitialized is null)
+                    if (UpstreamIsNativeCommand)
                     {
-                        lock (_sync)
-                        {
-                            processInitialized = _processInitialized ??= new SemaphoreSlim(0, 1);
-                        }
+                        _processInitialized ??= new SemaphoreSlim(0, 1);
+                        _processInitialized.Release();
                     }
-
-                    processInitialized?.Release();
                 }
 
                 if (this.Command.MyInvocation.PipelinePosition < this.Command.MyInvocation.PipelineLength)

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -69,6 +69,7 @@ namespace System.Management.Automation
         internal static MinishellStream ToMinishellStream(string stream)
         {
             Dbg.Assert(stream != null, "caller should validate the parameter");
+
             MinishellStream ms = MinishellStream.Unknown;
             if (OutputStream.Equals(stream, StringComparison.OrdinalIgnoreCase))
             {
@@ -132,7 +133,7 @@ namespace System.Management.Automation
         }
     }
 
-#nullable enable
+    #nullable enable
     /// <summary>
     /// This exception is used by the NativeCommandProcessor to indicate an error
     /// when a native command returns a non-zero exit code.
@@ -186,7 +187,7 @@ namespace System.Management.Automation
         public int ProcessId { get; }
 
     }
-#nullable restore
+    #nullable restore
 
     /// <summary>
     /// Provides way to create and execute native commands.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

Fixes #19876

# PR Summary

Marking the process as initialized was done inside a `try` that can be part of normal operation if `shell32!FindExecutableW` finds a valid console subsystem executable. This change moves it after the try so that scenario will be caught as well.

~~Also reduced some allocations in `IsExecutable`. That change is separated into it's own commit for easier review, but I'm also fine with reverting that commit if desired.~~

I don't think there's an non-interactive way to set a file extension these days so I'm not sure how this could be tested. If you know of a way (that doesn't use undocumented APIs) please comment.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
