### PR TITLE
Ensure filename is not null when loggin WDAC ETW events

### DIFF
--- a/src/System.Management.Automation/utils/tracing/PSEtwLog.cs
+++ b/src/System.Management.Automation/utils/tracing/PSEtwLog.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation.Tracing
             int querySuccess,
             int queryResult)
         {
-            provider.LogWDACQueryEvent(queryName, fileName, querySuccess, queryResult);
+            provider.LogWDACQueryEvent(queryName, fileName ?? string.Empty, querySuccess, queryResult);
         }
 
         /// <summary>


### PR DESCRIPTION
# PR Summary
Ensures the `filename` value used in WDAC ETW events is set to an empty string if the input value is null. This ensures the value matches up with the manifest defined which has the following properties for this task allowing ETW consumers to be able to consume this event.

## PR Context
The manifest defines the properties for this event as

```xml
<template tid="WDACQueryTobeusedwhenoperationisjustexecutingamethodArgs_V1">
    <data name="QueryName" inType="win:UnicodeString" />
    <data name="FileName" inType="win:UnicodeString" />
    <data name="QuerySuccess" inType="win:Int32" />
    <data name="QuerySResult" inType="win:Int32" />
</template>
```

When running as it is now and the `FileName` is `null` we get the following event in the event log

![image](https://github.com/PowerShell/PowerShell/assets/8462645/e329cd17-f6cd-4948-9a96-b467be4d4545)

The raw XML for the event is

```xml
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
<System>
  <Provider Name="PowerShellCore" Guid="{f90714a8-5509-434a-bf6d-b1624c8a19a2}" /> 
  <EventID>16386</EventID> 
  <Version>1</Version> 
  <Level>4</Level> 
  <Task>131</Task> 
  <Opcode>20</Opcode> 
  <Keywords>0x0</Keywords> 
  <TimeCreated SystemTime="2023-12-13T08:27:51.4381401Z" /> 
  <EventRecordID>3</EventRecordID> 
  <Correlation ActivityID="{b8f2cbfe-2d7f-0001-0ea6-f4b87f2dda01}" /> 
  <Execution ProcessID="8876" ThreadID="7492" /> 
  <Channel /> 
  <Computer>SERVER2022.domain.test</Computer> 
  <Security /> 
  </System>
<ProcessingErrorData>
  <ErrorCode>15005</ErrorCode> 
  <DataItemName>QuerySResult</DataItemName> 
  <EventPayload>57006C00640070004700650074004C006F0063006B0064006F0077006E0050006F006C0069006300790000000000001000000080</EventPayload> 
  </ProcessingErrorData>
  </Event>
```

The `ErrorCode` represents `ERROR_EVT_INVALID_EVENT_DATA` and the `EventPayload` shows the raw value which when formatted with `Format-Hex` shows

```
   Label: Byte[] (System.Byte[]) <318C4389>

          Offset Bytes                                           Ascii
                 00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
          ------ ----------------------------------------------- -----
0000000000000000 57 00 6C 00 64 00 70 00 47 00 65 00 74 00 4C 00 W l d p G e t L
0000000000000010 6F 00 63 00 6B 00 64 00 6F 00 77 00 6E 00 50 00 o c k d o w n P
0000000000000020 6F 00 6C 00 69 00 63 00 79 00 00 00 00 00 00 10 o l i c y      �
0000000000000030 00 00 00 80                                        �
```

We can see the first value for `QueryName` is the Unicode NULL terminated string `WldpGetLockdownPolicy`. The next string value is going to consume the `00 00` as the empty string NULL terminator for `FileName`. This only leaves 6 bytes left for the `QuerySuccess` and `QuerySResult` which is invalid causing the error. The problem here is there is actually no value for `FileName`, there should be an extra 2 0 bytes between the first and third value.

With this PR we can see that the event is now decoded properly

![image](https://github.com/PowerShell/PowerShell/assets/8462645/8c3d5b43-1bca-44cb-aaf6-c29a802a4f56)

```xml
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
<System>
  <Provider Name="PowerShellCore" Guid="{f90714a8-5509-434a-bf6d-b1624c8a19a2}" /> 
  <EventID>16386</EventID> 
  <Version>1</Version> 
  <Level>4</Level> 
  <Task>131</Task> 
  <Opcode>20</Opcode> 
  <Keywords>0x0</Keywords> 
  <TimeCreated SystemTime="2023-12-13T08:37:17.8895239Z" /> 
  <EventRecordID>373</EventRecordID> 
  <Correlation ActivityID="{b8f2cbfe-2d7f-0001-c7b4-f4b87f2dda01}" /> 
  <Execution ProcessID="5352" ThreadID="14300" /> 
  <Channel /> 
  <Computer>SERVER2022.domain.test</Computer> 
  <Security /> 
  </System>
<EventData>
  <Data Name="QueryName">WldpGetLockdownPolicy</Data> 
  <Data Name="FileName" /> 
  <Data Name="QuerySuccess">268435456</Data> 
  <Data Name="QuerySResult">-2147483648</Data> 
  </EventData>
  </Event>
```

There's probably other events affected but this is just what I came across when testing things out and only needed a simple fix.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
