### PR TITLE
Revert change to use `BinaryFormatter` for `Out-GridView`

### DIFF
--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/ComparableValueFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/ComparableValueFilterRule.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public abstract class ComparableValueFilterRule<T> : FilterRule where T : IComparable
     {
         #region Properties
@@ -59,19 +60,6 @@ namespace Microsoft.Management.UI.Internal
             }
 
             return this.Evaluate(castItem);
-        }
-
-        /// <summary>
-        /// Creates a clone of the ComparableValueFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the ComparableValueFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            ComparableValueFilterRule<T> rule = (ComparableValueFilterRule<T>)Activator.CreateInstance(this.GetType());
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/DoesNotEqualFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/DoesNotEqualFilterRule.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class DoesNotEqualFilterRule<T> : EqualsFilterRule<T> where T : IComparable
     {
         /// <summary>
@@ -22,20 +23,6 @@ namespace Microsoft.Management.UI.Internal
         {
             this.DisplayName = UICultureResources.FilterRule_DoesNotEqual;
             this.DefaultNullValueEvaluation = true;
-        }
-
-        /// <summary>
-        /// Creates a clone of the DoesNotEqualFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// A clone of the DoesNotEqualFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            DoesNotEqualFilterRule<T> rule = new DoesNotEqualFilterRule<T>();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/EqualsFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/EqualsFilterRule.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class EqualsFilterRule<T> : SingleValueComparableValueFilterRule<T> where T : IComparable
     {
         /// <summary>
@@ -22,20 +23,6 @@ namespace Microsoft.Management.UI.Internal
         public EqualsFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_Equals;
-        }
-
-        /// <summary>
-        /// Creates a new EqualsFilterRule that is a clone of the current instance.
-        /// </summary>
-        /// <returns>
-        /// A new EqualsFilterRule that is a clone of the current instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            EqualsFilterRule<T> rule = new EqualsFilterRule<T>();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRule.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Management.UI.Internal
     /// The base class for all filtering rules.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public abstract class FilterRule : IEvaluate
     {
         /// <summary>
@@ -47,12 +48,6 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="item">The item to evaluate.</param>
         /// <returns>Returns true if the item meets the criteria. False otherwise.</returns>
         public abstract bool Evaluate(object item);
-
-        /// <summary>
-        /// Creates a clone of this FilterRule.
-        /// </summary>
-        /// <returns>Returns a clone of this FilterRule.</returns>
-        public abstract FilterRule Clone();
 
         #region EvaluationResultInvalidated
 

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRuleExtensions.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRuleExtensions.cs
@@ -31,23 +31,19 @@ namespace Microsoft.Management.UI.Internal
 
 #pragma warning disable SYSLIB0050
             Debug.Assert(rule.GetType().IsSerializable, "rule is serializable");
-
 #pragma warning disable SYSLIB0011
-#pragma warning disable SYSLIB0050
             BinaryFormatter formatter = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.Clone));
