### PR TITLE
Show Recommended Actions in Error Concise View

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1349,10 +1349,15 @@ namespace System.Management.Automation.Runspaces
                                     }
 
                                     if ($ErrorView -eq 'ConciseView') {
+                                        $recommendedAction = $_.ErrorDetails.RecommendedAction
+                                        if (-not [String]::IsNullOrWhiteSpace($recommendedAction)) {
+                                            $recommendedAction = $newline + '  Recommendation: ' + $recommendedAction
+                                        }
+
                                         if ($err.PSMessageDetails) {
                                             $posmsg = "${errorColor}${posmsg}"
                                         }
-                                        return $posmsg
+                                        return $posmsg + $recommendedAction
                                     }
 
                                     $indent = 4

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
 
     It 'Exceptions not thrown do not get formatted as ErrorRecord' {
         $exp = [System.Exception]::new('test') | Out-String
-        $exp | Should -BeLike "*Message        : *test*"
+        $exp | Should -BeLike '*Message        : *test*'
     }
 
     Context 'ConciseView tests' {
@@ -49,24 +49,24 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e | Should -BeLike '* 4 *'
         }
 
-        It "Remote errors show up correctly" {
+        It 'Remote errors show up correctly' {
             Start-Job -ScriptBlock { Get-Item (New-Guid) } | Wait-Job | Receive-Job -ErrorVariable e -ErrorAction SilentlyContinue
             ($e | Out-String).Trim().Count | Should -Be 1
         }
 
-        It "Activity shows up correctly for scriptblocks" {
+        It 'Activity shows up correctly for scriptblocks' {
             $e = & "$PSHOME/pwsh" -noprofile -command 'Write-Error 'myError' -ErrorAction SilentlyContinue; $error[0] | Out-String'
-            [string]::Join('', $e).Trim() | Should -BeLike "*Write-Error:*myError*" # wildcard due to VT100
+            [string]::Join('', $e).Trim() | Should -BeLike '*Write-Error:*myError*' # wildcard due to VT100
         }
 
-        It "Function shows up correctly" {
+        It 'Function shows up correctly' {
             function test-myerror { [cmdletbinding()] param() Write-Error 'myError' }
 
             $e = & "$PSHOME/pwsh" -noprofile -command 'function test-myerror { [cmdletbinding()] param() write-error "myError" }; test-myerror -ErrorAction SilentlyContinue; $error[0] | Out-String'
-            [string]::Join('', $e).Trim() | Should -BeLike "*test-myerror:*myError*" # wildcard due to VT100
+            [string]::Join('', $e).Trim() | Should -BeLike '*test-myerror:*myError*' # wildcard due to VT100
         }
 
-        It "Pester Should shows test file and not pester" {
+        It 'Pester Should shows test file and not pester' {
             $testScript = '1 + 1 | Should -Be 3'
 
             Set-Content -Path $testScriptPath -Value $testScript
@@ -75,7 +75,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e | Should -Not -BeLike '*pester*'
         }
 
-        It "Long lines should be rendered correctly with indentation" {
+        It 'Long lines should be rendered correctly with indentation' {
             $testscript = @'
                         $myerrors = [System.Collections.ArrayList]::new()
                         Copy-Item (New-Guid) (New-Guid) -ErrorVariable +myerrors -ErrorAction SilentlyContinue
@@ -89,11 +89,10 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e | Should -BeLike '* 2 *'
         }
 
-        It "Long exception message gets rendered" {
+        It 'Long exception message gets rendered' {
 
-            $msg = "1234567890"
-            while ($msg.Length -le $Host.UI.RawUI.WindowSize.Width)
-            {
+            $msg = '1234567890'
+            while ($msg.Length -le $Host.UI.RawUI.WindowSize.Width) {
                 $msg += $msg
             }
 
@@ -101,19 +100,19 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e | Should -BeLike "*$msg*"
         }
 
-        It "Position message does not contain line information" {
+        It 'Position message does not contain line information' {
 
-            $e = & "$PSHOME/pwsh" -noprofile -command "foreach abc" 2>&1 | Out-String
+            $e = & "$PSHOME/pwsh" -noprofile -command 'foreach abc' 2>&1 | Out-String
             $e | Should -Not -BeNullOrEmpty
-            $e | Should -Not -BeLike "*At line*"
+            $e | Should -Not -BeLike '*At line*'
         }
 
         It "Error shows if `$PSModuleAutoLoadingPreference is set to 'none'" {
             $e = & "$PSHOME/pwsh" -noprofile -command '$PSModuleAutoLoadingPreference = "none"; cmdletThatDoesntExist' 2>&1 | Out-String
-            $e | Should -BeLike "*cmdletThatDoesntExist*"
+            $e | Should -BeLike '*cmdletThatDoesntExist*'
         }
 
-        It "Error shows for advanced function" {
+        It 'Error shows for advanced function' {
             # need to have it virtually interactive so that InvocationInfo.MyCommand is empty
             $e = '[cmdletbinding()]param()$pscmdlet.writeerror([System.Management.Automation.ErrorRecord]::new(([System.NotImplementedException]::new("myTest")),"stub","notimplemented","command"))' | pwsh -noprofile -file - 2>&1
             $e = $e | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } | Out-String
@@ -122,9 +121,8 @@ Describe 'Tests for $ErrorView' -Tag CI {
             # need to see if ANSI escape sequences are in the output as ANSI is disabled for CI
             if ($e.Contains("`e")) {
                 $e | Should -BeLike "*: `e*myTest*"
-            }
-            else {
-                $e | Should -BeLike "*: myTest*"
+            } else {
+                $e | Should -BeLike '*: myTest*'
             }
         }
 
@@ -134,12 +132,12 @@ Describe 'Tests for $ErrorView' -Tag CI {
         ) {
             param($newline)
 
-            Set-Content -path $testScriptPath -Value "throw 'hello${newline}there'"
+            Set-Content -Path $testScriptPath -Value "throw 'hello${newline}there'"
             $e = & "$PSHOME/pwsh" -noprofile -file $testScriptPath 2>&1 | Out-String
-            $e.Split("o${newline}t").Count | Should -Be 1 -Because "Error message should not contain newline"
+            $e.Split("o${newline}t").Count | Should -Be 1 -Because 'Error message should not contain newline'
         }
 
-        It "Script module error should not show line information" {
+        It 'Script module error should not show line information' {
             $testModule = @'
                 function Invoke-Error() {
                     throw 'oops'
@@ -149,7 +147,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
             Set-Content -Path $testModulePath -Value $testModule
             $e = & "$PSHOME/pwsh" -noprofile -command "Import-Module '$testModulePath'; Invoke-Error" 2>&1 | Out-String
             $e | Should -Not -BeNullOrEmpty
-            $e | Should -Not -BeLike "*Line*"
+            $e | Should -Not -BeLike '*Line*'
         }
 
         It 'Parser error shows line information' {
@@ -157,23 +155,29 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e = & "$PSHOME/pwsh" -noprofile -command $testScript 2>&1 | Out-String
             $e | Should -Not -BeNullOrEmpty
             $e = $e.Split([Environment]::NewLine)
-            $e[0] | Should -BeLike "ParserError:*"
-            $e[1] | Should -BeLike "Line *" -Because ($e | Out-String)
-            $e[2] | Should -BeLike "*|*1 ++ 1*"
+            $e[0] | Should -BeLike 'ParserError:*'
+            $e[1] | Should -BeLike 'Line *' -Because ($e | Out-String)
+            $e[2] | Should -BeLike '*|*1 ++ 1*'
         }
 
         It 'Faux remote parser error shows concise message' {
-            start-job { [cmdletbinding()]param() $e = [System.Management.Automation.ErrorRecord]::new([System.Exception]::new('hello'), 1, 'ParserError', $null); $pscmdlet.ThrowTerminatingError($e) } | Wait-Job | Receive-Job -ErrorVariable e -ErrorAction SilentlyContinue
+            Start-Job { [cmdletbinding()]param() $e = [System.Management.Automation.ErrorRecord]::new([System.Exception]::new('hello'), 1, 'ParserError', $null); $pscmdlet.ThrowTerminatingError($e) } | Wait-Job | Receive-Job -ErrorVariable e -ErrorAction SilentlyContinue
             $e | Out-String | Should -BeLike '*ParserError*'
         }
 
         It 'Exception thrown from Enumerator.MoveNext in a pipeline shows information' {
             $e = {
-                    $l = [System.Collections.Generic.List[string]] @('one', 'two')
-                    $l | ForEach-Object { $null = $l.Remove($_) }
+                $l = [System.Collections.Generic.List[string]] @('one', 'two')
+                $l | ForEach-Object { $null = $l.Remove($_) }
             } | Should -Throw -ErrorId 'BadEnumeration' -PassThru | Out-String
 
             $e | Should -BeLike 'InvalidOperation:*'
+        }
+
+        It 'Displays a RecommendedAction if present in the ErrorRecord' {
+            $testScript = 'Write-Error -Message ''TestError'' -RecommendedAction ''TestAction'''
+            $e = & "$PSHOME/pwsh" -noprofile -command $testScript 2>&1 | Out-String
+            $e | Should -BeLike "*$([Environment]::NewLine)  Recommendation: TestAction*"
         }
     }
 
@@ -184,11 +188,9 @@ Describe 'Tests for $ErrorView' -Tag CI {
                 $ErrorView = 'NormalView'
                 Set-StrictMode -Version 2
                 throw 'Oops!'
-            }
-            catch {
+            } catch {
                 $e = $_ | Out-String
-            }
-            finally {
+            } finally {
                 Set-StrictMode -Off
             }
 
@@ -202,8 +204,7 @@ Describe 'Tests for $ErrorView' -Tag CI {
             try {
                 $ErrorView = 'DetailedView'
                 throw 'Oops!'
-            }
-            catch {
+            } catch {
                 # an extra newline gets added by the formatting system so we remove them
                 $e = ($_ | Out-String).Trim([Environment]::NewLine.ToCharArray())
             }


### PR DESCRIPTION
CC @SteveL-MSFT per previous discussion.
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Exposes the RecommendedAction in an ErrorRecord to ConciseView

```
❯ write-Error 'oops' -RecommendedAction 'You should fix the oops'
Write-Error: oops
  Recommendation: You should fix the oops
```
<!-- Summarize your PR between here and the checklist. -->

## PR Context

If an ErrorRecord Author has gone to the trouble to define RecommendedAction, we should expose this to the user at the time of the Error to help guide them to a solution. This makes the most sense in the default ConciseView as that is where most new users are likely to see it.

This could be done with a Feedback Provider (and I have implemented one for example) but I think it makes more sense as a core message, especially as the users who will best benefit from this information are likely to be new users who don't even know what a Feedback Provider is much less enabling one, so having it default into ConciseView makes a lot of sense.

There is a potential breaking change here in cases where users are matching errors exactly say on text output of a pwsh process. While that is obviously discouraged it must be considered, however as the team previously switched the default ErrorView to `ConciseView` from `NormalView` as the default, it is assumed the team has an appetite for this type of change.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
