### PR TITLE
Add tilde expansion for windows native executables

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -24,6 +24,7 @@ namespace System.Management.Automation
         internal const string PSModuleAutoLoadSkipOfflineFilesFeatureName = "PSModuleAutoLoadSkipOfflineFiles";
         internal const string PSFeedbackProvider = "PSFeedbackProvider";
         internal const string PSCommandWithArgs = "PSCommandWithArgs";
+        internal const string PSNativeWindowsTildeExpansion = nameof(PSNativeWindowsTildeExpansion);
 
         #endregion
 
@@ -124,6 +125,10 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSCommandWithArgs,
                     description: "Enable `-CommandWithArgs` parameter for pwsh"),
+                new ExperimentalFeature(
+                    name: PSNativeWindowsTildeExpansion,
+                    description: "On windows, expand unquoted tilde (`~`) with the user's current home folder."
+                )
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -14,11 +14,11 @@ using Microsoft.PowerShell.Commands;
 namespace System.Management.Automation
 {
     using Language;
-	using static System.Management.Automation.Interpreter.InitializeLocalInstruction;
+    using static System.Management.Automation.Interpreter.InitializeLocalInstruction;
 
-	/// <summary>
-	/// The parameter binder for native commands.
-	/// </summary>
+    /// <summary>
+    /// The parameter binder for native commands.
+    /// </summary>
     internal class NativeCommandParameterBinder : ParameterBinderBase
     {
         #region ctor
@@ -401,7 +401,7 @@ namespace System.Management.Automation
             {
                 // Even if there are no wildcards, we still need to possibly
                 // expand ~ into the filesystem provider home directory path
-                if (ExpandTilde(parameter, arg))
+                if (ExpandTilde(arg, parameter))
                 {
                     argExpanded = true;
                 }
@@ -409,7 +409,7 @@ namespace System.Management.Automation
 #else
             if (!usedQuotes && ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeWindowsTildeExpansion))
             {
-                if (ExpandTilde(parameter, arg))
+                if (ExpandTilde(arg, parameter))
                 {
                     argExpanded = true;
                 }
@@ -429,12 +429,12 @@ namespace System.Management.Automation
         /// <param name="arg">The argument that possibly needs expansion.</param>
         /// <param name="parameter">The parameter associated with the operation.</param>
         /// <returns>True if tilde expansion occurred.</returns>
-        private bool ExpandTilde(CommandParameterInternal parameter, string arg)
+        private bool ExpandTilde(string arg, CommandParameterInternal parameter)
         {
             var fileSystemProvider = Context.EngineSessionState.GetSingleProvider(FileSystemProvider.ProviderName);
             var home = fileSystemProvider.Home;
             if (string.Equals(arg, "~"))
-			{
+            {
                 _arguments.Append(home);
                 AddToArgumentList(parameter, home);
                 return true;
@@ -442,7 +442,7 @@ namespace System.Management.Automation
             else if (arg.StartsWith("~/") || (OperatingSystem.IsWindows() && arg.StartsWith(@"~\")))
             {
                 var replacementString = string.Concat(home, arg.AsSpan(1));
-				_arguments.Append(replacementString);
+                _arguments.Append(replacementString);
                 AddToArgumentList(parameter, replacementString);
                 return true;
             }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -14,7 +14,6 @@ using Microsoft.PowerShell.Commands;
 namespace System.Management.Automation
 {
     using Language;
-    using static System.Management.Automation.Interpreter.InitializeLocalInstruction;
 
     /// <summary>
     /// The parameter binder for native commands.

--- a/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Native Windows tilde expansion tests' -tags "CI" {
+    BeforeAll {
+        $originalDefaultParams = $PSDefaultParameterValues.Clone()
+        $PSDefaultParameterValues["it:skip"] = -Not $IsWindows
+        $EnabledExperimentalFeatures.Contains('PSNativeWindowsTildeExpansion') | Should -BeTrue
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParams
+    }
+
+    # Test ~ expansion
+    It 'Tilde should be replaced by the filesystem provider home directory' {
+        cmd /c echo ~ | Should -BeExactly ($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)
+    }
+    # Test ~ expansion with a path fragment (e.g. ~/foo)
+    It '~/foo should be replaced by the <filesystem provider home directory>/foo' {
+        cmd /c echo ~/foo | Should -BeExactly "$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)/foo"
+        cmd /c echo ~\foo | Should -BeExactly "$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)\foo"
+    }
+	It '~ should not be replaced when quoted' {
+		cmd /c echo '~' | Should -BeExactly '~'
+		cmd /c echo "~" | Should -BeExactly '~'
+		cmd /c echo '~/foo' | Should -BeExactly '~/foo'
+		cmd /c echo "~/foo" | Should -BeExactly '~/foo'
+        cmd /c echo '~\foo' | Should -BeExactly '~\foo'
+		cmd /c echo "~\foo" | Should -BeExactly '~\foo'
+	}
+}

--- a/test/tools/TestMetadata.json
+++ b/test/tools/TestMetadata.json
@@ -2,6 +2,7 @@
   "ExperimentalFeatures": {
     "ExpTest.FeatureOne": [ "test/powershell/engine/ExperimentalFeature/ExperimentalFeature.Basic.Tests.ps1" ],
     "PSCultureInvariantReplaceOperator": [ "test/powershell/Language/Operators/ReplaceOperator.Tests.ps1" ],
-    "Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace": [ "test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceBreakpointManagement.Tests.ps1" ]
+    "Microsoft.PowerShell.Utility.PSManageBreakpointsInRunspace": [ "test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceBreakpointManagement.Tests.ps1" ],
+    "PSNativeWindowsTildeExpansion": [ "test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1" ]
   }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Attempted implementation for #20031.

Tilde expansion here is the same on windows as it is on unix, except that it also expands back slash.
i.e. ~, ~/...., and ~\\.... are expanded.

## PR Context

This comment: https://github.com/PowerShell/PowerShell/issues/20031#issuecomment-1653984644

My understanding is that tilde expansion was briefly introduced as part of a larger PR.
But that PR didn't handle double quotes properly, specifically `"~"` should not be expanded on windows, so it was removed.

There were also other issues with the `PSNativePSPathResolution` that lead to its removal, specifically around determining if the PSDrive argument was a file or not.

The failing example (from the previous PR) is:
```powershell
$arg = 'temp:foo'; /bin/echo $arg | Should -be $arg
```

> Expected: 'temp:foo' But was:  '/var/folde...'

For tilde expansion, we don't need to consider this information. Tilde (with no quotes) should be always expanded.

We can use an experimental feature here if required, not sure if it is needed 👍 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [x] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [x] Experimental feature name(s): Perhaps `PSNativeWindowsTildeExpansion`? It is similar to `PSNativePSPathResolution`, but with reduced scope.
- **User-facing changes**
    - [ ] Not Applicable: Maybe? It is debatable if this sort of behaviour is a breaking change, it would be strange if people expect tilde expansion to not occur I guess?
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
