### PR TITLE
Bump `xunit` to 2.6.3 and disable the `xUnit1031` warning

### DIFF
--- a/test/xUnit/AssemblyInfo.cs
+++ b/test/xUnit/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+// Disable the warning 'xUnit1031': https://xunit.net/xunit.analyzers/rules/xUnit1031
+[assembly: SuppressMessage("xUnit", "xUnit1031", Justification = "Parallelization is disabled")]

--- a/test/xUnit/xUnit.tests.csproj
+++ b/test/xUnit/xUnit.tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
     <PackageReference Include="XunitXml.TestLogger" Version="3.1.17" />


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Bump `xunit` to 2.6.3 and disable the `xUnit1031` warning.
Supersede https://github.com/PowerShell/PowerShell/pull/20891
