### PR TITLE
Block getting help from network locations in restricted remoting session

### DIFF
--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -490,37 +490,6 @@ Function PSGetSerializedShowCommandInfo
         }
 
         /// <summary>
-        /// Gets the command to be run to in order to import a module and refresh the command data.
-        /// </summary>
-        /// <param name="module">Module we want to import.</param>
-        /// <param name="isRemoteRunspace">Boolean flag determining whether Show-Command is queried in the local or remote runspace scenario.</param>
-        /// <param name="isFirstChance">Boolean flag to indicate that it is the second attempt to query Show-Command data.</param>
-        /// <returns>The command to be run to in order to import a module and refresh the command data.</returns>
-        internal static string GetImportModuleCommand(string module, bool isRemoteRunspace = false, bool isFirstChance = true)
-        {
-            string scriptBase = "Import-Module " + ShowCommandHelper.SingleQuote(module);
-
-            if (isRemoteRunspace)
-            {
-                if (isFirstChance)
-                {
-                    scriptBase += ";@(Get-Command " + ShowCommandHelper.CommandTypeSegment + @" -ShowCommandInfo )";
-                }
-                else
-                {
-                    scriptBase += GetSerializedCommandScript();
-                }
-            }
-            else
-            {
-                scriptBase += ";@(Get-Command " + ShowCommandHelper.CommandTypeSegment + ")";
-            }
-
-            scriptBase += ShowCommandHelper.GetGetModuleSuffix();
-            return scriptBase;
-        }
-
-        /// <summary>
         /// Gets the command to be run in order to show help for a command.
         /// </summary>
         /// <param name="command">Command we want to get help from.</param>

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1256,7 +1256,8 @@ namespace System.Management.Automation
 #if UNIX
             return false;
 #else
-            return path.StartsWith(@"\\.\") || path.StartsWith(@"\\?\");
+            // device paths can be network paths, we would need windows to parse it.
+            return path.StartsWith(@"\\.\") || path.StartsWith(@"\\?\") || path.StartsWith(@"\\;");
 #endif
         }
 
@@ -1522,6 +1523,23 @@ namespace System.Management.Automation
                 >= 1152921504606847000 => $"{(bytes / 1152921504606847000.0).ToString("0.000000000")} EB",
                 _ => $"0 Bytes",
             };
+        }
+
+        /// <summary>
+        /// Returns true if the current session is restricted (JEA or similar sessions)
+        /// </summary>
+        /// <param name="context">ExecutionContext.</param>
+        /// <returns>True if the session is restricted.</returns>
+        internal static bool IsSessionRestricted(ExecutionContext context)
+        {
+                CmdletInfo cmdletInfo = context.SessionState.InvokeCommand.GetCmdlet("Microsoft.PowerShell.Core\\Import-Module");
+                // if import-module is visible, then the session is not restricted,
+                // because the user can load arbitrary code.
+                if (cmdletInfo != null && cmdletInfo.Visibility == SessionStateEntryVisibility.Public)
+                {        
+                   return false; 
+                }
+                return true;
         }
     }
 }

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -255,6 +255,17 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
+#if !UNIX
+            string fileSystemPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(this.Name);
+            string normalizedName = FileSystemProvider.NormalizePath(fileSystemPath);
+            // In a restricted session, do not allow help on network paths or device paths, because device paths can be used to bypass the restrictions.
+            if (Utils.IsSessionRestricted(this.Context) && (FileSystemProvider.PathIsNetworkPath(normalizedName) || Utils.PathIsDevicePath(normalizedName))) {
+                Exception e = new ArgumentException(HelpErrors.NoNetworkCommands, "Name");
+                ErrorRecord errorRecord = new ErrorRecord(e, "CommandNameNotAllowed", ErrorCategory.InvalidArgument, null);
+                this.ThrowTerminatingError(errorRecord);
+            }
+#endif
+
             HelpSystem helpSystem = this.Context.HelpSystem;
             try
             {
@@ -504,7 +515,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Validates input parameters.
+        /// Validates input parameters. 
         /// </summary>
         /// <param name="cat">Category specified by the user.</param>
         /// <exception cref="ArgumentException">

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>
         /// The path with all / normalized to \
         /// </returns>
-        private static string NormalizePath(string path)
+        internal static string NormalizePath(string path)
         {
             return GetCorrectCasedPath(path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator));
         }

