### PR TITLE
Add support for back porting PRs from GitHub or the Private Azure Repos

### DIFF
--- a/test/releaseTools/releaseTools.tests.ps1
+++ b/test/releaseTools/releaseTools.tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 BeforeDiscovery {
 
     $testCases = @(

--- a/test/releaseTools/releaseTools.tests.ps1
+++ b/test/releaseTools/releaseTools.tests.ps1
@@ -1,0 +1,75 @@
+BeforeDiscovery {
+
+    $testCases = @(
+        @{
+            remoteInfo = 'upstream	git@ssh.dev.azure.com:v3/azDoOrg/PowerShellCore/PowerShell (fetch)'
+            upstreamRemote = 'upstream'
+            org = 'azDoOrg'
+            project = 'PowerShellCore'
+            UpstreamHost = 'git@ssh.dev.azure.com'
+            RemoteType = 'AzureRepo'
+        }
+        @{
+            remoteInfo = 'upstream	https://azDoOrg.visualstudio.com/PowerShell/_git/PowerShell (fetch)'
+            upstreamRemote = 'upstream'
+            org = 'azDoOrg'
+            project = 'PowerShell'
+            UpstreamHost = 'azDoOrg.visualstudio.com'
+            RemoteType = 'AzureRepo'
+        }
+        @{
+            remoteInfo = 'upstream	https://github.com/PowerShell/PowerShell.git (fetch)'
+            upstreamRemote = 'upstream'
+            org = 'PowerShell'
+            project = 'github.com'
+            UpstreamHost = 'github.com'
+            RemoteType = 'GitHub'
+        }
+        @{
+            remoteInfo = 'github	https://github.com/PowerShell/PowerShell.git (fetch)'
+            upstreamRemote = 'github'
+            org = 'PowerShell'
+            project = 'github.com'
+            UpstreamHost = 'github.com'
+            RemoteType = 'GitHub'
+        }
+        @{
+            remoteInfo = 'asonetuhasoeu	git@github.com:PowerShell/PowerShell.git (fetch)'
+            upstreamRemote = 'asonetuhasoeu'
+            org = 'PowerShell'
+            project = 'github.com'
+            UpstreamHost = 'github.com'
+            RemoteType = 'GitHub'
+        }
+
+    )
+}
+Describe "Get-UpstreamInfo" {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../tools/releaseTools.psm1 -force -Verbose
+    }
+    It "parses remote Info correctly: <RemoteInfo>" -TestCases $testCases -Test {
+        param(
+            [string]
+            $RemoteInfo,
+            [string]
+            $UpstreamRemote,
+            [string]
+            $org,
+            [string]
+            $Project,
+            [string]
+            $UpstreamHost,
+            [string]
+            $remoteType
+        )
+
+        $upstreamInfo = Get-UpstreamInfo -Upstream $RemoteInfo -UpstreamRemote $UpstreamRemote
+        $upstreamInfo | Should -Not -BeNullOrEmpty
+        $upstreamInfo.org | Should -Be $org
+        $upstreamInfo.project | Should -Be $Project
+        $upstreamInfo.repo | Should -Be 'PowerShell'
+        $upstreamInfo.host | Should -Be $UpstreamHost
+        $upstreamInfo.remoteType | Should -Be $remoteType
+    }
+}

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -851,7 +851,7 @@ function Invoke-PRBackport {
         Invoke-NativeCommand { git rev-parse --quiet $revParseParams }
     }
     catch {
-        throw "Commit does not exist. (git rev-parse $revParseParams)"
+        throw "Commit does not exist.  Try fetching the upstream. (git rev-parse $revParseParams)"
     }
 
 

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -828,6 +828,10 @@ $upstreamName = '(powershell(core)?)/(powershell)'
         $remoteType = [RemoteType]::AzureRepo
     }
 