+#pragma warning restore SYSLIB0011
             MemoryStream ms = new MemoryStream();
 
             FilterRule copy = null;
             try
             {
-#pragma warning disable SYSLIB0011
                 formatter.Serialize(ms, rule);
-#pragma warning restore SYSLIB0011
 
                 ms.Position = 0;
-#pragma warning disable SYSLIB0011
                 copy = (FilterRule)formatter.Deserialize(ms);
-#pragma warning restore SYSLIB0011
+#pragma warning restore SYSLIB0050
             }
             finally
             {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRuleExtensions.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRuleExtensions.cs
@@ -27,7 +27,34 @@ namespace Microsoft.Management.UI.Internal
         /// </returns>
         public static FilterRule DeepCopy(this FilterRule rule)
         {
-            return rule.Clone();
+            ArgumentNullException.ThrowIfNull(rule);
+
+#pragma warning disable SYSLIB0050
+            Debug.Assert(rule.GetType().IsSerializable, "rule is serializable");
+
+#pragma warning disable SYSLIB0011
+#pragma warning disable SYSLIB0050
+            BinaryFormatter formatter = new BinaryFormatter(null, new StreamingContext(StreamingContextStates.Clone));
+            MemoryStream ms = new MemoryStream();
+
+            FilterRule copy = null;
+            try
+            {
+#pragma warning disable SYSLIB0011
+                formatter.Serialize(ms, rule);
+#pragma warning restore SYSLIB0011
+
+                ms.Position = 0;
+#pragma warning disable SYSLIB0011
+                copy = (FilterRule)formatter.Deserialize(ms);
+#pragma warning restore SYSLIB0011
+            }
+            finally
+            {
+                ms.Close();
+            }
+
+            return copy;
         }
     }
 }

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsBetweenFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsBetweenFilterRule.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class IsBetweenFilterRule<T> : ComparableValueFilterRule<T> where T : IComparable
     {
         #region Properties
@@ -48,21 +49,6 @@ namespace Microsoft.Management.UI.Internal
         {
             get;
             protected set;
-        }
-
-        /// <summary>
-        /// Creates a clone of the FilterRule.
-        /// </summary>
-        /// <returns>
-        /// A clone of the FilterRule.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            IsBetweenFilterRule<T> clone = new IsBetweenFilterRule<T>();
-            clone.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            clone.StartValue = this.StartValue;
-            clone.EndValue = this.EndValue;
-            return clone;
         }
 
         #endregion Properties

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsEmptyFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsEmptyFilterRule.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Management.UI.Internal
     /// is empty or not.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class IsEmptyFilterRule : FilterRule
     {
         /// <summary>
@@ -18,18 +19,6 @@ namespace Microsoft.Management.UI.Internal
         public IsEmptyFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_IsEmpty;
-        }
-
-        /// <summary>
-        /// Creates a clone of the IsEmptyFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// A clone of IsEmptyFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            IsEmptyFilterRule rule = new IsEmptyFilterRule();
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsGreaterThanFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsGreaterThanFilterRule.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class IsGreaterThanFilterRule<T> : SingleValueComparableValueFilterRule<T> where T : IComparable
     {
         /// <summary>
@@ -22,20 +23,6 @@ namespace Microsoft.Management.UI.Internal
         public IsGreaterThanFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_GreaterThanOrEqual;
-        }
-
-        /// <summary>
-        /// Creates a new IsGreaterThanFilterRule that is a clone of the current instance.
-        /// </summary>
-        /// <returns>
-        /// A new IsGreaterThanFilterRule that is a clone of the current instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            IsGreaterThanFilterRule<T> rule = new IsGreaterThanFilterRule<T>();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsLessThanFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsLessThanFilterRule.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class IsLessThanFilterRule<T> : SingleValueComparableValueFilterRule<T> where T : IComparable
     {
         /// <summary>
@@ -22,20 +23,6 @@ namespace Microsoft.Management.UI.Internal
         public IsLessThanFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_LessThanOrEqual;
-        }
-
-        /// <summary>
-        /// Creates a new IsLessThanFilterRule that is a clone of the current instance.
-        /// </summary>
-        /// <returns>
-        /// A new IsLessThanFilterRule that is a clone of the current instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            IsLessThanFilterRule<T> rule = new IsLessThanFilterRule<T>();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsNotEmptyFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsNotEmptyFilterRule.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Management.UI.Internal
     /// is empty or not.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class IsNotEmptyFilterRule : IsEmptyFilterRule
     {
         /// <summary>
@@ -18,18 +19,6 @@ namespace Microsoft.Management.UI.Internal
         public IsNotEmptyFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_IsNotEmpty;
-        }
-
-        /// <summary>
-        /// Creates a clone of the IsNotEmptyFilterRule.
-        /// </summary>
-        /// <returns>
-        /// A clone of the IsNotEmptyFilterRule.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            IsNotEmptyFilterRule rule = new IsNotEmptyFilterRule();
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsNotEmptyValidationRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/IsNotEmptyValidationRule.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Management.UI.Internal
     /// The IsNotEmptyValidationRule checks a value to see if a value is not empty.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class IsNotEmptyValidationRule : DataErrorInfoValidationRule
     {
         #region Properties

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertiesTextContainsFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertiesTextContainsFilterRule.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Management.UI.Internal
     /// Represents a filter rule that searches for text within properties on an object.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class PropertiesTextContainsFilterRule : TextFilterRule
     {
         private static readonly string TextContainsCharactersRegexPattern = "{0}";
@@ -35,20 +36,6 @@ namespace Microsoft.Management.UI.Internal
         {
             get;
             private set;
-        }
-
-        /// <summary>
-        /// Creates a clone of this <see cref="PropertiesTextContainsFilterRule"/>.
-        /// </summary>
-        /// <returns>
-        /// A clone of this <see cref="PropertiesTextContainsFilterRule"/>.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            PropertiesTextContainsFilterRule clone = new PropertiesTextContainsFilterRule();
-            clone.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            clone.PropertyNames = new List<string>(this.PropertyNames);
-            return clone;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertyValueSelectorFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/PropertyValueSelectorFilterRule.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class PropertyValueSelectorFilterRule<T> : SelectorFilterRule where T : IComparable
     {
         #region Properties
@@ -65,11 +66,6 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         public PropertyValueSelectorFilterRule(string propertyName, string propertyDisplayName, IEnumerable<FilterRule> rules)
         {
-            ArgumentException.ThrowIfNullOrEmpty(propertyName);
-            ArgumentException.ThrowIfNullOrEmpty(propertyDisplayName);
-
-            ArgumentNullException.ThrowIfNull(rules);
-
             this.PropertyName = propertyName;
             this.DisplayName = propertyDisplayName;
 
@@ -118,17 +114,6 @@ namespace Microsoft.Management.UI.Internal
             }
 
             return this.AvailableRules.SelectedValue.Evaluate(propertyValue);
-        }
-
-        /// <summary>
-        /// Creates a clone of the PropertyValueSelectorFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the PropertyValueSelectorFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            return new PropertyValueSelectorFilterRule<T>(this.PropertyName, this.DisplayName, this.AvailableRules.AvailableValues);
         }
 
         #endregion Public Methods

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/SelectorFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/SelectorFilterRule.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Management.UI.Internal
     /// The SelectorFilterRule represents a rule composed of other rules.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class SelectorFilterRule : FilterRule
     {
         #region Properties
@@ -68,23 +69,6 @@ namespace Microsoft.Management.UI.Internal
             }
 
             return this.AvailableRules.SelectedValue.Evaluate(item);
-        }
-
-        /// <summary>
-        /// Creates a clone of the SelectorFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the SelectorFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            SelectorFilterRule clone = new SelectorFilterRule();
-            clone.DisplayName = this.DisplayName;
-            clone.AvailableRules = this.AvailableRules;
-            clone.AvailableRules.SelectedValueChanged += clone.AvailableRules_SelectedValueChanged;
-            clone.AvailableRules.SelectedValue.EvaluationResultInvalidated += clone.SelectedValue_EvaluationResultInvalidated;
-
-            return clone;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/SingleValueComparableValueFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/SingleValueComparableValueFilterRule.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Management.UI.Internal
     /// </summary>
     /// <typeparam name="T">The generic parameter.</typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public abstract class SingleValueComparableValueFilterRule<T> : ComparableValueFilterRule<T> where T : IComparable
     {
         #region Properties
@@ -52,15 +53,6 @@ namespace Microsoft.Management.UI.Internal
         }
 
         #endregion Ctor