--- a/src/System.Management.Automation/resources/HelpErrors.resx
+++ b/src/System.Management.Automation/resources/HelpErrors.resx
@@ -187,4 +187,7 @@ To update these Help topics, start PowerShell by using the "Run as Administrator
   <data name="CircularDependencyInHelpForwarding" xml:space="preserve">
     <value>ForwardHelpTargetName cannot refer to the function itself.</value>
   </data>
+  <data name="NoNetworkCommands" xml:space="preserve">
+    <value>Cannot get help from a network location when in a restricted session.</value>
+  </data>
 </root>

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+Import-Module HelpersCommon
+
 Describe 'Online help tests for PowerShell Cmdlets' -Tags "Feature" {
 
     # The csv files (V2Cmdlets.csv and V3Cmdlets.csv) contain a list of cmdlets and expected HelpURIs.
@@ -59,5 +61,20 @@ Describe 'Get-Help -Online is not supported on Nano Server and IoT' -Tags "CI" {
 
     It "Get-help -online <cmdletName> throws InvalidOperation." -Skip:$skipTest {
         { Get-Help Get-Help -Online } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.GetHelpCommand"
+    }
+}
+
+Describe 'Get-Help should throw on network paths' -Tags "CI" {
+    BeforeAll {
+        $script:skipTest = -not $IsWindows
+    }
+
+    It "Get-Help should throw not on <command>" -Skip:$skipTest -TestCases (Get-HelpNetworkTestCases -PositiveCases) {
+        param(
+            $Command,
+            $ExpectedError
+        )
+
+        { Get-Help -Name $Command  } | Should -Not -Throw
     }
 }

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -106,7 +106,6 @@ Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnW
             Unregister-PSSessionConfiguration -Name JEA -Force -ErrorAction SilentlyContinue
         }
     }
-
 }
 
 Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
