### PR TITLE
Fix rendering of DisplayRoot for network PSDrive

### DIFF
--- a/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
@@ -49,7 +49,8 @@ internal static partial class Interop
 
             if (errorCode == ERROR_SUCCESS)
             {
-                uncPath = uncBuffer.Slice(0, (int)bufferSize).ToString();
+                // exclude null terminator
+                uncPath = uncBuffer.Slice(0, (int)bufferSize - 1).ToString();
             }
             else if (errorCode == ERROR_MORE_DATA)
             {
@@ -61,7 +62,8 @@ internal static partial class Interop
 
                     if (errorCode == ERROR_SUCCESS)
                     {
-                        uncPath = uncBuffer.Slice(0, (int)bufferSize).ToString();
+                        // exclude null terminator
+                        uncPath = uncBuffer.Slice(0, (int)bufferSize - 1).ToString();
                     }
                 }
                 finally

--- a/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
@@ -52,7 +52,7 @@ internal static partial class Interop
 
             if (errorCode == ERROR_SUCCESS)
             {
-                uncPath = uncBuffer.Slice((int)bufferSize).ToString();
+                uncPath = ToString(uncBuffer.ToArray());
             }
             else if (errorCode == ERROR_MORE_DATA)
             {
@@ -64,7 +64,7 @@ internal static partial class Interop
 
                     if (errorCode == ERROR_SUCCESS)
                     {
-                        uncPath = uncBuffer.Slice((int)bufferSize).ToString();
+                        uncPath = ToString(uncBuffer.ToArray());
                     }
                 }
                 finally
@@ -77,6 +77,14 @@ internal static partial class Interop
             }
 
             return errorCode;
+        }
+
+        private static string ToString(ushort[] buffer)
+        {
+            // trim trailing null character
+            byte[] asBytes = new byte[(buffer.Length - 1) * sizeof(ushort)];
+            Buffer.BlockCopy(buffer, 0, asBytes, 0, asBytes.Length);
+            return System.Text.Encoding.Unicode.GetString(asBytes);
         }
     }
 }

--- a/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
@@ -13,8 +13,8 @@ internal static partial class Interop
     {
         private static bool s_WNetApiNotAvailable;
 
-        [LibraryImport("mpr.dll", EntryPoint = "WNetGetConnectionW")]
-        internal static partial int WNetGetConnection(ReadOnlySpan<ushort> localName, Span<ushort> remoteName, ref uint remoteNameLength);
+        [LibraryImport("mpr.dll", EntryPoint = "WNetGetConnectionW", StringMarshalling = StringMarshalling.Utf16)]
+        internal static partial int WNetGetConnection(ReadOnlySpan<char> localName, Span<char> remoteName, ref uint remoteNameLength);
 
         internal static int GetUNCForNetworkDrive(char drive, out string? uncPath)
         {
@@ -33,11 +33,8 @@ internal static partial class Interop
             bufferSize = 3;
 #endif
 
-            // TODO: change ushort with char after LibraryImport will support 'ref char'
-            // without applying the 'System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute'
-            // to the assembly.
-            ReadOnlySpan<ushort> driveName = stackalloc ushort[] { drive, ':', '\0' };
-            Span<ushort> uncBuffer = stackalloc ushort[(int)bufferSize];
+            ReadOnlySpan<char> driveName = stackalloc char[] { drive, ':', '\0' };
+            Span<char> uncBuffer = stackalloc char[(int)bufferSize];
             int errorCode = ERROR_NO_NETWORK;
 
             try
@@ -52,39 +49,31 @@ internal static partial class Interop
 
             if (errorCode == ERROR_SUCCESS)
             {
-                uncPath = ToString(uncBuffer.ToArray());
+                uncPath = uncBuffer.Slice(0, (int)bufferSize).ToString();
             }
             else if (errorCode == ERROR_MORE_DATA)
             {
-                ushort[]? rentedArray = null;
+                char[]? rentedArray = null;
                 try
                 {
-                    uncBuffer = rentedArray = ArrayPool<ushort>.Shared.Rent((int)bufferSize);
+                    uncBuffer = rentedArray = ArrayPool<char>.Shared.Rent((int)bufferSize);
                     errorCode = WNetGetConnection(driveName, uncBuffer, ref bufferSize);
 
                     if (errorCode == ERROR_SUCCESS)
                     {
-                        uncPath = ToString(uncBuffer.ToArray());
+                        uncPath = uncBuffer.Slice(0, (int)bufferSize).ToString();
                     }
                 }
                 finally
                 {
                     if (rentedArray is not null)
                     {
-                        ArrayPool<ushort>.Shared.Return(rentedArray);
+                        ArrayPool<char>.Shared.Return(rentedArray);
                     }
                 }
             }
 
             return errorCode;
-        }
-
-        private static string ToString(ushort[] buffer)
-        {
-            // trim trailing null character
-            byte[] asBytes = new byte[(buffer.Length - 1) * sizeof(ushort)];
-            Buffer.BlockCopy(buffer, 0, asBytes, 0, asBytes.Length);
-            return System.Text.Encoding.Unicode.GetString(asBytes);
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-PSDrive.Tests.ps1
@@ -17,6 +17,12 @@ Describe "Tests for New-PSDrive cmdlet." -Tag "CI","RequireAdminOnWindows" {
             { New-PSDrive -Name $PSDriveName -PSProvider FileSystem -Root $RemoteShare -Persist -ErrorAction Stop } | Should -Not -Throw
         }
 
+        It "Network drive initialization on pwsh startup DisplayRoot should have value of share" -Skip:(-not $IsWindows) {
+            $null = New-PSDrive -Name $PSDriveName -PSProvider FileSystem -Root $RemoteShare -Persist -ErrorAction Stop
+            $drive = pwsh -noprofile -outputformat XML -command "Get-PSDrive -Name $PSDriveName"
+            $drive.DisplayRoot | Should -Be $RemoteShare.TrimEnd('\')
+        }
+
         It "Should throw exception if root is not a remote share." -Skip:(-not $IsWindows) {
             { New-PSDrive -Name $PSDriveName -PSProvider FileSystem -Root "TestDrive:\" -Persist -ErrorAction Stop } | Should -Throw -ErrorId 'DriveRootNotNetworkPath'
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As part of some refactoring work to use spans, it appears that the code to get the DisplayRoot simply used `ToString()` on the ushort buffer.  However, `ToString()` only works on a span of chars, so this resulted in returning the type and size instead of the contents.  Fix is to get a Unicode string from the ushort buffer as bytes.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/19903

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
