### PR TITLE
Fix ///-comments that violate the docs schema

### DIFF
--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/ReadOnlyObservableAsyncCollection.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/ReadOnlyObservableAsyncCollection.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Management.UI.Internal
         /// Occurs when the collection changes, either by adding or removing an item.
         /// </summary>
         /// <remarks>
-        /// see <seealso cref="INotifyCollectionChanged"/>
+        /// see <see cref="INotifyCollectionChanged"/>
         /// </remarks>
         public event NotifyCollectionChangedEventHandler CollectionChanged;
 
@@ -52,7 +52,7 @@ namespace Microsoft.Management.UI.Internal
         /// Occurs when a property changes.
         /// </summary>
         /// <remarks>
-        /// see <seealso cref="INotifyPropertyChanged"/>
+        /// see <see cref="INotifyPropertyChanged"/>
         /// </remarks>
         public event PropertyChangedEventHandler PropertyChanged;
         #endregion Events

--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/ScalableImage.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/ScalableImage.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Override of <seealso cref="UIElement.GetLayoutClip"/>.
+        /// Override of <see cref="UIElement.GetLayoutClip"/>.
         /// Make this control to respect the ClipToBounds attribute value.
         /// </summary>
         /// <param name="layoutSlotSize">An instance of <see cref="System.Windows.Size"/> used for calculating an additional clip.</param>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/Innerlist.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Management.UI.Internal
 
         /// <summary>
         /// Gets ItemsSource instead.
-        /// <seealso cref="InnerList"/> Does not support adding to Items.
+        /// <see cref="InnerList"/> Does not support adding to Items.
         /// </summary>
         [Browsable(false)]
         public new ItemCollection Items

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -127,11 +127,11 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Gets the base name of the file containing the matching line.
+        /// </summary>
         /// <remarks>
         /// It will be the string "InputStream" if the object came from the input stream.
         /// This is a readonly property calculated from the path <see cref="Path"/>.
         /// </remarks>
