### PR TITLE
Remove public setter for VerbInfo class properties

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetVerbCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetVerbCommand.cs
@@ -70,11 +70,14 @@ namespace Microsoft.PowerShell.Commands
                             }
                         }
 
-                        VerbInfo verb = new();
-                        verb.Verb = field.Name;
-                        verb.AliasPrefix = VerbAliasPrefixes.GetVerbAliasPrefix(field.Name);
-                        verb.Group = groupName;
-                        verb.Description = VerbDescriptions.GetVerbDescription(field.Name);
+                        var verb = new VerbInfo()
+                        {
+                            Verb = field.Name,
+                            AliasPrefix = VerbAliasPrefixes.GetVerbAliasPrefix(field.Name),
+                            Group = groupName,
+                            Description = VerbDescriptions.GetVerbDescription(field.Name)
+                        };
+
                         WriteObject(verb);
                     }
                 }

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1123,22 +1123,22 @@ namespace System.Management.Automation
         /// <summary>
         /// The verb name, used to begin command names.
         /// </summary>
-        public string Verb { get; internal set; }
+        public string Verb { get; init; }
 
         /// <summary>
         /// The alias prefix, recommended for aliases to commands that begin with this verb.
         /// </summary>
-        public string AliasPrefix { get; internal set; }
+        public string AliasPrefix { get; init; }
 
         /// <summary>
         /// The name of the functional category of commands that begin with this verb.
         /// </summary>
-        public string Group { get; internal set; }
+        public string Group { get; init; }
 
         /// <summary>
         /// Explains what the verb is meant to do with its object.
         /// </summary>
-        public string Description { get; internal set; }
+        public string Description { get; init; }
 
         internal VerbInfo() { }
     }

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1139,6 +1139,8 @@ namespace System.Management.Automation
         /// Explains what the verb is meant to do with its object.
         /// </summary>
         public string Description { get; internal set; }
+
+        internal VerbInfo() { }
     }
 
     internal static class Verbs

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1123,34 +1123,22 @@ namespace System.Management.Automation
         /// <summary>
         /// The verb name, used to begin command names.
         /// </summary>
-        public string Verb
-        {
-            get; set;
-        }
+        public string Verb { get; internal set; }
 
         /// <summary>
         /// The alias prefix, recommended for aliases to commands that begin with this verb.
         /// </summary>
-        public string AliasPrefix
-        {
-            get; set;
-        }
+        public string AliasPrefix { get; internal set; }
 
         /// <summary>
         /// The name of the functional category of commands that begin with this verb.
         /// </summary>
-        public string Group
-        {
-            get; set;
-        }
+        public string Group { get; internal set; }
 
         /// <summary>
         /// Explains what the verb is meant to do with its object.
         /// </summary>
-        public string Description
-        {
-            get; set;
-        }
+        public string Description { get; internal set; }
     }
 
     internal static class Verbs


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR removes the public setter for VerbInfo class properties.

## PR Context

Fix #20061

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
