### PR TITLE
Redirecting to a variable should be possible

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -706,7 +706,14 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _append = value;
+                if (ExperimentalFeature.IsEnabled("PSRedirectToVariable"))
+                {
+                    _append = value;
+                }
+                else
+                {
+                    throw new ArgumentException("ExperimentalFeature 'PSRedirectToVariable' is not enabled");
+                }
             }
         }
 
@@ -737,10 +744,10 @@ namespace Microsoft.PowerShell.Commands
                 // but if they have more than one name, produce an error
                 if (Name.Length != 1)
                 {
-                    ErrorRecord er = new ErrorRecord(new InvalidOperationException(), "SetVariableAppend", ErrorCategory.InvalidOperation, Name);
-                    er.ErrorDetails = new ErrorDetails("SetVariable");
-                    er.ErrorDetails.RecommendedAction = "Use a single variable rather than a collection";
-                    ThrowTerminatingError(er);
+                    ErrorRecord appendVariableError = new ErrorRecord(new InvalidOperationException(), "SetVariableAppend", ErrorCategory.InvalidOperation, Name);
+                    appendVariableError.ErrorDetails = new ErrorDetails("SetVariable");
+                    appendVariableError.ErrorDetails.RecommendedAction = "Use a single variable rather than a collection";
+                    ThrowTerminatingError(appendVariableError);
                 }
                 _valueList = new List<object>();
                 var currentValue = Context.SessionState.PSVariable.Get(Name[0]);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -733,10 +733,10 @@ namespace Microsoft.PowerShell.Commands
 
                 _valueList = new List<object>();
                 var currentValue = Context.SessionState.PSVariable.Get(Name[0]);
