### PR TITLE
New-Guid add -Empty and -InputObject parameters

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -12,13 +12,48 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.New, "Guid", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2097130")]
     [OutputType(typeof(Guid))]
     public class NewGuidCommand : Cmdlet
-    {
+    {      
         /// <summary>
-        /// Returns a guid.
+        /// Generates an instance of the Guid structure whose value is all zeros.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Empty { get; set; }
+
+        /// <summary>
+        /// Converts a string to a Guid.
+        /// </summary>
+        [Parameter]
+        [ValidateNotNullOrWhiteSpace]
+        public string FromString { get; set; }
+
+        /// <summary>
+        /// Returns a Guid.
         /// </summary>
         protected override void EndProcessing()
         {
-            WriteObject(Guid.NewGuid());
+            if (Empty.IsPresent && FromString is not null)
+            {
+                ValidationMetadataException ex = new("The cmdlet cannot run because the following conflicting parameters are specified: Empty and FromString.");
+                ErrorRecord error = new(ex, "NewGuidParameterException", ErrorCategory.InvalidArgument, this);
+                ThrowTerminatingError(error);
+            }
+
+            Guid guid = Empty.IsPresent ? Guid.Empty : Guid.NewGuid();
+
+            if (FromString is not null)
+            {
+                try
+                {
+                    guid = new(FromString);
+                }
+                catch (Exception ex)
+                {
+                    ErrorRecord error = new(ex, "StringNotRecognizedAsGuid", ErrorCategory.InvalidOperation, null);
+                    ThrowTerminatingError(error);
+                }  
+            }
+
+            WriteObject(guid);
         }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.New, "Guid", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2097130")]
     [OutputType(typeof(Guid))]
     public class NewGuidCommand : Cmdlet
-    {      
+    {
         /// <summary>
         /// Generates an instance of the Guid structure whose value is all zeros.
         /// </summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Commands
     public class NewGuidCommand : PSCmdlet
     {
         /// <summary>
-        /// Generates an instance of the Guid structure whose value is all zeros.
+        /// Gets or sets a value indicating that the cmdlet should return a Guid structure whose value is all zeros.
         /// </summary>
         [Parameter(ParameterSetName = "Empty")]
         public SwitchParameter Empty { get; set; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -18,13 +18,13 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Generates an instance of the Guid structure whose value is all zeros.
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = "Empty")]
         public SwitchParameter Empty { get; set; }
 
         /// <summary>
         /// Converts a string to a Guid.
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = "FromString")]
         [ValidateNotNullOrWhiteSpace]
         public string? FromString { get; set; }
 
@@ -33,13 +33,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-            if (Empty.IsPresent && FromString is not null)
-            {
-                ValidationMetadataException ex = new("The cmdlet cannot run because the following conflicting parameters are specified: Empty and FromString.");
-                ErrorRecord error = new(ex, "NewGuidParameterException", ErrorCategory.InvalidArgument, this);
-                ThrowTerminatingError(error);
-            }
-
             Guid guid = Empty.IsPresent ? Guid.Empty : Guid.NewGuid();
 
             if (FromString is not null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Returns a Guid.
         /// </summary>
-        protected override void EndProcessing()
+        protected override void ProcessRecord()
         {
             Guid? guid = null;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-            Guid guid;
+            Guid? guid = null;
 
             if (ParameterSetName is "InputObject")
             {
@@ -47,8 +47,10 @@ namespace Microsoft.PowerShell.Commands
                     ThrowTerminatingError(error);
                 }  
             }
-
-            guid = ParameterSetName is "Empty" ? Guid.Empty : Guid.NewGuid();
+            else
+            {
+                guid = ParameterSetName is "Empty" ? Guid.Empty : Guid.NewGuid();
+            }
 
             WriteObject(guid);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     [Cmdlet(VerbsCommon.New, "Guid", DefaultParameterSetName = "Default", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2097130")]
     [OutputType(typeof(Guid))]
-    public class NewGuidCommand : Cmdlet
+    public class NewGuidCommand : PSCmdlet
     {
         /// <summary>
         /// Generates an instance of the Guid structure whose value is all zeros.
@@ -24,18 +24,18 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Converts a string to a Guid.
         /// </summary>
-        [Parameter(ParameterSetName = "FromString")]
-        [ValidateNotNullOrWhiteSpace]
-        public string? FromString { get; set; }
+        [Parameter(Position = 0, ValueFromPipeline = true, ParameterSetName = "FromString")]
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        public string FromString { get; set; }
 
         /// <summary>
         /// Returns a Guid.
         /// </summary>
         protected override void EndProcessing()
         {
-            Guid guid = Empty.IsPresent ? Guid.Empty : Guid.NewGuid();
+            Guid guid;
 
-            if (FromString is not null)
+            if (ParameterSetName is "FromString")
             {
                 try
                 {
@@ -47,6 +47,8 @@ namespace Microsoft.PowerShell.Commands
                     ThrowTerminatingError(error);
                 }  
             }
+
+            guid = ParameterSetName is "Empty" ? Guid.Empty : Guid.NewGuid();
 
             WriteObject(guid);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands
         public SwitchParameter Empty { get; set; }
 
         /// <summary>
-        /// Converts a string to a Guid.
+        /// Gets or sets the value to be converted to a Guid.
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ParameterSetName = "InputObject")]
         [System.Diagnostics.CodeAnalysis.AllowNull]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 catch (Exception ex)
                 {
-                    ErrorRecord error = new(ex, "StringNotRecognizedAsGuid", ErrorCategory.InvalidOperation, null);
+                    ErrorRecord error = new(ex, "StringNotRecognizedAsGuid", ErrorCategory.InvalidArgument, null);
                     ThrowTerminatingError(error);
                 }  
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// The implementation of the "new-guid" cmdlet.
     /// </summary>
-    [Cmdlet(VerbsCommon.New, "Guid", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2097130")]
+    [Cmdlet(VerbsCommon.New, "Guid", DefaultParameterSetName = "Default", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=2097130")]
     [OutputType(typeof(Guid))]
     public class NewGuidCommand : Cmdlet
     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -24,9 +24,9 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Converts a string to a Guid.
         /// </summary>
-        [Parameter(Position = 0, ValueFromPipeline = true, ParameterSetName = "FromString")]
+        [Parameter(Position = 0, ValueFromPipeline = true, ParameterSetName = "InputObject")]
         [System.Diagnostics.CodeAnalysis.AllowNull]
-        public string FromString { get; set; }
+        public string InputObject { get; set; }
 
         /// <summary>
         /// Returns a Guid.
@@ -35,11 +35,11 @@ namespace Microsoft.PowerShell.Commands
         {
             Guid guid;
 
-            if (ParameterSetName is "FromString")
+            if (ParameterSetName is "InputObject")
             {
                 try
                 {
-                    guid = new(FromString);
+                    guid = new(InputObject);
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Management.Automation;
 
@@ -24,7 +26,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrWhiteSpace]
-        public string FromString { get; set; }
+        public string? FromString { get; set; }
 
         /// <summary>
         /// Returns a Guid.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.Commands
                 catch (Exception ex)
                 {
                     ErrorRecord error = new(ex, "StringNotRecognizedAsGuid", ErrorCategory.InvalidArgument, null);
-                    ThrowTerminatingError(error);
+                    WriteError(error);
                 }  
             }
             else

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -32,6 +32,12 @@ Describe "New-Guid" -Tags "CI" {
         $guids[1].ToString() | Should -BeExactly '0f8fad5b-d9cb-469f-a165-70867728950e'
     }
 
+    It "Should accept pipeline input" {
+        $guids = 1..10 | foreach-object { [guid]::newguid() }
+        $observed = $guids.Foreach({$_.ToString()}) | New-Guid
+        $observed | Should -Be $guids
+    }
+
     It "Should return different guids with each call" {
         $guid1 = New-Guid
         $guid2 = New-Guid

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -27,10 +27,9 @@ Describe "New-Guid" -Tags "CI" {
     }
 
     It "Should convert a string to a guid, value from pipeline" {
-        $guid1 = New-Guid
-        $guid2 = $guid1.ToString() | New-Guid
-        $guid2 | Should -BeOfType System.Guid
-        $guid1.ToString() | Should -BeExactly $guid2.ToString()
+        $guids = '11c43ee8-b9d3-4e51-b73f-bd9dda66e29c','0f8fad5bd9cb469fa16570867728950e' | New-Guid
+        $guids[0].ToString() | Should -BeExactly '11c43ee8-b9d3-4e51-b73f-bd9dda66e29c'
+        $guids[1].ToString() | Should -BeExactly '0f8fad5b-d9cb-469f-a165-70867728950e'
     }
 
     It "Should return different guids with each call" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -2,17 +2,29 @@
 # Licensed under the MIT License.
 Describe "New-Guid" -Tags "CI" {
 
-    It "returns a new guid" {
+    It "Returns a new guid" {
         $guid = New-Guid
         $guid | Should -BeOfType System.Guid
     }
 
-    It "should not be all zeros" {
+    It "Should not be all zeros" {
         $guid = New-Guid
         $guid.ToString() | Should -Not -BeExactly "00000000-0000-0000-0000-000000000000"
     }
 
-    It "should return different guids with each call" {
+    It "Should be all zeros" {
+        $guid = New-Guid -Empty
+        $guid.ToString() | Should -BeExactly "00000000-0000-0000-0000-000000000000"
+    }
+
+    It "Should convert a string to a guid" {
+        $guid1 = New-Guid
+        $guid2 = New-Guid -FromString $guid1.ToString()
+        $guid2 | Should -BeOfType System.Guid
+        $guid1.ToString() | Should -BeExactly $guid2.ToString()
+    }
+
+    It "Should return different guids with each call" {
         $guid1 = New-Guid
         $guid2 = New-Guid
         $guid1.ToString() | Should -Not -Be $guid2.ToString()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -20,8 +20,10 @@ Describe "New-Guid" -Tags "CI" {
     It "Should convert a string to a guid" {
         $guid1 = New-Guid
         $guid2 = New-Guid -FromString $guid1.ToString()
+        $guid3 = New-Guid $guid1.ToString()
         $guid2 | Should -BeOfType System.Guid
         $guid1.ToString() | Should -BeExactly $guid2.ToString()
+        $guid1.ToString() | Should -BeExactly $guid3.ToString()
     }
 
     It "Should return different guids with each call" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -19,7 +19,7 @@ Describe "New-Guid" -Tags "CI" {
 
     It "Should convert a string to a guid" {
         $guid1 = New-Guid
-        $guid2 = New-Guid -FromString $guid1.ToString()
+        $guid2 = New-Guid -InputObject $guid1.ToString()
         $guid3 = New-Guid ($guid1.ToString())
         $guid2 | Should -BeOfType System.Guid
         $guid1.ToString() | Should -BeExactly $guid2.ToString()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -20,10 +20,17 @@ Describe "New-Guid" -Tags "CI" {
     It "Should convert a string to a guid" {
         $guid1 = New-Guid
         $guid2 = New-Guid -InputObject $guid1.ToString()
-        $guid3 = New-Guid ($guid1.ToString())
+        $guid3 = New-Guid $guid1.ToString()
         $guid2 | Should -BeOfType System.Guid
         $guid1.ToString() | Should -BeExactly $guid2.ToString()
         $guid1.ToString() | Should -BeExactly $guid3.ToString()
+    }
+
+    It "Should convert a string to a guid value from pipeline" {
+        $guid1 = New-Guid
+        $guid2 = $guid1.ToString() | New-Guid
+        $guid2 | Should -BeOfType System.Guid
+        $guid1.ToString() | Should -BeExactly $guid2.ToString()
     }
 
     It "Should return different guids with each call" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -20,7 +20,7 @@ Describe "New-Guid" -Tags "CI" {
     It "Should convert a string to a guid" {
         $guid1 = New-Guid
         $guid2 = New-Guid -FromString $guid1.ToString()
-        $guid3 = New-Guid $guid1.ToString()
+        $guid3 = New-Guid ($guid1.ToString())
         $guid2 | Should -BeOfType System.Guid
         $guid1.ToString() | Should -BeExactly $guid2.ToString()
         $guid1.ToString() | Should -BeExactly $guid3.ToString()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -26,7 +26,7 @@ Describe "New-Guid" -Tags "CI" {
         $guid1.ToString() | Should -BeExactly $guid3.ToString()
     }
 
-    It "Should convert a string to a guid value from pipeline" {
+    It "Should convert a string to a guid, value from pipeline" {
         $guid1 = New-Guid
         $guid2 = $guid1.ToString() | New-Guid
         $guid2 | Should -BeOfType System.Guid


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- New-Guid add -Empty parameter;  

`New-Guid -Empty` -->
```ps1
Guid
----
00000000-0000-0000-0000-000000000000
```
- New-Guid add -inputObject parameter;

`New-Guid -InputObject "8f9950e8-2589-4750-bf59-5d5a87f7b687"` -->
```ps1
Guid
----
8f9950e8-2589-4750-bf59-5d5a87f7b687
```
- Enable nullable

TODO:

- ~~Add tests~~
- ~~Add documentation~~

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Addresses https://github.com/PowerShell/PowerShell/issues/19950

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here -->https://github.com/MicrosoftDocs/PowerShell-Docs/issues/10296
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
