### PR TITLE
WIP: Improve command discovery of modules with a default command prefix

### DIFF
--- a/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
+++ b/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
@@ -121,11 +121,12 @@ namespace System.Management.Automation
                     }
 
                     result = new ConcurrentDictionary<string, CommandTypes>(3, moduleManifestProperties.Count, StringComparer.OrdinalIgnoreCase);
+                    string defaultPrefix = moduleManifestProperties["DefaultCommandPrefix"] as string;
 
                     var sawWildcard = false;
-                    var hadCmdlets = AddPsd1EntryToResult(result, moduleManifestProperties["CmdletsToExport"], CommandTypes.Cmdlet, ref sawWildcard);
-                    var hadFunctions = AddPsd1EntryToResult(result, moduleManifestProperties["FunctionsToExport"], CommandTypes.Function, ref sawWildcard);
-                    var hadAliases = AddPsd1EntryToResult(result, moduleManifestProperties["AliasesToExport"], CommandTypes.Alias, ref sawWildcard);
+                    var hadCmdlets = AddPsd1EntryToResult(result, defaultPrefix, moduleManifestProperties["CmdletsToExport"], CommandTypes.Cmdlet, ref sawWildcard);
+                    var hadFunctions = AddPsd1EntryToResult(result, defaultPrefix, moduleManifestProperties["FunctionsToExport"], CommandTypes.Function, ref sawWildcard);
+                    var hadAliases = AddPsd1EntryToResult(result, defaultPrefix, moduleManifestProperties["AliasesToExport"], CommandTypes.Alias, ref sawWildcard);
 
                     var analysisSucceeded = hadCmdlets && hadFunctions && hadAliases;
 
@@ -296,11 +297,12 @@ namespace System.Management.Automation
             return true;
         }
 
-        private static bool AddPsd1EntryToResult(ConcurrentDictionary<string, CommandTypes> result, object value, CommandTypes commandTypeToAdd, ref bool sawWildcard)
+        private static bool AddPsd1EntryToResult(ConcurrentDictionary<string, CommandTypes> result, string defaultPrefix, object value, CommandTypes commandTypeToAdd, ref bool sawWildcard)
         {
             string command = value as string;
             if (command != null)
             {
+                command = ModuleCmdletBase.AddPrefixToCommandName(command, defaultPrefix);
                 return AddPsd1EntryToResult(result, command, commandTypeToAdd, ref sawWildcard);
             }
 
@@ -309,7 +311,7 @@ namespace System.Management.Automation
             {
                 foreach (var o in commands)
                 {
-                    if (!AddPsd1EntryToResult(result, o, commandTypeToAdd, ref sawWildcard))
+                    if (!AddPsd1EntryToResult(result, defaultPrefix, o, commandTypeToAdd, ref sawWildcard))
                         return false;
                 }
 

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -335,7 +335,8 @@ namespace System.Management.Automation
             "NestedModules",
             "RootModule",
             "ModuleToProcess",
-            "ModuleVersion"
+            "ModuleVersion",
+            "DefaultCommandPrefix"
         };
 
         internal static Hashtable GetModuleManifestProperties(string psDataFilePath, string[] keys)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes command discovery of modules with a default command prefix that require analysis of the script module (Like if a wildcard has been specified in the exports, or if one of the export keys are missing from the manifest).
This along with the cache fix in: https://github.com/PowerShell/PowerShell/pull/20411 should fix all command discovery issues regarding prefixes.
WIP: Still need to add tests.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/12858
Fixes https://github.com/PowerShell/PowerShell/issues/15743
Fixes https://github.com/PowerShell/PowerShell/issues/2590
Fixes https://github.com/PowerShell/PowerShell/issues/13264
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
