### PR TITLE
Fix implicit remoting proxy cmdlets to act on common parameters

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1305,7 +1305,10 @@ namespace Microsoft.PowerShell.Commands
             // we are not sending CmdletBinding/DefaultParameterSet over the wire anymore
             // we need to infer IsProxyForCmdlet from presence of all common parameters
 
-            foreach (string commonParameterName in Cmdlet.CommonParameters)
+            // need to exclude `ProgressAction` which may not exist for downlevel platforms
+            var commonParameters = Cmdlet.CommonParameters;
+            commonParameters.Remove("ProgressAction");
+            foreach (string commonParameterName in commonParameters)
             {
                 if (!parameters.ContainsKey(commonParameterName))
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1300,14 +1300,18 @@ namespace Microsoft.PowerShell.Commands
                 parameterType);
         }
 
-        private static bool IsProxyForCmdlet(Dictionary<string, ParameterMetadata> parameters)
+        private bool IsProxyForCmdlet(Dictionary<string, ParameterMetadata> parameters)
         {
             // we are not sending CmdletBinding/DefaultParameterSet over the wire anymore
             // we need to infer IsProxyForCmdlet from presence of all common parameters
 
+            var commonParameters = new HashSet<string>(Cmdlet.CommonParameters);
             // need to exclude `ProgressAction` which may not exist for downlevel platforms
-            var commonParameters = Cmdlet.CommonParameters;
-            commonParameters.Remove("ProgressAction");
+            if ((Session.Runspace is RemoteRunspace remoteRunspace) && (remoteRunspace.ServerVersion != null) && (remoteRunspace.ServerVersion <= new Version(7, 3))) 
+            { 
+                commonParameters.Remove("ProgressAction");
+            } 
+
             foreach (string commonParameterName in commonParameters)
             {
                 if (!parameters.ContainsKey(commonParameterName))

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1306,6 +1306,7 @@ namespace Microsoft.PowerShell.Commands
             // we need to infer IsProxyForCmdlet from presence of all common parameters
 
             var commonParameters = new HashSet<string>(Cmdlet.CommonParameters);
+
             // need to exclude `ProgressAction` which may not exist for downlevel platforms
             if ((Session.Runspace is RemoteRunspace remoteRunspace) && (remoteRunspace.ServerVersion != null) && (remoteRunspace.ServerVersion <= new Version(7, 3))) 
             { 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -1538,7 +1538,7 @@ Describe "WinCompat importing should check availablity of built-in modules" -Tag
             $out = Invoke-Expression 'get-AppLockerFileInformation NoSuch.exe -ErrorAction Stop; "after"'
         }
         catch {
-            # do nothing
+            # do nothing as we expect an error, but execution should not continue
         }
 
         $out | Should -Not -Contain 'after'

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/CompatiblePSEditions.Module.Tests.ps1
@@ -1532,4 +1532,15 @@ Describe "WinCompat importing should check availablity of built-in modules" -Tag
         $result[4] | Should -BeExactly 'ConvertFrom-String'
         $result[5] | Should -BeExactly 'CFS'
     }
+
+    It 'ErrorAction should be used for cmdlet' {
+        try {
+            $out = Invoke-Expression 'get-AppLockerFileInformation NoSuch.exe -ErrorAction Stop; "after"'
+        }
+        catch {
+            # do nothing
+        }
+
+        $out | Should -Not -Contain 'after'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The PR to add `ProgressAction` common parameter caused this regression due to an internal helper to determine if the proxy is for a cmdlet.  It expected CommonParameters to never change so if they differ, then the parameter is treated as custom so it doesn't work as expected.  This works remoting from latest PS7 to latest PS7 since the common parameters match.  However, latest to older PS7 or WinPS5.1 (like via WinCompat layer) fails as the new `ProgressAction` isn't found on the target.

Fix is to exclude `ProgressAction` from this check to enable it to work for the other common parameters.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/20209

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
