### PR TITLE
Fix PSClassHelpProvider

### DIFF
--- a/src/System.Management.Automation/help/MamlClassHelpInfo.cs
+++ b/src/System.Management.Automation/help/MamlClassHelpInfo.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Xml;
 using System.Globalization;
+using System.Xml;
 
 namespace System.Management.Automation
 {

--- a/src/System.Management.Automation/help/MamlClassHelpInfo.cs
+++ b/src/System.Management.Automation/help/MamlClassHelpInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Xml;
+using System.Globalization;
 
 namespace System.Management.Automation
 {
@@ -110,15 +111,41 @@ namespace System.Management.Automation
         {
             get
             {
-                string tempSynopsis = string.Empty;
-                var intro = _fullHelpObject.Properties["introduction"];
-
-                if (intro != null && intro.Value != null)
+                if (_fullHelpObject == null)
                 {
-                    tempSynopsis = intro.Value.ToString();
+                    return string.Empty;
                 }
 
-                return tempSynopsis;
+                if (_fullHelpObject.Properties["introduction"] == null ||
+                    _fullHelpObject.Properties["introduction"].Value == null)
+                {
+                    return string.Empty;
+                }
+
+                object[] synopsisItems = (object[])LanguagePrimitives.ConvertTo(
+                    _fullHelpObject.Properties["introduction"].Value,
+                    typeof(object[]),
+                    CultureInfo.InvariantCulture);
+                if (synopsisItems == null || synopsisItems.Length == 0)
+                {
+                    return string.Empty;
+                }
+
+                PSObject firstSynopsisItem = synopsisItems[0] == null ? null : PSObject.AsPSObject(synopsisItems[0]);
+                if (firstSynopsisItem == null ||
+                    firstSynopsisItem.Properties["Text"] == null ||
+                    firstSynopsisItem.Properties["Text"].Value == null)
+                {
+                    return string.Empty;
+                }
+
+                string synopsis = firstSynopsisItem.Properties["Text"].Value.ToString();
+                if (synopsis == null)
+                {
+                    return string.Empty;
+                }
+
+                return synopsis.Trim();
             }
         }
 

--- a/src/System.Management.Automation/help/PSClassHelpProvider.cs
+++ b/src/System.Management.Automation/help/PSClassHelpProvider.cs
@@ -118,7 +118,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get the help in for the PS Class Info.        ///
+        /// Get the help in for the PS Class Info.
         /// </summary>
         /// <param name="searcher">Searcher for PS Classes.</param>
         /// <returns>Next HelpInfo object.</returns>
@@ -162,6 +162,26 @@ namespace System.Management.Automation
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Prepends helpfileIdentifier to the class name and adds the result to help cache.
+        /// </summary>
+        /// <param name="helpIdentifier">The path of the help file.</param>
+        /// <param name="className">Name of the class.</param>
+        /// <param name="helpInfo">Help object for the class.</param>
+        private void AddToClassCache(string helpIdentifier, string className, MamlClassHelpInfo helpInfo)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(className), "Class Name should not be null or empty.");
+
+            string key = className;
+
+            if (!string.IsNullOrEmpty(helpIdentifier))
+            {
+                key = helpIdentifier + "\\" + key;
+            }
+
+            AddCache(key, helpInfo);
         }
 
         /// <summary>
@@ -219,7 +239,7 @@ namespace System.Management.Automation
                     LoadHelpFile(helpFile, helpFile, classInfo.Name, reportErrors);
                 }
 
-                return GetFromPSClassHelpCache(helpFile, Automation.HelpCategory.Class);
+                return GetFromPSClassHelpCache(helpFile, classInfo.Name, Automation.HelpCategory.Class);
             }
 
             return null;
@@ -228,14 +248,21 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the HelpInfo object corresponding to the command.
         /// </summary>
