### PR TITLE
Fix UNC path completion regression

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4629,22 +4629,16 @@ namespace System.Management.Automation
                 string basePath;
                 if (!relativePaths)
                 {
-                    string providerName = $"{provider.ModuleName}\\{provider.Name}::";
-                    if (pathInfo.Path.StartsWith(providerName, StringComparison.OrdinalIgnoreCase))
+                    if (pathInfo.Drive is null)
                     {
-                        basePath = pathInfo.Path.Substring(providerName.Length);
+                        basePath = dirInfo.FullName;
                     }
                     else
                     {
-                        providerName = $"{provider.Name}::";
-                        if (pathInfo.Path.StartsWith(providerName, StringComparison.OrdinalIgnoreCase))
-                        {
-                            basePath = pathInfo.Path.Substring(providerName.Length);
-                        }
-                        else
-                        {
-                            basePath = pathInfo.Path;
-                        }
+                        int stringStartIndex = pathInfo.Drive.Root.EndsWith(provider.ItemSeparator)
+                            ? pathInfo.Drive.Root.Length - 1
+                            : pathInfo.Drive.Root.Length;
+                        basePath = string.Concat(pathInfo.Drive.Name, ":", dirInfo.FullName.AsSpan(stringStartIndex));
                     }
 
                     basePath = basePath.EndsWith(provider.ItemSeparator)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4638,7 +4638,10 @@ namespace System.Management.Automation
                         int stringStartIndex = pathInfo.Drive.Root.EndsWith(provider.ItemSeparator)
                             ? pathInfo.Drive.Root.Length - 1
                             : pathInfo.Drive.Root.Length;
-                        basePath = string.Concat(pathInfo.Drive.Name, ":", dirInfo.FullName.AsSpan(stringStartIndex));
+
+                        basePath = pathInfo.Drive.VolumeSeparatedByColon
+                            ? string.Concat(pathInfo.Drive.Name, ":", dirInfo.FullName.AsSpan(stringStartIndex))
+                            : string.Concat(pathInfo.Drive.Name, dirInfo.FullName.AsSpan(stringStartIndex));
                     }
 
                     basePath = basePath.EndsWith(provider.ItemSeparator)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4635,7 +4635,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        int stringStartIndex = pathInfo.Drive.Root.EndsWith(provider.ItemSeparator)
+                        int stringStartIndex = pathInfo.Drive.Root.EndsWith(provider.ItemSeparator) && pathInfo.Drive.Root.Length > 1
                             ? pathInfo.Drive.Root.Length - 1
                             : pathInfo.Drive.Root.Length;
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1276,7 +1276,7 @@ class InheritedClassTest : System.Attribute
         }
     }
 
-    It 'Should correct slashes in UNC path completion' -Skip:!$IsWindows {
+    It 'Should correct slashes in UNC path completion' -Skip:(!$IsWindows) {
         $Res = TabExpansion2 -inputScript 'Get-ChildItem //localhost/c$/Windows'
         $Res.CompletionMatches[0].CompletionText | Should -Be "'\\localhost\c$\Windows'"
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1276,6 +1276,11 @@ class InheritedClassTest : System.Attribute
         }
     }
 
+    It 'Should correct slashes in UNC path completion' -Skip:!$IsWindows {
+        $Res = TabExpansion2 -inputScript 'Get-ChildItem //localhost/c$/Windows'
+        $Res.CompletionMatches[0].CompletionText | Should -Be "'\\localhost\c$\Windows'"
+    }
+
     It 'Should keep custom drive names when completing file paths' {
         $TempDriveName = "asdf"
         $null = New-PSDrive -Name $TempDriveName -PSProvider FileSystem -Root $HOME


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes an issue where completing UNC paths would not correct the slashes properly. So this input: `Get-ChildItem //localhost/c$/Windows<Tab>` would turn into: `'//localhost/c$/\Windows'` instead of the proper: `'\\localhost\c$\Windows'` This regression was added here: https://github.com/PowerShell/PowerShell/pull/19921

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/20413
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
