### PR TITLE
Added `-Version` argument completer for `Set-StrictMode`

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2686,6 +2686,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets strict mode in the current scope.
         /// </summary>
         [Parameter(ParameterSetName = "Version", Mandatory = true)]
+        [ArgumentCompleter(typeof(StrictModeVersionArgumentCompleter))]
         [ArgumentToPSVersionTransformation]
         [ValidateVersion]
         [Alias("v")]
@@ -2717,6 +2718,42 @@ namespace Microsoft.PowerShell.Commands
             Context.EngineSessionState.CurrentScope.StrictModeVersion = _version;
         }
     }
+
+    /// <summary>
+    /// Provides argument completion for StrictMode Version parameter.
+    /// </summary>
+    public class StrictModeVersionArgumentCompleter : IArgumentCompleter
+    {
+        private static readonly string[] s_StrictModeVersions = new string[] { "1.0", "2.0", "3.0", "Latest" };
+
+        /// <summary>
+        /// Returns completion results for version parameter.
+        /// </summary>
+        /// <param name="commandName">The command name.</param>
+        /// <param name="parameterName">The parameter name.</param>
+        /// <param name="wordToComplete">The word to complete.</param>
+        /// <param name="commandAst">The command AST.</param>
+        /// <param name="fakeBoundParameters">The fake bound parameters.</param>
+        /// <returns>List of Completion Results.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters)
+        {
+            var strictModeVersionPattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
+
+            foreach (string version in s_StrictModeVersions)
+            {
+                if (strictModeVersionPattern.IsMatch(version))
+                {
+                    yield return new CompletionResult(version);
+                }
+            }
+        }
+    }
+
     #endregion Set-StrictMode
 
     #endregion Built-in cmdlets that are used by or require direct access to the engine.

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2724,7 +2724,7 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class StrictModeVersionArgumentCompleter : IArgumentCompleter
     {
-        private static readonly string[] s_StrictModeVersions = new string[] { "Latest", "3.0", "2.0", "1.0" };
+        private static readonly string[] s_strictModeVersions = new string[] { "Latest", "3.0", "2.0", "1.0" };
 
         /// <summary>
         /// Returns completion results for version parameter.

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2744,7 +2744,7 @@ namespace Microsoft.PowerShell.Commands
         {
             var strictModeVersionPattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
 
-            foreach (string version in s_StrictModeVersions)
+            foreach (string version in s_strictModeVersions)
             {
                 if (strictModeVersionPattern.IsMatch(version))
                 {

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2724,7 +2724,7 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class StrictModeVersionArgumentCompleter : IArgumentCompleter
     {
-        private static readonly string[] s_StrictModeVersions = new string[] { "1.0", "2.0", "3.0", "Latest" };
+        private static readonly string[] s_StrictModeVersions = new string[] { "Latest", "3.0", "2.0", "1.0" };
 
         /// <summary>
         /// Returns completion results for version parameter.

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -744,6 +744,30 @@ ConstructorTestClass(int i, bool b)
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '$TestVar1'
     }
 
+    Context 'StrictMode Version parameter completion' {
+        BeforeAll {
+            $allStrictModeVersions = '1.0 2.0 3.0 Latest'
+            $versionOne = '1.0'
+            $versionTwo = '2.0'
+            $versionThree = '3.0'
+            $latestVersion = 'Latest'
+        }
+
+        It "Should complete Version for '<TextInput>'" -TestCases @(
+            @{ TextInput = "Set-StrictMode -Version "; ExpectedVersions = $allStrictModeVersions }
+            @{ TextInput = "Set-StrictMode -Version 1"; ExpectedVersions = $versionOne }
+            @{ TextInput = "Set-StrictMode -Version 2"; ExpectedVersions = $versionTwo }
+            @{ TextInput = "Set-StrictMode -Version 3"; ExpectedVersions = $versionThree }
+            @{ TextInput = "Set-StrictMode -Version Lat"; ExpectedVersions = $latestVersion }
+            @{ TextInput = "Set-StrictMode -Version NonExistentVersion"; ExpectedVersions = '' }
+        ) {
+            param($TextInput, $ExpectedVersions)
+            $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
+            $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+            $completionText -join ' ' | Should -BeExactly $ExpectedVersions
+        }
+    }
+
     Context "Format cmdlet's View paramter completion" {
         BeforeAll {
             $viewDefinition = @'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #20429.

Added `-Version` argument completer for `Set-StrictMode`.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Currently if you try to tab complete strict mode versions with `Set-StrictMode -Version` there is no tab completion.

This PR adds a `StrictModeVersionArgumentCompleter` for `Set-StrictMode -Version` which does tab completion for strict mode versions `1.0`, `2.0`, `3.0` and `Latest`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
