### PR TITLE
Fix `Copy-Item` progress to only show completed when all files are copied

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3569,6 +3569,13 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     CopyItemLocalOrToSession(path, destinationPath, recurse, Force, null);
+                    if (_totalFiles > 0 && _copiedFiles == _totalFiles)
+                    {
+                        _copyStopwatch.Stop();
+                        var progress = new ProgressRecord(COPY_FILE_ACTIVITY_ID, " ", " ");
+                        progress.RecordType = ProgressRecordType.Completed;
+                        WriteProgress(progress);
+                    }
                 }
             }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3569,7 +3569,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     CopyItemLocalOrToSession(path, destinationPath, recurse, Force, null);
-                    if (_totalFiles > 0 && _copiedFiles == _totalFiles)
+                    if (Stopping || (_totalFiles > 0 && _copiedFiles == _totalFiles))
                     {
                         _copyStopwatch.Stop();
                         var progress = new ProgressRecord(COPY_FILE_ACTIVITY_ID, " ", " ");

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3569,7 +3569,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     CopyItemLocalOrToSession(path, destinationPath, recurse, Force, null);
-                    if (Stopping || (_totalFiles > 0 && _copiedFiles == _totalFiles))
+                    if (Stopping || _copiedFiles == _totalFiles)
                     {
                         _copyStopwatch.Stop();
                         var progress = new ProgressRecord(COPY_FILE_ACTIVITY_ID, " ", " ");

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3569,13 +3569,6 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     CopyItemLocalOrToSession(path, destinationPath, recurse, Force, null);
-                    if (_totalFiles > 0)
-                    {
-                        _copyStopwatch.Stop();
-                        var progress = new ProgressRecord(COPY_FILE_ACTIVITY_ID, " ", " ");
-                        progress.RecordType = ProgressRecordType.Completed;
-                        WriteProgress(progress);
-                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The previous code was always completing the progress between file copies so if you're just copying a folder of files, then the progress gets cleared quickly or before it shows so it appears that no progress is rendering.  Fix is to only complete the progress if all the files have been copied.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/19600

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
