### PR TITLE
Revert "Fix: Update AppxManifest.xml to show application name on DefaultTile for Windows 10 21H2/22H2 Start Menu"

### DIFF
--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -37,11 +37,6 @@
         </uap3:Extension>
       </Extensions>
       <uap:VisualElements DisplayName="$DISPLAYNAME$" Description="PowerShell is an automation and configuration management platform. It consists of a cross-platform (Windows, Linux, and macOS) command-line shell and associated scripting language." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
-        <uap:DefaultTile Square150x150Logo="assets\Square150x150Logo.png" ShortName="PowerShell">
-          <uap:ShowNameOnTiles> 
-            <uap:ShowOn Tile="square150x150Logo"/>
-          </uap:ShowNameOnTiles>
-        </uap:DefaultTile>
       </uap:VisualElements>
     </Application>
   </Applications>


### PR DESCRIPTION
Reverts PowerShell/PowerShell#20080

This change is causing our build to fail when producing MSIX package for Windows x64, x86 and arm64.

<details>

<summary>
Expand to see the build log and error message of the failure.
</summary>

Option Overwrite specified
Option ProjectRoot specified
Option Configxml specified

Microsoft (R) MakePRI Tool
Copyright (C) 2013 Microsoft. All rights reserved.

#### Usage:
    MakePri.exe new /pr <project root> /cf <config file> [options]

#### Example:
    MakePri.exe new /pr C:\MyApp\src\ /cf C:\MyApp\priconfig.xml /mn
    C:\MyApp\AppXManifest.xml /of C:\MyApp\src\resources.pri /o

#### Description:
    Creates a PRI file at [outputfile] by indexing all files in the
    [projectroot]and its subdirectories as directed by the [configxml]. The
    index will be assigned [indexname] to reference resources in the application

#### Required Parameters:
    /ProjectRoot(pr)  : <FOLDERPATH> Root location of project files
    /ConfigXml(cf)    : <FILEPATH> Configuration file location. Use
                        'Makepri.exe createconfig' command to generate one

#### Options:
    /OutputFile(of)   : <FILEPATH> Output location of PRI file, default is
                        [current directory]\resources.pri
    /Manifest(mn)     : <FILEPATH> Location of the application or component's
                        manifest. This parameter is ignored if [indexname]
                        is given. Default is [projectroot]\AppXManifest.xml
    /IndexName(in)    : <STRING> Name for the generated index of resources.
                        Typically matches the AppX package name, class library
                        simple name, etc. May be supplied via the
                        [manifest] parameter.
                        If IndexName is not specified and an AppX manifest
                        file is not present, the default name 'Application'
                        will be used.
    /VersionMajor(vma): <INTEGER> [Deprecated] Major version number for
                        index, default is 1
    /IndexLog(il)     : <FILEPATH> XML Log of indexed resources, no file
                        generated by default
    /AutoMerge(am)    : This flag is not recommended for normal use with AppX
                        packages. It causes Makepri.exe to set the auto
                        merge flag within the PRI file. Default is not set.
    /ReverseMap(rm)   : Generate a reverse mapping section in the PRI file
                        which can be used for debugging purposes.
    /MappingFile(mf)  : <MAPPINGFILETYPE> Generate a mapping file in the given
                        file format.
    /SchemaFile(sf)   : <FILEPATH> Output location of XML resource schema
                        description.
    /IndexOptions(io) : <OPTIONS> Options to provide detailed control over
                        behavior of resource indexers.
    /Overwrite(o)     : Overwrite an existing output file of the same name
                        without prompting
    /Verbose(v)       : Causes verbose messages to be output to the console
    /Help(h, ?)       : Display the usage help text
    /ExtensionDll(ex) : <FILEPATH> Location of the MRT environment extension
                        DLL. This DLL must be signed by a Microsoft-issued
                        certificate. Default is an empty path (no DLL
                        will be used).

    FOLDERPATH       - is a valid path to a folder
    FILEPATH         - is a path to a file, either relative to the current
                       directory or absolute
    MAPPINGFILETYPE  - Supported File type(s): 'AppX'


ERROR: PRI191: 0x80080204 - Appx manifest not found or is invalid. Please ensure well-formed manifest file is present. Or specify an index name with /in switch.

error C00CE015: App manifest validation error: The app manifest must be valid as per schema: Line 28, Column 26, Reason: The attribute 'Square150x150Logo' on the element '{http://schemas.microsoft.com/appx/manifest/uap/windows10}DefaultTile' is not defined in the DTD/Schema.

</details>