### PR TITLE
[release/v7.4.0-preview.6] Bump JsonSchema.Net from 5.2.1 to 5.2.5

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="8.0.0-preview.7.23375.6" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.0-preview.5.23280.5" />
-    <PackageReference Include="JsonSchema.Net" Version="5.2.1" />
+    <PackageReference Include="JsonSchema.Net" Version="5.2.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Backport #20225