### PR TITLE
Ensure literals upto 32 bit wide be considered as unsigned

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -185,8 +185,6 @@ namespace System.Management.Automation
                     switch (digits.Length)
                     {
                         // Only accept sign bits at these lengths:
-                        case 8: // byte
-                        case 16: // short
                         case 32: // int
                         case 64: // long
                         case 96: // decimal

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -882,10 +882,10 @@ foo``u{2195}abc
             @{ Script = "0b0"; ExpectedValue = "0"; ExpectedType = [int] }
             @{ Script = "0b10"; ExpectedValue = "2"; ExpectedType = [int] }
             @{ Script = "-0b10"; ExpectedValue = "-2"; ExpectedType = [int] }
-            @{ Script = "0b11111111"; ExpectedValue = "-1"; ExpectedType = [int] }
-            @{ Script = "0b1111111111111111"; ExpectedValue = "-1"; ExpectedType = [int] }
-            @{ Script = "0b11111111111111111111111111111111"; ExpectedValue = "-1"; ExpectedType = [int] }
-            @{ Script = "0b1111111111111111111111111111111111111111111111111111111111111111"; ExpectedValue = "-1"; ExpectedType = [long] }
+            @{ Script = "0b11111111"; ExpectedValue = "255"; ExpectedType = [int] }
+            @{ Script = "0b1111111111111111"; ExpectedValue = "65535"; ExpectedType = [int] }
+            @{ Script = "0b11111111111111111111111111111111"; ExpectedValue = "4294967295"; ExpectedType = [int] }
+            @{ Script = "0b1111111111111111111111111111111111111111111111111111111111111111"; ExpectedValue = "18446744073709551615"; ExpectedType = [long] }
             #Multipliers
             @{ Script = "1kb"; ExpectedValue = "1024"; ExpectedType = [int] }
             @{ Script = "1mb"; ExpectedValue = "1048576"; ExpectedType = [int] }
@@ -966,7 +966,7 @@ foo``u{2195}abc
             @{ Script = "0b0s"; ExpectedValue = "0"; ExpectedType = [short] }
             @{ Script = "0b10s"; ExpectedValue = "2"; ExpectedType = [short] }
             @{ Script = "-0b10s"; ExpectedValue = "-2"; ExpectedType = [short] }
-            @{ Script = "0b11111111s"; ExpectedValue = "-1"; ExpectedType = [short] }
+            @{ Script = "0b11111111s"; ExpectedValue = "255"; ExpectedType = [short] }
             #Multipliers
             @{ Script = "1skb"; ExpectedValue = "1024"; ExpectedType = [short] }
 
@@ -995,7 +995,7 @@ foo``u{2195}abc
             @{ Script = "0b0l"; ExpectedValue = "0"; ExpectedType = [long] }
             @{ Script = "0b10l"; ExpectedValue = "2"; ExpectedType = [long] }
             @{ Script = "-0b10l"; ExpectedValue = "-2"; ExpectedType = [long] }
-            @{ Script = "0b11111111l"; ExpectedValue = "-1"; ExpectedType = [long] }
+            @{ Script = "0b11111111l"; ExpectedValue = "255"; ExpectedType = [long] }
             #Multipliers
             @{ Script = "1lkb"; ExpectedValue = "1024"; ExpectedType = [long] }
             @{ Script = "1lmb"; ExpectedValue = "1048576"; ExpectedType = [long] }
@@ -1025,7 +1025,7 @@ foo``u{2195}abc
             @{ Script = "0b0n"; ExpectedValue = "0"; ExpectedType = [bigint] }
             @{ Script = "0b10n"; ExpectedValue = "2"; ExpectedType = [bigint] }
             @{ Script = "-0b10n"; ExpectedValue = "-2"; ExpectedType = [bigint] }
-            @{ Script = "0b11111111n"; ExpectedValue = "-1"; ExpectedType = [bigint] }
+            @{ Script = "0b11111111n"; ExpectedValue = "255"; ExpectedType = [bigint] }
             #Multipliers
             @{ Script = "1Nkb"; ExpectedValue = "1024"; ExpectedType = [bigint] }
             @{ Script = "1Nmb"; ExpectedValue = "1048576"; ExpectedType = [bigint] }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This change ensures that literals like 0b11111111 returns 255 instead of simply resolving to -1
as discussed here in https://github.com/PowerShell/PowerShell/issues/19218 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

quoting @vexx32 for context mentioned in this reply https://github.com/PowerShell/PowerShell/issues/19218#issuecomment-1494990918

> We suggest the parsing should be modified to line up functionally with the hexadecimal parsing: all literals up to 32-bits wide should be considered effectively "unsigned" -- so that things like 0b11111111 should not resolve to a -1, and the only accepted sign bits should be 32, 64, and above that are currently accepted by the parsing.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] Yes (?)
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/PowerShell/PowerShell/issues/19218 
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
