### PR TITLE
Harden Start-Process test of -UseNewEnvironment parameter.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1954,8 +1954,12 @@ namespace Microsoft.PowerShell.Commands
                 if (_UseNewEnvironment)
                 {
                     startInfo.EnvironmentVariables.Clear();
+#if UNIX
+                    LoadEnvironmentVariable(startInfo, Context.SessionState.GetInitialEnvironmentVariables());
+#else
                     LoadEnvironmentVariable(startInfo, System.Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Machine));
                     LoadEnvironmentVariable(startInfo, System.Environment.GetEnvironmentVariables(EnvironmentVariableTarget.User));
+#endif
                 }
 
                 if (_environment != null)

--- a/src/System.Management.Automation/engine/SessionStatePublic.cs
+++ b/src/System.Management.Automation/engine/SessionStatePublic.cs
@@ -100,6 +100,25 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Get the initial state of environment variables.
+        /// </summary>
+        public Collections.Hashtable GetInitialEnvironmentVariables()
+        {
+            try
+            {
+                // This can throw because there is no environment provider.
+                // In this case, we cannot report anything.
+                // we should not report the current state because we don't have a notion
+                // of "initial".
+                return Microsoft.PowerShell.Commands.EnvironmentProvider.InitialEnvironment;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets the APIs to access paths and location.
         /// </summary>
         public PathIntrinsics Path

--- a/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
+++ b/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
@@ -25,6 +25,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public const string ProviderName = "Environment";
 
+        /// <summary>
+        /// Save off the environment block found when we initialize the provider.
+        /// </summary>
+        public static Hashtable InitialEnvironment { get; set; } = null;
+
         #region Constructor
 
         /// <summary>
@@ -35,15 +40,33 @@ namespace Microsoft.PowerShell.Commands
         {
         }
 
+        static EnvironmentProvider()
+        {
+            try
+            {
+                // GetEnvironmentVariables can throw if you don't have privilege
+                var envvarHashtable = Environment.GetEnvironmentVariables() as Hashtable;
+                if (envvarHashtable is not null)
+                {
+                    InitialEnvironment = (Hashtable)envvarHashtable.Clone();
+                }
+            }
+            catch
+            {
+                // no-op, but empty catch blocks are not desired.
+                InitialEnvironment = null;
+            }
+        }
+
         #endregion Constructor
 
         #region DriveCmdletProvider overrides
 
         /// <summary>
-        /// Initializes the alias drive.
+        /// Initializes the environment drive.
         /// </summary>
         /// <returns>
-        /// An array of a single PSDriveInfo object representing the alias drive.
+        /// An array of a single PSDriveInfo object representing the environment drive.
         /// </returns>
         protected override Collection<PSDriveInfo> InitializeDefaultDrives()
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -189,24 +189,30 @@ Describe "Start-Process tests requiring admin" -Tags "Feature","RequireAdminOnWi
 Describe "Environment Tests" -Tags "Feature" {
 
     It "UseNewEnvironment parameter should reset environment variables for child process" {
-
+        
         $PWSH = (Get-Process -Id $PID).MainModule.FileName
-        $outputFile = Join-Path -Path $TestDrive -ChildPath output.txt
-
-        $env:TestEnvVariable | Should -BeNullOrEmpty
-
         $env:TestEnvVariable = 1
-        $userName = $env:USERNAME
 
         try {
-            Start-Process $PWSH -ArgumentList '-NoProfile','-Command Write-Output \"$($env:TestEnvVariable);$($env:USERNAME)\"' -RedirectStandardOutput $outputFile -Wait
-            Get-Content -LiteralPath $outputFile | Should -BeExactly "1;$userName"
+            $outputFile = Join-Path -Path $TestDrive -ChildPath output1.txt
+            $cmd = '"Get-ChildItem env: | Select-Object Name,Value | ConvertTo-Json"'
+            Start-Process $PWSH -ArgumentList '-NoProfile',"-Command $cmd" -RedirectStandardOutput $outputFile -Wait
+            $fullEnvVariables = Get-Content $outputFile | ConvertFrom-Json
+            $fullVariableCount = $fullEnvVariables.Count
+            $fullVariableCount | Should -BeGreaterThan 3
+            $expectedVariable = $fullEnvVariables | Where-Object Name -ceq TestEnvVariable
+            $expectedVariable.Value | Should -be $env:TestEnvVariable
 
             # Check that:
-            # 1. Environment variables is resetted (TestEnvVariable is removed)
-            # 2. Environment variables comes from current user profile
-            Start-Process $PWSH -ArgumentList '-NoProfile','-Command Write-Output \"$($env:TestEnvVariable);$($env:USERNAME)\"' -RedirectStandardOutput $outputFile -Wait -UseNewEnvironment
-            Get-Content -LiteralPath $outputFile | Should -BeExactly ";$userName"
+            # 1. Environment variables are reset (TestEnvVariable is removed)
+            # 2. An environment variable found now, should also be in the full set
+            $outputFile = Join-Path -Path $TestDrive -ChildPath output2.txt
+            Start-Process $PWSH -ArgumentList '-NoProfile',"-Command $cmd" -RedirectStandardOutput $outputFile -Wait -UseNewEnvironment
+            $envVariables = Get-Content $outputFile | ConvertFrom-Json
+            $envVariables.Count | Should -BeLessThan $fullVariableCount
+            $envVariables | Where-Object Name -ceq TestEnvVariable | Should -BeNullOrEmpty
+            $currentVariable = $envVariables[0]
+            $fullEnvVariables.Where({$_.Name -ceq $currentVariable.Name}).Value | Should -be $currentVariable.Value
         } finally {
             $env:TestEnvVariable = $null
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -189,7 +189,7 @@ Describe "Start-Process tests requiring admin" -Tags "Feature","RequireAdminOnWi
 Describe "Environment Tests" -Tags "Feature" {
 
     It "UseNewEnvironment parameter should reset environment variables for child process" {
-        
+
         $PWSH = (Get-Process -Id $PID).MainModule.FileName
         $env:TestEnvVariable = 1
 


### PR DESCRIPTION
We can test more accurately the environment which is created when -UseNewEnvironment parameter is used.
The current test uses ";" as a string separator which may look like a statement separator. Also `$env:USERNAME` may actually not be set in all circumstances (say on a MAC).

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
