### PR TITLE
Include Module Version in error messages when module is not found

### DIFF
--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -306,7 +306,7 @@ namespace System.Management.Automation
                         ScriptRequiresException scriptRequiresException =
                             new ScriptRequiresException(
                                 scriptInfo.Name,
-                                new Collection<string> { requiredModule.ToString() },
+                                new Collection<string> { requiredModule.GetRequiredModuleNotFoundVersionMessage() },
                                 "ScriptRequiresMissingModules",
                                 false,
                                 error);

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -306,7 +306,7 @@ namespace System.Management.Automation
                         ScriptRequiresException scriptRequiresException =
                             new ScriptRequiresException(
                                 scriptInfo.Name,
-                                new Collection<string> { requiredModule.Name },
+                                new Collection<string> { requiredModule.ToString() },
                                 "ScriptRequiresMissingModules",
                                 false,
                                 error);

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -169,31 +169,20 @@ namespace Microsoft.PowerShell.Commands
         {
             if (Version != null) 
             {
-                return StringUtil.Format(
-                    Modules.RequiredModuleNotFoundModuleVersion,
-                    Name,
-                    Version);
+                return StringUtil.Format(Modules.RequiredModuleNotFoundModuleVersion, Name, Version);
             }
 
             if (RequiredVersion != null) 
             {
-                return StringUtil.Format(
-                    Modules.RequiredModuleNotFoundRequiredVersion,
-                    Name,
-                    RequiredVersion);
+                return StringUtil.Format(Modules.RequiredModuleNotFoundRequiredVersion, Name, RequiredVersion);
             }
 
             if (MaximumVersion != null) 
             {
-                return StringUtil.Format(
-                    Modules.RequiredModuleNotFoundMaximumVersion,
-                    Name,
-                    MaximumVersion);
+                return StringUtil.Format(Modules.RequiredModuleNotFoundMaximumVersion, Name, MaximumVersion);
             }
 
-            return StringUtil.Format(
-                Modules.RequiredModuleNotFoundWithoutVersion,
-                Name);
+            return StringUtil.Format(Modules.RequiredModuleNotFoundWithoutVersion, Name);
         }
 
         internal ModuleSpecification(PSModuleInfo moduleInfo)

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -165,6 +165,37 @@ namespace Microsoft.PowerShell.Commands
             return null;
         }
 
