### PR TITLE
Increase Buffer / Use SequentialScan For Get-FileHash

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -175,10 +175,10 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 openfilestream = new FileStream(
-                    path, 
-                    FileMode.Open, 
-                    FileAccess.Read, 
-                    FileShare.Read, 
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read,
                     64 * 1024,
                     FileOptions.SequentialScan);
                 byte[] bytehash = ComputeHash(openfilestream);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -175,12 +175,12 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 openfilestream = new FileStream(
-					path, 
-					FileMode.Open, 
-					FileAccess.Read, 
-					FileShare.Read, 
-					64 * 1024,
-					FileOptions.SequentialScan);
+                    path, 
+                    FileMode.Open, 
+                    FileAccess.Read, 
+                    FileShare.Read, 
+                    64 * 1024,
+                    FileOptions.SequentialScan);
                 byte[] bytehash = ComputeHash(openfilestream);
 
                 hash = Convert.ToHexString(bytehash);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -174,7 +174,13 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                openfilestream = File.OpenRead(path);
+                openfilestream = new FileStream(
+					path, 
+					FileMode.Open, 
+					FileAccess.Read, 
+					FileShare.Read, 
+					64 * 1024,
+					FileOptions.SequentialScan);
                 byte[] bytehash = ComputeHash(openfilestream);
 
                 hash = Convert.ToHexString(bytehash);


### PR DESCRIPTION
# PR Summary

This change uses an alternate constructor in `Get-FileHash` to increase the buffer size to 64 KiB and specifies the SequentialScan option to support scenarios where the kernel / drivers may benefit from knowing the intended read strategy.  

## PR Context

The current Get-FileHash -Path and Get-FileHash -LiteralPath functions currently use System.IO.File.OpenRead() establish a file stream before computing the hash. This function, in turn, calls the FileStream constructor using a default buffer size of 4KiB. While this buffer size is probably a good general purpose value for opening files not knowing how they are going to be used, it does not incorporate the contextual knowledge we have that we are going to read the entirety of the file into memory and we are going to do so sequentially.   In testing, this change has notable benefits as file sizes increased.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: #20875  <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
