### PR TITLE
Fix four issues for the WDAC logging feature

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -3989,21 +3989,24 @@ namespace System.Management.Automation
                     bool canProceedWithConversion = ecFromTLS == null || (ecFromTLS.LanguageMode == PSLanguageMode.FullLanguage && !ecFromTLS.LanguageModeTransitionInParameterBinding);
                     if (!canProceedWithConversion)
                     {
-                        if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
+                        if (SystemPolicy.GetSystemLockdownPolicy() != SystemEnforcementMode.Audit)
                         {
-                            SystemPolicy.LogWDACAuditMessage(
+                            throw InterpreterError.NewInterpreterException(
+                                valueToConvert,
+                                typeof(RuntimeException),
+                                errorPosition: null,
+                                "HashtableToObjectConversionNotSupportedInDataSection",
+                                ParserStrings.HashtableToObjectConversionNotSupportedInDataSection,
+                                resultType.ToString());
+                        }
+
+                        // When in audit mode, we report but don't enforce, so we will proceed with the conversion.
+                        SystemPolicy.LogWDACAuditMessage(
                                 context: ecFromTLS,
                                 title: ExtendedTypeSystem.WDACHashTypeLogTitle,
                                 message: StringUtil.Format(ExtendedTypeSystem.WDACHashTypeLogMessage, resultType.FullName),
                                 fqid: "LanguageHashtableConversionNotAllowed",
                                 dropIntoDebugger: true);
-                        }
-                        else
-                        {
-                            RuntimeException rte = InterpreterError.NewInterpreterException(valueToConvert, typeof(RuntimeException), null,
-                                "HashtableToObjectConversionNotSupportedInDataSection", ParserStrings.HashtableToObjectConversionNotSupportedInDataSection, resultType.ToString());
-                            throw rte;
-                        }
                     }
 
                     result = _constructor();

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -2278,7 +2278,7 @@ namespace Microsoft.PowerShell.Commands
             // Semantic checks on the using statement have already validated that there are no arbitrary expressions,
             // so we'll allow these expressions in everything but NoLanguage mode.
 
-            bool allowUsingExpressions = (Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage);
+            bool allowUsingExpressions = Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
             object[] usingValuesInArray = null;
             IDictionary usingValuesInDict = null;
 
@@ -2428,7 +2428,7 @@ namespace Microsoft.PowerShell.Commands
                 // GetExpressionValue ensures that it only does variable access when supplied a VariableExpressionAst.
                 // So, this is still safe to use in ConstrainedLanguage and will not result in arbitrary code
                 // execution.
-                bool allowVariableAccess = (Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage);
+                bool allowVariableAccess = Context.SessionState.LanguageMode != PSLanguageMode.NoLanguage;
 
                 foreach (var varAst in paramUsingVars)
                 {

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5524,7 +5524,7 @@ namespace System.Management.Automation.Language
                     return target.ThrowRuntimeError(args, moreTests, errorID, resourceString);
                 }
 
