### PR TITLE
Fix #20400, Start-Process with -NoNewWindow returns null ExitCode on Process object with -PassThru

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2126,6 +2126,9 @@ namespace Microsoft.PowerShell.Commands
                     jobAssigned = jobObject.AssignProcessToJobObject(processInfo.Process);
                 }
 
+                // Fetch process handle to trigger Process object to update its state by calling SetProcessHandle, discard result.
+                _ = process.Handle;
+
                 // Resume the process now that is has been set up.
                 processInfo.Resume();
 #endif

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2126,7 +2126,6 @@ namespace Microsoft.PowerShell.Commands
                     jobAssigned = jobObject.AssignProcessToJobObject(processInfo.Process);
                 }
 
-                // Addresses issue #20400: Start-Process does not populate the process object's exit code with NoNewWindow switch
                 // Because the process wasn't spawned by .NET, we need to trigger .NET to get a lock on the handle of the process.
                 // Otherwise, .NET silently throws this exception when accessing properties like ExitCode: Process was not started by this object, so requested information cannot be determined.
                 // Fetching the process handle will trigger Process object to update its internal state by calling SetProcessHandle, the result is discarded as it's not used later in this code.

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2126,9 +2126,11 @@ namespace Microsoft.PowerShell.Commands
                     jobAssigned = jobObject.AssignProcessToJobObject(processInfo.Process);
                 }
 
-                // Because the process wasn't spawned by .NET, we need to trigger .NET to get a lock on the handle of the process.
-                // Otherwise, .NET silently throws this exception when accessing properties like ExitCode: Process was not started by this object, so requested information cannot be determined.
-                // Fetching the process handle will trigger Process object to update its internal state by calling SetProcessHandle, the result is discarded as it's not used later in this code.
+                // Since the process wasn't spawned by .NET, we need to trigger .NET to get a lock on the handle of the process.
+                // Otherwise, accessing properties like `ExitCode` will throw the following exception:
+                //   "Process was not started by this object, so requested information cannot be determined."
+                // Fetching the process handle will trigger the `Process` object to update its internal state by calling `SetProcessHandle`,
+                // the result is discarded as it's not used later in this code.
                 _ = process.Handle;
 
                 // Resume the process now that is has been set up.

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2126,7 +2126,10 @@ namespace Microsoft.PowerShell.Commands
                     jobAssigned = jobObject.AssignProcessToJobObject(processInfo.Process);
                 }
 
-                // Fetch process handle to trigger Process object to update its state by calling SetProcessHandle, discard result.
+                // Addresses issue #20400: Start-Process does not populate the process object's exit code with NoNewWindow switch
+                // Because the process wasn't spawned by .NET, we need to trigger .NET to get a lock on the handle of the process.
+                // Otherwise, .NET silently throws this exception when accessing properties like ExitCode: Process was not started by this object, so requested information cannot be determined.
+                // Fetching the process handle will trigger Process object to update its internal state by calling SetProcessHandle, the result is discarded as it's not used later in this code.
                 _ = process.Handle;
 
                 // Resume the process now that is has been set up.

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -115,6 +115,11 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
         { Start-Process -FilePath $pingCommand -NoNewWindow -WindowStyle Normal -ErrorAction Stop } | Should -Throw -ErrorId "InvalidOperationException,Microsoft.PowerShell.Commands.StartProcessCommand"
     }
 
+    It "ExitCode returns with -NoNewWindow, -PassThru and -Wait" {
+        $process = Start-Process -FilePath $pingCommand -ArgumentList $pingParam -NoNewWindow -PassThru -Wait -ErrorAction Stop
+        $process.ExitCode | Should -Be 0
+    }
+
     It "Should start cmd.exe with Verb 'open' and WindowStyle 'Minimized'" -Skip:(!$isFullWin) {
         $fileToWrite = Join-Path $TestDrive "VerbTest.txt"
         $process = Start-Process cmd.exe -ArgumentList "/c echo abc > $fileToWrite" -Verb open -WindowStyle Minimized -PassThru


### PR DESCRIPTION
# PR Summary

Fixing issue #20400 along with some duplicates.

This issue was introduced by change #19096.
This change moved from .NET creating process objects to use P/Invoke (Windows APIs). The code would fetch the Process object from .NET but by design it throws an exception silently and ExitCode is null because it didn't handle spawning the process itself.

Calling the Handle property on the fetched Process will resolve ExitCode state because it fetches the underlying SafeHandle used to update the ExitCode property.

## PR Context

When you call Start-Process with -NoNewWindow, ExitCode will be null. This breaks a lot of customers of PowerShell both internally and externally. 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
