### PR TITLE
Removed value from SecureString/PSCredential string conversion exception message

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -21,6 +21,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using System.Security;
 
 using Dbg = System.Management.Automation.Diagnostics;
 using MethodCacheEntry = System.Management.Automation.DotNetAdapter.MethodCacheEntry;
@@ -4918,8 +4919,25 @@ namespace System.Management.Automation
 
             typeConversion.WriteLine("Type Conversion failed.");
             errorId = "ConvertToFinalInvalidCastException";
-            errorMsg = StringUtil.Format(ExtendedTypeSystem.InvalidCastException, valueToConvert.ToString(),
-                                         ObjectToTypeNameString(valueToConvert), resultType.ToString());
+
+            string valueToConvertTypeName = ObjectToTypeNameString(valueToConvert);
+            string resultTypeName = resultType.ToString();
+
+            if (resultType == typeof(SecureString)) {
+                errorMsg = StringUtil.Format(
+                    ExtendedTypeSystem.InvalidCastExceptionWithoutValue,
+                    valueToConvertTypeName,
+                    resultTypeName);
+            }
+            else 
+            {
+                errorMsg = StringUtil.Format(
+                    ExtendedTypeSystem.InvalidCastException,
+                    valueToConvert.ToString(),
+                    valueToConvertTypeName,
+                    resultTypeName);
+            }
+
             return Tuple.Create(errorId, errorMsg);
         }
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4923,13 +4923,14 @@ namespace System.Management.Automation
             string valueToConvertTypeName = ObjectToTypeNameString(valueToConvert);
             string resultTypeName = resultType.ToString();
 
