### PR TITLE
Dont include the internal non prefixed commands in Get-Command results

### DIFF
--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1443,7 +1443,8 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 foreach ((string functionName, FunctionInfo functionInfo) in module.SessionState.Internal.GetFunctionTable())
                                 {
-                                    if (matcher.IsMatch(functionName) && functionInfo.IsImported)
+                                    string prefixedFunctionName = ModuleCmdletBase.AddPrefixToCommandName(functionName, functionInfo.Prefix);
+                                    if (matcher.IsMatch(prefixedFunctionName) && functionInfo.IsImported)
                                     {
                                         // make sure function doesn't come from the current module's nested module
                                         if (functionInfo.Module.Path.Equals(module.Path, StringComparison.OrdinalIgnoreCase))
@@ -1457,7 +1458,8 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 foreach (var alias in module.SessionState.Internal.GetAliasTable())
                                 {
-                                    if (matcher.IsMatch(alias.Key) && alias.Value.IsImported)
+                                    string prefixedAlias = ModuleCmdletBase.AddPrefixToCommandName(alias.Key, alias.Value.Prefix);
+                                    if (matcher.IsMatch(prefixedAlias) && alias.Value.IsImported)
                                     {
                                         // make sure alias doesn't come from the current module's nested module
                                         if (alias.Value.Module.Path.Equals(module.Path, StringComparison.OrdinalIgnoreCase))

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Management.Automation.Runspaces;
 using System.Text;
-
+using Microsoft.PowerShell.Commands;
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation.Internal
@@ -501,27 +501,28 @@ namespace System.Management.Automation.Internal
 
                             foreach (KeyValuePair<string, CommandInfo> entry in psModule.ExportedCommands)
                             {
-                                if (commandPattern.IsMatch(entry.Value.Name) ||
-                                    (fuzzyMatcher is not null && fuzzyMatcher.IsFuzzyMatch(entry.Value.Name, pattern)) ||
-                                    (useAbbreviationExpansion && string.Equals(pattern, AbbreviateName(entry.Value.Name), StringComparison.OrdinalIgnoreCase)))
+                                string entryName = ModuleCmdletBase.AddPrefixToCommandName(entry.Value.Name, entry.Value.Prefix);
+                                if (commandPattern.IsMatch(entryName) ||
+                                    (fuzzyMatcher is not null && fuzzyMatcher.IsFuzzyMatch(entryName, pattern)) ||
+                                    (useAbbreviationExpansion && string.Equals(pattern, AbbreviateName(entryName), StringComparison.OrdinalIgnoreCase)))
                                 {
                                     CommandInfo current = null;
                                     switch (entry.Value.CommandType)
                                     {
                                         case CommandTypes.Alias:
-                                            current = new AliasInfo(entry.Value.Name, definition: null, context);
+                                            current = new AliasInfo(entryName, definition: null, context);
                                             break;
                                         case CommandTypes.Function:
-                                            current = new FunctionInfo(entry.Value.Name, ScriptBlock.EmptyScriptBlock, context);
+                                            current = new FunctionInfo(entryName, ScriptBlock.EmptyScriptBlock, context);
                                             break;
                                         case CommandTypes.Filter:
-                                            current = new FilterInfo(entry.Value.Name, ScriptBlock.EmptyScriptBlock, context);
+                                            current = new FilterInfo(entryName, ScriptBlock.EmptyScriptBlock, context);
                                             break;
                                         case CommandTypes.Configuration:
-                                            current = new ConfigurationInfo(entry.Value.Name, ScriptBlock.EmptyScriptBlock, context);
+                                            current = new ConfigurationInfo(entryName, ScriptBlock.EmptyScriptBlock, context);
                                             break;
                                         case CommandTypes.Cmdlet:
-                                            current = new CmdletInfo(entry.Value.Name, implementingType: null, helpFile: null, PSSnapin: null, context);
+                                            current = new CmdletInfo(entryName, implementingType: null, helpFile: null, PSSnapin: null, context);
                                             break;
                                         default:
                                             Dbg.Assert(false, "cannot be hit");

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -117,6 +117,19 @@ Describe "Get-Command" -Tag CI {
     BeforeAll {
         Import-Module Microsoft.PowerShell.Management
     }
+
+    Context "Prefix tests" {
+        It "Should not find the non-prefixed commands" {
+            $TestModulePath = Join-Path -Path $testdrive PrefixModuleTest
+            $ModuleFilePath = Join-Path -Path $TestModulePath PrefixModuleTest.psm1
+            $null = New-Item -Path $TestModulePath -Force -ItemType Directory
+            "function Test-DemoCommand1 {}" | Set-Content -Path $ModuleFilePath -Force
+            Import-Module $ModuleFilePath -Prefix PrefixTest
+            Get-Command -Name Test-DemoCommand1* -All | Should -HaveCount 0
+            {Get-Command -Name Test-DemoCommand1 -All -ErrorAction Stop} | Should -Throw -ErrorId 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+        }
+    }
+
     Context "-Syntax tests" {
         It "Should return a string object when -Name is an alias and -Syntax is specified" {
             $Result = Get-Command -Name del -Syntax


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes issue where the non prefixed command would be found for imported modules if the "All" switch was given to "Get-Command".
Eg. if you have a command named: `Test-Something` with a prefix: `Foo` then `Get-Command Test-Something -All` would return the internal non-prefixed variant. This also happened with wildcard searches, though if the wildcard would have found the prefixed variant (eg. `Get-Command Test-*Something* -All`) then only that would have been returned.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