-
-        /// <summary>
-        /// Creates a clone of the FilterRule.
-        /// </summary>
-        /// <returns>A clone of the FilterRule.</returns>
-        public override FilterRule Clone()
-        {
-            return base.Clone();
-        }
 
         private void Value_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextContainsFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextContainsFilterRule.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Management.UI.Internal
     /// check if it is contains the rule's value within it.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class TextContainsFilterRule : TextFilterRule
     {
         private static readonly string TextContainsCharactersRegexPattern = "{0}";
@@ -22,20 +23,6 @@ namespace Microsoft.Management.UI.Internal
         public TextContainsFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_Contains;
-        }
-
-        /// <summary>
-        /// Creates a clone of the TextContainsFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the TextContainsFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            TextContainsFilterRule rule = new TextContainsFilterRule();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextDoesNotContainFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextDoesNotContainFilterRule.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Management.UI.Internal
     /// check if it is does not contain the rule's value within it.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class TextDoesNotContainFilterRule : TextContainsFilterRule
     {
         /// <summary>
@@ -19,20 +20,6 @@ namespace Microsoft.Management.UI.Internal
         {
             this.DisplayName = UICultureResources.FilterRule_DoesNotContain;
             this.DefaultNullValueEvaluation = true;
-        }
-
-        /// <summary>
-        /// Creates a clone of the TextDoesNotContainFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// A clone of the TextDoesNotContainFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            TextDoesNotContainFilterRule rule = new TextDoesNotContainFilterRule();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextDoesNotEqualFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextDoesNotEqualFilterRule.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Management.UI.Internal
     /// check if it is not equal to the rule's value.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class TextDoesNotEqualFilterRule : TextEqualsFilterRule
     {
         /// <summary>
@@ -19,20 +20,6 @@ namespace Microsoft.Management.UI.Internal
         {
             this.DisplayName = UICultureResources.FilterRule_DoesNotEqual;
             this.DefaultNullValueEvaluation = true;
-        }
-
-        /// <summary>
-        /// Creates a clone of the TextDoesNotEqualFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the TextDoesNotEqualFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            TextDoesNotEqualFilterRule rule = new TextDoesNotEqualFilterRule();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextEndsWithFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextEndsWithFilterRule.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Management.UI.Internal
     /// check if it ends with the rule's value.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class TextEndsWithFilterRule : TextFilterRule
     {
         private static readonly string TextEndsWithCharactersRegexPattern = "{0}$";
@@ -22,20 +23,6 @@ namespace Microsoft.Management.UI.Internal
         public TextEndsWithFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_TextEndsWith;
-        }
-
-        /// <summary>
-        /// Creates a clone of the TextEndsWithFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the TextEndsWithFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            TextEndsWithFilterRule rule = new TextEndsWithFilterRule();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextEqualsFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextEqualsFilterRule.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Management.UI.Internal
     /// check if it is equal to the rule's value.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class TextEqualsFilterRule : TextFilterRule
     {
         private static readonly string TextEqualsCharactersRegexPattern = "^{0}$";
@@ -21,20 +22,6 @@ namespace Microsoft.Management.UI.Internal
         public TextEqualsFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_Equals;
-        }
-
-        /// <summary>
-        /// Creates a clone of the TextEqualsFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the TextEqualsFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            TextEqualsFilterRule rule = new TextEqualsFilterRule();
-            rule.Value = this.Value;
-            rule.DefaultNullValueEvaluation = this.DefaultNullValueEvaluation;
-            return rule;
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextFilterRule.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Management.UI.Internal
     /// evaluating string operations.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public abstract class TextFilterRule : SingleValueComparableValueFilterRule<string>
     {
         /// <summary>
@@ -58,17 +59,6 @@ namespace Microsoft.Management.UI.Internal
 
                 this.NotifyEvaluationResultInvalidated();
             }
-        }
-
-        /// <summary>
-        /// Creates a clone of the FilterRule.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the FilterRule.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            return base.Clone();
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextStartsWithFilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/TextStartsWithFilterRule.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Management.UI.Internal
     /// check if it starts with the rule's value.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class TextStartsWithFilterRule : TextFilterRule
     {
         private static readonly string TextStartsWithCharactersRegexPattern = "^{0}";
@@ -22,17 +23,6 @@ namespace Microsoft.Management.UI.Internal
         public TextStartsWithFilterRule()
         {
             this.DisplayName = UICultureResources.FilterRule_TextStartsWith;
-        }
-
-        /// <summary>
-        /// Creates a clone of the TextStartsWithFilterRule instance.
-        /// </summary>
-        /// <returns>
-        /// Returns a clone of the TextStartsWithFilterRule instance.
-        /// </returns>
-        public override FilterRule Clone()
-        {
-            return base.Clone();
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingSelectorValue.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingSelectorValue.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class ValidatingSelectorValue<T> : ValidatingValueBase
     {
         #region Properties

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValue.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValue.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Management.UI.Internal
     /// The generic parameter.
     /// </typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class ValidatingValue<T> : ValidatingValueBase
     {
         #region Properties

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValueBase.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValueBase.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Management.UI.Internal
     /// classes to support validation via the IDataErrorInfo interface.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public abstract class ValidatingValueBase : IDataErrorInfo, INotifyPropertyChanged
     {
         #region Properties

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidationRules/DataErrorInfoValidationRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidationRules/DataErrorInfoValidationRule.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Management.UI.Internal
     /// Provides a way to create a custom rule in order to check the validity of user input.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public abstract class DataErrorInfoValidationRule
     {
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRuleToDisplayNameConverter.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRuleToDisplayNameConverter.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Management.UI.Internal
     /// a FilterRule value to its DisplayName.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class FilterRuleToDisplayNameConverter : IValueConverter
     {
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/ManagementListStateDescriptor.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/ManagementList/ManagementListStateDescriptor.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Management.UI.Internal
     /// Allows the state of the ManagementList to be saved and restored.
     /// </summary>
     [SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
+    [Serializable]
     public class ManagementListStateDescriptor : StateDescriptor<ManagementList>
     {
         #region Fields

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -13,6 +13,7 @@
     <ApplicationManifest>..\..\assets\pwsh.manifest</ApplicationManifest>
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     <TargetPlatformVersion>8.0</TargetPlatformVersion>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Revert  #20050

`Out-GridView` was designed around using the `BinaryFormatter` to make deep copies of Filters.  When we removed usage of that type, we inadvertently broke filtering (although `contains` filter still worked, but only that one).  This change reverts the specific removal of use of `BinaryFormatter` for `Out-GridView` to bring back the previous functionality.  The previous change to a `Clone()` method was removed as it was incomplete.

Manually tested each filter and duplicate filters.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/20223

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