+    Write-Verbose -Verbose "remotetype: $remoteType"
+    $upstreamMatchInfo | Format-Table | Out-String -Stream -Width 9999 | Write-Verbose -Verbose
+
+
     Invoke-NativeCommand { git fetch $UpstreamRemote $Target }
 
     $switch = '-c'

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -796,11 +796,6 @@ function Invoke-PRBackport {
     }
 
     $upstream = $null
-    <#
-$upstreamName = '(powershell(core)?)/(powershell)'
-'mscodehub   git@ssh.dev.azure.com:v3/mscodehub/PowerShellCore/PowerShell (fetch)'
--match "^mscodehub\s*[^@.]*\@?(.*)\:.*/([-\w]+)/$upstreamName.*fetch";@{org=$matches[2];project=$matches[3];repo=$matches[5];host=$matches[1]};$matches
-    #>
     $upstreamName = '(powershell(core)?)/(powershell)'
     $upstream = Invoke-NativeCommand { git remote -v }
     $upstream = $upstream | Where-Object { $_ -match "^$UpstreamRemote\s*[^@.]*\@?(.*)\:.*/([-\w]+)/$upstreamName.*fetch" }
@@ -858,7 +853,7 @@ $upstreamName = '(powershell(core)?)/(powershell)'
     if ($PSCmdlet.ShouldProcess("Create the PR")) {
         $body = "Backport #$PrNumber"
         switch($remoteType) {
-            [RemoteType]::AzureRepo {
+            "AzureRepo" {
                 Write-Verbose -Verbose "Pushing branch to $UpstreamRemote"
                 git push --set-upstream $UpstreamRemote HEAD
                 $parameters = @(
@@ -914,7 +909,7 @@ $upstreamName = '(powershell(core)?)/(powershell)'
                 Write-Verbose -Verbose "az $parameters"
                 Invoke-NativeCommand { az $parameters }
             }
-            [RemoteType]::GitHub {
+            "GitHub" {
                 Write-Verbose -Verbose "Creating PR using gh CLI"
                 gh pr create --base $Target --title $backportTitle --body $body --web
             }

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -907,7 +907,7 @@ function Invoke-PRBackport {
                 )
 
                 Write-Verbose -Verbose "az $parameters"
-                Invoke-NativeCommand { az $parameters }
+                $null = Invoke-NativeCommand { az $parameters }
             }
             "GitHub" {
                 Write-Verbose -Verbose "Creating PR using gh CLI"

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -825,7 +825,7 @@ $upstreamName = '(powershell(core)?)/(powershell)'
     }
 
     if ($upstreamMatchInfo.host -like '*azure.com') {
-        $remoteType = [RemoteType]::AzureRepo
+        [RemoteType] $remoteType = [RemoteType]::AzureRepo
     }
 
     Write-Verbose -Verbose "remotetype: $remoteType"

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -760,6 +760,9 @@ function Get-UpstreamInfo {
         if ($upstreamHost -eq 'https') {
             $upstreamHost = $org
         }
+        # matches everything but `.` ending in a `.`
+        # in other word, matching the first part of a hostname.
+        # like `www.microsoft.com` it would match `www.` with `www` in a capture group.
         if ($org -match '([^\..]*)\.') {
             $org = $Matches[1]
         }

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -844,6 +844,18 @@ function Invoke-PRBackport {
     }
 
     try {
+        $revParseParams = @(
+            '--verify'
+            "$commitId^{commit}"
+        )
+        Invoke-NativeCommand { git rev-parse --quiet $revParseParams }
+    }
+    catch {
+        throw "Commit does not exist. (git rev-parse $revParseParams)"
+    }
+
+
+    try {
         Invoke-NativeCommand { git cherry-pick $commitId }
     }
     catch {

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -739,7 +739,6 @@ function Get-UpstreamInfo {
 
     $upstreamName = '(powershell(core)?)(/_git)?/(powershell)'
     $pattern = "^$UpstreamRemote\s*(.*)\:(.*/([-\w.]+)/)?$upstreamName(\.git)?.*fetch"
-    #(.*/([-\w.]+))?(PowerShell(core)?)(/_git)?/(PowerShell)(\.git)?.*fetch
     Write-Verbose -Verbose "searching for an upstream with regex: '$pattern'"
     $upstream = $upstream | Where-Object { $_ -match $pattern }
 

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -859,6 +859,7 @@ $upstreamName = '(powershell(core)?)/(powershell)'
         $body = "Backport #$PrNumber"
         switch($remoteType) {
             [RemoteType]::AzureRepo {
+                Write-Verbose -Verbose "Pushing branch to $UpstreamRemote"
                 git push --set-upstream $UpstreamRemote HEAD
                 $parameters = @(
                     'repos'
@@ -910,10 +911,15 @@ $upstreamName = '(powershell(core)?)/(powershell)'
                     $upstreamMatchInfo.repo
                 )
 
+                Write-Verbose -Verbose "az $parameters"
                 Invoke-NativeCommand { az $parameters }
             }
             [RemoteType]::GitHub {
+                Write-Verbose -Verbose "Creating PR using gh CLI"
                 gh pr create --base $Target --title $backportTitle --body $body --web
+            }
+            default {
+                throw "unknown remoteType: $remoteType"
             }
         }
     }

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -740,7 +740,7 @@ function Get-UpstreamInfo {
     $upstreamName = '(powershell(core)?)(/_git)?/(powershell)'
     $pattern = "^$UpstreamRemote\s*(.*)\:(.*/([-\w.]+)/)?$upstreamName(\.git)?.*fetch"
     Write-Verbose -Verbose "searching for an upstream with regex: '$pattern'"
-    $upstream = $upstream | Where-Object { $_ -match $pattern }
+    $Upstream = $Upstream | Where-Object { $_ -match $pattern }
 
     Write-Verbose -Verbose "found $upstream"
 

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -742,9 +742,9 @@ function Get-UpstreamInfo {
     Write-Verbose -Verbose "searching for an upstream with regex: '$pattern'"
     $Upstream = $Upstream | Where-Object { $_ -match $pattern }
 
-    Write-Verbose -Verbose "found $upstream"
+    Write-Verbose -Verbose "found $Upstream"
 
-    if (!$upstream) {
+    if (!$Upstream) {
         throw "Please create an upstream remote that points to $upstreamName"
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add support for back porting PRs from GitHub or the Private Azure Repos

This pull request enhances the `releaseTools` module by adding functionality to handle different remote repository types (GitHub and Azure Repos) and improving the `Invoke-PRBackport` function to support these changes. The most important changes include the addition of a new function to parse upstream information, updates to handle different remote types, and new test cases to validate these changes.

Enhancements to handle different remote repository types:

* [`tools/releaseTools.psm1`](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bR726-R793): Added a new `RemoteType` enum and `Get-UpstreamInfo` function to parse and handle upstream remote information for both GitHub and Azure Repos.
* [`tools/releaseTools.psm1`](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bL751-R822): Updated the `Invoke-PRBackport` function to utilize the new `Get-UpstreamInfo` function and handle different remote types when creating and pushing branches. [[1]](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bL751-R822) [[2]](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bL795-R873) [[3]](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bL815-R900) [[4]](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bL827-R974)
* [`tools/releaseTools.psm1`](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bL851-R998): Exported the `Get-UpstreamInfo` function to make it available for other modules.

New test cases:

* [`test/releaseTools/releaseTools.tests.ps1`](diffhunk://#diff-0858c6b60bffa01d40018b911bb7d96e5528a26daefd8ac572bb32908bd5d6f8R1-R78): Added new test cases to validate the `Get-UpstreamInfo` function for different remote configurations, ensuring it correctly parses remote information for GitHub and Azure Repos.
## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
