### PR TITLE
Test-FileCatalog changes to use File.OpenRead to better handle when the file is executing or open Fix #20703

### DIFF
--- a/src/System.Management.Automation/security/CatalogHelper.cs
+++ b/src/System.Management.Automation/security/CatalogHelper.cs
@@ -423,7 +423,7 @@ namespace System.Management.Automation
             FileStream fileStream;
             try
             {
-                fileStream = File.Open(filePath, FileMode.Open, FileAccess.Read);
+                fileStream = File.OpenRead(filePath);
             }
             catch (Exception e)
             {

--- a/src/System.Management.Automation/security/CatalogHelper.cs
+++ b/src/System.Management.Automation/security/CatalogHelper.cs
@@ -423,7 +423,7 @@ namespace System.Management.Automation
             FileStream fileStream;
             try
             {
-                fileStream = File.OpenRead(filePath);
+                fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             }
             catch (Exception e)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -447,28 +447,28 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
         It "Test-FileCatalog should pass when target file has an open reader with FileMode Open FileAccess Read and FileShare Read" {
             $script:catalogPath = "$env:TEMP\TestCatalogFileOpenValidation.cat"
             $null = New-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath -CatalogVersion 2
-            $fileHandle = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
-           try{
+            $fileStream = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
+            try{
                 $result = Test-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath
                 $result | Should -Be "Valid"
             }
             finally {
-                $fileHandle.Close()
-                $fileHandle.Dispose()
+                $fileStream.Close()
+                $fileStream.Dispose()
             }
         }
 
         It "Test-FileCatalog should pass when target file has an open reader with FileMode Open FileAccess Read and FileShare ReadWrite" {
             $script:catalogPath = "$env:TEMP\TestCatalogFileOpenValidation.cat"
             $null = New-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath -CatalogVersion 2
-            $fileHandle = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+            $fileStream = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
             try{
                 $result = Test-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath
                 $result | Should -Be "Valid"
             }
             finally {
-                $fileHandle.Close()
-                $fileHandle.Dispose()
+                $fileStream.Close()
+                $fileStream.Dispose()
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -416,6 +416,62 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $catalogPath | Should -Not -Exist
         }
     }
+
+    Context "TestCatalog Executing File Validation Tests"{
+
+        AfterEach {
+            Remove-Item "$script:catalogPath" -Force -ErrorAction SilentlyContinue
+        }
+
+        It "Test-FileCatalog should pass when target file is an executing process" {
+            $processFolder =  (Get-Process -Id $pid).Path
+            $script:catalogPath = "$env:TEMP\TestCatalogExecutingFileValidation.cat"
+            $null = New-FileCatalog -Path "$processFolder" -CatalogFilePath $script:catalogPath -CatalogVersion 2
+            $result = Test-FileCatalog -Path "$processFolder" -CatalogFilePath $script:catalogPath
+            $result | Should -Be "Valid"
+        }
+    }
+
+    Context "TestCatalog File Open Validation Tests"{
+
+        BeforeEach {
+            $null = New-Item -ItemType Directory -Path "$env:TEMP\testCatalog" -Force -ErrorAction SilentlyContinue
+            Set-Content -PassThru "$env:TEMP\testCatalog\test.txt" -Value "Test Data" | Out-Null
+        }
+
+        AfterEach {
+            Remove-Item "$script:catalogPath" -Force -ErrorAction SilentlyContinue
+            Remove-Item "$env:TEMP\testCatalog" -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        It "Test-FileCatalog should pass when target file has an open reader with FileMode Open FileAccess Read and FileShare Read" {
+            $script:catalogPath = "$env:TEMP\TestCatalogFileOpenValidation.cat"
+            $null = New-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath -CatalogVersion 2
+            $fileHandle = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
+           try{
+                $result = Test-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath
+                $result | Should -Be "Valid"
+            }
+            finally {
+                $fileHandle.Close()
+                $fileHandle.Dispose()
+            }
+        }
+
+        It "Test-FileCatalog should pass when target file has an open reader with FileMode Open FileAccess Read and FileShare ReadWrite" {
+            $script:catalogPath = "$env:TEMP\TestCatalogFileOpenValidation.cat"
+            $null = New-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath -CatalogVersion 2
+            $fileHandle = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+            try{
+                $result = Test-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath
+                $result | Should -Be "Valid"
+            }
+            finally {
+                $fileHandle.Close()
+                $fileHandle.Dispose()
+            }
+        }
+    }
 }
 
 } finally {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -432,7 +432,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
         }
     }
 
-    Context "TestCatalog File Open Validation Tests"{
+    Context "TestCatalog File Open Validation Tests" {
 
         BeforeEach {
             $null = New-Item -ItemType Directory -Path "$env:TEMP\testCatalog" -Force -ErrorAction SilentlyContinue
@@ -444,29 +444,19 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             Remove-Item "$env:TEMP\testCatalog" -Recurse -Force -ErrorAction SilentlyContinue
         }
 
-        It "Test-FileCatalog should pass when target file has an open reader with FileMode Open FileAccess Read and FileShare Read" {
-            $script:catalogPath = "$env:TEMP\TestCatalogFileOpenValidation.cat"
-            $null = New-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath -CatalogVersion 2
-            $fileStream = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
-            try{
-                $result = Test-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath
-                $result | Should -Be "Valid"
-            }
-            finally {
-                $fileStream.Close()
-                $fileStream.Dispose()
-            }
-        }
+        it "Test-FileCatalog should pass when target file has an open reader with FileMode Open FileAccess Read and FileShare <name>" -TestCases @(
+            @{ Name = "Read"; fileShareParameter = [System.IO.FileShare]::Read }
+            @{ Name = "ReadWrite"; fileShareParameter = [System.IO.FileShare]::ReadWrite }
+        ) {
+            param($name, [System.IO.FileShare] $fileShareParameter)
 
-        It "Test-FileCatalog should pass when target file has an open reader with FileMode Open FileAccess Read and FileShare ReadWrite" {
             $script:catalogPath = "$env:TEMP\TestCatalogFileOpenValidation.cat"
             $null = New-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath -CatalogVersion 2
-            $fileStream = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
-            try{
+            $fileStream = [System.IO.File]::Open("$env:TEMP\testCatalog\test.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, $fileShareParameter)
+            try {
                 $result = Test-FileCatalog -Path "$env:TEMP\testCatalog\" -CatalogFilePath $script:catalogPath
                 $result | Should -Be "Valid"
-            }
-            finally {
+            } finally {
                 $fileStream.Close()
                 $fileStream.Dispose()
             }


### PR DESCRIPTION
Test-FileCatalog changes to use File.OpenRead Fix #20703 
Added test cases to test Test-FileCatalog with an exe that is executing 
Added test cases to test Test-FileCatalog with files with FileShare.Read and ReadWrite

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
