### PR TITLE
Get-PSCallstack - Adding -First/-Skip (Fixes #20493)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSCallStack.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSCallStack.cs
@@ -13,13 +13,45 @@ namespace Microsoft.PowerShell.Commands
     public class GetPSCallStackCommand : PSCmdlet
     {
         /// <summary>
+        /// Gets or sets the number of items to return.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName=true)]
+        public uint First { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets the number of items to skip.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName=true)]
+        public uint Skip { get; set; } = 0;
+
+        /// <summary>
         /// Get the call stack.
         /// </summary>
         protected override void ProcessRecord()
         {
+            uint skipped = 0;
+            uint count   = 0;            
             foreach (CallStackFrame frame in Context.Debugger.GetCallStack())
             {
-                WriteObject(frame);
+                if (this.Skip > 0 && skipped < this.Skip)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                if (this.First > 0)
+                {
+                    if (count >= this.First)
+                    {
+                        break;
+                    }
+                    count++;
+                    WriteObject(frame);    
+                }
+                else
+                {
+                    WriteObject(frame);
+                }
             }
         }
     }


### PR DESCRIPTION
# PR Summary

Get-PSCallstack - Adding -First/-Skip (Fixes #20493)

## PR Context

Adding a -First and -Skip parameter to Get-PSCallstack, to improve usability and (slightly improve) performance when callstack peeking.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
