### PR TITLE
Add support to `Get-Error` to handle BoundParameters

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -917,20 +917,8 @@ namespace System.Management.Automation.Runspaces
                                             $null = $output.Append($newline)
                                             $null = $output.Append($prop.Value)
                                         }
-                                        # Handle `BoundParameters` to show as Key/Value pairs, need to check the type name as the type is internal
-                                        elseif ($prop.Value.GetType().Name -eq 'PSBoundParametersDictionary') {
-                                            $isFirstElement = $true
-                                            foreach ($key in ($prop.Value.Keys | Sort-Object) ) {
-                                                if ($isFirstElement) {
-                                                    $null = $output.Append($newline)
-                                                }
-
-                                                $null = $output.Append(""${prefix}    ${accentColor}${key} : ${resetColor}$($prop.Value[$key])${newline}"")
-                                                $isFirstElement = $false
-                                            }
-                                        }
                                         # Dictionary and Hashtable we want to show as Key/Value pairs, we don't do the extra whitespace alignment here
-                                        elseif ($prop.Value.GetType().Name.StartsWith('Dictionary') -or $prop.Value.GetType().Name -eq 'Hashtable') {
+                                        elseif ($prop.Value -is [System.Collections.Dictionary]) {
                                             $isFirstElement = $true
                                             foreach ($key in $prop.Value.Keys) {
                                                 if ($isFirstElement) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -918,9 +918,9 @@ namespace System.Management.Automation.Runspaces
                                             $null = $output.Append($prop.Value)
                                         }
                                         # Dictionary and Hashtable we want to show as Key/Value pairs, we don't do the extra whitespace alignment here
-                                        elseif ($prop.Value -is [System.Collections.Dictionary]) {
+                                        elseif ($prop.Value -is [System.Collections.IDictionary]) {
                                             $isFirstElement = $true
-                                            foreach ($key in $prop.Value.Keys) {
+                                            foreach ($key in ($prop.Value.Keys | Sort-Object)) {
                                                 if ($isFirstElement) {
                                                     $null = $output.Append($newline)
                                                 }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -920,7 +920,7 @@ namespace System.Management.Automation.Runspaces
                                         # Handle `BoundParameters` to show as Key/Value pairs, need to check the type name as the type is internal
                                         elseif ($prop.Value.GetType().Name -eq 'PSBoundParametersDictionary') {
                                             $isFirstElement = $true
-                                            foreach ($key in $prop.Value.Keys) {
+                                            foreach ($key in ($prop.Value.Keys | Sort-Object) ) {
                                                 if ($isFirstElement) {
                                                     $null = $output.Append($newline)
                                                 }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -917,6 +917,18 @@ namespace System.Management.Automation.Runspaces
                                             $null = $output.Append($newline)
                                             $null = $output.Append($prop.Value)
                                         }
+                                        # Handle `BoundParameters` to show as Key/Value pairs, need to check the type name as the type is internal
+                                        elseif ($prop.Value.GetType().Name -eq 'PSBoundParametersDictionary') {
+                                            $isFirstElement = $true
+                                            foreach ($key in $prop.Value.Keys) {
+                                                if ($isFirstElement) {
+                                                    $null = $output.Append($newline)
+                                                }
+
+                                                $null = $output.Append(""${prefix}    ${accentColor}${key} : ${resetColor}$($prop.Value[$key])${newline}"")
+                                                $isFirstElement = $false
+                                            }
+                                        }
                                         # Dictionary and Hashtable we want to show as Key/Value pairs, we don't do the extra whitespace alignment here
                                         elseif ($prop.Value.GetType().Name.StartsWith('Dictionary') -or $prop.Value.GetType().Name -eq 'Hashtable') {
                                             $isFirstElement = $true

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -155,4 +155,17 @@ Describe 'Get-Error tests' -Tag CI {
         $out = pwsh -noprofile -command 'Set-StrictMode -Version Latest; $PSStyle.OutputRendering = "PlainText"; 1/0; Get-Error' | Out-String
         $out | Should -Match "Message : Attempted to divide by zero."
     }
+
+    It 'BoundParameters show as name/value pairs' {
+        try {
+            function test { [CmdletBinding()]param($A,$B) }
+            $Param = @{ A = "First"; B = "Second"; C = 24 }
+            test @Param
+        }
+        catch {
+        }
+
+        $out = Get-Error | Out-String
+        $out | Should -Match "BoundParameters\s+:\s+A : First\s+B : Second\s"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Error.Tests.ps1
@@ -163,6 +163,7 @@ Describe 'Get-Error tests' -Tag CI {
             test @Param
         }
         catch {
+            # do nothing
         }
 
         $out = Get-Error | Out-String


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

BoundParameters is a PSBoundParametersDictionary so `Get-Error` didn't have special code to handle that so just tried to render it like any other .NET object which is not useful.  Instead, add code to handle this case to render as name/value pairs (similar to the default formatting for this type).

![image](https://github.com/PowerShell/PowerShell/assets/11859881/387e6f64-2bf7-4714-8b6a-91a888d5d635)

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/20633

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