-        /// <param name="helpFileIdentifier">Help file identifier (either name of PSSnapIn or simply full path to help file).</param>
+        /// <param name="helpFileIdentifier">The full path to the help file.</param>
+        /// <param name="className">The name of the class in the help file.</param>
         /// <param name="helpCategory">Help Category for search.</param>
         /// <returns>HelpInfo object.</returns>
-        private HelpInfo GetFromPSClassHelpCache(string helpFileIdentifier, HelpCategory helpCategory)
+        private HelpInfo GetFromPSClassHelpCache(string helpFileIdentifier, string className, HelpCategory helpCategory)
         {
-            Debug.Assert(!string.IsNullOrEmpty(helpFileIdentifier), "helpFileIdentifier should not be null or empty.");
+            Debug.Assert(!string.IsNullOrEmpty(className), "Class Name should not be null or empty.");
 
-            HelpInfo result = GetCache(helpFileIdentifier);
+            string key = className;
+            if (!string.IsNullOrEmpty(helpFileIdentifier))
+            {
+                key = helpFileIdentifier + "\\" + key;
+            }
+
+            HelpInfo result = GetCache(key);
 
             if (result != null)
             {
@@ -358,7 +385,7 @@ namespace System.Management.Automation
                             if (helpInfo != null)
                             {
                                 this.HelpSystem.TraceErrors(helpInfo.Errors);
-                                AddCache(helpFileIdentifier, helpInfo);
+                                AddToClassCache(helpFileIdentifier, helpInfo.Name, helpInfo);
                             }
                         }
                     }

