### PR TITLE
[release/v7.4.0-preview.6] Use fxdependent-win-desktop runtime for compliance runs

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/compliance/apiscan.yml
+++ b/tools/releaseBuild/azureDevOps/templates/compliance/apiscan.yml
@@ -55,7 +55,7 @@ jobs:
     - pwsh: |
         Import-Module .\build.psm1 -force
         Find-DotNet
-        Start-PSBuild -Configuration StaticAnalysis -PSModuleRestore -Clean
+        Start-PSBuild -Configuration StaticAnalysis -PSModuleRestore -Clean -Runtime fxdependent-win-desktop
 
         $OutputFolder = Split-Path (Get-PSOutput)
         Write-Host "##vso[task.setvariable variable=BinDir]$OutputFolder"


### PR DESCRIPTION
Backport #20326