-        /// </summary>
         /// <value>The file name.</value>
         public string Filename
         {
@@ -150,10 +150,13 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Gets or sets the full path of the file containing the matching line.
+        /// </summary>
         /// <remarks>
         /// It will be "InputStream" if the object came from the input stream.
         /// </remarks>
-        /// </summary>
+        /// <remarks>
+        /// It will be "InputStream" if the object came from the input stream.
+        /// </remarks>
         /// <value>The path name.</value>
         public string Path
         {
@@ -182,11 +185,11 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Returns the path of the matching file truncated relative to the <paramref name="directory"/> parameter.
+        /// </summary>
         /// <remarks>
         /// For example, if the matching path was c:\foo\bar\baz.c and the directory argument was c:\foo
         /// the routine would return bar\baz.c .
         /// </remarks>
-        /// </summary>
         /// <param name="directory">The directory base the truncation on.</param>
         /// <returns>The relative path that was produced.</returns>
         public string RelativePath(string directory)
@@ -232,12 +235,12 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Returns the string representation of this object. The format
         /// depends on whether a path has been set for this object or not.
+        /// </summary>
         /// <remarks>
         /// If the path component is set, as would be the case when matching
         /// in a file, ToString() would return the path, line number and line text.
         /// If path is not set, then just the line text is presented.
         /// </remarks>
-        /// </summary>
         /// <returns>The string representation of the match object.</returns>
         public override string ToString()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -154,9 +154,6 @@ namespace Microsoft.PowerShell.Commands
         /// <remarks>
         /// It will be "InputStream" if the object came from the input stream.
         /// </remarks>
-        /// <remarks>
-        /// It will be "InputStream" if the object came from the input stream.
-        /// </remarks>
         /// <value>The path name.</value>
         public string Path
         {

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1356,11 +1356,11 @@ namespace System.Management.Automation
         /// Gets or sets the custom error message pattern that is displayed to the user.
         /// The text representation of the object being validated and the validating regex is passed as
         /// the first and second formatting parameters to the ErrorMessage formatting pattern.
-        /// <example>
+        /// <c>
         /// <code>
         /// [ValidatePattern("\s+", ErrorMessage="The text '{0}' did not pass validation of regex '{1}'")]
         /// </code>
-        /// </example>
+        /// </c>
         /// </summary>
         public string ErrorMessage { get; set; }
 
@@ -1422,11 +1422,11 @@ namespace System.Management.Automation
         /// Gets or sets the custom error message that is displayed to the user.
         /// The item being validated and the validating scriptblock is passed as the first and second
         /// formatting argument.
-        /// <example>
+        /// <c>
         /// <code>
         /// [ValidateScript("$_ % 2", ErrorMessage = "The item '{0}' did not pass validation of script '{1}'")]
         /// </code>
-        /// </example>
+        /// </c>
         /// </summary>
         public string ErrorMessage { get; set; }
 
@@ -1687,11 +1687,11 @@ namespace System.Management.Automation
         /// Gets or sets the custom error message that is displayed to the user.
         /// The item being validated and a text representation of the validation set is passed as the
         /// first and second formatting argument to the <see cref="ErrorMessage"/> formatting pattern.
-        /// <example>
+        /// <c>
         /// <code>
         /// [ValidateSet("A","B","C", ErrorMessage="The item '{0}' is not part of the set '{1}'.")
         /// </code>
-        /// </example>
+        /// </c>
         /// </summary>
         public string ErrorMessage { get; set; }
 

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -24,26 +24,20 @@ namespace System.Management.Automation
     {
         /// <summary>
         /// Aliases create a name that refers to other command types.
-        /// </summary>
-        /// <remarks>
         /// Aliases are only persisted within the execution of a single engine.
-        /// </remarks>
+        /// </summary>
         Alias = 0x0001,
 
         /// <summary>
         /// Script functions that are defined by a script block.
-        /// </summary>
-        /// <remarks>
         /// Functions are only persisted within the execution of a single engine.
-        /// </remarks>
+        /// </summary>
         Function = 0x0002,
 
         /// <summary>
         /// Script filters that are defined by a script block.
-        /// </summary>
-        /// <remarks>
         /// Filters are only persisted within the execution of a single engine.
-        /// </remarks>
+        /// </summary>
         Filter = 0x0004,
 
         /// <summary>
@@ -58,11 +52,9 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Any existing application (can be console or GUI).
-        /// </summary>
-        /// <remarks>
         /// An application can have any extension that can be executed either directly through CreateProcess
         /// or indirectly through ShellExecute.
-        /// </remarks>
+        /// </summary>
         Application = 0x0020,
 
         /// <summary>
@@ -77,11 +69,9 @@ namespace System.Management.Automation
 
         /// <summary>
         /// All possible command types.
+        /// NOTE: a CommandInfo instance will never specify All as its CommandType
+        /// but All can be used when filtering the CommandTypes.
         /// </summary>
-        /// <remarks>
-        /// Note, a CommandInfo instance will never specify
-        /// All as its CommandType but All can be used when filtering the CommandTypes.
-        /// </remarks>
         All = Alias | Function | Filter | Cmdlet | Script | ExternalScript | Application | Configuration,
     }
 

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -28,13 +28,15 @@ namespace System.Management.Automation
     public enum ErrorCategory
     {
         /// <summary>
+        /// <para>
         /// No error category is specified, or the error category is invalid.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// Do not specify ErrorCategory.NotSpecified when creating an
         /// <see cref="System.Management.Automation.ErrorRecord"/>.
         /// Choose the best match from among the other values.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         NotSpecified = 0,
 
         /// <summary>
@@ -132,14 +134,16 @@ namespace System.Management.Automation
         WriteError = 23,
 
         /// <summary>
+        /// <para>
         /// A native command reported an error to its STDERR pipe.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// The Engine uses this ErrorCategory when it executes a native
         /// console applications and captures the errors reported by the
         /// native application.  Avoid using ErrorCategory.FromStdErr
         /// in other circumstances.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         FromStdErr = 24,
 
         /// <summary>

--- a/src/System.Management.Automation/engine/ProgressRecord.cs
+++ b/src/System.Management.Automation/engine/ProgressRecord.cs
@@ -505,7 +505,7 @@ namespace System.Management.Automation
             string activity = string.IsNullOrEmpty(Activity) ? " " : Activity;
 
             PSObject progressAsPSObject = RemotingEncoder.CreateEmptyPSObject();
-            
+
             progressAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ProgressRecord_Activity, activity));
             progressAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ProgressRecord_ActivityId, this.ActivityId));
             progressAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ProgressRecord_StatusDescription, this.StatusDescription));
