### PR TITLE
Fix: Update AppxManifest.xml to show application name on DefaultTile for Windows 10 21H2/22H2 Start Menu

### DIFF
--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -41,7 +41,7 @@
           <uap:ShowNameOnTiles> 
             <uap:ShowOn Tile="square150x150Logo"/>
           </uap:ShowNameOnTiles>
-      </uap:DefaultTile>
+        </uap:DefaultTile>
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -37,6 +37,11 @@
         </uap3:Extension>
       </Extensions>
       <uap:VisualElements DisplayName="$DISPLAYNAME$" Description="PowerShell is an automation and configuration management platform. It consists of a cross-platform (Windows, Linux, and macOS) command-line shell and associated scripting language." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
+        <uap:DefaultTile Square150x150Logo="assets\Square150x150Logo.png" ShortName="PowerShell">
+          <uap:ShowNameOnTiles> 
+            <uap:ShowOn Tile="square150x150Logo"/>
+          </uap:ShowNameOnTiles>
+      </uap:DefaultTile>
       </uap:VisualElements>
     </Application>
   </Applications>


### PR DESCRIPTION
# PR Summary

Fix: Update AppxManifest.xml to show application name on DefaultTile for Windows 10 21H2/22H2 Start Menu

## PR Context

- Modified: AppxManifest.xml
- Attempt to fix the issue of Powershell's magnet icon being too large on the Windows 10 start menu and not displaying the application name.

Original issue: https://github.com/PowerShell/PowerShell/issues/20055

![powershell](https://github.com/PowerShell/PowerShell/assets/140673973/17c7361c-01e8-4f26-ad76-9465142408da) 

Expected fix: Fixed tile displaying application name 'PowerShell' on Windows 10 22h2 Start menu

## PR Checklist

- [x] PR title clearly indicates the modification of AppxManifest.xml
- [x] PR description summarizes the changes in AppxManifest.xml  
- [x] No breaking change observed in AppxManifest.xml
- [x] Updated manifest version in AppxManifest.xml
- [x] Impacts user interface, documentation needs to be updated
- [ ] Start menu screenshot provided to demonstrate the fix
- [ ] Test cases added to cover manifest file changes
- [x] Manifest tool used to validate schema compliance  
- [x] No permission changes observed in AppxManifest.xml
- [x] App upgrade impact considered for manifest changes