### PR TITLE
[release/v7.4.0] Fix `Group-Object` so output uses current culture

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.Commands
 
                         foreach (object item in propertyValueItems)
                         {
-                            sb.Append(CultureInfo.InvariantCulture, $"{item}, ");
+                            sb.AppendFormat(CultureInfo.CurrentCulture, $"{item}, ");
                         }
 
                         sb = sb.Length > length ? sb.Remove(sb.Length - 2, 2) : sb;
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        sb.Append(CultureInfo.InvariantCulture, $"{propValuePropertyValue}, ");
+                        sb.AppendFormat(CultureInfo.CurrentCulture, $"{propValuePropertyValue}, ");
                     }
                 }
             }


### PR DESCRIPTION
Backport #20608