### PR TITLE
Fix unixmode to handle setuid/sticky when not executable

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -601,7 +601,7 @@ namespace System.Management.Automation
                 private const char StickyAndNotExec = 'T';
 
                 // The item type and the character representation for the first element in the stat string
-                private readonly Dictionary<ItemType, char> itemTypeTable = new()
+                private static readonly Dictionary<ItemType, char> itemTypeTable = new()
                 {
                     { ItemType.BlockDevice,     'b' },
                     { ItemType.CharacterDevice, 'c' },
@@ -631,7 +631,8 @@ namespace System.Management.Automation
                     {
                        return OwnerReadWriteGroupReadOtherRead;
                     }
-                    else if ((ItemType == ItemType.Directory) & ((Mode & 0xFFF) == 493))
+
+                    if (ItemType == ItemType.Directory & (Mode & 0xFFF) == 493)
                     {
                         return DirectoryOwnerFullGroupReadExecOtherReadExec;
                     }

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -612,32 +612,13 @@ namespace System.Management.Automation
                     { ItemType.SymbolicLink,    'l' },
                 };
 
-                private const string OwnerReadGroupReadOtherRead = "-r--r--r--";
-                private const string OwnerReadWriteGroupReadOtherRead = "-rw-r--r--";
-                private const string DirectoryOwnerFullGroupReadExecOtherReadExec = "drwxr-xr-x";
-
                 /// <summary>Convert the mode to a string which is usable in our formatting.</summary>
                 /// <returns>The mode converted into a Unix style string similar to the output of ls.</returns>
                 public string GetModeString()
                 {
-                    Span<char> modeCharacters = stackalloc char[10];
+                    char[] modeCharacters = new char[10];
                     modeCharacters[0] = itemTypeTable[ItemType];
                     bool isExecutable;
-
-                    // We'll do a couple of common mode strings here to reduce allocations and improve performance a bit.
-                    // On an Ubuntu system (docker), these 3 are roughly 70% of all the permissions
-                    if ((Mode & 0xFFF) == 292)
-                    {
-                        return OwnerReadGroupReadOtherRead;
-                    }
-                    else if ((Mode & 0xFFF) == 420)
-                    {
-                        return OwnerReadWriteGroupReadOtherRead;
-                    }
-                    else if ((ItemType == ItemType.Directory) & ((Mode & 0xFFF) == 493))
-                    {
-                        return DirectoryOwnerFullGroupReadExecOtherReadExec;
-                    }
 
                     UnixFileMode modeInfo = (UnixFileMode)Mode;
                     modeCharacters[1] = modeInfo.HasFlag(UnixFileMode.UserRead) ? CanRead : NoPerm;

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -594,81 +594,47 @@ namespace System.Management.Automation
                 private const char CanRead = 'r';
                 private const char CanWrite = 'w';
                 private const char CanExecute = 'x';
-
-                // helper for getting unix mode
-                private readonly Dictionary<StatMask, char> modeMap = new()
-                {
-                        { StatMask.OwnerRead, CanRead },
-                        { StatMask.OwnerWrite, CanWrite },
-                        { StatMask.OwnerExecute, CanExecute },
-                        { StatMask.GroupRead, CanRead },
-                        { StatMask.GroupWrite, CanWrite },
-                        { StatMask.GroupExecute, CanExecute },
-                        { StatMask.OtherRead, CanRead },
-                        { StatMask.OtherWrite, CanWrite },
-                        { StatMask.OtherExecute, CanExecute },
-                };
-
-                private readonly StatMask[] permissions = new StatMask[]
-                {
-                    StatMask.OwnerRead,
-                    StatMask.OwnerWrite,
-                    StatMask.OwnerExecute,
-                    StatMask.GroupRead,
-                    StatMask.GroupWrite,
-                    StatMask.GroupExecute,
-                    StatMask.OtherRead,
-                    StatMask.OtherWrite,
-                    StatMask.OtherExecute
-                };
+                private const char NoPerm = '-';
+                private const char SetAndExec = 's';
+                private const char SetAndNotExec = 'S';
+                private const char StickyAndExec = 't';
+                private const char StickyAndNotExec = 'T';
 
                 // The item type and the character representation for the first element in the stat string
                 private readonly Dictionary<ItemType, char> itemTypeTable = new()
                 {
-                    { ItemType.BlockDevice, 'b' },
+                    { ItemType.BlockDevice,     'b' },
                     { ItemType.CharacterDevice, 'c' },
-                    { ItemType.Directory, 'd' },
-                    { ItemType.File, '-' },
-                    { ItemType.NamedPipe, 'p' },
-                    { ItemType.Socket, 's' },
-                    { ItemType.SymbolicLink, 'l' },
+                    { ItemType.Directory,       'd' },
+                    { ItemType.File,            '-' },
+                    { ItemType.NamedPipe,       'p' },
+                    { ItemType.Socket,          's' },
+                    { ItemType.SymbolicLink,    'l' },
                 };
 
                 /// <summary>Convert the mode to a string which is usable in our formatting.</summary>
                 /// <returns>The mode converted into a Unix style string similar to the output of ls.</returns>
                 public string GetModeString()
                 {
-                    int offset = 0;
                     char[] modeCharacters = new char[10];
-                    modeCharacters[offset++] = itemTypeTable[ItemType];
+                    modeCharacters[0] = itemTypeTable[ItemType];
+                    bool isExecutable;
 
-                    foreach (StatMask permission in permissions)
-                    {
-                        // determine whether we are setuid, sticky, or the usual rwx.
-                        if ((Mode & (int)permission) == (int)permission)
-                        {
-                            if ((permission == StatMask.OwnerExecute && IsSetUid) || (permission == StatMask.GroupExecute && IsSetGid))
-                            {
-                                // Check for setuid and add 's'
-                                modeCharacters[offset] = 's';
-                            }
-                            else if (permission == StatMask.OtherExecute && IsSticky && (ItemType == ItemType.Directory))
-                            {
-                                // Directories are sticky, rather than setuid
-                                modeCharacters[offset] = 't';
-                            }
-                            else
-                            {
-                                modeCharacters[offset] = modeMap[permission];
-                            }
-                        }
-                        else
-                        {
-                            modeCharacters[offset] = '-';
-                        }
+                    UnixFileMode modeInfo = (UnixFileMode)Mode;
+                    modeCharacters[1] = modeInfo.HasFlag(UnixFileMode.UserRead) ? CanRead : NoPerm;
+                    modeCharacters[2] = modeInfo.HasFlag(UnixFileMode.UserWrite) ? CanWrite : NoPerm;
+                    isExecutable = modeInfo.HasFlag(UnixFileMode.UserExecute);
+                    modeCharacters[3] = modeInfo.HasFlag(UnixFileMode.SetUser) ? (isExecutable ? SetAndExec : SetAndNotExec) : (isExecutable ? CanExecute : NoPerm);
 
-                        offset++;
-                    }
+                    modeCharacters[4] = modeInfo.HasFlag(UnixFileMode.GroupRead) ? CanRead : NoPerm;
+                    modeCharacters[5] = modeInfo.HasFlag(UnixFileMode.GroupWrite) ? CanWrite : NoPerm;
+                    isExecutable = modeInfo.HasFlag(UnixFileMode.GroupExecute);
+                    modeCharacters[6] = modeInfo.HasFlag(UnixFileMode.SetGroup) ? (isExecutable ? SetAndExec : SetAndNotExec) : (isExecutable ? CanExecute : NoPerm);
+
+                    modeCharacters[7] = modeInfo.HasFlag(UnixFileMode.OtherRead) ? CanRead : NoPerm;
+                    modeCharacters[8] = modeInfo.HasFlag(UnixFileMode.OtherWrite) ? CanWrite : NoPerm;
+                    isExecutable = modeInfo.HasFlag(UnixFileMode.OtherExecute);
+                    modeCharacters[9] = modeInfo.HasFlag(UnixFileMode.StickyBit) ? (isExecutable ? StickyAndExec : StickyAndNotExec) : (isExecutable ? CanExecute : NoPerm);
 
                     return new string(modeCharacters);
                 }

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -612,13 +612,32 @@ namespace System.Management.Automation
                     { ItemType.SymbolicLink,    'l' },
                 };
 
