### PR TITLE
Get-Event - Supporting -First/-Skip/-Descending (Fixes #20444)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
@@ -143,7 +143,8 @@ namespace Microsoft.PowerShell.Commands
                     (!WildcardPattern.ContainsWildcardCharacters(_sourceIdentifier));
                 bool lookingForId = (_eventId >= 0);
 
-                if (! (lookingForSource || lookingForId)) {
+                if (!(lookingForSource || lookingForId))
+                {
                     return;
                 }
                 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
@@ -60,19 +60,19 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// If set, will return results in descending order (most recent event first)
+        /// Gets or sets the order of results.  If set, will return results in descending order (most recent event first).
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Descending { get; set; }
 
         /// <summary>
-        /// If provided, will only return the first N results.
+        /// Gets or sets the number of events to return.  If provided, will only return the first N results.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public long First { get; set; } = 0;
 
         /// <summary>
-        /// If provided, will skip the first N results.
+        /// Gets or Sets the number of events to skip.  If provided, will skip the first N results.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public long Skip { get; set; } = 0;
@@ -118,12 +118,14 @@ namespace Microsoft.PowerShell.Commands
                     continue;
                 }
 
-                if (Skip > 0 && skipCount < Skip) {
+                if (Skip > 0 && skipCount < Skip)
+                {
                     skipCount++;
                     continue;
                 }
                 
-                if (First > 0 && outputCount >= First) {                    
+                if (First > 0 && outputCount >= First)
+                {
                     break;
                 }
 
@@ -134,37 +136,38 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Generate an error if we couldn't find the subscription identifier,
-            // and no globbing was done.
-            if (!foundMatch)
+            // and no globbing was done (and Skip and First were not passed).
+            if (!foundMatch && Skip == 0 && First == 0)
             {
                 bool lookingForSource = (_sourceIdentifier != null) &&
                     (!WildcardPattern.ContainsWildcardCharacters(_sourceIdentifier));
                 bool lookingForId = (_eventId >= 0);
 
-                if (lookingForSource || lookingForId)
-                {
-                    object identifier = null;
-                    string error = null;
-
-                    if (lookingForSource)
-                    {
-                        identifier = _sourceIdentifier;
-                        error = EventingStrings.SourceIdentifierNotFound;
-                    }
-                    else if (lookingForId)
-                    {
-                        identifier = _eventId;
-                        error = EventingStrings.EventIdentifierNotFound;
-                    }
-
-                    ErrorRecord errorRecord = new(
-                        new ArgumentException(string.Format(System.Globalization.CultureInfo.CurrentCulture, error, identifier)),
-                        "INVALID_SOURCE_IDENTIFIER",
-                        ErrorCategory.InvalidArgument,
-                        null);
-
-                    WriteError(errorRecord);
+                if (! (lookingForSource || lookingForId)) {
+                    return;
                 }
+                
+                object identifier = null;
+                string error = null;
+
+                if (lookingForSource)
+                {
+                    identifier = _sourceIdentifier;
+                    error = EventingStrings.SourceIdentifierNotFound;
+                }
+                else if (lookingForId)
+                {
+                    identifier = _eventId;
+                    error = EventingStrings.EventIdentifierNotFound;
+                }
+
+                ErrorRecord errorRecord = new(
+                    new ArgumentException(string.Format(System.Globalization.CultureInfo.CurrentCulture, error, identifier)),
+                    "INVALID_SOURCE_IDENTIFIER",
+                    ErrorCategory.InvalidArgument,
+                    null);
+
+                WriteError(errorRecord);                
             }
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
@@ -97,7 +97,8 @@ namespace Microsoft.PowerShell.Commands
             lock (Events.ReceivedEvents.SyncRoot)
             {
                 eventArgsCollection = new List<PSEventArgs>(Events.ReceivedEvents);
-                if (this.Descending) {
+                if (this.Descending)
+                {
                     eventArgsCollection.Reverse();
                 }
             }


### PR DESCRIPTION
# PR Summary

Improving Get-Event to allow for -First/-Skip/-Descending (using the events as a stack for interactive purposes) (Fixes #20444)

## PR Context

A large number of scenarios require you to pay attention to the most recent event, rather than the earliest event.

Get-Event made this more difficult than it needs to be.  With a few small parameter changes, this cmdlet can be vastly more useful.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
