### PR TITLE
Additional test hardening for tests which fail in release pass.

### DIFF
--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -37,10 +37,10 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "Feature","RequireAd
     BeforeAll {
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
 
-        $pendingTest = (Test-IsWinWow64)
+        $skipTest = (Test-IsWinWow64) -or !$IsWindows
 
-        if ($pendingTest) {
-            $global:PSDefaultParameterValues["it:pending"] = $true
+        if ($skipTest) {
+            $global:PSDefaultParameterValues["it:skip"] = $true
             return
         }
 
@@ -58,7 +58,7 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "Feature","RequireAd
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
-    It "Method should successfully invoke command on remote runspace" -Skip:(!$IsWindows) {
+    It "Method should successfully invoke command on remote runspace" -Skip:$skipTest {
 
         $command = [System.Management.Automation.PSCommand]::new()
         $command.AddScript('"Hello!"')

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -35,27 +35,20 @@ Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
 Describe "InvokeOnRunspace method on remote runspace" -tags "Feature","RequireAdminOnWindows" {
 
     BeforeAll {
-        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-
         $skipTest = (Test-IsWinWow64) -or !$IsWindows
 
         if ($skipTest) {
-            $global:PSDefaultParameterValues["it:skip"] = $true
             return
         }
 
-        if ($IsWindows) {
-            $script:remoteRunspace = New-RemoteRunspace
-        }
+        $script:remoteRunspace = New-RemoteRunspace
     }
 
     AfterAll {
-        if ($script:remoteRunspace -and -not $pendingTest)
+        if ($script:remoteRunspace)
         {
             $script:remoteRunspace.Dispose();
         }
-
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
     It "Method should successfully invoke command on remote runspace" -Skip:$skipTest {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -361,6 +361,11 @@ Describe "Run native command from a mounted FAT-format VHD" -tags @("Feature", "
     }
 
     It "Should run 'whoami.exe' from FAT file system without error" -Skip:(!$IsWindows) {
+        if ((Test-IsWinServer2012R2) -or (Test-IsWindows2016)) {
+            Set-ItResult -Pending -Because "Marking as pending since whomai.exe is not found on T:\ on 2012R2 and 2016 after copying to VHD"
+            return
+        }
+
         $expected = & "$env:WinDir\System32\whoami.exe"
         $result = T:\whoami.exe
         $result | Should -BeExactly $expected

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -451,9 +451,9 @@ Describe "Import-Module from CompatiblePSEditions-checked paths" -Tag "CI" {
 Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
 
     BeforeAll {
-        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
         if ( ! $IsWindows ) {
-            $PSDefaultParameterValues["it:skip"] = $true
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            return
         }
 
         $ModuleName = "DesktopModule"
@@ -468,7 +468,10 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
     }
 
     AfterAll {
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        if ( ! $IsWindows ) {
+            Pop-DefaultParameterValueStack
+            return
+        }
     }
 
     Context "Tests that ErrorAction/WarningAction have effect when Import-Module with WinCompat is used" {
@@ -766,14 +769,16 @@ Remove-Module $desktopModuleToUse
 Describe "PSModulePath changes interacting with other PowerShell processes" -Tag "Feature" {
     BeforeAll {
         $pwsh = "$PSHOME/pwsh"
-        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
         if ( ! $IsWindows ) {
-            $PSDefaultParameterValues["it:skip"] = $true
+            Push-DefaultParameterValueStack @{  "it:skip" = $true }
+            return
         }
     }
 
     AfterAll {
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        if ( ! $IsWindows ) {
+            Pop-DefaultParameterValueStack
+        }
     }
 
     Context "System32 module path prepended to PSModulePath" {
@@ -1408,8 +1413,7 @@ Describe "Import-Module nested module behaviour with Edition checking" -Tag "Fea
 Describe "WinCompat importing should check availablity of built-in modules" -Tag "CI" {
     BeforeAll {
         if (-not $IsWindows ) {
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
+            Push-DefaultParameterValueStack @{  "it:skip" = $true }
             return
         }
 
@@ -1431,7 +1435,7 @@ Describe "WinCompat importing should check availablity of built-in modules" -Tag
 
     AfterAll {
         if (-not $IsWindows) {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
+            Pop-DefaultParameterValueStack
             return
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -666,6 +666,11 @@ Describe "Additional tests for Import-Module with WinCompat" -Tag "Feature" {
         }
 
         It "NoClobber WinCompat list in powershell.config is a Desktop-edition module" {
+            if (Test-IsWinWow64) {
+                Set-ItResult -Skipped -Because "This test is not applicable to WoW64."
+                return
+            }
+
             if (-not $desktopModuleToUse) {
                 throw 'Neither the "PersistentMemory" module nor the "RemoteDesktop" module is available. Please check and use a desktop-edition module that is under the System32 module path.'
             }
@@ -1481,6 +1486,11 @@ Describe "WinCompat importing should check availablity of built-in modules" -Tag
     }
 
     It "Attempt to load a 'Desktop' edition module should fail because 'Export-PSSession' cannot be found" {
+        if (Test-IsWinWow64) {
+            Set-ItResult -Skipped -Because "This test is not applicable to WoW64."
+            return
+        }
+
         if (-not $desktopModuleToUse) {
             throw 'Neither the "PersistentMemory" module nor the "RemoteDesktop" module is available. Please check and use a desktop-edition module that is under the System32 module path.'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -843,7 +843,7 @@ namespace PowershellTestConfigNamespace
 }
 finally
 {
-    $global:PSDefaultParameterValues = $originalDefaultParameterValues
+    Pop-DefaultParameterValueStack
     $WarningPreference = $originalWarningPreference
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -11,7 +11,15 @@ try
     $WarningPreference = "SilentlyContinue"
     # Skip all tests if can't write to $PSHOME as Register-PSSessionConfiguration writes to $PSHOME
     # or if the processor architecture is Arm64
-    $IsNotSkipped = ($IsWindows -and $IsCoreCLR -and (Test-IsElevated) -and (Test-CanWriteToPsHome) -and [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -ne [System.Runtime.InteropServices.Architecture]::Arm64)
+    $IsNotSkipped = (
+        $IsWindows -and
+        $IsCoreCLR -and
+        (Test-IsElevated) -and
+        (Test-CanWriteToPsHome) -and
+        -not (Test-IsWindowsArm64) -and
+        -not (Test-IsWinWow64)
+    )
+
     $PSDefaultParameterValues["it:skip"] = !$IsNotSkipped
 
     #

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -182,7 +182,8 @@ Describe "Get-ChildItem" -Tags "CI" {
             (Get-ChildItem -File -LiteralPath TestDrive:/ -Filter noext*.*).Name | Should -BeExactly 'noextension'
         }
 
-        It "Understand APPEXECLINKs" -Skip:$true -Because "dotnet API is not available, see PR 16044" {
+        # Because "dotnet API is not available, see PR 16044
+        It "Understand APPEXECLINKs" -Skip {
             $app = Get-ChildItem -Path ~\appdata\local\microsoft\windowsapps\*.exe | Select-Object -First 1
             $app.Target | Should -Not -Be $app.FullName
             $app.LinkType | Should -BeExactly 'AppExeCLink'

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -38,11 +38,6 @@ Describe "Get-ChildItem" -Tags "CI" {
                 @{Parameters = @{Path = (Join-Path $searchRoot 'F*.txt'); Recurse = $true; File = $true }; ExpectedCount = 1; Title = "file with wildcard filename"}
             )
 
-            $SkipAppExeCLinks = $true
-            if ($IsWindows -and (Get-ChildItem -Path ~\AppData\Local\Microsoft\WindowsApps\*.exe -ErrorAction Ignore) -ne $null)
-            {
-                $SkipAppExeCLinks = $false
-            }
         }
 
         It "Should list the contents of the current folder" {
@@ -187,7 +182,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             (Get-ChildItem -File -LiteralPath TestDrive:/ -Filter noext*.*).Name | Should -BeExactly 'noextension'
         }
 
-        It "Understand APPEXECLINKs" -Skip:($SkipAppExeCLinks) {
+        It "Understand APPEXECLINKs" -Skip:$true -Because "dotnet API is not available, see PR 16044" {
             $app = Get-ChildItem -Path ~\appdata\local\microsoft\windowsapps\*.exe | Select-Object -First 1
             $app.Target | Should -Not -Be $app.FullName
             $app.LinkType | Should -BeExactly 'AppExeCLink'

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -232,6 +232,10 @@ Describe "Get-ChildItem" -Tags "CI" {
         It 'Works with Windows volume paths' -Skip:(!$IsWindows) {
             $volume = (Get-Volume -DriveLetter $env:SystemDrive[0]).Path
             $items = Get-ChildItem -LiteralPath "${volume}Windows"
+            Write-Verbose -Verbose "Trying files in '${volume}Windows'"
+            if (-not $items) {
+                Write-Verbose -Verbose "`$items is null!!"
+            }
             $items[0].Parent | Should -BeExactly "${volume}Windows"
             $items | Should -HaveCount (Get-ChildItem $env:SystemRoot).Count
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -262,6 +262,14 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
 
     Context "MTUSizeDetect" {
         It "MTUSizeDetect works" {
+
+            $platform = Get-PlatformInfo
+
+            if ($platform.platform -match 'suse' -and $platform.Version -match '15') {
+                Set-ItResult -Skipped -Because "MTUSizeDetect is not supported on OpenSUSE 15"
+                return
+            }
+
             $result = Test-Connection $testAddress -MtuSize
 
             $result | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingMtuStatus

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -265,7 +265,7 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
 
             $platform = Get-PlatformInfo
 
-            if ($platform.platform -match 'suse' -and $platform.Version -match '15') {
+            if ($platform.platform -match 'suse') {
                 Set-ItResult -Skipped -Because "MTUSizeDetect is not supported on OpenSUSE 15"
                 return
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -266,7 +266,7 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
             $platform = Get-PlatformInfo
             $platform | Out-String -Stream | Write-Verbose -Verbose
 
-            if ($platform.platform -match 'suse') {
+            if ($platform.platform -match 'sles' -and $platform.version -match '15') {
                 Set-ItResult -Skipped -Because "MTUSizeDetect is not supported on OpenSUSE 15"
                 return
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -264,6 +264,7 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
         It "MTUSizeDetect works" {
 
             $platform = Get-PlatformInfo
+            $platform | Out-String -Stream | Write-Verbose -Verbose
 
             if ($platform.platform -match 'suse') {
                 Set-ItResult -Skipped -Because "MTUSizeDetect is not supported on OpenSUSE 15"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4469,6 +4469,12 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     BeforeAll {
         $unixSocket = Get-UnixSocketName
         $skipTests = $false
+
+        if (Test-IsWindows2016) {
+            $skipTests = $true
+            return
+        }
+
         try {
             $WebListener = Start-UnixSocket $unixSocket
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4487,19 +4487,19 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
         }
 
         try {
-            $WebListener = Start-UnixSocket $unixSocket
+            $WebListener = Start-UnixSocket $unixSocket -ErrorAction Stop
         }
         catch {
-            if ($_.Exception.Message -match "Unix sockets are not supported on this platform.") {
-                $WebListener = $null
-                $skipTests = $true
-            }
+            Write-Verbose -Verbose -Message "Exception: $_"
+            $WebListener = $null
+            $skipTests = $true
         }
     }
 
     It "Execute Invoke-WebRequest with -UnixSocket" {
         if ($skipTest) {
             Set-ItResult -Skipped -Because "Unix sockets are not supported on this platform."
+            return
         }
 
         $uri = Get-UnixSocketUri
@@ -4511,6 +4511,7 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     It "Execute Invoke-RestMethod with -UnixSocket" {
         if ($skipTest) {
             Set-ItResult -Skipped -Because "Unix sockets are not supported on this platform."
+            return
         }
 
         $uri = Get-UnixSocketUri

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4479,14 +4479,16 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
 
 Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     BeforeAll {
-        $unixSocket = Get-UnixSocketName
-        $skipTests = (Test-IsWindows2016) -or (Test-IsWinServer2012R2)
-
+        $isWin2016 = Test-IsWindows2016
+        $isWin2012 = Test-IsWinServer2012R2
+        $skipTests = $isWin2016 -or $isWin2012
+        Write-Verbose -Verbose -Message "IsWin2016: $isWin2016 - IsWin2012: $isWin2012 - SkipTests: $skipTests"
         if ($skipTests){
             return
         }
 
         try {
+            $unixSocket = Get-UnixSocketName -ErrorAction Stop
             $WebListener = Start-UnixSocket $unixSocket -ErrorAction Stop
         }
         catch {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4499,7 +4499,7 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     }
 
     It "Execute Invoke-WebRequest with -UnixSocket" {
-        if ($skipTest) {
+        if ($skipTests) {
             Set-ItResult -Skipped -Because "Unix sockets are not supported on this platform."
             return
         }
@@ -4511,7 +4511,7 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     }
 
     It "Execute Invoke-RestMethod with -UnixSocket" {
-        if ($skipTest) {
+        if ($skipTests) {
             Set-ItResult -Skipped -Because "Unix sockets are not supported on this platform."
             return
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -505,6 +505,12 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         @{ httpVersion = '2'}
     ) {
         param($httpVersion)
+
+        if(Test-IsWinServer2012R2 -and $httpVersion -eq '2') {
+            Set-ItResult -Skipped -Because "HTTP/2 is not supported on Windows Server 2012R2"
+            return
+        }
+
         # Operation options
         $uri = Get-WebListenerUrl -Test 'Get' -Https
         $command = "Invoke-WebRequest -Uri $uri -HttpVersion $httpVersion -SkipCertificateCheck"
@@ -2572,6 +2578,12 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         @{ httpVersion = '2'}
     ) {
         param($httpVersion)
+
+        if(Test-IsWinServer2012R2 -and $httpVersion -eq '2') {
+            Set-ItResult -Skipped -Because "HTTP/2 is not supported on Windows Server 2012R2"
+            return
+        }
+
         # Operation options
         $uri = Get-WebListenerUrl -Test 'Get' -Https
         $command = "Invoke-RestMethod -Uri $uri -HttpVersion $httpVersion -SkipCertificateCheck"
@@ -4468,10 +4480,9 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
 Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     BeforeAll {
         $unixSocket = Get-UnixSocketName
-        $skipTests = $false
+        $skipTests = (Test-IsWindows2016) -or (Test-IsWinServer2012R2)
 
-        if (Test-IsWindows2016) {
-            $skipTests = $true
+        if ($skipTests){
             return
         }
 
@@ -4488,7 +4499,7 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
 
     It "Execute Invoke-WebRequest with -UnixSocket" {
         if ($skipTest) {
-            Set-ItResult -Skipped -Becuase "Unix sockets are not supported on this platform."
+            Set-ItResult -Skipped -Because "Unix sockets are not supported on this platform."
         }
 
         $uri = Get-UnixSocketUri
@@ -4499,7 +4510,7 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
 
     It "Execute Invoke-RestMethod with -UnixSocket" {
         if ($skipTest) {
-            Set-ItResult -Skipped -Becuase "Unix sockets are not supported on this platform."
+            Set-ItResult -Skipped -Because "Unix sockets are not supported on this platform."
         }
 
         $uri = Get-UnixSocketUri

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -4468,10 +4468,23 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support Cancellation through C
 Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     BeforeAll {
         $unixSocket = Get-UnixSocketName
-        $WebListener = Start-UnixSocket $unixSocket
+        $skipTests = $false
+        try {
+            $WebListener = Start-UnixSocket $unixSocket
+        }
+        catch {
+            if ($_.Exception.Message -match "Unix sockets are not supported on this platform.") {
+                $WebListener = $null
+                $skipTests = $true
+            }
+        }
     }
 
     It "Execute Invoke-WebRequest with -UnixSocket" {
+        if ($skipTest) {
+            Set-ItResult -Skipped -Becuase "Unix sockets are not supported on this platform."
+        }
+
         $uri = Get-UnixSocketUri
         $result = Invoke-WebRequest $uri -UnixSocket $unixSocket
         $result.StatusCode | Should -Be "200"
@@ -4479,6 +4492,10 @@ Describe "Web cmdlets Unix Sockets tests" -Tags "CI", "RequireAdminOnWindows" {
     }
 
     It "Execute Invoke-RestMethod with -UnixSocket" {
+        if ($skipTest) {
+            Set-ItResult -Skipped -Becuase "Unix sockets are not supported on this platform."
+        }
+
         $uri = Get-UnixSocketUri
         $result = Invoke-RestMethod  $uri -UnixSocket $unixSocket
         $result | Should -Be "Hello World Unix Socket."

--- a/test/powershell/engine/Remoting/InvokeCommandRemoteDebug.Tests.ps1
+++ b/test/powershell/engine/Remoting/InvokeCommandRemoteDebug.Tests.ps1
@@ -126,8 +126,8 @@ Describe "Invoke-Command remote debugging tests" -Tags 'Feature','RequireAdminOn
             $PSDefaultParameterValues["it:skip"] = $true
             return
         }
-        elseif (Test-IsWindowsArm64) {
-            Write-Verbose "remoting is not setup on ARM64, skipping tests" -Verbose
+        elseif ((Test-IsWindowsArm64) -or (Test-IsWinWow64)) {
+            Write-Verbose "remoting is not setup on ARM64 or x86, skipping tests" -Verbose
             $PSDefaultParameterValues["it:skip"] = $true
             return
         }
@@ -156,7 +156,7 @@ Describe "Invoke-Command remote debugging tests" -Tags 'Feature','RequireAdminOn
 
     AfterAll {
 
-        if (!$IsWindows)
+        if (!$IsWindows -or (Test-IsWindowsArm64) -or (Test-IsWinWow64))
         {
             $global:PSDefaultParameterValues = $originalDefaultParameterValues
             return

--- a/test/powershell/engine/Remoting/InvokeCommandRemoteDebug.Tests.ps1
+++ b/test/powershell/engine/Remoting/InvokeCommandRemoteDebug.Tests.ps1
@@ -4,8 +4,7 @@
 ## PowerShell Invoke-Command -RemoteDebug Tests
 ##
 
-if ($IsWindows)
-{
+if ($IsWindows) {
     $typeDef = @'
     using System;
     using System.Globalization;
@@ -120,18 +119,15 @@ Describe "Invoke-Command remote debugging tests" -Tags 'Feature','RequireAdminOn
 
     BeforeAll {
 
-        if (!$IsWindows)
-        {
-            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
+        $isArm64orWow64 = (Test-IsWindowsArm64) -or (Test-IsWinWow64)
+        $skipTest = ! $IsWindows -or $isArm64orWow64
+        if ($skipTest) {
+            if ($isArm64orWow64) {
+                Write-Verbose "remoting is not setup on ARM64 or x86, skipping tests" -Verbose
+            }
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
             return
         }
-        elseif ((Test-IsWindowsArm64) -or (Test-IsWinWow64)) {
-            Write-Verbose "remoting is not setup on ARM64 or x86, skipping tests" -Verbose
-            $PSDefaultParameterValues["it:skip"] = $true
-            return
-        }
-
 
         $sb = [scriptblock]::Create('"Hello!"')
 
@@ -156,9 +152,8 @@ Describe "Invoke-Command remote debugging tests" -Tags 'Feature','RequireAdminOn
 
     AfterAll {
 
-        if (!$IsWindows -or (Test-IsWindowsArm64) -or (Test-IsWinWow64))
-        {
-            $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        if ($skipTest) {
+            Pop-DefaultParameterValueStack
             return
         }
 
@@ -171,11 +166,15 @@ Describe "Invoke-Command remote debugging tests" -Tags 'Feature','RequireAdminOn
     }
 
     BeforeEach {
-
-        $remoteSession = New-RemoteSession
+        if (!$skipTest) {
+            $remoteSession = New-RemoteSession
+        }
     }
 
     AfterEach {
+        if ($skipTest) {
+            return
+        }
 
         $ps.Commands.Clear()
         $ps2.Commands.Clear()

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -67,7 +67,14 @@ Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnW
         }
         else
         {
-            Enable-PSRemoting -SkipNetworkProfileCheck
+            try {
+                Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
+            }
+            catch {
+                Write-Verbose -Verbose ($_.Message)
+                $global:PSDefaultParameterValues["it:skip"] = $true
+                return
+            }
         }
     }
 
@@ -109,7 +116,14 @@ Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
         }
         else
         {
-            Enable-PSRemoting -SkipNetworkProfileCheck
+            try {
+                Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
+            }
+            catch {
+                Write-Verbose -Verbose ($_.Message)
+                $global:PSDefaultParameterValues["it:skip"] = $true
+                return
+            }
         }
     }
 
@@ -149,7 +163,14 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
         }
         else
         {
-            Enable-PSRemoting -SkipNetworkProfileCheck
+            try {
+                Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
+            }
+            catch {
+                Write-Verbose -Verbose ($_.Message)
+                $global:PSDefaultParameterValues["it:skip"] = $true
+                return
+            }
             $configName = "PowerShell." + $PSVersionTable.GitCommitId
             $configuration = Get-PSSessionConfiguration -Name $configName -ErrorAction Ignore
             if ($null -eq $configuration) {

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -70,7 +70,7 @@ Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnW
             Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
         }
         catch {
-            Write-Verbose -Verbose ($_.Message)
+            Write-Verbose -Verbose "exception: $_"
             Push-DefaultParameterValueStack @{ "it:skip" = $true }
             $skipTest = $true
             return

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -120,7 +120,7 @@ Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
                 Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
             }
             catch {
-                Write-Verbose -Verbose ($_.Message)
+                Write-Verbose -Verbose "Enable-PSRemoting failed: $($_.Message)"
                 $global:PSDefaultParameterValues["it:skip"] = $true
                 return
             }
@@ -167,7 +167,7 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
                 Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
             }
             catch {
-                Write-Verbose -Verbose ($_.Message)
+                Write-Verbose -Verbose "Enable-PSRemoting failed: $($_.Message)"
                 $global:PSDefaultParameterValues["it:skip"] = $true
                 return
             }

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -59,27 +59,30 @@ Describe "Basic Auth over HTTP not allowed on Unix" -Tag @("CI") {
 
 Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnWindows') {
     BeforeAll {
-        $originalDefaultParameterValues = $global:PSDefaultParameterValues.Clone()
 
-        if ( ! $IsWindows -or !(Test-CanWriteToPsHome))
-        {
-            $global:PSDefaultParameterValues["it:skip"] = $true
+        $skipTest = ! $IsWindows -or !(Test-CanWriteToPsHome)
+        if ($skipTest) {
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            return
         }
-        else
-        {
-            try {
-                Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
-            }
-            catch {
-                Write-Verbose -Verbose ($_.Message)
-                $global:PSDefaultParameterValues["it:skip"] = $true
-                return
-            }
+
+        try {
+            Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
+        }
+        catch {
+            Write-Verbose -Verbose ($_.Message)
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            $skipTest = $true
+            return
         }
     }
 
     AfterAll {
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        if ($skipTest) {
+            Pop-DefaultParameterValueStack
+            return
+        }
+        Pop-DefaultParameterValueStack
     }
 
     It "Configuration name should be in the transcript header" {
@@ -108,27 +111,29 @@ Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnW
 
 Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
     BeforeAll {
-        $originalDefaultParameterValues = $global:PSDefaultParameterValues.Clone()
 
-        if ( ! $IsWindows -or !(Test-CanWriteToPsHome))
-        {
-            $global:PSDefaultParameterValues["it:skip"] = $true
+        $skipTest = ! $IsWindows -or !(Test-CanWriteToPsHome)
+        if ($skipTest) {
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            return
         }
-        else
-        {
-            try {
-                Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
-            }
-            catch {
-                Write-Verbose -Verbose "Enable-PSRemoting failed: $($_.Message)"
-                $global:PSDefaultParameterValues["it:skip"] = $true
-                return
-            }
+
+        try {
+            Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
+        }
+        catch {
+            Write-Verbose -Verbose "Enable-PSRemoting failed: $($_.Message)"
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            $skipTest = $true
+            return
         }
     }
 
     AfterAll {
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        if ($skipTest) {
+            Pop-DefaultParameterValueStack
+            return
+        }
     }
 
     It "Get-Help should work in JEA sessions" {
@@ -155,85 +160,89 @@ Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
 Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeAll {
 
-        $originalDefaultParameterValues = $global:PSDefaultParameterValues.Clone()
-
-        if ( ! $IsWindows )
-        {
-            $global:PSDefaultParameterValues["it:skip"] = $true
+        $skipTest = ! $IsWindows
+        if ($skipTest) {
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            return
         }
-        else
+
+        try {
+            Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
+        }
+        catch {
+            Write-Verbose -Verbose "Enable-PSRemoting failed: $($_.Message)"
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            $skipTest = $true
+            return
+        }
+
+        $configName = "PowerShell." + $PSVersionTable.GitCommitId
+        $configuration = Get-PSSessionConfiguration -Name $configName -ErrorAction Ignore
+        if ($null -eq $configuration) {
+            Push-DefaultParameterValueStack @{ "it:skip" = $true }
+            $skipTest = $true
+            return
+        }
+
+        $endPoint = $configuration.Name
+        $disconnectedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost | Disconnect-PSSession
+        $closedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost
+        $closedSession.Runspace.Close()
+        $openSession = New-RemoteSession -ConfigurationName $endPoint
+
+        $ParameterError = @(
+            @{
+                parameters    = @{
+                    'InDisconnectedSession' = $true
+                    'AsJob'                 = $true
+                    'ScriptBlock'           = {1}
+                    'ComputerName'          = 'localhost'
+                    'ConfigurationName'     = $endpoint
+                }
+                expectedError = 'System.InvalidOperationException,Microsoft.PowerShell.Commands.InvokeCommandCommand'
+                title         = 'Cannot use InDisconnectedState and AsJob together'
+            },
+            @{
+                parameters    = @{
+                    'ScriptBlock' = {1}
+                    'SessionName' = 'SomeSessionName'
+                }
+                expectedError = 'System.InvalidOperationException,Microsoft.PowerShell.Commands.InvokeCommandCommand'
+                title         = 'Cannot use SessionName without InDisconnectedSession'
+            },
+            @{
+                parameters    = @{
+                    'ScriptBlock' = { 1 }
+                    'Session'     = $disconnectedSession
+                    'ErrorAction' = 'Stop'
+                }
+                expectedError = 'InvokeCommandCommandInvalidSessionState,Microsoft.PowerShell.Commands.InvokeCommandCommand'
+                title         = 'Cannot use Invoke-Command on a disconnected session'
+            }
+            @{
+                parameters    = @{
+                    'ScriptBlock' = { 1 }
+                    'Session'     = $closedSession
+                    'ErrorAction' = 'Stop'
+                }
+                expectedError = 'InvokeCommandCommandInvalidSessionState,Microsoft.PowerShell.Commands.InvokeCommandCommand'
+                title         = 'Cannot use Invoke-Command on a closed session'
+            }
+        )
+
+        function script:ValidateSessionInfo($session, $state)
         {
-            try {
-                Enable-PSRemoting -SkipNetworkProfileCheck -ErrorAction Stop
-            }
-            catch {
-                Write-Verbose -Verbose "Enable-PSRemoting failed: $($_.Message)"
-                $global:PSDefaultParameterValues["it:skip"] = $true
-                return
-            }
-            $configName = "PowerShell." + $PSVersionTable.GitCommitId
-            $configuration = Get-PSSessionConfiguration -Name $configName -ErrorAction Ignore
-            if ($null -eq $configuration) {
-                $global:PSDefaultParameterValues["it:skip"] = $true
-                return
-            }
-            $endPoint = $configuration.Name
-            $disconnectedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost | Disconnect-PSSession
-            $closedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost
-            $closedSession.Runspace.Close()
-            $openSession = New-RemoteSession -ConfigurationName $endPoint
-
-            $ParameterError = @(
-                @{
-                    parameters    = @{
-                        'InDisconnectedSession' = $true
-                        'AsJob'                 = $true
-                        'ScriptBlock'           = {1}
-                        'ComputerName'          = 'localhost'
-                        'ConfigurationName'     = $endpoint
-                    }
-                    expectedError = 'System.InvalidOperationException,Microsoft.PowerShell.Commands.InvokeCommandCommand'
-                    title         = 'Cannot use InDisconnectedState and AsJob together'
-                },
-                @{
-                    parameters    = @{
-                        'ScriptBlock' = {1}
-                        'SessionName' = 'SomeSessionName'
-                    }
-                    expectedError = 'System.InvalidOperationException,Microsoft.PowerShell.Commands.InvokeCommandCommand'
-                    title         = 'Cannot use SessionName without InDisconnectedSession'
-                },
-                @{
-                    parameters    = @{
-                        'ScriptBlock' = { 1 }
-                        'Session'     = $disconnectedSession
-                        'ErrorAction' = 'Stop'
-                    }
-                    expectedError = 'InvokeCommandCommandInvalidSessionState,Microsoft.PowerShell.Commands.InvokeCommandCommand'
-                    title         = 'Cannot use Invoke-Command on a disconnected session'
-                }
-                @{
-                    parameters    = @{
-                        'ScriptBlock' = { 1 }
-                        'Session'     = $closedSession
-                        'ErrorAction' = 'Stop'
-                    }
-                    expectedError = 'InvokeCommandCommandInvalidSessionState,Microsoft.PowerShell.Commands.InvokeCommandCommand'
-                    title         = 'Cannot use Invoke-Command on a closed session'
-                }
-            )
-
-            function script:ValidateSessionInfo($session, $state)
-            {
-                $session.ComputerName | Should -BeExactly 'localhost'
-                $session.ConfigurationName | Should -BeExactly $endPoint
-                $session.State | Should -Be $state
-            }
+            $session.ComputerName | Should -BeExactly 'localhost'
+            $session.ConfigurationName | Should -BeExactly $endPoint
+            $session.State | Should -Be $state
         }
     }
 
     AfterAll {
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        If ($skipTest) {
+            Pop-DefaultParameterValueStack
+            return
+        }
 
         if($IsWindows)
         {
@@ -244,36 +253,31 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
     It 'Can connect to default endpoint' {
         $session = New-RemoteSession -ConfigurationName $endPoint
 
-        try
-        {
+        try {
             ValidateSessionInfo -session $session -state 'Opened'
         }
-        finally
-        {
+        finally {
             $session | Remove-PSSession -ErrorAction SilentlyContinue
         }
     }
 
     It 'Can execute command in a disconnected session' {
         $session = Invoke-RemoteCommand -InDisconnectedSession -ComputerName 'localhost' -ScriptBlock { 1 + 1 } -ConfigurationName $endPoint
-        try
-        {
+        try {
             ValidateSessionInfo -session $session -state 'Disconnected'
 
             $result = Receive-PSSession -Session $session
             $result | Should -Be 2
             $result.PSComputerName | Should -BeExactly 'localhost'
         }
-        finally
-        {
+        finally {
             $session | Remove-PSSession -ErrorAction SilentlyContinue
         }
     }
 
     It 'Can disconnect and connect to PSSession' {
         $session = New-RemoteSession -ConfigurationName $endPoint
-        try
-        {
+        try {
             ValidateSessionInfo -session $session -state 'Opened'
             Disconnect-PSSession -Session $session
 
@@ -284,8 +288,7 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
             $result | Should -Be 2
             $result.PSComputerName | Should -BeExactly 'localhost'
         }
-        finally
-        {
+        finally {
             $session | Remove-PSSession -ErrorAction SilentlyContinue
         }
     }
@@ -297,12 +300,10 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
     }
 
     It 'Can execute command if one of the sessions is available' {
-        try
-        {
+        try {
             $result = Invoke-Command -Session $openSession,$disconnectedSession,$closedSession -ScriptBlock { 1+1 } -ErrorAction SilentlyContinue
         }
-        catch
-        {
+        catch {
             if($_.FullyQualifiedErrorId -ne 'InvokeCommandCommandInvalidSessionState,Microsoft.PowerShell.Commands.InvokeCommandCommand')
             {
                 # We expect the error from $disconnectedSession and $closedSession. Hence, throw otherwise.
@@ -337,14 +338,12 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
         Connect-RemoteSession -ComputerName localhost -Name $connectionNames -ConfigurationName $endpoint
         $sessions = Get-PSSession -Name $connectionNames
-        try
-        {
+        try {
             $sessions | ForEach-Object {
                 ValidateSessionInfo -session $_ -state 'Opened'
             }
         }
-        finally
-        {
+        finally {
             $sessions | Remove-PSSession -ErrorAction SilentlyContinue
         }
     }

--- a/test/powershell/engine/Security/FileSignature.Tests.ps1
+++ b/test/powershell/engine/Security/FileSignature.Tests.ps1
@@ -102,7 +102,7 @@ Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWin
         foreach($path in $paths) {
             if (Test-Path $path) {
                 # failing to remove is not fatal
-                Remove-Item -Force -Path $path -ErrorAction Continue
+                Remove-Item -Force -Path $path -ErrorAction Ignore
             }
         }
     }

--- a/test/powershell/engine/Security/FileSignature.Tests.ps1
+++ b/test/powershell/engine/Security/FileSignature.Tests.ps1
@@ -22,12 +22,11 @@ Describe "Windows platform file signatures" -Tags 'Feature' {
 }
 
 Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWindows') {
-    $shouldSkip = (-not $IsWindows) -or (Test-IsWinServer2012R2)
-
-    $PSDefaultParameterValues = @{ "It:Skip" = $shouldSkip }
-
     BeforeAll {
+        $shouldSkip = (-not $IsWindows) -or (Test-IsWinServer2012R2)
+
         if ($shouldSkip) {
+            Push-DefaultParameterValueStack @{ "it:skip" = $shouldSkip }
             return
         }
 
@@ -100,7 +99,7 @@ Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWin
         )
 
         foreach($path in $paths) {
-            if (Test-Path $path -ItemType Leaf) {
+            if (Test-Path $path -PathType Leaf) {
                 # failing to remove is not fatal
                 Remove-Item -Force -Path $path -ErrorAction Ignore
             }

--- a/test/powershell/engine/Security/FileSignature.Tests.ps1
+++ b/test/powershell/engine/Security/FileSignature.Tests.ps1
@@ -100,7 +100,7 @@ Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWin
         )
 
         foreach($path in $paths) {
-            if (Test-Path $path) {
+            if (Test-Path $path -ItemType Leaf) {
                 # failing to remove is not fatal
                 Remove-Item -Force -Path $path -ErrorAction Ignore
             }

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
@@ -38,9 +38,16 @@ FunctionsToExport = @(
         'Test-IsWindowsArm64'
         'Test-IsWinServer2012R2'
         'Test-IsWinWow64'
+        'Test-IsWindows2016'
         'Test-TesthookIsSet'
         'Wait-FileToBePresent'
         'Wait-UntilTrue'
+        'Initialize-PSDefaultParameterValue'
+        'Reset-DefaultParameterValueStack'
+        'Get-DefaultParameterValueStack'
+        'Test-PSDefaultParameterValue'
+        'Push-DefaultParameterValueStack'
+        'Pop-DefaultParameterValueStack'
     )
 
 CmdletsToExport= @()

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -456,3 +456,12 @@ function Test-IsWinServer2012R2
     $osInfo = [System.Environment]::OSVersion.Version
     return ($osInfo.Major -eq 6 -and $osInfo.Minor -eq 3)
 }
+
+function Test-IsWindows2016 {
+    if (-not $IsWindows) {
+        return $false
+    }
+
+    $osInfo = [System.Environment]::OSVersion.Version
+    return ($osInfo.Major -eq 10 -and $osInfo.Minor -eq 0 -and $osInfo.Build -eq 14393)
+}

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -465,3 +465,71 @@ function Test-IsWindows2016 {
     $osInfo = [System.Environment]::OSVersion.Version
     return ($osInfo.Major -eq 10 -and $osInfo.Minor -eq 0 -and $osInfo.Build -eq 14393)
 }
+
+
+# helpers for managing psdefaultparametervalues
+[system.collections.generic.Stack[hashtable]]$script:DefaultParameterValueStack = [system.collections.generic.Stack[hashtable]]::new()
+
+# Ensure that the global:PSDefaultParameterValues variable is a hashtable
+function Initialize-PSDefaultParameterValue {
+	if ( $global:PSDefaultParameterValues -isnot [hashtable] ) {
+		$global:PSDefaultParameterValues = @{}
+	}
+}
+
+# reset the stack
+function Reset-DefaultParameterValueStack {
+	$script:DefaultParameterValueStack = [system.collections.generic.Stack[hashtable]]::new()
+    Initialize-PSDefaultParameterValue
+}
+
+# return the current stack
+function Get-DefaultParameterValueStack {
+	$script:DefaultParameterValueStack
+}
+
+# PSDefaultParameterValue may not have both skip and pending keys
+function Test-PSDefaultParameterValue {
+    if ( $global:PSDefaultParameterValues -is [hashtable] ) {
+        if ( $global:PSDefaultParameterValues.ContainsKey('skip') -and $global:PSDefaultParameterValues.ContainsKey('pending') ) {
+            return $false
+        }
+        return $true
+    }
+    Initialize-PSDefaultParameterValue
+}
+
+# push a new value onto the stack
+# if $ht is null, then the current value of $global:PSDefaultParameterValues is pushed
+# if $NewValue is used, then $ht is used as the new value of $global:PSDefaultParameterValues
+function Push-DefaultParameterValueStack {
+	param ([hashtable]$ht, [switch]$NewValue)
+    Initialize-PSDefaultParameterValue
+
+	$script:DefaultParameterValueStack.Push($global:PSDefaultParameterValues.Clone())
+	if ( $ht ) {
+		if ( $NewValue ) {
+			$global:PSDefaultParameterValues = $ht
+		}
+		else {
+			foreach ($k in $ht.Keys) {
+				$global:PSDefaultParameterValues[$k] = $ht[$k]
+			}
+		}
+        if ( ! (Test-PSDefaultParameterValue)) {
+            Write-Warning -Message "PSDefaultParameterValues may not have both skip and pending keys, resetting."
+            Pop-DefaultParameterValueStack
+        }
+	}
+}
+
+function Pop-DefaultParameterValueStack {
+	try {
+		$global:PSDefaultParameterValues = $script:DefaultParameterValueStack.Pop()
+		return $true
+	}
+	catch {
+        Initialize-PSDefaultParameterValue
+		return $false
+	}
+}

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -125,7 +125,6 @@ function Start-PSPackage {
             # Runtime will be one of win7-x64, win7-x86, "win-arm" and "win-arm64" on Windows.
             # Build the name suffix for universal win-plat packages.
             switch ($Runtime) {
-                "win-arm"   { $NameSuffix = "win-arm32" }
                 "win-arm64" { $NameSuffix = "win-arm64" }
                 default     { $NameSuffix = $_ -replace 'win\d+', 'win' }
             }

--- a/tools/releaseBuild/azureDevOps/templates/global-tool-pkg-sbom.yml
+++ b/tools/releaseBuild/azureDevOps/templates/global-tool-pkg-sbom.yml
@@ -14,7 +14,6 @@ parameters:
     - PowerShell.Linux.arm32
     - PowerShell.Linux.arm64
     - PowerShell.Windows.x64
-    - PowerShell.Windows.arm32
 
 steps:
 

--- a/tools/releaseBuild/azureDevOps/templates/release-ValidatePackageNames.yml
+++ b/tools/releaseBuild/azureDevOps/templates/release-ValidatePackageNames.yml
@@ -70,7 +70,7 @@ steps:
 - pwsh: |
     $message = @()
     Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -include *.zip, *.msi | ForEach-Object {
-        if($_.Name -notmatch 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm32|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
+        if($_.Name -notmatch 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
         {
             $messageInstance = "$($_.Name) is not a valid package name"
             $message += $messageInstance

--- a/tools/releaseBuild/azureDevOps/templates/vpackReleaseJob.yml
+++ b/tools/releaseBuild/azureDevOps/templates/vpackReleaseJob.yml
@@ -55,7 +55,7 @@ jobs:
   - pwsh: |
       $message = @()
       Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -include *.zip, *.msi | ForEach-Object {
-          if($_.Name -notmatch 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm32|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
+          if($_.Name -notmatch 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
           {
                 $messageInstance = "$($_.Name) is not a valid package name"
                 $message += $messageInstance

--- a/tools/releaseBuild/azureDevOps/templates/windows-hosted-build.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-hosted-build.yml
@@ -53,7 +53,6 @@ jobs:
         {
           "x64" { "win7-x64" }
           "x86" { "win7-x86" }
-          "arm" { "win-arm"}
           "arm64" { "win-arm64" }
           "fxdependent" { "fxdependent" }
           "fxdependentWinDesktop" { "fxdependent-win-desktop" }

--- a/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-package-signing.yml
@@ -97,12 +97,6 @@ jobs:
 
   - template: upload.yml
     parameters:
-      architecture: arm32
-      version: $(version)
-      msi: no
-
-  - template: upload.yml
-    parameters:
       architecture: arm64
       version: $(version)
       msi: no

--- a/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
+++ b/tools/releaseBuild/azureDevOps/templates/windows-packaging.yml
@@ -43,7 +43,7 @@ jobs:
   - template: shouldSign.yml
 
   - pwsh: |
-      $pkgFilter = if ( '$(Architecture)' -eq 'arm' ) { "arm32" } else { '$(Architecture)' }
+      $pkgFilter = '$(Architecture)'
       if ($env:BuildConfiguration -eq 'minSize') { $pkgFilter += '-gc' }
 
       $vstsCommandString = "vso[task.setvariable variable=PkgFilter]$pkgFilter"
@@ -243,7 +243,6 @@ jobs:
         {
           "x64" { "win7-x64" }
           "x86" { "win7-x86" }
-          "arm" { "win-arm"}
           "arm64" { "win-arm64" }
           "fxdependent" { "fxdependent" }
           "fxdependentWinDesktop" { "fxdependent-win-desktop" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary


<!-- Summarize your PR between here and the checklist. -->

## PR Context

In our release pass testing a number of tests fail. This PR attempts to allow those tests to be skipped on the various platforms where they do not pass. 

- Start-UnixSocket is failing on some windows platforms as it is not supported on those platforms
- there are platforms where remoting cannot be enabled (if enable-psremoting fails, those tests will be skipped)
- being unable to remove a certificate is not a fatal error
-  
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