@@ -152,6 +151,34 @@ Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
         finally
         {
             Unregister-PSSessionConfiguration -Name JEA -Force -ErrorAction SilentlyContinue
+            Remove-Item $RoleCapDirectory -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "Get-Help should throw <ExpectedError> on <command>" -TestCases (Get-HelpNetworkTestCases) {
+        param(
+            $Command,
+            $ExpectedError
+        )
+
+        [string] $RoleCapDirectory = (New-Item -Path "$TestDrive\RoleCapability" -ItemType Directory -Force).FullName
+        [string] $PSSessionConfigFile = "$RoleCapDirectory\TestConfig.pssc"
+        $configurationName = 'RestrictedWithNoGetHelpProxy'
+        try
+        {
+            New-PSSessionConfigurationFile -Path $PSSessionConfigFile `
+                -SessionType Empty `
+                -LanguageMode NoLanguage `
+                -ModulesToImport 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Core' `
+                -VisibleCmdlets 'Get-command', 'measure-object', 'select-object', 'enter-pssession', 'get-formatdata', 'out-default', 'out-file', 'exit-pssession', 'get-help'
+            Register-PSSessionConfiguration -Name $configurationName -Path $PSSessionConfigFile -Force -ErrorAction SilentlyContinue
+            $scriptBlock = [scriptblock]::Create("Get-Help -Name $Command")
+            {Invoke-Command -ConfigurationName $configurationName -ComputerName localhost -ScriptBlock $scriptBlock -ErrorAction Stop} |
+                Should -Throw -ErrorId $ExpectedError
+        }
+        finally
+        {
+            Unregister-PSSessionConfiguration -Name $configurationName -Force -ErrorAction SilentlyContinue
             Remove-Item $RoleCapDirectory -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
@@ -358,6 +385,7 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
         $session = New-RemoteSession -ConfigurationName $endPoint
         try {
             $result = Invoke-Command -Session $session -ScriptBlock { $Host.Version }
+            Write-Verbose "host version: $result" -Verbose
             $result | Should -Be $PSVersionTable.PSVersion
         }
         finally {

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
@@ -48,6 +48,7 @@ FunctionsToExport = @(
         'Test-PSDefaultParameterValue'
         'Push-DefaultParameterValueStack'
         'Pop-DefaultParameterValueStack'
+        'Get-HelpNetworkTestCases'
     )
 
 CmdletsToExport= @()

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -533,3 +533,87 @@ function Pop-DefaultParameterValueStack {
 		return $false
 	}
 }
+
+function Get-HelpNetworkTestCases
+{
+    param(
+        [switch]
+        $PositiveCases
+    )
+    # .NET doesn't consider these path rooted and we won't go to the network:
+    # \\?
+    # \\.
+    # \??
+
+    # Command discovery does not follow symlinks to network locations for module qualified paths
+    $networkBlockedError = "CommandNameNotAllowed,Microsoft.PowerShell.Commands.GetHelpCommand"
+    $scriptBlockedError = "ScriptsNotAllowed"
+
+    $formats = @(
+        '//{0}/share/{1}'
+        '\\{0}\share\{1}'
+        '//{0}\share/{1}'
+        'Microsoft.PowerShell.Core\filesystem:://{0}/share/{1}'
+    )
+
+    if (!$PositiveCases) {
+        $formats += 'filesystem:://{0}/share/{1}'
+    }
+
+    $moduleQualifiedCommand = 'test.dll\fakecommand'
+    $lanManFormat = @(
+        '//;LanmanRedirector/{0}/share/{1}'
+    )
+
+    $hosts = @(
+        'fakehost'
+        'fakehost.pstest'
+    )
+
+    $commands = @(
+        'test.ps1'
+        'test.dll'
+        $moduleQualifiedCommand
+    )
+
+    $variants = @()
+    $cases = @()
+    foreach($command in $commands)  {
+        $hostName = $hosts[0]
+        $format = $formats[0]
+        $cases += @{
+            Command = $format -f $hostName, $command
+            ExpectedError = $networkBlockedError
+        }
+    }
+
+    foreach($hostName in $hosts) {
+        # chose the format with backslashes(\) to match the host with blackslashes
+        $format = $formats[1]
+        $command = $commands[0]
+        $cases += @{
+            Command = $format -f $hostName, $command
+            ExpectedError = $networkBlockedError
+        }
+    }
+    foreach($format in $formats) {
+        $hostName = $hosts[0]
+        $command = $commands[0]
+        $cases += @{
+            Command = $format -f $hostName, $command
+            ExpectedError = $networkBlockedError
+        }
+    }
+
+    foreach($format in $lanManFormat) {
+        $hostName = $hosts[0]
+        $command = $moduleQualifiedCommand
+        $cases += @{
+            Command = $format -f $hostName, $command
+            ExpectedError = $scriptBlockedError
+        }
+    }
+
+    return $cases | Sort-Object -Property ExpectedError, Command -Unique
+}
+


### PR DESCRIPTION

# PR Summary
Block getting help from network locations in restricted remoting session (JEA, exchange remoting, and similar custom remoting sessions)

## PR Context

This was already released in the servicing releases. 

This is mitigated if the restricted proxy is used for get-help or if the file system provider is hidden for the session, but not all customers implemented this way. 

We have already documented that you should have these other protections in place to protect these scenarios:
https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/security/securing-restricted-sessions?view=powershell-7.3



Defense in depth security fix

Conflicts:
* src/System.Management.Automation/engine/Utils.cs
* test/tools/Modules/HelpersCommon/HelpersCommon.psd1
* test/tools/Modules/HelpersCommon/HelpersCommon.psm1

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