-                string targetName = (targetValue as Type)?.FullName;
+                string targetName = (targetValue as Type)?.FullName ?? targetValue?.GetType().FullName;
                 SystemPolicy.LogWDACAuditMessage(
                     context: context,
                     title: ParameterBinderStrings.WDACBinderInvocationLogTitle,

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -714,7 +714,8 @@ namespace System.Management.Automation
                 // of invoking it. So the trustworthiness is defined by the trustworthiness of the
                 // script block's language mode.
                 bool isTrusted = scriptBlock.LanguageMode == PSLanguageMode.FullLanguage;
-                if (scriptBlock.LanguageMode == PSLanguageMode.ConstrainedLanguage && SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
+                if (scriptBlock.LanguageMode == PSLanguageMode.ConstrainedLanguage
+                    && SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
                 {
                     // In audit mode, report but don't enforce.
                     isTrusted = true;

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -714,6 +714,17 @@ namespace System.Management.Automation
                 // of invoking it. So the trustworthiness is defined by the trustworthiness of the
                 // script block's language mode.
                 bool isTrusted = scriptBlock.LanguageMode == PSLanguageMode.FullLanguage;
+                if (scriptBlock.LanguageMode == PSLanguageMode.ConstrainedLanguage && SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Audit)
+                {
+                    // In audit mode, report but don't enforce.
+                    isTrusted = true;
+                    SystemPolicy.LogWDACAuditMessage(
+                        context: context,
+                        title: ParserStrings.WDACGetSteppablePipelineLogTitle,
+                        message: ParserStrings.WDACGetSteppablePipelineLogMessage,
+                        fqid: "GetSteppablePipelineMayFail",
+                        dropIntoDebugger: true);
+                }
 
                 foreach (var commandAst in pipelineAst.PipelineElements.Cast<CommandAst>())
                 {
@@ -729,7 +740,7 @@ namespace System.Management.Automation
 
                         var exprAst = (ExpressionAst)commandElement;
                         var argument = Compiler.GetExpressionValue(exprAst, isTrusted, context);
-                        var splatting = (exprAst is VariableExpressionAst && ((VariableExpressionAst)exprAst).Splatted);
+                        var splatting = exprAst is VariableExpressionAst && ((VariableExpressionAst)exprAst).Splatted;
                         commandParameters.Add(CommandParameterInternal.CreateArgument(argument, exprAst, splatting));
                     }
 
@@ -797,8 +808,8 @@ namespace System.Management.Automation
             }
 
             object argumentValue = Compiler.GetExpressionValue(argumentAst, isTrusted, context);
-            bool spaceAfterParameter = (errorPos.EndLineNumber != argumentAst.Extent.StartLineNumber ||
-                                        errorPos.EndColumnNumber != argumentAst.Extent.StartColumnNumber);
+            bool spaceAfterParameter = errorPos.EndLineNumber != argumentAst.Extent.StartLineNumber ||
+                                       errorPos.EndColumnNumber != argumentAst.Extent.StartColumnNumber;
             return CommandParameterInternal.CreateParameterWithArgument(commandParameterAst, commandParameterAst.ParameterName,
                                                                         errorPos.Text, argumentAst, argumentValue,
                                                                         spaceAfterParameter);

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1362,7 +1362,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>The ForEach keyword will fail '{0}' iteration item method invocation when run in Constrained Language mode.</value>
   </data>
   <data name="WDACGetSteppablePipelineLogTitle" xml:space="preserve">
-    <value>ExpressionAst evaluation</value>
+    <value>Expression Evaluation May Fail</value>
   </data>
   <data name="WDACGetSteppablePipelineLogMessage" xml:space="preserve">
     <value>Creating a steppable pipeline from a script block may require evaluating some expressions within the script block. The expression evaluation will silently fail and return 'null' in Constrained Language mode, unless the expression represents a constant value.</value>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1361,4 +1361,10 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="WDACParserForEachOperatorLogMessage" xml:space="preserve">
     <value>The ForEach keyword will fail '{0}' iteration item method invocation when run in Constrained Language mode.</value>
   </data>
+  <data name="WDACGetSteppablePipelineLogTitle" xml:space="preserve">
+    <value>ExpressionAst evaluation</value>
+  </data>
+  <data name="WDACGetSteppablePipelineLogMessage" xml:space="preserve">
+    <value>Creating a steppable pipeline from a script block may require evaluating some expressions within the script block. The expression evaluation will silently fail and return 'null' in Constrained Language mode, unless the expression represents a constant value.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1715,7 +1715,7 @@ SSH client process terminated before connection could be established.</value>
     <value>The session configuration file contains an unknown configuration option: {0}.</value>
   </data>
   <data name="WDACGetPowerShellLogTitle" xml:space="preserve">
-    <value>ExpressionAst evaluation</value>
+    <value>Expression Evaluation May Fail</value>
   </data>
   <data name="WDACGetPowerShellLogMessage" xml:space="preserve">
     <value>Creating a PowerShell object from a script block may require evaluating some expressions within the script block. The expression evaluation will silently fail and return 'null' in Constrained Language mode, unless the expression represents a constant value.</value>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1714,4 +1714,10 @@ SSH client process terminated before connection could be established.</value>
   <data name="DISCUnknownConfigName" xml:space="preserve">
     <value>The session configuration file contains an unknown configuration option: {0}.</value>
   </data>
+  <data name="WDACGetPowerShellLogTitle" xml:space="preserve">
+    <value>ExpressionAst evaluation</value>
+  </data>
+  <data name="WDACGetPowerShellLogMessage" xml:space="preserve">
+    <value>Creating a PowerShell object from a script block may require evaluating some expressions within the script block. The expression evaluation will silently fail and return 'null' in Constrained Language mode, unless the expression represents a constant value.</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #20785 
Fix #20768

Address 4 issues for the WDAC logging feature:
- Hashtable-to-object conversion checking was wrong;
- A call to `GetPowerShell` and a call to `GetSteppablePipeline` show different behaviors when it's truly in Constrained mode, but the Audit feature didn't cover them.
- For the property/method access check in binder, fix the target name to also capture the target when `targetValue` is not a `Type` object.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
