### PR TITLE
[release/v7.4.0-preview.6] Bump JsonSchema.Net from 5.1.3 to 5.2.1

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0-2.final" />
     <PackageReference Include="System.Threading.AccessControl" Version="8.0.0-preview.7.23375.6" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.0-preview.5.23280.5" />
-    <PackageReference Include="JsonSchema.Net" Version="5.1.3" />
+    <PackageReference Include="JsonSchema.Net" Version="5.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Backport #20193