--- a/test/powershell/help/PSClassHelpProvider.Tests.ps1
+++ b/test/powershell/help/PSClassHelpProvider.Tests.ps1
@@ -1,0 +1,179 @@
+New-Module PesterInterop {
+    if ((Get-Module Pester).Version -lt '5.1') {
+        function BeforeDiscovery {
+            . $args[0]
+        }
+    }
+} | Import-Module
+
+Describe 'ClassHelp' {
+    BeforeDiscovery {
+        Add-Type -AssemblyName System.Xml.Linq
+
+        # Slightly hacky way to make help info available across pester scopes / It blocks.
+        $testCases = @(
+            @{ ClassName = 'ClassOne'; HelpInfo = @{ Value = $null } }
+            @{ ClassName = 'ClassTwo'; HelpInfo = @{ Value = $null } }
+        )
+    }
+
+    BeforeAll {
+        $modulePath = Join-Path $PSScriptRoot -ChildPath 'PSClassHelpProvider'
+        $helpFilePath = Join-Path $PSScriptRoot -ChildPath 'PSClassHelpProvider\module\en-US\module-help.xml'
+
+        $psModulePath = $env:PSModulePath
+        $env:PSModulePath = $modulePath + [System.IO.Path]::PathSeparator + $modulePath
+    }
+
+    AfterAll {
+        $env:PSModulePath = $psModulePath
+    }
+
+    It 'Should find and load the test module' {
+        { Import-Module module -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'Should include a maml help document' {
+        $helpFilePath | Should -Exist
+    }
+
+    It 'Should have a valid help file according to the MAML schema' {
+        $xDocument = [System.Xml.Linq.XDocument]::Load(
+            $helpFilePath,
+            'SetLineInfo'
+        )
+
+        $xmlSchemaSet = [System.Xml.Schema.XmlSchemaSet]::new()
+        $xmlSchemaSet.XmlResolver = [System.Xml.XmlUrlResolver]::new()
+        $null = $xmlSchemaSet.Add(
+            'http://schemas.microsoft.com/maml/2004/10',
+            (Join-Path $PSHome -ChildPath 'Schemas\PSMaml\Maml.xsd')
+        )
+
+        $validateErrors = [System.Collections.Generic.List[string]]::new()
+        [System.Xml.Schema.Extensions]::Validate(
+            $xDocument,
+            $xmlSchemaSet,
+            {
+                param ($sender, $eventArgs)
+
+                if ($eventArgs.Severity -in 'Error', 'Warning') {
+                    $message = 'Line {0}, Column {1}, {2}' -f @(
+                        $eventArgs.LineNumber
+                        $eventArgs.LinePosition
+                        $eventArgs.Message
+                    )
+                    $validateErrors.Add($message)
+                }
+            }
+        )
+        $validateErrors | Should -BeNullOrEmpty
+    }
+
+    It 'Should get the class "<ClassName>"' -TestCases $testCases {
+        param ($ClassName)
+
+        module\Get-ModuleClass -Name $ClassName | Should -Not -BeNullOrEmpty
+    }
+
+    Context 'Help content' {
+        It 'Should get help for the class "<ClassName">' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $HelpInfo.Value = Get-Help $ClassName -Category Class
+            $HelpInfo.Value | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have a synopsis for the class "<ClassName>"' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: Class synopsis.' -f $ClassName
+
+            $HelpInfo.Value.introduction.Text | Should -Be $expected
+            $HelpInfo.Value.Synopsis | Should -Be $expected
+        }
+
+        It 'Should contain a description for each property of the class "<ClassName>"' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: Property description.' -f $ClassName
+
+            $field = $HelpInfo.Value.members.member | Where-Object type -eq 'field'
+            $field | Should -Not -BeNullOrEmpty
+            $field.introduction.Text | Should -Be $expected
+            $field.fieldData.name | Should -Be 'Property'
+            $field.fieldData.type.name | Should -Be 'string'
+        }
+
+        It 'Should contain information about a default constructor of the class "<ClassName>"' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: Constructor description.' -f $ClassName
+
+            $ctor = $HelpInfo.Value.members.member | Where-Object { $_.title -eq 'ctor' -and -not $_.Parameters }
+            $ctor | Should -Not -BeNullOrEmpty
+            $ctor.introduction.Text | Should -Be $expected
+        }
+
+        It 'Should contain information about a constructor which requires arguments of the class "<ClassName">' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: Constructor with argument description.' -f $ClassName
+
+            $ctor = $HelpInfo.Value.members.member | Where-Object { $_.title -eq 'ctor' -and $_.Parameters }
+            $ctor | Should -Not -BeNullOrEmpty
+            $ctor.introduction.Text | Should -Be $expected
+            $ctor.Parameters | Should -HaveCount 1
+            $ctor.Parameters.Parameter.Name | Should -Be 'argument'
+            $ctor.Parameters.Parameter.type.name | Should -Be 'string'
+        }
+
+        It 'Should contain information about a method which returns nothing and requires no arguments in the class "<ClassName>"' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: Void method description.' -f $ClassName
+
+            $method = $HelpInfo.Value.members.member | Where-Object { $_.title -eq 'voidMethod' -and -not $_.Parameters }
+            $method | Should -Not -BeNullOrEmpty
+            $method.introduction.Text | Should -Be $expected
+            $method.Parameters | Should -BeNullOrEmpty
+        }
+
+        It 'Should contain information about a method which returns nothing and requires arguments in the class "<ClassName>"' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: Void method with argument description.' -f $ClassName
+
+            $method = $HelpInfo.Value.members.member | Where-Object { $_.title -eq 'voidMethod' -and $_.Parameters }
+            $method | Should -Not -BeNullOrEmpty
+            $method.introduction.Text | Should -Be $expected
+            $method.Parameters | Should -HaveCount 1
+            $method.Parameters.Parameter.Name | Should -Be 'argument'
+            $method.Parameters.Parameter.type.name | Should -Be 'string'
+        }
+
+        It 'Should contain information about a method which returns a value and requires no arguments in the class "<ClassName>"' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: String method description.' -f $ClassName
+
+            $method = $HelpInfo.Value.members.member | Where-Object { $_.title -eq 'returnMethod' -and -not $_.Parameters }
+            $method | Should -Not -BeNullOrEmpty
+            $method.introduction.Text | Should -Be $expected
+            $method.Parameters | Should -BeNullOrEmpty
+        }
+
+        It 'Should contain information about a method which returns a value and requires arguments in the class "<ClassName>"' -TestCases $testCases {
+            param ($ClassName, $HelpInfo)
+
+            $expected = '{0}: String method with argument description.' -f $ClassName
+
+            $method = $HelpInfo.Value.members.member | Where-Object { $_.title -eq 'returnMethod' -and $_.Parameters }
+            $method | Should -Not -BeNullOrEmpty
+            $method.introduction.Text | Should -Be $expected
+            $method.Parameters | Should -HaveCount 1
+            $method.Parameters.Parameter.Name | Should -Be 'argument'
+            $method.Parameters.Parameter.type.name | Should -Be 'string'
+        }
+    }
+}