@@ -529,9 +529,10 @@ namespace System.Management.Automation
     enum ProgressRecordType
     {
         /// <summary>
+        /// <para>
         /// Operation just started or is not yet complete.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// A cmdlet can call WriteProgress with ProgressRecordType.Processing
         /// as many times as it wishes.  However, at the end of the operation,
         /// it should call once more with ProgressRecordType.Completed.
@@ -542,17 +543,20 @@ namespace System.Management.Automation
         /// of the same Id, the host will update that display.
         /// Finally, when the host receives a 'completed' record
         /// for that activity, it will remove the progress indicator.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         Processing,
 
         /// <summary>
+        /// <para>
         /// Operation is complete.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// If a cmdlet uses WriteProgress, it should use
         /// ProgressRecordType.Completed exactly once, in the last call
         /// to WriteProgress.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         Completed
     }
 }

--- a/src/System.Management.Automation/engine/cmdlet.cs
+++ b/src/System.Management.Automation/engine/cmdlet.cs
@@ -1820,14 +1820,16 @@ namespace System.Management.Automation
         None = 0x0,
 
         /// <summary>
+        /// <para>
         /// WhatIf behavior was requested.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// In the host, WhatIf behavior can be requested explicitly
         /// for one cmdlet instance using the -WhatIf commandline parameter,
         /// or implicitly for all SupportsShouldProcess cmdlets with $WhatIfPreference.
         /// Other hosts may have other ways to request WhatIf behavior.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         WhatIf = 0x1,
     }
 }

