### PR TITLE
Add comment about pinned packages

### DIFF
--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -22,7 +22,11 @@
     <PackageReference Include="System.IO.Packaging" Version="8.0.0-preview.7.23375.6" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.0-preview.7.23375.6" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0-preview.7.23375.6" />
-    <!-- the following package(s) are from https://github.com/dotnet/wcf -->
+    <!--
+        the following package(s) are from https://github.com/dotnet/wcf
+        they are pinned to the version 4.10.2 due to a breaking change in newer versions.
+        see https://github.com/PowerShell/PowerShell/issues/19238 for details.
+     -->
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.2" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.10.2" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.2" />


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

The `System.ServiceModel.xxx` packages are pinned due to a breaking change in newer versions.
See https://github.com/PowerShell/PowerShell/issues/19238 for details.