### PR TITLE
Add error if invalid `-ExecutionPolicy` is passed to `pwsh`

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -1078,7 +1078,16 @@ namespace Microsoft.PowerShell
                 {
                     ParseExecutionPolicy(args, ref i, ref _executionPolicy, CommandLineParameterParserStrings.MissingExecutionPolicyParameter);
                     ParametersUsed |= ParameterBitmap.ExecutionPolicy;
-                    ParametersUsed |= GetExecutionPolicy(_executionPolicy);
+                    var executionPolicy = GetExecutionPolicy(_executionPolicy);
+                    if (executionPolicy == ParameterBitmap.EPIncorrect)
+                    {
+                        SetCommandLineError(
+                            string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.InvalidExecutionPolicyArgument, _executionPolicy),
+                            showHelp: true);
+                        break;
+                    }
+
+                    ParametersUsed |= executionPolicy;
                 }
                 else if (MatchSwitch(switchKey, "encodedcommand", "e") || MatchSwitch(switchKey, "ec", "e"))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -222,4 +222,7 @@ Valid formats are:
   <data name="NullElementInArgs" xml:space="preserve">
     <value>The specified arguments must not contain null elements.</value>
   </data>
+  <data name="InvalidExecutionPolicyArgument" xml:space="preserve">
+    <value>Invalid ExecutionPolicy value '{0}'.</value>
+  </data>
 </root>

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -945,7 +945,7 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
     }
 
     It 'Errors for invalid ExecutionPolicy string' {
-        $out = pwsh -nologo -noprofile -executionpolicy foo -c 'exit 0' 2>&1
+        $out = pwsh -nologo -noprofile -executionpolicy NonExistingExecutionPolicy -c 'exit 0' 2>&1
         $out | Should -Not -BeNullOrEmpty
         $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
     }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -943,6 +943,12 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
             $out | Should -Be $expected
         }
     }
+
+    It 'Errors for invalid ExecutionPolicy string' {
+        $out = pwsh -nologo -noprofile -executionpolicy foo -c 'exit 0' 2>&1
+        $out | Should -Not -BeNullOrEmpty
+        $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
+    }
 }
 
 Describe "WindowStyle argument" -Tag Feature {

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -868,10 +868,12 @@ namespace PSTests.Parallel
             Assert.True(cpp.AbortStartup);
             Assert.True(cpp.NoExit);
             Assert.True(cpp.ShowShortHelp);
-            Assert.True(cpp.ShowBanner);
-            Assert.Equal((uint)ConsoleHost.ExitCodeSuccess, cpp.ExitCode);
+            Assert.False(cpp.ShowBanner);
+            Assert.Equal((uint)ConsoleHost.ExitCodeBadCommandLineParameter, cpp.ExitCode);
             Assert.Equal(commandLine[1], cpp.ExecutionPolicy);
-            Assert.Null(cpp.ErrorMessage);
+            Assert.Equal(
+                string.Format(CommandLineParameterParserStrings.InvalidExecutionPolicyArgument, "InvalidPolicy"),
+                cpp.ErrorMessage);
         }
 
         [Theory]

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -867,7 +867,7 @@ namespace PSTests.Parallel
 
             Assert.True(cpp.AbortStartup);
             Assert.True(cpp.NoExit);
-            Assert.False(cpp.ShowShortHelp);
+            Assert.True(cpp.ShowShortHelp);
             Assert.True(cpp.ShowBanner);
             Assert.Equal((uint)ConsoleHost.ExitCodeSuccess, cpp.ExitCode);
             Assert.Equal(commandLine[1], cpp.ExecutionPolicy);

--- a/test/xUnit/csharp/test_CommandLineParser.cs
+++ b/test/xUnit/csharp/test_CommandLineParser.cs
@@ -856,16 +856,16 @@ namespace PSTests.Parallel
         }
 
         [Theory]
-        [InlineData("-executionpolicy", "XML")]
-        [InlineData("-ex", "XML")]
-        [InlineData("-ep", "XML")]
-        public static void TestParameter_ExecutionPolicy_With_Right_Value(params string[] commandLine)
+        [InlineData("-executionpolicy", "InvalidPolicy")]
+        [InlineData("-ex", "InvalidPolicy")]
+        [InlineData("-ep", "InvalidPolicy")]
+        public static void TestParameter_ExecutionPolicy_With_Wrong_Value(params string[] commandLine)
         {
             var cpp = new CommandLineParameterParser();
 
             cpp.Parse(commandLine);
 
-            Assert.False(cpp.AbortStartup);
+            Assert.True(cpp.AbortStartup);
             Assert.True(cpp.NoExit);
             Assert.False(cpp.ShowShortHelp);
             Assert.True(cpp.ShowBanner);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Looks like the command line parameter parser has a provision to check if the value of `-ExecutionPolicy` is invalid, but it isn't used.  Fix is to check for this and return an error message.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/20449

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