--- a/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
@@ -6,7 +6,7 @@ using Dbg = System.Management.Automation.Diagnostics;
 namespace System.Management.Automation.Host
 {
     /// <summary>
-    /// Provides a description of a choice for use by <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>.
+    /// Provides a description of a choice for use by <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>.
     /// <!--Used by the engine to describe cmdlet parameters.-->
     /// </summary>
     public sealed
@@ -84,7 +84,7 @@ namespace System.Management.Automation.Host
         /// <remarks>
         /// Note that the special character &amp; (ampersand) may be embedded in the label string to identify the next character in the label
         /// as a "hot key" (aka "keyboard accelerator") that the Console.PromptForChoice implementation may use to allow the user to
-        /// quickly set input focus to this choice.  The implementation of <seealso cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
+        /// quickly set input focus to this choice.  The implementation of <see cref="System.Management.Automation.Host.PSHostUserInterface.PromptForChoice"/>
         /// is responsible for parsing the label string for this special character and rendering it accordingly.
         ///
         /// For examples, a choice named "Yes to All" might have "Yes to &amp;All" as it's label.

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -95,7 +95,7 @@ namespace System.Management.Automation.Runspaces
         /// The <see cref="StreamingContext"/> that contains contextual information
         /// about the source or destination.
         /// </param>
-        [Obsolete("Legacy serialization support is deprecated since .NET 8", DiagnosticId = "SYSLIB0051")] 
+        [Obsolete("Legacy serialization support is deprecated since .NET 8", DiagnosticId = "SYSLIB0051")]
         protected InvalidRunspaceStateException(SerializationInfo info, StreamingContext context)
         {
             throw new NotSupportedException();
@@ -219,12 +219,9 @@ namespace System.Management.Automation.Runspaces
         ReuseThread = 2,
 
         /// <summary>
-        /// Doesn't create a new thread; the execution occurs on the
-        /// thread that calls Invoke.
+        /// Doesn't create a new thread; the execution occurs on the thread
+        /// that calls Invoke. This option is not valid for asynchronous calls.
         /// </summary>
-        /// <remarks>
-        /// This option is not valid for asynchronous calls
-        /// </remarks>
         UseCurrentThread = 3
     }
 

--- a/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
@@ -165,7 +165,7 @@ namespace System.Management.Automation.Host
 
         /// <summary>
         /// A short, human-presentable message to describe and identify the field.  If supplied, a typical implementation of
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> will use this value instead of
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> will use this value instead of
         /// the field name to identify the field to the user.
         /// </summary>
         /// <exception cref="System.Management.Automation.PSArgumentNullException">
@@ -174,9 +174,9 @@ namespace System.Management.Automation.Host
         /// <remarks>
         /// Note that the special character &amp; (ampersand) may be embedded in the label string to identify the next
         /// character in the label as a "hot key" (aka "keyboard accelerator") that the
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> implementation may use
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> implementation may use
         /// to allow the user to quickly set input focus to this field.  The implementation of
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> is responsible for parsing
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> is responsible for parsing
         /// the label string for this special character and rendering it accordingly.
         ///
         /// For example, a field named "SSN" might have "&amp;Social Security Number" as it's label.
@@ -256,12 +256,12 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Gets and sets the default value, if any, for the implementation of <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
+        /// Gets and sets the default value, if any, for the implementation of <see cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// to pre-populate its UI with. This is a PSObject instance so that the value can be serialized, converted,
         /// manipulated like any pipeline object.
         /// </summary>
         /// <remarks>
-        /// It is up to the implementer of <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> to decide if it
+        /// It is up to the implementer of <see cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/> to decide if it
         /// can make use of the object in its presentation of the fields prompt.
         ///
         /// </remarks>
@@ -283,7 +283,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Gets the Attribute classes that apply to the field. In the case that <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
+        /// Gets the Attribute classes that apply to the field. In the case that <see cref="System.Management.Automation.Host.PSHostUserInterface.Prompt"/>
         /// is being called from the engine, this will contain the set of prompting attributes that are attached to a
         /// cmdlet parameter declaration.
         /// </summary>

--- a/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
@@ -1784,7 +1784,7 @@ namespace System.Management.Automation.Host
 
         /// <summary>
         /// Creates a 2D array of BufferCells by examining <paramref name="contents"/>.Character.
-        /// <seealso cref="PSHostRawUserInterface"/>
+        /// <see cref="PSHostRawUserInterface"/>
         /// </summary>
         /// <param name="width">
         /// The number of columns of the resulting array

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -112,10 +112,10 @@ namespace System.Management.Automation.Host
 
         /// <summary>
         /// The default implementation writes a carriage return to the screen buffer.
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Write(string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Write(System.ConsoleColor, System.ConsoleColor, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine(string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine(System.ConsoleColor, System.ConsoleColor, string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.Write(string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.Write(System.ConsoleColor, System.ConsoleColor, string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine(string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine(System.ConsoleColor, System.ConsoleColor, string)"/>
         /// </summary>
         public virtual void WriteLine()
         {
@@ -170,10 +170,10 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Writes a line to the "error display" of the host, as opposed to the "output display," which is
         /// written to by the variants of
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Write(string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.Write(System.ConsoleColor, System.ConsoleColor, string)"/>
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine()"/> and
-        /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine(string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.Write(string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.Write(System.ConsoleColor, System.ConsoleColor, string)"/>
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine()"/> and
+        /// <see cref="System.Management.Automation.Host.PSHostUserInterface.WriteLine(string)"/>
         /// </summary>
         /// <param name="value">
         /// The characters to be written.
@@ -314,7 +314,7 @@ namespace System.Management.Automation.Host
                 return string.Empty;
             }
 
-            PSStyle psstyle = PSStyle.Instance;                
+            PSStyle psstyle = PSStyle.Instance;
             switch (formatStyle)
             {
                 case FormatStyle.Reset:

--- a/src/System.Management.Automation/engine/lang/interface/PSToken.cs
+++ b/src/System.Management.Automation/engine/lang/interface/PSToken.cs
@@ -370,223 +370,275 @@ namespace System.Management.Automation
         /// <summary>
         /// Unknown token.
         /// </summary>
-        /// <remarks>
-        /// </remarks>
         Unknown,
 
         /// <summary>
+        /// <para>
         /// Command.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// </para>
         /// For example, 'get-process' in
         ///
-        ///     get-process -name foo
-        /// </remarks>
+        ///     <c><code>get-process -name foo</code></c>
+        /// </para>
+        /// </summary>
         Command,
 
         /// <summary>
+        /// <para>
         /// Command Parameter.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, '-name' in
         ///
-        ///     get-process -name foo
-        /// </remarks>
+        ///     <c><code>get-process -name foo</code></c>
+        /// </para>
+        /// </summary>
         CommandParameter,
 
         /// <summary>
+        /// <para>
         /// Command Argument.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, 'foo' in
         ///
-        ///     get-process -name foo
-        /// </remarks>
+        ///     <c><code>get-process -name foo</code></c>
+        /// </para>
+        /// </summary>
         CommandArgument,
 
         /// <summary>
+        /// <para>
         /// Number.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, 12 in
         ///
-        ///     $a=12
-        /// </remarks>
+        ///     <c><code>$a=12</code></c>
+        /// </para>
+        /// </summary>
         Number,
 
         /// <summary>
+        /// <para>
         /// String.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, "12" in
         ///
-        ///     $a="12"
-        /// </remarks>
+        ///     <c><code>$a="12"</code></c>
+        /// </para>
+        /// </summary>
         String,
 
         /// <summary>
+        /// <para>
         /// Variable.
-        /// </summary>
+        /// </para>
+        /// <para>
         /// <remarks>
         /// For example, $a in
         ///
-        ///     $a="12"
-        /// </remarks>
+        ///     <c><code>$a="12"</code></c>
+        /// <para>
+        /// </summary>
         Variable,
 
         /// <summary>
+        /// <para>
         /// Property name or method name.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, Name in
         ///
-        ///     $a.Name
-        /// </remarks>
+        ///     <c><code>$a.Name</code></c>
+        /// </para>
+        /// </summary>
         Member,
 
         /// <summary>
+        /// <para>
         /// Loop label.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, :loop in
         ///
+        /// <c><code>
         ///     :loop
         ///     foreach($a in $b)
         ///     {
         ///         $a
         ///     }
-        /// </remarks>
+        /// </code></c>
+        /// </summary>
         LoopLabel,
 
         /// <summary>
+        /// <para>
         /// Attributes.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, Mandatory in
         ///
-        ///     param([Mandatory] $a)
-        /// </remarks>
+        ///     <c><code>param([Mandatory] $a)</code></c>
+        /// </para>
+        /// </summary>
         Attribute,
 
         /// <summary>
+        /// <para>
         /// Types.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, [string] in
         ///
-        ///     $a = [string] 12
-        /// </remarks>
+        ///     <c><code>$a = [string] 12</code></c>
+        /// </para>
+        /// </summary>
         Type,
 
         /// <summary>
+        /// <para>
         /// Operators.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, + in
         ///
-        ///     $a = 1 + 2
-        /// </remarks>
+        ///     <c><code>$a = 1 + 2</code></c>
+        /// </para>
+        /// </summary>
         Operator,
 
         /// <summary>
+        /// <para>
         /// Group Starter.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, { in
         ///
+        /// <c><code>
         ///     if ($a -gt 4)
         ///     {
         ///         $a++;
         ///     }
-        /// </remarks>
+        /// </code></c>
+        /// </para>
+        /// </summary>
         GroupStart,
 
         /// <summary>
+        /// <para>
         /// Group Ender.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, } in
         ///
+        /// <c><code>
         ///     if ($a -gt 4)
         ///     {
         ///         $a++;
         ///     }
-        /// </remarks>
+        /// </code></c>
+        /// </para>
+        /// </summary>
         GroupEnd,
 
         /// <summary>
+        /// <para>
         /// Keyword.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, if in
         ///
+        /// <c><code>
         ///     if ($a -gt 4)
         ///     {
         ///         $a++;
         ///     }
-        /// </remarks>
+        /// </code></c>
+        /// </para>
+        /// </summary>
         Keyword,
 
         /// <summary>
+        /// <para>
         /// Comment.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, #here in
         ///
+        /// <c><code>
         ///     #here
         ///     if ($a -gt 4)
         ///     {
         ///         $a++;
         ///     }
-        /// </remarks>
+        /// </code></c>
+        /// </para>
+        /// </summary>
         Comment,
 
         /// <summary>
+        /// <para>
         /// Statement separator. This is ';'
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, ; in
         ///
+        /// <c><code>
         ///     #here
         ///     if ($a -gt 4)
         ///     {
         ///         $a++;
         ///     }
-        /// </remarks>
+        /// </code></c>
+        /// </para>
+        /// </summary>
         StatementSeparator,
 
         /// <summary>
+        /// <para>
         /// New line. This is '\n'
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, \n in
         ///
+        /// <c><code>
         ///     #here
         ///     if ($a -gt 4)
         ///     {
         ///         $a++;
         ///     }
-        /// </remarks>
+        /// </code></c>
+        /// </para>
+        /// </summary>
         NewLine,
 
         /// <summary>
+        /// <para>
         /// Line continuation.
-        /// </summary>
-        /// <remarks>
+        /// </para>
+        /// <para>
         /// For example, ` in
         ///
+        /// <c><code>
         ///     get-command -name `
         ///     foo
-        /// </remarks>
+        /// </code></c>
+        /// </para>
+        /// </summary>
         LineContinuation,
 
         /// <summary>
+        /// <para>
         /// Position token.
-        /// </summary>
-        /// <remarks>
-        /// Position token are bogus tokens generated for identifying a location
+        /// </para>
+        /// <para>
+        /// Position tokens are bogus tokens generated for identifying a location
         /// in the script.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         Position
     }
 }

--- a/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace System.Management.Automation.Language
 {
     /// <summary>
-    /// Each Visit* method in <see ref="AstVisitor"/> returns one of these values to control
+    /// Each Visit* method in <see cref="AstVisitor" /> returns one of these values to control
     /// how visiting nodes in the AST should proceed.
     /// </summary>
     public enum AstVisitAction

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -6038,8 +6038,8 @@ namespace System.Management.Automation.Language
         /// <para>Returns the name of the command invoked by this ast.</para>
         /// <para>This command name may not be known statically, in which case null is returned.</para>
         /// <para>
-        /// For example, if the command name is in a variable: <example>&amp; $foo</example>, then the parser cannot know which command is executed.
-        /// Similarly, if the command is being invoked in a module: <example>&amp; (gmo SomeModule) Bar</example>, then the parser does not know the
+        /// For example, if the command name is in a variable: <code>&amp; $foo</code>, then the parser cannot know which command is executed.
+        /// Similarly, if the command is being invoked in a module: <code>&amp; (gmo SomeModule) Bar</code>, then the parser does not know the
         /// command name is Bar because the parser can't determine that the expression <code>(gmo SomeModule)</code> returns a module instead
         /// of a string.
         /// </para>

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -1180,7 +1180,7 @@ namespace System.Management.Automation.Language
 #endif
 
         /// <summary>
-        /// Return all the flags for a given <ref>TokenKind</ref>.
+        /// Return all the flags for a given <see cref="TokenKind" />.
         /// </summary>
         public static TokenFlags GetTraits(this TokenKind kind)
         {
@@ -1188,7 +1188,7 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
-        /// Return true if the <ref>TokenKind</ref> has the given trait.
+        /// Return true if the <see cref="TokenKind" /> has the given trait.
         /// </summary>
         public static bool HasTrait(this TokenKind kind, TokenFlags flag)
         {
@@ -1202,7 +1202,7 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
-        /// Return the text for a given <ref>TokenKind</ref>.
+        /// Return the text for a given <see cref="TokenKind" />.
         /// </summary>
         public static string Text(this TokenKind kind)
         {

--- a/src/System.Management.Automation/namespaces/ProviderDeclarationAttribute.cs
+++ b/src/System.Management.Automation/namespaces/ProviderDeclarationAttribute.cs
@@ -82,50 +82,58 @@ namespace System.Management.Automation.Provider
         None = 0x0,
 
         /// <summary>
+        /// <para>
         /// The provider does the inclusion filtering for those commands that take an Include
         /// parameter. The PowerShell engine should not try to do the filtering on behalf of this
         /// provider.
-        /// </summary>
-        /// <remarks>
-        /// Note, the provider should make every effort to filter in a way that is consistent
+        /// </para>
+        /// <para>
+        /// The implementer of the provider should make every effort to filter in a way that is consistent
         /// with the PowerShell engine. This option is allowed because in many cases the provider
         /// can be much more efficient at filtering.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         Include = 0x1,
 
         /// <summary>
+        /// <para>
         /// The provider does the exclusion filtering for those commands that take an Exclude
         /// parameter. The PowerShell engine should not try to do the filtering on behalf of this
         /// provider.
-        /// </summary>
-        /// <remarks>
-        /// Note, the provider should make every effort to filter in a way that is consistent
+        /// </para>
+        /// <para>
+        /// The implementer of the provider should make every effort to filter in a way that is consistent
         /// with the PowerShell engine. This option is allowed because in many cases the provider
         /// can be much more efficient at filtering.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         Exclude = 0x2,
 
         /// <summary>
+        /// <para>
         /// The provider can take a provider specific filter string.
-        /// </summary>
-        /// <remarks>
-        /// When this attribute is specified a provider specific filter can be passed from
+        /// </para>
+        /// <para>
+        /// For implementers of providers using this attribute, a provider specific filter can be passed from
         /// the Core Commands to the provider. This filter string is not interpreted in any
         /// way by the PowerShell engine.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         Filter = 0x4,
 
         /// <summary>
+        /// <para>
         /// The provider does the wildcard matching for those commands that allow for it. The PowerShell
         /// engine should not try to do the wildcard matching on behalf of the provider when this
         /// flag is set.
-        /// </summary>
-        /// <remarks>
-        /// Note, the provider should make every effort to do the wildcard matching in a way that is consistent
+        /// </para>
+        /// <para>
+        /// The implementer of the provider should make every effort to do the wildcard matching in a way that is consistent
         /// with the PowerShell engine. This option is allowed because in many cases wildcard matching
         /// cannot occur via the path name or because the provider can do the matching in a much more
         /// efficient manner.
-        /// </remarks>
+        /// </para>
+        /// </summary>
         ExpandWildcards = 0x8,
 
         /// <summary>

--- a/src/System.Management.Automation/utils/StructuredTraceSource.cs
+++ b/src/System.Management.Automation/utils/StructuredTraceSource.cs
@@ -144,13 +144,10 @@ namespace System.Management.Automation
         Assert = 0x00004000,
 
         /// <summary>
-        /// A combination of flags that trace the execution flow will
-        /// be traced.
-        /// </summary>
-        /// <remarks>
+        /// A combination of flags that trace the execution flow.
         /// The methods associated with the flags; Constructor, Dispose,
-        /// Finalizer, Method, Delegates, and Events will be enabled
-        /// </remarks>
+        /// Finalizer, Method, Delegates, and Events will be enabled.
+        /// </summary>
         ExecutionFlow =
             Constructor |
             Dispose |
@@ -161,13 +158,10 @@ namespace System.Management.Automation
             Scope,
 
         /// <summary>
-        /// A combination of flags that trace the data will be traced
-        /// be traced.
-        /// </summary>
-        /// <remarks>
+        /// A combination of flags that trace the data.
         /// The methods associated with the flags; Constructor, Dispose,
-        /// Finalizer, Property, and WriteLine will be enabled
-        /// </remarks>
+        /// Finalizer, Property, and WriteLine will be enabled.
+        /// </summary>
         Data =
             Constructor |
             Dispose |
@@ -178,22 +172,17 @@ namespace System.Management.Automation
 
         /// <summary>
         /// A combination of flags that trace the errors.
-        /// </summary>
-        /// <remarks>
         /// The methods associated with the flags; Error,
-        /// and Exception will be enabled
-        /// </remarks>
+        /// and Exception will be enabled.
+        /// </summary>
         Errors =
             Error |
             Exception,
 
         /// <summary>
-        /// All combination of trace flags will be set
-        /// be traced.
-        /// </summary>
-        /// <remarks>
+        /// All combination of trace flags will be set.
         /// All methods for tracing will be enabled.
-        /// </remarks>
+        /// </summary>
         All =
             Constructor |
             Dispose |


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR fixes formatting issues in ///-comments. These comments provide the .NET API documentation for the PowerShell SDK. 

## PR Context

The docs build system requires that the XML structure of the tags uses in the comments must conform to the schema defined in https://github.com/mono/api-doc-tools/blob/main/mdoc/Resources/monodoc-ecma.xsd.

This PR resolve the following problems from the docs build report:
- Please note: `<remarks>` node on Enum fields will be ignored.
- An XML element was used in a context that is not permitted.

This PR only changes comments. No code changes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