+        internal string GetRequiredModuleNotFoundVersionMessage() 
+        {
+            if (Version != null) 
+            {
+                return StringUtil.Format(
+                    Modules.RequiredModuleNotFoundModuleVersion,
+                    Name,
+                    Version);
+            }
+
+            if (RequiredVersion != null) 
+            {
+                return StringUtil.Format(
+                    Modules.RequiredModuleNotFoundRequiredVersion,
+                    Name,
+                    RequiredVersion);
+            }
+
+            if (MaximumVersion != null) 
+            {
+                return StringUtil.Format(
+                    Modules.RequiredModuleNotFoundMaximumVersion,
+                    Name,
+                    MaximumVersion);
+            }
+
+            return StringUtil.Format(
+                Modules.RequiredModuleNotFoundWithoutVersion,
+                Name);
+        }
+
         internal ModuleSpecification(PSModuleInfo moduleInfo)
         {
             ArgumentNullException.ThrowIfNull(moduleInfo);

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -171,24 +171,20 @@ namespace Microsoft.PowerShell.Commands
             {
                 return StringUtil.Format(Modules.RequiredModuleNotFoundRequiredVersion, Name, RequiredVersion);
             }
-            else
-            {
-                if (Version != null && MaximumVersion != null)
-                {
-                    return StringUtil.Format(Modules.RequiredModuleNotFoundModuleAndMaximumVersion, Name, Version, MaximumVersion);
-                }
-                else
-                {
-                    if (Version != null)
-                    {
-                        return StringUtil.Format(Modules.RequiredModuleNotFoundModuleVersion, Name, Version);
-                    }
 
-                    if (MaximumVersion != null)
-                    {
-                        return StringUtil.Format(Modules.RequiredModuleNotFoundMaximumVersion, Name, MaximumVersion);
-                    }
-                }
+            if (Version != null && MaximumVersion != null)
+            {
+                return StringUtil.Format(Modules.RequiredModuleNotFoundModuleAndMaximumVersion, Name, Version, MaximumVersion);
+            }
+
+            if (Version != null)
+            {
+                return StringUtil.Format(Modules.RequiredModuleNotFoundModuleVersion, Name, Version);
+            }
+
+            if (MaximumVersion != null)
+            {
+                return StringUtil.Format(Modules.RequiredModuleNotFoundMaximumVersion, Name, MaximumVersion);
             }
 
             return StringUtil.Format(Modules.RequiredModuleNotFoundWithoutVersion, Name);

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -167,22 +167,25 @@ namespace Microsoft.PowerShell.Commands
 
         internal string GetRequiredModuleNotFoundVersionMessage()
         {
-            if (RequiredVersion != null)
+            if (RequiredVersion is not null)
             {
                 return StringUtil.Format(Modules.RequiredModuleNotFoundRequiredVersion, Name, RequiredVersion);
             }
 
-            if (Version != null && MaximumVersion != null)
+            bool hasVersion = Version is not null;
+            bool hasMaximumVersion = MaximumVersion is not null;
+
+            if (hasVersion && hasMaximumVersion)
             {
                 return StringUtil.Format(Modules.RequiredModuleNotFoundModuleAndMaximumVersion, Name, Version, MaximumVersion);
             }
 
-            if (Version != null)
+            if (hasVersion)
             {
                 return StringUtil.Format(Modules.RequiredModuleNotFoundModuleVersion, Name, Version);
             }
 
-            if (MaximumVersion != null)
+            if (hasMaximumVersion)
             {
                 return StringUtil.Format(Modules.RequiredModuleNotFoundMaximumVersion, Name, MaximumVersion);
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -169,7 +169,10 @@ namespace Microsoft.PowerShell.Commands
         {
             if (RequiredVersion is not null)
             {
-                return StringUtil.Format(Modules.RequiredModuleNotFoundRequiredVersion, Name, RequiredVersion);
+                return StringUtil.Format(
+                    Modules.RequiredModuleNotFoundRequiredVersion,
+                    Name,
+                    RequiredVersion);
             }
 
             bool hasVersion = Version is not null;
@@ -177,20 +180,32 @@ namespace Microsoft.PowerShell.Commands
 
             if (hasVersion && hasMaximumVersion)
             {
-                return StringUtil.Format(Modules.RequiredModuleNotFoundModuleAndMaximumVersion, Name, Version, MaximumVersion);
+                return StringUtil.Format(
+                    Modules.RequiredModuleNotFoundModuleAndMaximumVersion,
+                    Name,
+                    Version,
+                    MaximumVersion);
             }
 
             if (hasVersion)
             {
-                return StringUtil.Format(Modules.RequiredModuleNotFoundModuleVersion, Name, Version);
+                return StringUtil.Format(
+                    Modules.RequiredModuleNotFoundModuleVersion,
+                    Name,
+                    Version);
             }
 
             if (hasMaximumVersion)
             {
-                return StringUtil.Format(Modules.RequiredModuleNotFoundMaximumVersion, Name, MaximumVersion);
+                return StringUtil.Format(
+                    Modules.RequiredModuleNotFoundMaximumVersion,
+                    Name,
+                    MaximumVersion);
             }
 
-            return StringUtil.Format(Modules.RequiredModuleNotFoundWithoutVersion, Name);
+            return StringUtil.Format(
+                Modules.RequiredModuleNotFoundWithoutVersion,
+                Name);
         }
 
         internal ModuleSpecification(PSModuleInfo moduleInfo)

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -165,21 +165,30 @@ namespace Microsoft.PowerShell.Commands
             return null;
         }
 
-        internal string GetRequiredModuleNotFoundVersionMessage() 
+        internal string GetRequiredModuleNotFoundVersionMessage()
         {
-            if (Version != null) 
-            {
-                return StringUtil.Format(Modules.RequiredModuleNotFoundModuleVersion, Name, Version);
-            }
-
-            if (RequiredVersion != null) 
+            if (RequiredVersion != null)
             {
                 return StringUtil.Format(Modules.RequiredModuleNotFoundRequiredVersion, Name, RequiredVersion);
             }
-
-            if (MaximumVersion != null) 
+            else
             {
-                return StringUtil.Format(Modules.RequiredModuleNotFoundMaximumVersion, Name, MaximumVersion);
+                if (Version != null && MaximumVersion != null)
+                {
+                    return StringUtil.Format(Modules.RequiredModuleNotFoundModuleAndMaximumVersion, Name, Version, MaximumVersion);
+                }
+                else
+                {
+                    if (Version != null)
+                    {
+                        return StringUtil.Format(Modules.RequiredModuleNotFoundModuleVersion, Name, Version);
+                    }
+
+                    if (MaximumVersion != null)
+                    {
+                        return StringUtil.Format(Modules.RequiredModuleNotFoundMaximumVersion, Name, MaximumVersion);
+                    }
+                }
             }
 
             return StringUtil.Format(Modules.RequiredModuleNotFoundWithoutVersion, Name);

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -240,6 +240,9 @@
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
     <value>The module '{0}' cannot be found with MaximumVersion '{1}'</value>
   </data>
+  <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
+    <value>The module '{0}' cannot be found with Module Version '{1}' and MaximumVersion '{2}'</value>
+  </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
     <value>The module '{0}' cannot be found</value>
   </data>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -241,7 +241,7 @@
     <value>The module '{0}' cannot be found with MaximumVersion '{1}'</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with Module Version '{1}' and MaximumVersion '{2}'</value>
+    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
     <value>The module '{0}' cannot be found</value>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -231,6 +231,18 @@
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
     <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
   </data>
+  <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
+    <value>The module '{0}' cannot be found with ModuleVersion '{1}'</value>
+  </data>
+  <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
+    <value>The module '{0}' cannot be found with RequiredVersion '{1}'</value>
+  </data>
+  <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
+    <value>The module '{0}' cannot be found with MaximumVersion '{1}'</value>
+  </data>
+  <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
+    <value>The module '{0}' cannot be found</value>
+  </data>
   <data name="NoModulesRemoved" xml:space="preserve">
     <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
   </data>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -232,19 +232,19 @@
     <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'</value>
+    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'</value>
+    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'</value>
+    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'</value>
+    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found</value>
+    <value>The module '{0}' cannot be found.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
     <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>

--- a/test/powershell/Language/Scripting/Requires.Tests.ps1
+++ b/test/powershell/Language/Scripting/Requires.Tests.ps1
@@ -118,11 +118,17 @@ Describe "#requires -Modules" -Tags "CI" {
             $badName = 'ModuleThatDoesNotExist'
             $badPath = Join-Path $TestDrive 'ModuleThatDoesNotExist'
             $version = '1.0'
+            $requiredVersion = '1.1'
+            $maximumVersion = '1.2'
             $testCases = @(
-                @{ ModuleRequirement = "'$badName'"; Scenario = 'name' }
-                @{ ModuleRequirement = "'$badPath'"; Scenario = 'path' }
-                @{ ModuleRequirement = "@{ ModuleName = '$badName'; ModuleVersion = '$version' }"; Scenario = 'fully qualified name with name' }
-                @{ ModuleRequirement = "@{ ModuleName = '$badPath'; ModuleVersion = '$version' }"; Scenario = 'fully qualified name with path' }
+                @{ ModuleRequirement = $badName; Scenario = 'fully qualified with module name' }
+                @{ ModuleRequirement = $badPath; Scenario = 'fully qualified with module path' }
+                @{ ModuleRequirement = "@{ ModuleName = '$badName'; ModuleVersion = '$version' }"; Scenario = 'fully qualified with module name and version' }
+                @{ ModuleRequirement = "@{ ModuleName = '$badPath'; ModuleVersion = '$version' }"; Scenario = 'fully qualified with module name and version' }
+                @{ ModuleRequirement = "@{ ModuleName = '$badName'; RequiredVersion = '$requiredVersion' }"; Scenario = 'fully qualified with module name and required version' }
+                @{ ModuleRequirement = "@{ ModuleName = '$badPath'; RequiredVersion = '$requiredVersion' }"; Scenario = 'fully qualified with module path and required version' }
+                @{ ModuleRequirement = "@{ ModuleName = '$badName'; MaximumVersion = '$maximumVersion' }"; Scenario = 'fully qualified with module name and maximum version' }
+                @{ ModuleRequirement = "@{ ModuleName = '$badPath'; MaximumVersion = '$maximumVersion' }"; Scenario = 'fully qualified with module path and maximum version' }
             )
         }
 
@@ -132,7 +138,8 @@ Describe "#requires -Modules" -Tags "CI" {
             $script = "#requires -Modules $ModuleRequirement`n`nWrite-Output 'failed'"
             $null = New-Item -Path $scriptPath -Value $script -Force
 
-            { & $scriptPath } | Should -Throw -ErrorId 'ScriptRequiresMissingModules'
+            $ex = { & $scriptPath } | Should -Throw -ErrorId 'ScriptRequiresMissingModules' -PassThru
+            $ex.Exception.Message | Should -Match ([regex]::Escape($ModuleRequirement))
         }
     }
 

--- a/test/powershell/Language/Scripting/Requires.Tests.ps1
+++ b/test/powershell/Language/Scripting/Requires.Tests.ps1
@@ -161,6 +161,16 @@ Describe "#requires -Modules" -Tags "CI" {
                     Scenario = 'fully qualified with module path and maximum version'
                     ExpectedMessageStrings = @($badPath, $maximumVersion)
                 }
+                @{
+                    ModuleRequirement = "@{ ModuleName = '$badName'; ModuleVersion = '$version'; MaximumVersion = '$maximumVersion' }"
+                    Scenario = 'fully qualified with module name and version and maximum version'
+                    ExpectedMessageStrings = @($badName, $version, $maximumVersion)
+                }
+                @{
+                    ModuleRequirement = "@{ ModuleName = '$badPath'; ModuleVersion = '$version'; MaximumVersion = '$maximumVersion' }"
+                    Scenario = 'fully qualified with module path and version and maximum version'
+                    ExpectedMessageStrings = @($badPath, $version, $maximumVersion)
+                }
             )
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #20142

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Added more user friendly `#requires` error message when a module cannot be loaded, instead of just the module name.

If you had a required module included like:

```powershell
#Requires -Modules @{ ModuleName = 'CosmosDB'; RequiredVersion = '4.6.0'}
```

### Previous Behaviour

Just shows module name.

```powershell
.\test.ps1: The script 'test.ps1' cannot be run because the following modules that are specified by the "#requires" statements of the script are missing: CosmosDB.
```

### Current Behaviour

Includes full RESX message with module name and version.

```powershell
.\test.ps1: The script 'test.ps1' cannot be run because the following modules that are specified by the "#requires" statements of the script are missing: The module 'CosmosDB' cannot be found with RequiredVersion '4.6.0'.
```

The new RESX messages are like below for each version type and if no version is specified

```powershell
#Requires -Modules @{ ModuleName = 'CosmosDB'; RequiredVersion = '4.6.0' }
The module 'CosmosDB' cannot be found with RequiredVersion '4.6.0'. 

#Requires -Modules @{ ModuleName = 'CosmosDB'; ModuleVersion = '4.6.0' }
The module 'CosmosDB' cannot be found with ModuleVersion '4.6.0'.

#Requires -Modules @{ ModuleName = 'CosmosDB'; MaximumVersion = '4.6.0' }
The module 'CosmosDB' cannot be found with MaximumVersion '4.6.0'.

#Requires -Modules @{ ModuleName = 'CosmosDB'; ModuleVersion = '4.6.0';  MaximumVersion = '4.7.0' }
The module 'CosmosDB' cannot be found with ModuleVersion '4.6.0' and MaximumVersion '4.7.0'.

 #Requires -Modules @{ ModuleName = 'CosmosDB' }
The module 'CosmosDB' cannot be found.
```

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
