### PR TITLE
Fix `Group-Object` so output uses current culture

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.Commands
 
                         foreach (object item in propertyValueItems)
                         {
-                            sb.Append(CultureInfo.InvariantCulture, $"{item}, ");
+                            sb.AppendFormat(CultureInfo.InvariantCulture, "{0}, ", item.ToString());
                         }
 
                         sb = sb.Length > length ? sb.Remove(sb.Length - 2, 2) : sb;
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        sb.Append(CultureInfo.InvariantCulture, $"{propValuePropertyValue}, ");
+                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}, ", propValuePropertyValue.ToString());
                     }
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.Commands
 
                         foreach (object item in propertyValueItems)
                         {
-                            sb.AppendFormat(CultureInfo.InvariantCulture, "{0}, ", item.ToString());
+                            sb.AppendFormat(CultureInfo.CurrentCulture, $"{item}, ");
                         }
 
                         sb = sb.Length > length ? sb.Remove(sb.Length - 2, 2) : sb;
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}, ", propValuePropertyValue.ToString());
+                        sb.AppendFormat(CultureInfo.CurrentCulture, $"{propValuePropertyValue}, ");
                     }
                 }
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

A regression in `Group-Object` due to refactoring to use interpolated strings which doesn't take into account CurrentCulture.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/20584

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
