### PR TITLE
Fix `Show-Markdown` cmdlet to handle string array input

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowMarkdownCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowMarkdownCommand.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
+using System.Text;
 
 using Microsoft.PowerShell.MarkdownRender;
 
@@ -61,6 +62,8 @@ namespace Microsoft.PowerShell.Commands
 
         private System.Management.Automation.PowerShell _powerShell;
 
+        private readonly StringBuilder _inputObjectBuffer = new();
+
         /// <summary>
         /// Override BeginProcessing.
         /// </summary>
@@ -80,6 +83,10 @@ namespace Microsoft.PowerShell.Commands
                     if (InputObject.BaseObject is MarkdownInfo markdownInfo)
                     {
                         ProcessMarkdownInfo(markdownInfo);
+                    }
+                    else if (InputObject.BaseObject is string objectString)
+                    {
+                        _inputObjectBuffer.AppendLine(objectString);
                     }
                     else
                     {
@@ -224,6 +231,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
+            if (_inputObjectBuffer.Length > 0)
+            {
+                ConvertFromMarkdown(ParameterSetName, _inputObjectBuffer.ToString());
+            }
+
             _powerShell?.Dispose();
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/MarkdownCmdlets.Tests.ps1
@@ -525,6 +525,15 @@ bool function()`n{`n}
                 { Show-Markdown -UseBrowser -InputObject $markdownInfo -ErrorAction Stop } | Should -Throw -ErrorId 'HtmlIsNullOrEmpty,Microsoft.PowerShell.Commands.ShowMarkdownCommand'
             }
         }
+
+        It "Can show markdown piped directly to cmdlet as array of strings" {
+            $testMarkDownPath = Join-Path -Path $TestDrive -ChildPath 'test.md'
+            Set-Content -Path $testMarkDownPath -Value "# Header`n`ntext"
+            $fileLinesArray = Get-Content -Path $testMarkDownPath
+            $result = $fileLinesArray | Show-Markdown
+            $expectedString = (ConvertFrom-Markdown -Path $testMarkDownPath -AsVT100EncodedString).VT100EncodedString
+            $result | Should -BeExactly $expectedString
+        }
     }
 
     Context "Hosted PowerShell scenario" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #20951

Added fix to `Show-Markdown` to allow pipeline processing of array of strings using `-InputObject`.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Added input object buffer to process strings in `EndProcessing()` instead of `ProcessRecord()` so all strings can be collected at once from `-InputObject`.

This change follows similar approach to buffering in `ConvertFrom-Json`. 

```pwsh
> Get-WhatsNew | Show-Markdown
Release notes for PowerShell 7.4

Breaking changes

- Nano server docker images aren't available for this release
- Added the ProgressAction parameter to the Common Parameters
- Update some PowerShell APIs to throw ArgumentException instead of ArgumentNullException when the argument is an empty string (#19215][19215]) (Thanks @xtqqczze!)
- Remove code related to #requires -pssnapin (#19320][19320])
- Test-Json now uses Json.Schema.Net instead of Newtonsoft.Json.Schema. With this change, Test-Json no longer supports the older Draft 4 schemas. (#18141][18141]) (Thanks @gregsdennis!)
- Output from Test-Connection now includes more detailed information about TCP connection tests

Installer updates

The Windows MSI package now provides an option to disable PowerShell telemetry during installation. For more information, see Install the msi package from the command line][01].

...
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
