### PR TITLE
Fix `Test-Connection` due to .NET 8 changes

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -484,6 +484,9 @@ namespace Microsoft.PowerShell.Commands
                                 reply.Status == IPStatus.Success
                                     ? reply.RoundtripTime
                                     : timer.ElapsedMilliseconds,
+
+                                // If we use the empty buffer, then .NET actually uses a 32 byte buffer so we want to show
+                                // as the result object the actual buffer size used instead of 0.
                                 buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length,
                                 pingNum: i);
                             WriteObject(new TraceStatus(

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -874,11 +874,6 @@ namespace Microsoft.PowerShell.Commands
                 sendBuffer[i] = (byte)((int)'a' + i % 23);
             }
 
-            if (bufferSize == DefaultSendBufferSize && s_DefaultSendBuffer.Length == 0)
-            {
-                s_DefaultSendBuffer = sendBuffer;
-            }
-
             return sendBuffer;
         }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Private Fields
 
-        private static byte[] s_DefaultSendBuffer = Array.Empty<byte>();
+        private static readonly byte[] s_DefaultSendBuffer = Array.Empty<byte>();
 
         private readonly CancellationTokenSource _dnsLookupCancel = new();
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Private Fields
 
-        private static byte[]? s_DefaultSendBuffer;
+        private static byte[] s_DefaultSendBuffer = Array.Empty<byte>();
 
         private readonly CancellationTokenSource _dnsLookupCancel = new();
 
@@ -484,7 +484,7 @@ namespace Microsoft.PowerShell.Commands
                                 reply.Status == IPStatus.Success
                                     ? reply.RoundtripTime
                                     : timer.ElapsedMilliseconds,
-                                buffer.Length,
+                                buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length,
                                 pingNum: i);
                             WriteObject(new TraceStatus(
                                 currentHop,
@@ -707,7 +707,7 @@ namespace Microsoft.PowerShell.Commands
                         resolvedTargetName,
                         reply,
                         reply.RoundtripTime,
-                        buffer.Length,
+                        buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length,
                         pingNum: (uint)i));
                 }
 
@@ -862,7 +862,7 @@ namespace Microsoft.PowerShell.Commands
         // Creates and fills a send buffer. This follows the ping.exe and CoreFX model.
         private static byte[] GetSendBuffer(int bufferSize)
         {
-            if (bufferSize == DefaultSendBufferSize && s_DefaultSendBuffer != null)
+            if (bufferSize == DefaultSendBufferSize)
             {
                 return s_DefaultSendBuffer;
             }
@@ -874,7 +874,7 @@ namespace Microsoft.PowerShell.Commands
                 sendBuffer[i] = (byte)((int)'a' + i % 23);
             }
 
-            if (bufferSize == DefaultSendBufferSize && s_DefaultSendBuffer == null)
+            if (bufferSize == DefaultSendBufferSize && s_DefaultSendBuffer.Length == 0)
             {
                 s_DefaultSendBuffer = sendBuffer;
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

.NET 8 made a change on how a custom buffer works on Linux, so we have to change the code to use a default empty buffer so that .NET uses its own default buffer.  A custom buffer size requires `sudo` on Linux.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/17018

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/10458
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