-                if (currentValue != null) {
-                    if (currentValue.Value is IList<object>)
+                if (currentValue is not null) {
+                    if (currentValue.Value is IList<object> ilist)
                     {
-                        _valueList.AddRange(currentValue.Value as IList<object>);
+                        _valueList.AddRange(ilist);
                     }
                     else
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -694,7 +694,7 @@ namespace Microsoft.PowerShell.Commands
         private bool _passThru;
 
         /// <summary>
-        /// Append to the variable if it exists.
+        /// Gets whether we will append to the variable if it exists.
         /// </summary>
         [Parameter]
         [Experimental("PSRedirectToVariable", ExperimentAction.Show)]
@@ -733,7 +733,8 @@ namespace Microsoft.PowerShell.Commands
 
                 _valueList = new List<object>();
                 var currentValue = Context.SessionState.PSVariable.Get(Name[0]);
-                if (currentValue is not null) {
+                if (currentValue is not null)
+                {
                     if (currentValue.Value is IList<object> ilist)
                     {
                         _valueList.AddRange(ilist);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -703,6 +703,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 return _append;
             }
+
             set
             {
                 _append = value;
@@ -744,7 +745,7 @@ namespace Microsoft.PowerShell.Commands
                 _valueList = new List<object>();
                 var currentValue = Context.SessionState.PSVariable.Get(Name[0]);
                 if (currentValue != null) {
-                    if (currentValue.Value is IList)
+                    if (currentValue.Value is IList<object>)
                     {
                         _valueList.AddRange(currentValue.Value as IList<object>);
                     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -697,7 +697,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets whether we will append to the variable if it exists.
         /// </summary>
         [Parameter]
-        [Experimental("PSRedirectToVariable", ExperimentAction.Show)]
+        [Experimental(ExperimentalFeature.PSRedirectToVariable, ExperimentAction.Show)]
         public SwitchParameter Append { get; set; }
 
         private bool _nameIsFormalParameter;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -697,27 +697,8 @@ namespace Microsoft.PowerShell.Commands
         /// Append to the variable if it exists
         /// </summary>
         [Parameter]
-        public SwitchParameter Append
-        {
-            get
-            {
-                return _append;
-            }
-
-            set
-            {
-                if (ExperimentalFeature.IsEnabled("PSRedirectToVariable"))
-                {
-                    _append = value;
-                }
-                else
-                {
-                    throw new ArgumentException("ExperimentalFeature 'PSRedirectToVariable' is not enabled");
-                }
-            }
-        }
-
-        private bool _append;
+        [Experimental("PSRedirectToVariable", ExperimentAction.Show)]
+        public SwitchParameter Append { get; set; }
 
         private bool _nameIsFormalParameter;
         private bool _valueIsFormalParameter;
@@ -738,7 +719,7 @@ namespace Microsoft.PowerShell.Commands
                 _valueIsFormalParameter = true;
             }
 
-            if (_append)
+            if (Append)
             {
                 // create the list here and add to it if it has a value
                 // but if they have more than one name, produce an error
@@ -749,6 +730,7 @@ namespace Microsoft.PowerShell.Commands
                     appendVariableError.ErrorDetails.RecommendedAction = "Use a single variable rather than a collection";
                     ThrowTerminatingError(appendVariableError);
                 }
+
                 _valueList = new List<object>();
                 var currentValue = Context.SessionState.PSVariable.Get(Name[0]);
                 if (currentValue != null) {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -694,7 +694,7 @@ namespace Microsoft.PowerShell.Commands
         private bool _passThru;
 
         /// <summary>
-        /// Append to the variable if it exists
+        /// Append to the variable if it exists.
         /// </summary>
         [Parameter]
         [Experimental("PSRedirectToVariable", ExperimentAction.Show)]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -726,8 +726,8 @@ namespace Microsoft.PowerShell.Commands
                 if (Name.Length != 1)
                 {
                     ErrorRecord appendVariableError = new ErrorRecord(new InvalidOperationException(), "SetVariableAppend", ErrorCategory.InvalidOperation, Name);
-                    appendVariableError.ErrorDetails = new ErrorDetails("SetVariable");
-                    appendVariableError.ErrorDetails.RecommendedAction = "Use a single variable rather than a collection";
+                    appendVariableError.ErrorDetails = new ErrorDetails("SetVariableAppend");
+                    appendVariableError.ErrorDetails.RecommendedAction = VariableCommandStrings.UseSingleVariable;
                     ThrowTerminatingError(appendVariableError);
                 }
 
@@ -759,6 +759,16 @@ namespace Microsoft.PowerShell.Commands
         {
             if (_nameIsFormalParameter && _valueIsFormalParameter)
             {
+                if (Append)
+                {
+                    if (Value != AutomationNull.Value)
+                    {
+                        _valueList ??= new List<object>();
+
+                        _valueList.Add(Value);
+                    }
+                }
+
                 return;
             }
 
@@ -789,7 +799,14 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (_valueIsFormalParameter)
                 {
-                    SetVariable(Name, Value);
+                    if (Append)
+                    {
+                        SetVariable(Name, _valueList);
+                    }
+                    else
+                    {
+                        SetVariable(Name, Value);
+                    }
                 }
                 else
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/VariableCommandStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/VariableCommandStrings.resx
@@ -123,6 +123,9 @@
   <data name="SetVariableTarget" xml:space="preserve">
     <value>Name: {0} Value: {1}</value>
   </data>
+  <data name="UseSingleVariable" xml:space="preserve">
+    <value>Use a single variable rather than a collection</value>
+  </data>
   <data name="NewVariableAction" xml:space="preserve">
     <value>New variable</value>
   </data>

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -25,6 +25,7 @@ namespace System.Management.Automation
         internal const string PSFeedbackProvider = "PSFeedbackProvider";
         internal const string PSCommandWithArgs = "PSCommandWithArgs";
         internal const string PSNativeWindowsTildeExpansion = nameof(PSNativeWindowsTildeExpansion);
+        internal const string PSRedirectToVariable = "PSRedirectToVariable";
 
         #endregion
 
@@ -127,8 +128,10 @@ namespace System.Management.Automation
                     description: "Enable `-CommandWithArgs` parameter for pwsh"),
                 new ExperimentalFeature(
                     name: PSNativeWindowsTildeExpansion,
-                    description: "On windows, expand unquoted tilde (`~`) with the user's current home folder."
-                )
+                    description: "On windows, expand unquoted tilde (`~`) with the user's current home folder."),
+                new ExperimentalFeature(
+                    name: PSRedirectToVariable,
+                    description: "Add support for redirecting to the variable drive"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1281,9 +1281,15 @@ namespace System.Management.Automation
                 // is more specific tp the redirection operation...
                 if (rte.ErrorRecord.Exception is System.ArgumentException)
                 {
-                    throw InterpreterError.NewInterpreterExceptionWithInnerException(null,
-                        typeof(RuntimeException), null, "RedirectionFailed", ParserStrings.RedirectionFailed,
-                            rte.ErrorRecord.Exception, File, rte.ErrorRecord.Exception.Message);
+                    throw InterpreterError.NewInterpreterExceptionWithInnerException(
+                        null,
+                        typeof(RuntimeException),
+                        null,
+                        "RedirectionFailed",
+                        ParserStrings.RedirectionFailed,
+                        rte.ErrorRecord.Exception,
+                        File,
+                        rte.ErrorRecord.Exception.Message);
                 }
 
                 throw;

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1228,7 +1228,7 @@ namespace System.Management.Automation
             CommandProcessorBase commandProcessor;
             var name = context.SessionState.Path.GetUnresolvedProviderPathFromPSPath(File, out p, out d);
 
-            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable") && p != null && p.NameEquals(context.ProviderNames.Variable))
+            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSRedirectToVariable) && p != null && p.NameEquals(context.ProviderNames.Variable))
             {
                 commandProcessor = context.CreateCommand("Set-Variable", false);
                 Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1215,7 +1215,7 @@ namespace System.Management.Automation
             CommandProcessorBase commandProcessor;
             var name = context.SessionState.Path.GetUnresolvedProviderPathFromPSPath(File, out p, out d);
 
-            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable") && p.NameEquals(context.ProviderNames.Variable))
+            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable") && p != null && p.NameEquals(context.ProviderNames.Variable))
             {
                 commandProcessor = context.CreateCommand("Set-Variable", false);
                 Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1227,7 +1227,7 @@ namespace System.Management.Automation
 
                 if (this.Appending)
                 {
-                    commandProcessor.AddParameter(CommandParameterInternal.CreateParameter("Append","-Append",null));
+                    commandProcessor.AddParameter(CommandParameterInternal.CreateParameter("Append", "-Append", null));
                 }
             }
             else
@@ -1254,7 +1254,6 @@ namespace System.Management.Automation
                     commandProcessor.AddParameter(cpi);
                 }
             }
-
 
             PipelineProcessor = new PipelineProcessor();
             PipelineProcessor.Add(commandProcessor);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1092,7 +1092,7 @@ namespace System.Management.Automation
         {
             // Check first to see if File is a variable path. If so, we'll not create the FileBytePipe
             bool redirectToVariable = false;
-            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable"))
+            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSRedirectToVariable))
             {
                 ProviderInfo p;
                 context.SessionState.Path.GetUnresolvedProviderPathFromPSPath(File, out p, out _);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1215,7 +1215,7 @@ namespace System.Management.Automation
             CommandProcessorBase commandProcessor;
             var name = context.SessionState.Path.GetUnresolvedProviderPathFromPSPath(File, out p, out d);
 
-            if (p.NameEquals(context.ProviderNames.Variable))
+            if (ExperimentalFeature.IsEnabled("PSRedirectToVariable") && p.NameEquals(context.ProviderNames.Variable))
             {
                 commandProcessor = context.CreateCommand("Set-Variable", false);
                 Diagnostics.Assert(commandProcessor != null, "CreateCommand returned null");

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -173,7 +173,7 @@ Describe "Redirection and Set-Variable -append tests" -tags CI {
                         $a.Message | Should -BeExactly "verb"
                         }
                      },
-                 @{ Name = "Debug stream should be redirectable" 
+                 @{ Name = "Debug stream should be redirectable"
                      scriptBlock = { write-debug -debug deb 5>variable:a}
                      validation = {
                         $a |Should -BeOfType [System.Management.Automation.DebugRecord]
@@ -224,6 +224,24 @@ Describe "Redirection and Set-Variable -append tests" -tags CI {
             param ( $scriptBlock, $validation )
             . $scriptBlock
             . $validation
+        }
+
+        It 'Redirection of a native application is correct' {
+            $expected = @('Arg 0 is <hi>','Arg 1 is <bye>')
+            TestExe -echoargs hi bye > variable:observed
+            $observed | Should -Be $expected
+        }
+
+        It 'Redirection while in variable provider is correct' {
+            $expected = @('Arg 0 is <hi>','Arg 1 is <bye>')
+            try {
+                Push-Location variable:
+                TestExe -echoargs hi bye > observed
+            }
+            finally {
+                Pop-Location
+            }
+            $observed | Should -Be $expected
         }
     }
 }

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -124,9 +124,15 @@ Describe "File redirection should have 'DoComplete' called on the underlying pip
     }
 }
 
-Describe "Redirection and Set-Variable -append tests" {
+Describe "Redirection and Set-Variable -append tests" -tags CI {
     Context "variable redirection should work" {
         BeforeAll {
+            if ( $EnabledExperimentalFeatures -contains "PSRedirectToVariable" ) {
+                $skipTest = $false
+            }
+            else {
+                $skipTest = $true
+            }
             $testCases = @{ Name = "Variable should be created"; scriptBlock = { 1..3>variable:a }; Validation = { ($a -join "") | Should -Be ((1..3) -join "") } },
                 @{ Name = "variable should be appended"; scriptBlock = {1..3>variable:a; 4..6>>variable:a}; Validation = { ($a -join "") | Should -Be ((1..6) -join "")}},
                 @{ Name = "variable should maintain type"; scriptBlock = {@{one=1}>variable:a};Validation = {$a | Should -BeOfType [hashtable]}},
@@ -214,7 +220,7 @@ Describe "Redirection and Set-Variable -append tests" {
 
 
         }
-        It "<name>" -TestCases $testCases {
+        It "<name>" -TestCases $testCases -skip:$skipTest {
             param ( $scriptBlock, $validation )
             . $scriptBlock
             . $validation

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -228,7 +228,7 @@ Describe "Redirection and Set-Variable -append tests" -tags CI {
 
         It 'Redirection of a native application is correct' {
             $expected = @('Arg 0 is <hi>','Arg 1 is <bye>')
-            TestExe -echoargs hi bye > variable:observed
+            testexe -echoargs hi bye > variable:observed
             $observed | Should -Be $expected
         }
 
@@ -236,7 +236,7 @@ Describe "Redirection and Set-Variable -append tests" -tags CI {
             $expected = @('Arg 0 is <hi>','Arg 1 is <bye>')
             try {
                 Push-Location variable:
-                TestExe -echoargs hi bye > observed
+                testexe -echoargs hi bye > observed
             }
             finally {
                 Pop-Location

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -123,3 +123,101 @@ Describe "File redirection should have 'DoComplete' called on the underlying pip
         $errorContent | Should -Match "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand"
     }
 }
+
+Describe "Redirection and Set-Variable -append tests" {
+    Context "variable redirection should work" {
+        BeforeAll {
+            $testCases = @{ Name = "Variable should be created"; scriptBlock = { 1..3>variable:a }; Validation = { ($a -join "") | Should -Be ((1..3) -join "") } },
+                @{ Name = "variable should be appended"; scriptBlock = {1..3>variable:a; 4..6>>variable:a}; Validation = { ($a -join "") | Should -Be ((1..6) -join "")}},
+                @{ Name = "variable should maintain type"; scriptBlock = {@{one=1}>variable:a};Validation = {$a | Should -BeOfType [hashtable]}},
+                @{
+                    Name = "variable should maintain type for multiple objects"
+                    scriptBlock = {@{one=1}>variable:a;@{two=2}>>variable:a;1>>variable:a;"string">>variable:a}
+                    Validation = {
+                        $a.count | Should -Be 4
+                        ,$a | Should -BeOfType [array]
+                        $a[0] | Should -BeOfType [hashtable]
+                        $a[1] | Should -BeOfType [hashtable]
+                        $a[2] | Should -BeOfType [int]
+                        $a[3] | Should -BeOfType [string]
+                        $a[0].one | Should -Be 1
+                        $a[1].two | Should -Be 2
+                        $a[2] | Should -Be 1
+                        $a[3] | Should -Be "string"
+                        }
+                    },
+                 @{ Name = "Error stream should be redirectable"
+                     scriptBlock = { write-error bad 2>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.ErrorRecord]
+                        $a.Exception.Message | Should -BeExactly "bad"
+                        }
+                     },
+                 @{ Name = "Warning stream should be redirectable"
+                     scriptBlock = { write-warning warn 3>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.WarningRecord]
+                        $a.Message | Should -BeExactly "warn"
+                        }
+                     },
+                 @{ Name = "Verbose stream should be redirectable"
+                     scriptBlock = { write-verbose -verbose verb 4>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.VerboseRecord]
+                        $a.Message | Should -BeExactly "verb"
+                        }
+                     },
+                 @{ Name = "Debug stream should be redirectable" 
+                     scriptBlock = { write-debug -debug deb 5>variable:a}
+                     validation = {
+                        $a |Should -BeOfType [System.Management.Automation.DebugRecord]
+                        $a.Message | Should -BeExactly "deb"
+                        }
+                     },
+                 @{ Name = "Information stream should be redirectable"
+                     scriptBlock = { write-information info 6>variable:a}
+                     validation = {
+                         $a |Should -BeOfType [System.Management.Automation.InformationRecord]
+                         $a.MessageData | Should -BeExactly "info"
+                         }
+                     },
+                 @{ Name = "Complex redirection should be supported"
+                     scriptBlock = {
+                        . {
+                            write-error bad
+                            write-information info
+                            } *>variable:a
+                        }
+                    validation = {
+                        $a.Count | Should -Be 2
+                        $a[0] | Should -BeOfType [System.Management.Automation.ErrorRecord]
+                        $a[0].Exception.Message | Should -Be "bad"
+                        $a[1] |Should -BeOfType [System.Management.Automation.InformationRecord]
+                        $a[1].MessageData | Should -BeExactly "info"
+                        }
+                    },
+                  @{
+                    Name = "multiple redirections should work"
+                     scriptBlock = {
+                        . {
+                            write-error bad
+                            write-information info
+                            } 2>variable:e 6>variable:i
+                        }
+                     validation = {
+                        $e | Should -BeOfType [System.Management.Automation.ErrorRecord]
+                        $e.Exception.Message | Should -Be "bad"
+                        $i | Should -BeOfType [System.Management.Automation.InformationRecord]
+                        $i.MessageData | Should -BeExactly "info"
+                     }
+                 }
+
+
+        }
+        It "<name>" -TestCases $testCases {
+            param ( $scriptBlock, $validation )
+            . $scriptBlock
+            . $validation
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -460,7 +460,7 @@ try
             $rs.Open()
             $pl = $rs.CreatePipeline('"Hello" > c:\temp\foo.txt')
 
-            $e = { $pl.Invoke() } | Should -Throw -ErrorId "CmdletInvocationException"
+            $e = { $pl.Invoke() } | Should -Throw -ErrorId "DriveNotFoundException"
 
             $rs.Dispose()
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -460,7 +460,7 @@ try
             $rs.Open()
             $pl = $rs.CreatePipeline('"Hello" > c:\temp\foo.txt')
 
-            $e = { $pl.Invoke() } | Should -Throw -ErrorId "DriveNotFoundException"
+            $e = { $pl.Invoke() } | Should -Throw -ErrorId "CmdletInvocationException"
 
             $rs.Dispose()
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There are a number of situations where it would be very convenient to _redirect_ data to a variable using the `variable:name` syntax. This PR provides this behavior by inspecting the target of the redirection and if it uses the variable provider will call `Set-Variable` rather than `Out-File`.

With this PR the following scenarios are possible:

```powershell
PS /> .{                                                                                   
>> "Output 1"
>> Write-Warning "Warning, Warning!"
>> "Output 2"
>> } 3> variable:warns
Output 1
Output 2
PS /> $warns
WARNING: Warning, Warning!
PS /> 
```

This could prove very helpful to some logging scenarios as well.

```powershell
S /> .{                                                                                   
>> "Output 1"
>> Write-Warning "This is a warning"
>> "Output 2"
>> Write-Debug -Debug "and a debug message"
>> "Output 3"
>> } *> variable:kitchenSync
PS /> $kitchenSync
Output 1
WARNING: This is a warning
Output 2
DEBUG: and a debug message
Output 3
```

Append is also supported via `>>`

```powershell
PS /> .{ "output 1" } *>variable:outputs                                                   
PS /> .{ "output 2" } *>>variable:outputs
PS /> .{ write-warning warn! } *>>variable:outputs
PS /> .{ "output 3" } *>>variable:outputs         
PS /> $outputs                   
output 1
output 2
WARNING: warn!
output 3
```

and redirecting multiple streams to multiple targets, based on the stream number:

```powershell
PS /> .{
>> "output 1"
>> write-warning "Warning!"
>> "output 2"
>> write-debug -debug "debug here"
>> "output 3"
>> write-information Info
>> "output 4"
>> write-error "That's bad!"
>> Write-Verbose -Verbose "and verbose"
>> "all done"
>> } > variable:outputStream 2>variable:errorStream 3>variable:warningStream 4>variable:verboseStream 5>variable:debugStream 6>variable:InfoStream
PS /> $outputStream
output 1
output 2
output 3
output 4
all done
PS /> $errorStream 
Write-Error: That's bad!
PS /> $warningStream
WARNING: Warning!
PS /> $verboseStream                   
VERBOSE: and verbose
PS /> $debugStream  
DEBUG: debug here
PS /> $InfoStream 
Info
```

Lastly, object-ness is preserved:

```powershell
PS /> .{                                 
>> "output"
>> write-error "bad"
>> write-warning "warn"
>> write-verbose -verbose "verbose"
>> write-debug -debug debug
>> } *>variable:all
PS /> $all | %{$_.gettype()}

IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     True     String                                   System.Object
True     False    ErrorRecord                              System.Object
True     False    WarningRecord                            System.Management.Automation.InformationalRecord
True     False    VerboseRecord                            System.Management.Automation.InformationalRecord
True     False    DebugRecord                              System.Management.Automation.InformationalRecord
```


This is not to say that redirection to a variable should take the place of assignment, but it does enable some new scenarios.

the current behavior when redirecting to a variable is an error (because redirection is implemented via `Out-File`):

```powershell
PS /> "sldfkj" >variable:no          
Out-File: Cannot open file because the current provider (Microsoft.PowerShell.Core\Variable) cannot open a file.
```

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): `PSRedirectToVariable`
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
