### PR TITLE
ConvertFrom-Json: Add -DateKind parameter

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -49,6 +49,12 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public SwitchParameter NoEnumerate { get; set; }
 
+        /// <summary>
+        /// Gets or sets the switch to control how DateTime values are to be parsed as a dotnet object.
+        /// </summary>
+        [Parameter]
+        public JsonDateKind DateKind { get; set; } = JsonDateKind.Default;
+
         #endregion parameters
 
         #region overrides
@@ -113,7 +119,7 @@ namespace Microsoft.PowerShell.Commands
         private bool ConvertFromJsonHelper(string input)
         {
             ErrorRecord error = null;
-            object result = JsonObject.ConvertFromJson(input, AsHashtable.IsPresent, Depth, out error);
+            object result = JsonObject.ConvertFromJson(input, AsHashtable.IsPresent, Depth, DateKind, out error);
 
             if (error != null)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonDateKind.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonDateKind.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+namespace Microsoft.PowerShell.Commands
+{
+    /// <summary>
+    /// Enums for ConvertFrom-Json -DateKind parameter.
+    /// </summary>
+    public enum JsonDateKind
+    {
+        /// <summary>
+        /// DateTime values are returned as a DateTime with the Kind representing the time zone in the raw string.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// DateTime values are returned as the Local kind representation of the value.
+        /// </summary>
+        Local,
+
+        /// <summary>
+        /// DateTime values are returned as the UTC kind representation of the value.
+        /// </summary>
+        Utc,
+
+        /// <summary>
+        /// DateTime values are returned as a DateTimeOffset value preserving the timezone information.
+        /// </summary>
+        Offset,
+
+        /// <summary>
+        /// DateTime values are returned as raw strings.
+        /// </summary>
+        String,
+    }
+}

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.Commands
         /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
         public static object ConvertFromJson(string input, bool returnHashtable, int? maxDepth, out ErrorRecord error)
-            => ConvertFromJson(input, returnHashtable, maxDepth, jsonDateKind: JsonDateKind.Local, out error);
+            => ConvertFromJson(input, returnHashtable, maxDepth, jsonDateKind: JsonDateKind.Default, out error);
 
         /// <summary>
         /// Convert a JSON string back to an object of type <see cref="System.Management.Automation.PSObject"/> or

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -151,8 +151,57 @@ namespace Microsoft.PowerShell.Commands
         /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
         public static object ConvertFromJson(string input, bool returnHashtable, int? maxDepth, out ErrorRecord error)
+            => ConvertFromJson(input, returnHashtable, maxDepth, jsonDateKind: JsonDateKind.Local, out error);
+
+        /// <summary>
+        /// Convert a JSON string back to an object of type <see cref="System.Management.Automation.PSObject"/> or
+        /// <see cref="System.Collections.Hashtable"/> depending on parameter <paramref name="returnHashtable"/>.
+        /// </summary>
+        /// <param name="input">The JSON text to convert.</param>
+        /// <param name="returnHashtable">True if the result should be returned as a <see cref="System.Collections.Hashtable"/>
+        /// instead of a <see cref="System.Management.Automation.PSObject"/>.</param>
+        /// <param name="maxDepth">The max depth allowed when deserializing the json input. Set to null for no maximum.</param>
+        /// <param name="jsonDateKind">Controls how DateTime values are to be converted.</param>
+        /// <param name="error">An error record if the conversion failed.</param>
+        /// <returns>A <see cref="System.Management.Automation.PSObject"/> or a <see cref="System.Collections.Hashtable"/>
+        /// if the <paramref name="returnHashtable"/> parameter is true.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "Preferring Json over JSON")]
+        internal static object ConvertFromJson(string input, bool returnHashtable, int? maxDepth, JsonDateKind jsonDateKind, out ErrorRecord error)
         {
             ArgumentNullException.ThrowIfNull(input);
+
+            DateParseHandling dateParseHandling;
+            DateTimeZoneHandling dateTimeZoneHandling;
+            switch (jsonDateKind)
+            {
+                case JsonDateKind.Default:
+                    dateParseHandling = DateParseHandling.DateTime;
+                    dateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
+                    break;
+
+                case JsonDateKind.Local:
+                    dateParseHandling = DateParseHandling.DateTime;
+                    dateTimeZoneHandling = DateTimeZoneHandling.Local;
+                    break;
+
+                case JsonDateKind.Utc:
+                    dateParseHandling = DateParseHandling.DateTime;
+                    dateTimeZoneHandling = DateTimeZoneHandling.Utc;
+                    break;
+
+                case JsonDateKind.Offset:
+                    dateParseHandling = DateParseHandling.DateTimeOffset;
+                    dateTimeZoneHandling = DateTimeZoneHandling.Unspecified;
+                    break;
+
+                case JsonDateKind.String:
+                    dateParseHandling = DateParseHandling.None;
+                    dateTimeZoneHandling = DateTimeZoneHandling.Unspecified;
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unknown JsonDateKind value requested '{jsonDateKind}'");
+            }
 
             error = null;
             try
@@ -161,6 +210,9 @@ namespace Microsoft.PowerShell.Commands
                     input,
                     new JsonSerializerSettings
                     {
+                        DateParseHandling = dateParseHandling,
+                        DateTimeZoneHandling = dateTimeZoneHandling,
+
                         // This TypeNameHandling setting is required to be secure.
                         TypeNameHandling = TypeNameHandling.None,
                         MetadataPropertyHandling = MetadataPropertyHandling.Ignore,


### PR DESCRIPTION
# PR Summary

Adds the -DateKind parameter to the ConvertFrom-Json that allows the caller to control how DateTime strings are converted into an object. The default behaviour is to create a DateTime value with the Kind being Unspecified if no TZ is set, Utc if the TZ Z is set, Local (after conversion) if an explicit TZ is set. This adds a Utc, Local to explicitly set the Kind as desired as well as a Offset and String value to create a DateTimeOffset or keep as a string.

## PR Context

Provides the user the ability to create a `DateTimeOffset` value so that the underlying time zone information is preserved. Also gives the user the ability to keep it as a string or a specific `DateTime` with the `Local` or `Utc` kind.

Fixes: https://github.com/PowerShell/PowerShell/issues/13598

Docs PR for this change: https://github.com/MicrosoftDocs/PowerShell-Docs/pull/10737

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/pull/10737
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