-            if (resultType == typeof(SecureString)) {
+            if (resultType == typeof(SecureString))
+            {
                 errorMsg = StringUtil.Format(
                     ExtendedTypeSystem.InvalidCastExceptionWithoutValue,
                     valueToConvertTypeName,
                     resultTypeName);
             }
-            else 
+            else
             {
                 errorMsg = StringUtil.Format(
                     ExtendedTypeSystem.InvalidCastException,

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -4923,7 +4923,7 @@ namespace System.Management.Automation
             string valueToConvertTypeName = ObjectToTypeNameString(valueToConvert);
             string resultTypeName = resultType.ToString();
 
-            if (resultType == typeof(SecureString))
+            if (resultType == typeof(SecureString) || resultType == typeof(PSCredential))
             {
                 errorMsg = StringUtil.Format(
                     ExtendedTypeSystem.InvalidCastExceptionWithoutValue,

--- a/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
+++ b/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
@@ -189,6 +189,9 @@
   <data name="InvalidCastException" xml:space="preserve">
     <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
   </data>
+  <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
+    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+  </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
     <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -43,16 +43,12 @@ Describe "SecureString conversion tests" -Tags "CI" {
     }
 
     It "Using invalid secure string with ConvertFrom-SecureString produces an exception message without value" {
-        { ConvertFrom-SecureString "1234" } |
-            Should -Throw `
-                -ErrorId "CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand" `
-                -ExpectedMessage 'Cannot bind parameter ''SecureString''. Cannot convert the value of type "System.String" to type "System.Security.SecureString".'
+        $ex = { ConvertFrom-SecureString "1234" } | Should -Throw -ErrorId "CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand" -PassThru
+        $ex.Exception.Message | Should -Not -Match "1234"
     }
 
     It "Using invalid securestring with cast produces an exception message without value" {
-        { [securestring]"1234" } |
-            Should -Throw `
-            -ErrorId "ConvertToFinalInvalidCastException" `
-            -ExpectedMessage 'Cannot convert the value of type "System.String" to type "System.Security.SecureString".'
+        $ex = { [securestring]"1234" } | Should -Throw -ErrorId "ConvertToFinalInvalidCastException" -PassThru
+        $ex.Exception.Message | Should -Not -Match "1234"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -41,4 +41,18 @@ Describe "SecureString conversion tests" -Tags "CI" {
         $ss2 = $encodedStr | ConvertTo-SecureString -Key $key
         $ss2 | ConvertFrom-SecureString -AsPlainText | Should -BeExactly $testString
     }
+
+    It "Using invalid secure string with ConvertFrom-SecureString produces an exception message without value" {
+        { ConvertFrom-SecureString "1234" } |
+            Should -Throw `
+                -ErrorId "CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand" `
+                -ExpectedMessage 'Cannot bind parameter ''SecureString''. Cannot convert the value of type "System.String" to type "System.Security.SecureString".'
+    }
+
+    It "Using invalid securestring with cast produces an exception message without value" {
+        { [securestring]"1234" } |
+            Should -Throw `
+            -ErrorId "ConvertToFinalInvalidCastException" `
+            -ExpectedMessage 'Cannot convert the value of type "System.String" to type "System.Security.SecureString".'
+    }
 }

--- a/test/powershell/engine/Basic/Credential.Tests.ps1
+++ b/test/powershell/engine/Basic/Credential.Tests.ps1
@@ -5,4 +5,11 @@ Describe "Credential tests" -Tags "CI" {
          # We should explicitly check that the expression returns $null
          [PSCredential]::Empty.GetNetworkCredential() | Should -BeNullOrEmpty
     }
+
+    It "Explicit credential cast with string produces an exception message without value" {
+        { [pscredential]"1234" } |
+            Should -Throw `
+            -ErrorId "ConvertToFinalInvalidCastException" `
+            -ExpectedMessage 'Cannot convert the value of type "System.String" to type "System.Management.Automation.PSCredential".'
+    }
 }

--- a/test/powershell/engine/Basic/Credential.Tests.ps1
+++ b/test/powershell/engine/Basic/Credential.Tests.ps1
@@ -7,9 +7,7 @@ Describe "Credential tests" -Tags "CI" {
     }
 
     It "Explicit credential cast with string produces an exception message without value" {
-        { [pscredential]"1234" } |
-            Should -Throw `
-            -ErrorId "ConvertToFinalInvalidCastException" `
-            -ExpectedMessage 'Cannot convert the value of type "System.String" to type "System.Management.Automation.PSCredential".'
+        $ex = { [pscredential]"1234" } | Should -Throw -ErrorId "ConvertToFinalInvalidCastException" -PassThru
+        $ex.Exception.Message | Should -Not -Match "1234"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #19375

Removed value from exception message when `[securestring]` or `ConvertFrom-SecureString` fails to convert string to secure string.

Also removed value when string is casted to PSCredential.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

### Current behaviour

Below shows string to convert in exception message which should not be shown in-case it is sensitive data like tokens, passwords etc.

```powershell
PS C:\> [securestring]"p@ssword"
InvalidArgument: Cannot convert the "p@ssword" value of type "System.String" to type "System.Security.SecureString".

PS C:\> ConvertFrom-SecureString "p@assword"
ConvertFrom-SecureString: Cannot bind parameter 'SecureString'. Cannot convert the "p@assword" value of type "System.String" to type "System.Security.SecureString".

PS C>\> [pscredential]"p@assword"
InvalidArgument: Cannot convert the "p@assword" value of type "System.String" to type "System.Management.Automation.PSCredential".
```

### New behaviour

Removes string entirely from exception message.

```powershell
PS C:\> [securestring]"p@ssword"
InvalidArgument: Cannot convert the value of type "System.String" to type "System.Security.SecureString".

PS C:\> ConvertFrom-SecureString "p@assword"
ConvertFrom-SecureString: Cannot bind parameter 'SecureString'. Cannot convert the value of type "System.String" to type "System.Security.SecureString".

[pscredential]"p@assword"
InvalidArgument: Cannot convert the value of type "System.String" to type "System.Management.Automation.PSCredential".
```

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
