### PR TITLE
Fix `Group-Object` output using interpolated strings

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.Commands
 
                         foreach (object item in propertyValueItems)
                         {
-                            sb.AppendFormat(CultureInfo.CurrentCulture, $"{item}, ");
+                            sb.Append(CultureInfo.CurrentCulture, $"{item}, ");
                         }
 
                         sb = sb.Length > length ? sb.Remove(sb.Length - 2, 2) : sb;
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        sb.AppendFormat(CultureInfo.CurrentCulture, $"{propValuePropertyValue}, ");
+                        sb.Append(CultureInfo.CurrentCulture, $"{propValuePropertyValue}, ");
                     }
                 }
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -131,8 +131,12 @@ Describe "Group-Object" -Tags "CI" {
         $result[0].Group | Should -Be '@{X=}'
     }
 
-    It "Should not throw with format-like strings containing curly braces (issue #20711)" {
-        { '{', '}', '{0}' | Group-Object } | Should -Not -Throw
+    It "Should handle format-like strings with curly braces like normal strings" {
+        $result = '{', '}', '{0}' | Group-Object
+        $result.Count | Should -Be 3
+        $result[0].Name | Should -Be '{'
+        $result[1].Name | Should -Be '{0}'
+        $result[2].Name | Should -Be '}'
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -130,6 +130,10 @@ Describe "Group-Object" -Tags "CI" {
         $result[0].Name | Should -Be ""
         $result[0].Group | Should -Be '@{X=}'
     }
+
+    It "Should not throw with format-like strings containing curly braces (issue #20711)" {
+        { '{', '}', '{0}' | Group-Object } | Should -Not -Throw
+    }
 }
 
 Describe "Check 'Culture' parameter in order object cmdlets (Group-Object, Sort-Object, Compare-Object)" -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -134,9 +134,9 @@ Describe "Group-Object" -Tags "CI" {
     It "Should handle format-like strings with curly braces like normal strings" {
         $result = '{', '}', '{0}' | Group-Object
         $result.Count | Should -Be 3
-        $result[0].Name | Should -Be '{'
-        $result[1].Name | Should -Be '{0}'
-        $result[2].Name | Should -Be '}'
+        $result[0].Name | Should -BeExactly '{'
+        $result[1].Name | Should -BeExactly '{0}'
+        $result[2].Name | Should -BeExactly '}'
     }
 }
 


### PR DESCRIPTION
# PR Summary

Fixes regression from #20608 which mixed up use of `StringBuilder.AppendFormat` and interpolated strings, thereby passing the actual value to be formatted as the format string.

## PR Context

Fixes #20711.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
