### PR TITLE
Continued improvement to tests for release automation

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -83,7 +83,7 @@ try
                 $result = Get-Command NestedFn1 2> $null;
                 return ($result -ne $null)
 '@
-                $isCommandAccessible = powershell.exe -noprofile -nologo -c $command
+                $isCommandAccessible = pwsh.exe -noprofile -nologo -c $command
             }
             finally
             {

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -104,7 +104,24 @@ function Initialize
 
 function Remove-InstalledModules
 {
-    Get-InstalledModule -Name $TestModule -AllVersions -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module -Force
+    try {
+        $mod = Get-InstalledModule -Name $TestModule -AllVersions -ErrorAction SilentlyContinue
+        if ($null -eq $mod) {
+            return
+        }
+
+        if (Get-Module -Name $TestModule -ErrorAction Ignore) {
+            Remove-Module -Force -Name $TestModule
+        }
+
+        $installedPath = $mod.InstalledLocation
+        if (Test-Path $installedPath) {
+            Remove-Item -Force -Recurse $installedPath -ErrorAction Ignore
+        }
+    }
+    catch {
+        Write-Warning "Remove-InstalledModules: $_"
+    }
 }
 
 Describe "PowerShellGet - Module tests" -tags "Feature" {
@@ -172,7 +189,20 @@ Describe "PowerShellGet - Module tests (Admin)" -Tags @('Feature', 'RequireAdmin
 
 function Remove-InstalledScripts
 {
-    Get-InstalledScript -Name $TestScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+    $installedScript = Get-InstalledScript -Name $TestScript -ErrorAction SilentlyContinue
+    if ($null -eq $installedScript) {
+        return
+    }
+
+	$scriptPath = Join-Path ${installedScript}.InstalledLocation "${TestScript}.ps1"
+	if (test-Path -Type Leaf -Path $scriptPath) {
+		Remove-Item -Force -Path $scriptPath -ErrorAction Ignore
+	}
+
+	$xmlPath = Join-Path ${installedScript}.InstalledLocation InstalledScriptInfos "${TestScript}_InstalledScriptInfo.xml"
+	if (test-Path -Type Leaf -Path $xmlPath) {
+		Remove-Item -Force -Path $xmlPath -ErrorAction Ignore
+	}
 }
 
 Describe "PowerShellGet - Script tests" -tags "Feature" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There are still some release tests which have failures.
This PR addresses an issue in the native app invocation which invokes powershell.exe rather than pwsh.exe
This PR also hardens some of the powershellget tests when removing installed modules or scripts

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
