### PR TITLE
Remove the comment trigger from feedback provider

### DIFF
--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/FeedbackHub.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/FeedbackHub.cs
@@ -183,12 +183,10 @@ namespace System.Management.Automation.Subsystem.Feedback
 
         private static bool CanSkip(IEnumerable<IFeedbackProvider> providers)
         {
-            const FeedbackTrigger possibleTriggerOnSuccess = FeedbackTrigger.Success | FeedbackTrigger.Comment;
-
             bool canSkip = true;
             foreach (IFeedbackProvider provider in providers)
             {
-                if ((provider.Trigger & possibleTriggerOnSuccess) != 0)
+                if (provider.Trigger.HasFlag(FeedbackTrigger.Success))
                 {
                     canSkip = false;
                     break;
@@ -249,7 +247,8 @@ namespace System.Management.Automation.Subsystem.Feedback
 
             if (IsPureComment(tokens))
             {
-                trigger = FeedbackTrigger.Comment;
+                // Don't trigger anything in this case.
+                return false;
             }
             else if (questionMarkValue)
             {

--- a/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
+++ b/src/System.Management.Automation/engine/Subsystem/FeedbackSubsystem/IFeedbackProvider.cs
@@ -19,31 +19,26 @@ namespace System.Management.Automation.Subsystem.Feedback
     public enum FeedbackTrigger
     {
         /// <summary>
-        /// The last command line is comment only.
-        /// </summary>
-        Comment = 0x0001,
-
-        /// <summary>
         /// The last command line executed successfully.
         /// </summary>
-        Success = 0x0002,
+        Success = 0x0001,
 
         /// <summary>
         /// The last command line failed due to a command-not-found error.
         /// This is a special case of <see cref="Error"/>.
         /// </summary>
-        CommandNotFound = 0x0004,
+        CommandNotFound = 0x0002,
 
         /// <summary>
         /// The last command line failed with an error record.
         /// This includes the case of command-not-found error.
         /// </summary>
-        Error = CommandNotFound | 0x0008,
+        Error = CommandNotFound | 0x0004,
 
         /// <summary>
         /// All possible triggers.
         /// </summary>
-        All = Comment | Success | Error
+        All = Success | Error
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As discussed with @StevenBucher98 and @SteveL-MSFT, we decided to remove the comment trigger from feedback provider for 2 reasons:
1. A feedback provider may be triggered unexpectedly when the user runs script in PowerShell with right-click paste.
2. The comment trigger seems to make sense for AI scenarios, however, the time delay when talking to LLM is too big to make it really useful.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
