### PR TITLE
Fix `-OlderThan`/`-NewerThan` parameters for `Test-Path` when using `PathType` and date range

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestPathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestPathCommand.cs
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.Commands
         {
             object result = null;
 
-            if (this.PathType == TestPathType.Any && !IsValid)
+            if (!IsValid)
             {
                 if (Path != null && Path.Length > 0 && Path[0] != null)
                 {
@@ -212,19 +212,15 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
+                        result = InvokeProvider.Item.Exists(path, currentContext);
+
                         if (this.PathType == TestPathType.Container)
                         {
-                            result = InvokeProvider.Item.IsContainer(path, currentContext);
+                            result &= InvokeProvider.Item.IsContainer(path, currentContext);
                         }
                         else if (this.PathType == TestPathType.Leaf)
                         {
-                            result =
-                                InvokeProvider.Item.Exists(path, currentContext) &&
-                                !InvokeProvider.Item.IsContainer(path, currentContext);
-                        }
-                        else
-                        {
-                            result = InvokeProvider.Item.Exists(path, currentContext);
+                            result &= !InvokeProvider.Item.IsContainer(path, currentContext);
                         }
                     }
                 }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3319,12 +3319,12 @@ namespace Microsoft.PowerShell.Commands
 
                     if (itemExistsDynamicParameters.OlderThan.HasValue)
                     {
-                        result = lastWriteTime < itemExistsDynamicParameters.OlderThan.Value;
+                        result &= lastWriteTime < itemExistsDynamicParameters.OlderThan.Value;
                     }
 
                     if (itemExistsDynamicParameters.NewerThan.HasValue)
                     {
-                        result = lastWriteTime > itemExistsDynamicParameters.NewerThan.Value;
+                        result &= lastWriteTime > itemExistsDynamicParameters.NewerThan.Value;
                     }
                 }
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -12,6 +12,24 @@ Describe "Test-Path" -Tags "CI" {
 
         $nonExistentDir = Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin
         $nonExistentPath = Join-Path -Path (Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin) -ChildPath error
+
+        $today = Get-Date
+        $oneDayOld = (Get-Date).AddDays(-1)
+        $twoDaysOld = (Get-Date).AddDays(-2)
+
+        $oldFilePath = Join-Path -Path $testdirectory -ChildPath oldfile
+        $oldFile = New-Item -Path $oldFilePath -ItemType File
+        $oldFile.LastWriteTime = $oneDayOld
+
+        $oldDirPath = Join-Path -Path $testdirectory -ChildPath olddir
+        $oldDir = New-Item -Path $oldDirPath -ItemType Directory
+        $oldDir.LastWriteTime = $oneDayOld
+
+        $newFilePath = Join-Path -Path $testdirectory -ChildPath newfile
+        New-Item -Path $newFilePath -ItemType File | Out-Null
+
+        $newDirPath = Join-Path -Path $testdirectory -ChildPath newdir
+        New-Item -Path $newDirPath -ItemType Directory | Out-Null
     }
 
     It "Should be called on an existing path without error" {
@@ -141,4 +159,57 @@ Describe "Test-Path" -Tags "CI" {
         Test-Path Env:\PATH  | Should -BeTrue
     }
 
+    It "Should return true if NewerThan is used and path is newer than one day" {
+        Test-Path -Path $newFilePath -PathType Leaf -NewerThan $oneDayOld | Should -BeTrue
+        Test-Path -Path $newDirPath -PathType Container -NewerThan $oneDayOld | Should -BeTrue
+        Test-Path -Path $newFilePath -PathType Any -NewerThan $oneDayOld | Should -BeTrue
+        Test-Path -Path $newDirPath -PathType Any -NewerThan $oneDayOld | Should -BeTrue
+        Test-Path -Path $newFilePath -NewerThan $oneDayOld | Should -BeTrue
+        Test-Path -Path $newDirPath -NewerThan $oneDayOld | Should -BeTrue
+    }
+
+    It "Should return false if NewerThan is used and path is not newer than today" {
+        Test-Path -Path $oldFilePath -PathType Leaf -NewerThan $today | Should -BeFalse
+        Test-Path -Path $oldDirPath -PathType Container -NewerThan $today | Should -BeFalse
+        Test-Path -Path $oldFilePath -PathType Any -NewerThan $today | Should -BeFalse
+        Test-Path -Path $oldDirPath -PathType Any -NewerThan $today | Should -BeFalse
+        Test-Path -Path $oldFilePath -NewerThan $today | Should -BeFalse
+        Test-Path -Path $oldDirPath -NewerThan $today | Should -BeFalse
+    }
+
+    It "Should return true if OlderThan is used and path is older than today" {
+        Test-Path -Path $oldFilePath -PathType Leaf -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldDirPath -PathType Container -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldFilePath -PathType Any -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldDirPath -PathType Any -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldFilePath -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldDirPath -OlderThan $today | Should -BeTrue
+    }
+
+    It "Should return false if OlderThan is used and path is not older than one day" {
+        Test-Path -Path $newFilePath -PathType Leaf -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newDirPath -PathType Container -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newFilePath -PathType Any -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newDirPath -PathType Any -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newFilePath -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newDirPath -OlderThan $oneDayOld | Should -BeFalse
+    }
+
+    It "Should return true if OlderThan and NewerThan is used together and path exists in date range" {
+        Test-Path -Path $oldFilePath -PathType Leaf -NewerThan $twoDaysOld -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldDirPath -PathType Container -NewerThan $twoDaysOld -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldFilePath -PathType Any -NewerThan $twoDaysOld -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldDirPath -PathType Any -NewerThan $twoDaysOld -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldFilePath -NewerThan $twoDaysOld -OlderThan $today | Should -BeTrue
+        Test-Path -Path $oldDirPath -NewerThan $twoDaysOld -OlderThan $today | Should -BeTrue
+    }
+
+    It "Should return false if OlderThan and NewerThan is used together and path does not exist in date range" {
+        Test-Path -Path $newFilePath -PathType Leaf -NewerThan $twoDaysOld -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newDirPath -PathType Container -NewerThan $twoDaysOld -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newFilePath -PathType Any -NewerThan $twoDaysOld -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newDirPath -PathType Any -NewerThan $twoDaysOld -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newFilePath -NewerThan $twoDaysOld -OlderThan $oneDayOld | Should -BeFalse
+        Test-Path -Path $newDirPath -NewerThan $twoDaysOld -OlderThan $oneDayOld | Should -BeFalse
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #19855
Fixes #19462

Fix `-OlderThan`/`-NewerThan` dynamic parameters for `Test-Path` when using `PathType` and date range. 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Made the following changes to improve experience using date parameters:

- Removed `this.PathType == TestPathType.Any` check from `GetDynamicParameters` method so  `-OlderThan`/`-NewerThan`  can be used with any path type.
- Updated file system provider logic which checks  `-OlderThan`/`-NewerThan` last write time in `ItemExists` method to do a logical AND so it checks path existence within a time range instead of `NewerThan` overwriting `OlderThan` if they are both used. This change is probably considered a **bucket 3 breaking change** since its highly unlikely anyone relied in previous broken behaviour.
- Updated `Test-Path` to run `ItemExists` on directories as well so they can be checked with  `-OlderThan`/`-NewerThan` parameters, since before it only checked `IsItemContainer`, which didn't run the dynamic parameter date checks.
- Updated tests to check  `-OlderThan`/`-NewerThan` parameters since there was no code coverage for this functonality before this PR. Included multiple combinations of path types against files & directories.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/10742
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
