### PR TITLE
Fix where HelpParagraphBuilder would only add the first line of a param description

### DIFF
--- a/src/Microsoft.Management.UI.Internal/HelpWindow/HelpParagraphBuilder.cs
+++ b/src/Microsoft.Management.UI.Internal/HelpWindow/HelpParagraphBuilder.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Management.Automation;
@@ -212,6 +214,21 @@ namespace Microsoft.Management.UI.Internal
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Gets the multiline text from all objects of a property of type PSObject[].
+        /// </summary>
+        /// <param name="psObj">Object to get text from.</param>
+        /// <param name="propertyText">Property with PSObject[] containing text.</param>
+        /// <returns>The lines of the text from a property of type PSObject[].</returns>
+        private static IEnumerable<string> GetMultilineTextFromArray(PSObject psObj, string propertyText)
+        {
+            PSObject[] introductionObjects = HelpParagraphBuilder.GetPropertyObject(psObj, propertyText) as PSObject[];
+            for (var i = 0; i < introductionObjects?.Length; i++)
+            {
+                yield return GetPropertyString(introductionObjects[i], "text");
+            }
         }
 
         /// <summary>
@@ -758,7 +775,7 @@ namespace Microsoft.Management.UI.Internal
 
                 string parameterValue = GetPropertyString(parameter, "parameterValue");
                 string name = GetPropertyString(parameter, "name");
-                string description = GetTextFromArray(parameter, "description");
+                IEnumerable<string> description = GetMultilineTextFromArray(parameter, "description");
                 string required = GetPropertyString(parameter, "required");
                 string position = GetPropertyString(parameter, "position");
                 string pipelineinput = GetPropertyString(parameter, "pipelineInput");
@@ -789,8 +806,11 @@ namespace Microsoft.Management.UI.Internal
 
                 if (description != null)
                 {
-                    this.AddText(HelpParagraphBuilder.AddIndent(description, 2), false);
-                    this.AddText("\r\n", false);
+                    foreach (var line in description)
+                    {
+                        this.AddText(HelpParagraphBuilder.AddIndent(line, 2), false);
+                        this.AddText("\r\n", false);
+                    }
                 }
 
                 this.AddText("\r\n", false);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
The changes done ensure that the HelpParagraphBuilder adds all text objects of a parameter's description properly.
The param description will be formatted in a similar way as when running `Get-Help <command> -Parameter <parameter>`.

![image](https://github.com/PowerShell/PowerShell/assets/8781673/a36a125d-a92f-40f4-9fc3-9213ee0ff476)

![image](https://github.com/PowerShell/PowerShell/assets/8781673/61cb4151-51e6-44aa-872e-4dccd61ee91e)
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes #17015
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
