### PR TITLE
Fix alpine tar package name and do not crossgen alpine fxdependent package

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -273,7 +273,7 @@ function Test-IsReleaseCandidate
     return $false
 }
 
-$optimizedFddRegex = 'fxdependent-(linux|linux-musl|win|win7|osx)-(x64|x86|arm64|arm)'
+$optimizedFddRegex = 'fxdependent-(linux|win|win7|osx)-(x64|x86|arm64|arm)'
 
 function Start-PSBuild {
     [CmdletBinding(DefaultParameterSetName="Default")]
@@ -309,7 +309,7 @@ function Start-PSBuild {
         # If this parameter is not provided it will get determined automatically.
         [ValidateSet("linux-musl-x64",
                      "fxdependent",
-                     "fxdependent-linux-musl-x64",
+                     "fxdependent-noopt-linux-musl-x64",
                      "fxdependent-linux-x64",
                      "fxdependent-linux-arm64",
                      "fxdependent-win-desktop",
@@ -900,7 +900,7 @@ function New-PSOptions {
         [ValidateSet("",
                      "linux-musl-x64",
                      "fxdependent",
-                     "fxdependent-linux-musl-x64",
+                     "fxdependent-noopt-linux-musl-x64",
                      "fxdependent-linux-x64",
                      "fxdependent-linux-arm64",
                      "fxdependent-win-desktop",

--- a/build.psm1
+++ b/build.psm1
@@ -563,7 +563,7 @@ Fix steps:
             Write-Verbose "Building with shim" -Verbose
             $globalToolSrcFolder = Resolve-Path (Join-Path $Options.Top "../Microsoft.PowerShell.GlobalTool.Shim") | Select-Object -ExpandProperty Path
 
-            if ($Options.Runtime -eq 'fxdependent') {
+            if ($Options.Runtime -eq 'fxdependent' -or $Options.Runtime -eq 'fxdependent-noopt-linux-musl-x64') {
                 $Arguments += "/property:SDKToUse=Microsoft.NET.Sdk"
             } elseif ($Options.Runtime -eq 'fxdependent-win-desktop') {
                 $Arguments += "/property:SDKToUse=Microsoft.NET.Sdk.WindowsDesktop"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -594,7 +594,7 @@ function Start-PSPackage {
                     Name = $Name
                     Version = $Version
                     Force = $Force
-                    Architecture = "linux-musl-x64"
+                    Architecture = "musl-x64"
                     ExcludeSymbolicLinks = $true
                     R2RVerification = [R2RVerification]@{
                         R2RState = 'R2R'

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -115,7 +115,7 @@ function Start-PSPackage {
             New-PSOptions -Configuration "Release" -Runtime 'fxdependent-linux-arm64' -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
         }
         elseif ($Type.Count -eq 1 -and $Type[0] -eq "tar-alpine-fxdependent") {
-            New-PSOptions -Configuration "Release" -Runtime 'fxdependent-linux-musl-x64' -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
+            New-PSOptions -Configuration "Release" -Runtime 'fxdependent-noopt-linux-musl-x64' -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
         }
         else {
             New-PSOptions -Configuration "Release" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
@@ -456,11 +456,11 @@ function Start-PSPackage {
                     $Arguments = @{
                         PackageSourcePath = $Source
                         Name = $Name
-                        PackageNameSuffix = 'alpine-fxdependent'
+                        PackageNameSuffix = 'musl-fxdependent'
                         Version = $Version
                         Force = $Force
                         R2RVerification = [R2RVerification]@{
-                            R2RState = 'R2R'
+                            R2RState = 'NoR2R'
                             OperatingSystem = "Linux"
                         }
                     }
@@ -4606,7 +4606,7 @@ function Invoke-AzDevOpsLinuxPackageBuild {
                 Remove-Item -Path $binDir -Recurse -Force
             }
 
-            $buildParams['Runtime'] = 'fxdependent-linux-musl-x64'
+            $buildParams['Runtime'] = 'fxdependent-noopt-linux-musl-x64'
             $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${amd64AlpineFxdBuildFolder}"
             Start-PSBuild -Clean @buildParams @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
             # Remove symbol files, xml document files.

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -456,7 +456,7 @@ function Start-PSPackage {
                     $Arguments = @{
                         PackageSourcePath = $Source
                         Name = $Name
-                        PackageNameSuffix = 'musl-fxdependent'
+                        PackageNameSuffix = 'musl-noopt-fxdependent'
                         Version = $Version
                         Force = $Force
                         R2RVerification = [R2RVerification]@{

--- a/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
@@ -59,7 +59,7 @@ function BuildPackages {
             $buildParams.Add("Runtime", "fxdependent")
         } elseif ($Alpine.IsPresent) {
             $projectAssetsZipName = 'linuxAlpineProjectAssetssymbols.zip'
-            $buildParams.Add("Runtime", 'linux-musl-x64')
+            $buildParams.Add("Runtime", 'musl-x64')
         } else {
             # make the artifact name unique
             $projectAssetsZipName = "linuxProjectAssets-$((Get-Date).Ticks)-symbols.zip"

--- a/tools/releaseBuild/azureDevOps/templates/nuget.yml
+++ b/tools/releaseBuild/azureDevOps/templates/nuget.yml
@@ -111,7 +111,7 @@ jobs:
   - task: ExtractFiles@1
     displayName: 'Extract files alpine-fxdependent'
     inputs:
-      archiveFilePatterns: '$(System.ArtifactsDirectory)/packages/powershell-*-linux-x64-alpine-fxdependent.tar.gz'
+      archiveFilePatterns: '$(System.ArtifactsDirectory)/packages/powershell-*-linux-x64-musl-fxdependent.tar.gz'
       destinationFolder: '$(alpineFxdPath)'
 
   - template: SetVersionVariables.yml

--- a/tools/releaseBuild/azureDevOps/templates/nuget.yml
+++ b/tools/releaseBuild/azureDevOps/templates/nuget.yml
@@ -111,7 +111,7 @@ jobs:
   - task: ExtractFiles@1
     displayName: 'Extract files alpine-fxdependent'
     inputs:
-      archiveFilePatterns: '$(System.ArtifactsDirectory)/packages/powershell-*-linux-x64-musl-fxdependent.tar.gz'
+      archiveFilePatterns: '$(System.ArtifactsDirectory)/packages/powershell-*-linux-x64-musl-noopt-fxdependent.tar.gz'
       destinationFolder: '$(alpineFxdPath)'
 
   - template: SetVersionVariables.yml

--- a/tools/releaseBuild/azureDevOps/templates/release-ValidatePackageNames.yml
+++ b/tools/releaseBuild/azureDevOps/templates/release-ValidatePackageNames.yml
@@ -44,7 +44,7 @@ steps:
 - pwsh: |
     $message = @()
     Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -filter *.tar.gz | ForEach-Object {
-        if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?(linux|osx|linux-linux-musl)+\-(x64\-fxdependent|x64|arm32|arm64|x64\-alpine\-fxdependent)\.(tar\.gz)')
+        if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?(linux|osx|linux-musl)+\-(x64\-fxdependent|x64|arm32|arm64|x64\-musl\-fxdependent)\.(tar\.gz)')
         {
             $messageInstance = "$($_.Name) is not a valid package name"
             $message += $messageInstance


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There was regression in previous release where the name of the alpine package as created as *-linux-linux-musl.tar.gz. This PR fixes it to *-linux-musl.tar.gz

There was a regression 2 releases ago where the fxdependent alpine package was getting crossgen'ed. This PR fixes it to be not crossgen'ed

## PR Context

Fixes #20177

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