--- a/test/powershell/help/PSClassHelpProvider.Tests.ps1
+++ b/test/powershell/help/PSClassHelpProvider.Tests.ps1
@@ -55,13 +55,13 @@ Describe 'ClassHelp' {
             $xDocument,
             $xmlSchemaSet,
             {
-                param ($sender, $eventArgs)
+                param ($node, $data)
 
-                if ($eventArgs.Severity -in 'Error', 'Warning') {
+                if ($data.Severity -in 'Error', 'Warning') {
                     $message = 'Line {0}, Column {1}, {2}' -f @(
-                        $eventArgs.LineNumber
-                        $eventArgs.LinePosition
-                        $eventArgs.Message
+                        $data.LineNumber
+                        $data.LinePosition
+                        $data.Message
                     )
                     $validateErrors.Add($message)
                 }

--- a/test/powershell/help/PSClassHelpProvider/module/en-US/module-help.xml
+++ b/test/powershell/help/PSClassHelpProvider/module/en-US/module-help.xml
@@ -1,0 +1,231 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:class xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http//msdn.microsoft.com/mshelp">
+    <command:title>classOne</command:title>
+    <command:introduction>
+      <maml:para>ClassOne: Class synopsis.</maml:para>
+    </command:introduction>
+    <command:members>
+      <command:member type="field">
+        <command:introduction>
+          <maml:para>ClassOne: Property description.</maml:para>
+        </command:introduction>
+        <command:fieldData>
+          <command:name>Property</command:name>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+        </command:fieldData>
+      </command:member>
+      <command:member type="method">
+        <command:title>ctor</command:title>
+        <command:introduction>
+          <maml:para>ClassOne: Constructor description.</maml:para>
+        </command:introduction>
+        <command:Parameters />
+      </command:member>
+      <command:member type="method">
+        <command:title>ctor</command:title>
+        <command:introduction>
+          <maml:para>ClassOne: Constructor with argument description.</maml:para>
+        </command:introduction>
+        <command:Parameters>
+          <command:Parameter>
+            <command:name>argument</command:name>
+            <dev:type>
+              <maml:name>string</maml:name>
+              <maml:uri />
+            </dev:type>
+          </command:Parameter>
+        </command:Parameters>
+      </command:member>
+      <command:member type="method">
+        <command:title>voidMethod</command:title>
+        <command:introduction>
+          <maml:para>ClassOne: Void method description.</maml:para>
+        </command:introduction>
+        <command:Parameters />
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+      <command:member type="method">
+        <command:title>voidMethod</command:title>
+        <command:introduction>
+          <maml:para>ClassOne: Void method with argument description.</maml:para>
+        </command:introduction>
+        <command:Parameters>
+          <command:Parameter>
+            <command:name>argument</command:name>
+            <dev:type>
+              <maml:name>string</maml:name>
+              <maml:uri />
+            </dev:type>
+          </command:Parameter>
+        </command:Parameters>
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+      <command:member type="method">
+        <command:title>returnMethod</command:title>
+        <command:introduction>
+          <maml:para>ClassOne: String method description.</maml:para>
+        </command:introduction>
+        <command:Parameters />
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+      <command:member type="method">
+        <command:title>returnMethod</command:title>
+        <command:introduction>
+          <maml:para>ClassOne: String method with argument description.</maml:para>
+        </command:introduction>
+        <command:Parameters>
+          <command:Parameter>
+            <command:name>argument</command:name>
+            <dev:type>
+              <maml:name>string</maml:name>
+              <maml:uri />
+            </dev:type>
+          </command:Parameter>
+        </command:Parameters>
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+    </command:members>
+  </command:class>
+  <command:class xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http//msdn.microsoft.com/mshelp">
+    <command:title>classTwo</command:title>
+    <command:introduction>
+      <maml:para>classTwo: Class synopsis.</maml:para>
+    </command:introduction>
+    <command:members>
+      <command:member type="field">
+        <command:introduction>
+          <maml:para>classTwo: Property description.</maml:para>
+        </command:introduction>
+        <command:fieldData>
+          <command:name>Property</command:name>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+        </command:fieldData>
+      </command:member>
+      <command:member type="method">
+        <command:title>ctor</command:title>
+        <command:introduction>
+          <maml:para>classTwo: Constructor description.</maml:para>
+        </command:introduction>
+        <command:Parameters />
+      </command:member>
+      <command:member type="method">
+        <command:title>ctor</command:title>
+        <command:introduction>
+          <maml:para>classTwo: Constructor with argument description.</maml:para>
+        </command:introduction>
+        <command:Parameters>
+          <command:Parameter>
+            <command:name>argument</command:name>
+            <dev:type>
+              <maml:name>string</maml:name>
+              <maml:uri />
+            </dev:type>
+          </command:Parameter>
+        </command:Parameters>
+      </command:member>
+      <command:member type="method">
+        <command:title>voidMethod</command:title>
+        <command:introduction>
+          <maml:para>classTwo: Void method description.</maml:para>
+        </command:introduction>
+        <command:Parameters />
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+      <command:member type="method">
+        <command:title>voidMethod</command:title>
+        <command:introduction>
+          <maml:para>classTwo: Void method with argument description.</maml:para>
+        </command:introduction>
+        <command:Parameters>
+          <command:Parameter>
+            <command:name>argument</command:name>
+            <dev:type>
+              <maml:name>string</maml:name>
+              <maml:uri />
+            </dev:type>
+          </command:Parameter>
+        </command:Parameters>
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+      <command:member type="method">
+        <command:title>returnMethod</command:title>
+        <command:introduction>
+          <maml:para>classTwo: String method description.</maml:para>
+        </command:introduction>
+        <command:Parameters />
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+      <command:member type="method">
+        <command:title>returnMethod</command:title>
+        <command:introduction>
+          <maml:para>classTwo: String method with argument description.</maml:para>
+        </command:introduction>
+        <command:Parameters>
+          <command:Parameter>
+            <command:name>argument</command:name>
+            <dev:type>
+              <maml:name>string</maml:name>
+              <maml:uri />
+            </dev:type>
+          </command:Parameter>
+        </command:Parameters>
+        <command:returnValue>
+          <dev:type>
+            <maml:name>string</maml:name>
+            <maml:uri />
+          </dev:type>
+          <maml:description />
+        </command:returnValue>
+      </command:member>
+    </command:members>
+  </command:class>
+</helpItems>

--- a/test/powershell/help/PSClassHelpProvider/module/module.psm1
+++ b/test/powershell/help/PSClassHelpProvider/module/module.psm1
@@ -3,86 +3,26 @@
 #>
 
 class classOne {
-    <#
-        .DESCRIPTION
-            ClassOne: class description.
-    #>
-
-    <#
-        ClassOne: Property description.
-    #>
     [string] $Property
 
-    <#
-        ClassOne: Constructor description.
-    #>
     classOne() { }
-
-    <#
-        ClassOne: Constructor with argument description.
-    #>
     classOne([string] $argument) { }
 
-    <#
-        ClassOne: Void method description.
-    #>
     [void] voidMethod() { }
-
-    <#
-        ClassOne: Void method with argument description.
-    #>
     [void] voidMethod([string] $argument) { }
-
-    <#
-        ClassOne: String method description.
-    #>
     [string] returnMethod() { return '' }
-
-    <#
-        ClassOne: String method with argument description.
-    #>
     [string] returnMethod([string] $argument) { return '' }
 }
 
 class classTwo {
-    <#
-        .DESCRIPTION
-            classTwo: class description.
-    #>
-
-    <#
-        classTwo: Property description.
-    #>
     [string] $Property
 
-    <#
-        classTwo: Constructor description.
-    #>
     classTwo() { }
-
-    <#
-        classTwo: Constructor with argument description.
-    #>
     classTwo([string] $argument) { }
 
-    <#
-        classTwo: Void method description.
-    #>
     [void] voidMethod() { }
-
-    <#
-        classTwo: Void method with argument description.
-    #>
     [void] voidMethod([string] $argument) { }
-
-    <#
-        classTwo: String method description.
-    #>
     [string] returnMethod() { return '' }
-
-    <#
-        classTwo: String method with argument description.
-    #>
     [string] returnMethod([string] $argument) { return '' }
 }
 

--- a/test/powershell/help/PSClassHelpProvider/module/module.psm1
+++ b/test/powershell/help/PSClassHelpProvider/module/module.psm1
@@ -1,0 +1,101 @@
+<#
+    .EXTERNALHELP module-help.xml
+#>
+
+class classOne {
+    <#
+        .DESCRIPTION
+            ClassOne: class description.
+    #>
+
+    <#
+        ClassOne: Property description.
+    #>
+    [string] $Property
+
+    <#
+        ClassOne: Constructor description.
+    #>
+    classOne() { }
+
+    <#
+        ClassOne: Constructor with argument description.
+    #>
+    classOne([string] $argument) { }
+
+    <#
+        ClassOne: Void method description.
+    #>
+    [void] voidMethod() { }
+
+    <#
+        ClassOne: Void method with argument description.
+    #>
+    [void] voidMethod([string] $argument) { }
+
+    <#
+        ClassOne: String method description.
+    #>
+    [string] returnMethod() { return '' }
+
+    <#
+        ClassOne: String method with argument description.
+    #>
+    [string] returnMethod([string] $argument) { return '' }
+}
+
+class classTwo {
+    <#
+        .DESCRIPTION
+            classTwo: class description.
+    #>
+
+    <#
+        classTwo: Property description.
+    #>
+    [string] $Property
+
+    <#
+        classTwo: Constructor description.
+    #>
+    classTwo() { }
+
+    <#
+        classTwo: Constructor with argument description.
+    #>
+    classTwo([string] $argument) { }
+
+    <#
+        classTwo: Void method description.
+    #>
+    [void] voidMethod() { }
+
+    <#
+        classTwo: Void method with argument description.
+    #>
+    [void] voidMethod([string] $argument) { }
+
+    <#
+        classTwo: String method description.
+    #>
+    [string] returnMethod() { return '' }
+
+    <#
+        classTwo: String method with argument description.
+    #>
+    [string] returnMethod([string] $argument) { return '' }
+}
+
+function Get-ModuleClass {
+    <#
+        .SYNOPSIS
+            A self-test utility function.
+    #>
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Name
+    )
+
+    return $Name -as [Type]
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the PSClassHelpProvider.

This is written up as a non-impacting change as the provider is currently broken and there's very little evidence of this system being used by anyone at all anywhere (except me).

See #20265.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

The PSClassHelpProvider used a single key derived from the help file name to cache the content of a parsed help file.

The outcome of this is that the help provider could only ever offer help for a single class (the last class) defined in the help file.

This PR fixes the incomplete implementation, bringing it closer to the command help provider implementation.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
