### PR TITLE
Leave the input/output/error handles unset when they are not redirected

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2444,7 +2444,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (hasRedirection)
             {
-                // STARTF_USESTDHANDLES
+                // Set STARTF_USESTDHANDLES only if there is redirection.
                 lpStartupInfo.dwFlags = 0x100;
             }
 
@@ -2793,9 +2793,6 @@ namespace Microsoft.PowerShell.Commands
 
     internal static class ProcessNativeMethods
     {
-        [DllImport(PinvokeDllNames.GetStdHandleDllName, SetLastError = true)]
-        public static extern IntPtr GetStdHandle(int whichHandle);
-
         [DllImport(PinvokeDllNames.CreateProcessWithLogonWDllName, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool CreateProcessWithLogonW(string userName,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2414,44 +2414,39 @@ namespace Microsoft.PowerShell.Commands
 
         private void SetStartupInfo(ProcessStartInfo startinfo, ref ProcessNativeMethods.STARTUPINFO lpStartupInfo, ref int creationFlags)
         {
+            bool hasRedirection = false;
             // RedirectionStandardInput
             if (_redirectstandardinput != null)
             {
+                hasRedirection = true;
                 startinfo.RedirectStandardInput = true;
                 _redirectstandardinput = ResolveFilePath(_redirectstandardinput);
                 lpStartupInfo.hStdInput = GetSafeFileHandleForRedirection(_redirectstandardinput, FileMode.Open);
-            }
-            else
-            {
-                lpStartupInfo.hStdInput = new SafeFileHandle(ProcessNativeMethods.GetStdHandle(-10), false);
             }
 
             // RedirectionStandardOutput
             if (_redirectstandardoutput != null)
             {
+                hasRedirection = true;
                 startinfo.RedirectStandardOutput = true;
                 _redirectstandardoutput = ResolveFilePath(_redirectstandardoutput);
                 lpStartupInfo.hStdOutput = GetSafeFileHandleForRedirection(_redirectstandardoutput, FileMode.Create);
-            }
-            else
-            {
-                lpStartupInfo.hStdOutput = new SafeFileHandle(ProcessNativeMethods.GetStdHandle(-11), false);
             }
 
             // RedirectionStandardError
             if (_redirectstandarderror != null)
             {
+                hasRedirection = true;
                 startinfo.RedirectStandardError = true;
                 _redirectstandarderror = ResolveFilePath(_redirectstandarderror);
                 lpStartupInfo.hStdError = GetSafeFileHandleForRedirection(_redirectstandarderror, FileMode.Create);
             }
-            else
-            {
-                lpStartupInfo.hStdError = new SafeFileHandle(ProcessNativeMethods.GetStdHandle(-12), false);
-            }
 
-            // STARTF_USESTDHANDLES
-            lpStartupInfo.dwFlags = 0x100;
+            if (hasRedirection)
+            {
+                // STARTF_USESTDHANDLES
+                lpStartupInfo.dwFlags = 0x100;
+            }
 
             if (startinfo.CreateNoWindow)
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/TaskbarJumpList.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/TaskbarJumpList.cs
@@ -33,13 +33,12 @@ namespace Microsoft.PowerShell
             {
                 try
                 {
-                    TaskbarJumpList.CreateElevatedEntry(ConsoleHostStrings.RunAsAdministrator);
+                    CreateElevatedEntry(ConsoleHostStrings.RunAsAdministrator);
                 }
-                catch (Exception exception)
+                catch (Exception)
                 {
                     // Due to COM threading complexity there might still be sporadic failures but they can be
                     // ignored as creating the JumpList is not critical and persists after its first creation.
-                    Debug.Fail($"Creating 'Run as Administrator' JumpList failed. {exception}");
                 }
             });
 
@@ -48,7 +47,7 @@ namespace Microsoft.PowerShell
                 thread.SetApartmentState(ApartmentState.STA);
                 thread.Start();
             }
-            catch (System.Threading.ThreadStartException)
+            catch (ThreadStartException)
             {
                 // STA may not be supported on some platforms
             }
@@ -117,7 +116,6 @@ namespace Microsoft.PowerShell
                     var CLSID_EnumerableObjectCollection = new Guid(@"2d3468c1-36a7-43b6-ac24-d3f02fd9607a");
                     const uint CLSCTX_INPROC_HANDLER = 2;
                     const uint CLSCTX_INPROC = CLSCTX_INPROC_SERVER | CLSCTX_INPROC_HANDLER;
-                    var ComSvrInterface_GUID = new Guid(@"555E2D2B-EE00-47AA-AB2B-39F953F6B339");
                     hResult = CoCreateInstance(ref CLSID_EnumerableObjectCollection, null, CLSCTX_INPROC, ref IID_IUnknown, out object instance);
                     if (hResult < 0)
                     {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

This PR is to fix `Start-Process` to address https://github.com/PowerShell/PSReadLine/issues/288.

Basically, when starting `pwsh` with `Start-Process` in the following ways, the new console and the existing console get weirdly tied together, which causes `Console.ReadKey` running in those 2 consoles to interfere with each other (block and unblock each other):
- `Start-Process pwsh -RedirectStandardError .\error.txt`: start `pwsh` with its stderr redirected to the file `error.txt`
- `Start-Process pwsh -PassThru -Credential (Get-Credential <another-user>)`: start `pwsh` as a different user.

Based on the investigation in https://github.com/PowerShell/PSReadLine/issues/288#issuecomment-1673605171, we should not explicitly set the standard input/output/error handles when they are not redirected. Instead, just let Windows figure out the default to use when creating the process.

Note that, the change in `TaskbarJumpList.cs` is related. When running `Start-Process pwsh -Credential` as a non-admin user, the "TaskbarJumpList" code throws `AccessDenied` exception, which causes a debug build to crash. The `Debug.Fail` is not needed. The `catch (ThreadStartException)` below simply ignore the exception too.

## Manual validation

I verified the changes on both Windows 11 and Windows 10, and it works fine for the abovementioned scenarios. I also verified that the `"redirecting input/output/error to files"` are still working fine, regardless of using `-Credential` or not.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.