+                private const string OwnerReadGroupReadOtherRead = "-r--r--r--";
+                private const string OwnerReadWriteGroupReadOtherRead = "-rw-r--r--";
+                private const string DirectoryOwnerFullGroupReadExecOtherReadExec = "drwxr-xr-x";
+
                 /// <summary>Convert the mode to a string which is usable in our formatting.</summary>
                 /// <returns>The mode converted into a Unix style string similar to the output of ls.</returns>
                 public string GetModeString()
                 {
-                    char[] modeCharacters = new char[10];
+                    Span<char> modeCharacters = stackalloc char[10];
                     modeCharacters[0] = itemTypeTable[ItemType];
                     bool isExecutable;
+
+                    // We'll do a couple of common mode strings here to reduce allocations and improve performance a bit.
+                    // On an Ubuntu system (docker), these 3 are roughly 70% of all the permissions
+                    if ((Mode & 0xFFF) == 292)
+                    {
+                        return OwnerReadGroupReadOtherRead;
+                    }
+                    else if ((Mode & 0xFFF) == 420)
+                    {
+                        return OwnerReadWriteGroupReadOtherRead;
+                    }
+                    else if ((ItemType == ItemType.Directory) & ((Mode & 0xFFF) == 493))
+                    {
+                        return DirectoryOwnerFullGroupReadExecOtherReadExec;
+                    }
 
                     UnixFileMode modeInfo = (UnixFileMode)Mode;
                     modeCharacters[1] = modeInfo.HasFlag(UnixFileMode.UserRead) ? CanRead : NoPerm;

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -626,7 +626,8 @@ namespace System.Management.Automation
                     {
                         return OwnerReadGroupReadOtherRead;
                     }
-                    else if ((Mode & 0xFFF) == 420)
+
+                    if ((Mode & 0xFFF) == 420)
                     {
                        return OwnerReadWriteGroupReadOtherRead;
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
@@ -69,7 +69,7 @@ Describe "UnixFileSystem additions" -Tag "CI" {
             }
             else {
                 $i = Get-Item $Item
-                $i.UnixMode | Should -Be $Perm
+                $i.UnixMode | Should -BeExactly $Perm
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
@@ -61,6 +61,8 @@ Describe "UnixFileSystem additions" -Tag "CI" {
 
         It "Should present filemode '<Mode>' string correctly as '<Perm>'" -testCase $testCase {
             param ($Mode, $Perm, $Item )
+            # chmod can fail for some modes so be sure to handle that here.
+            # specifically, when setting setgid chmod can fail if the group is privileged.
             chmod "$Mode" "${Item}"
             if ($LASTEXITCODE -ne 0) {
                 set-itresult -skip -because "chmod '$mode' failed"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/UnixStat.Tests.ps1
@@ -37,6 +37,10 @@ Describe "UnixFileSystem additions" -Tag "CI" {
                         @{ Mode = '555';  Perm = '-r-xr-xr-x'; Item = "${testFile}" },
                         @{ Mode = '666';  Perm = '-rw-rw-rw-'; Item = "${testFile}" },
                         @{ Mode = '777';  Perm = '-rwxrwxrwx'; Item = "${testFile}" },
+                        @{ Mode = '4644'; Perm = '-rwSr--r--'; Item = "${testFile}" },
+                        @{ Mode = '1644'; Perm = '-rw-r--r-T'; Item = "${testFile}" },
+                        @{ Mode = '2644'; Perm = '-rw-r-Sr--'; Item = "${testFile}" },
+                        @{ Mode = '7644'; Perm = '-rwSr-Sr-T'; Item = "${testFile}" },
                         @{ Mode = '4777'; Perm = '-rwsrwxrwx'; Item = "${testFile}" },
                         @{ Mode = '1777'; Perm = 'drwxrwxrwt'; Item = "${testDir}"  }
         }
@@ -58,8 +62,13 @@ Describe "UnixFileSystem additions" -Tag "CI" {
         It "Should present filemode '<Mode>' string correctly as '<Perm>'" -testCase $testCase {
             param ($Mode, $Perm, $Item )
             chmod "$Mode" "${Item}"
-            $i = Get-Item $Item
-            $i.UnixMode | Should -Be $Perm
+            if ($LASTEXITCODE -ne 0) {
+                set-itresult -skip -because "chmod '$mode' failed"
+            }
+            else {
+                $i = Get-Item $Item
+                $i.UnixMode | Should -Be $Perm
+            }
         }
 
         It "Should retrieve the user name for the file" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This is a fix for #20278 

<!-- Summarize your PR between here and the checklist. -->

## PR Context

I'm not addressing the CodeFactor reported complexity as I don't believe this method is overly complicated.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
