### PR TITLE
Add `-Force` parameter to `Resolve-Path` and `Convert-Path` cmdlets to support wildcard hidden files

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ConvertPathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ConvertPathCommand.cs
@@ -55,6 +55,16 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
+        /// <summary>
+        /// Gets or sets the force property.
+        /// </summary>
+        [Parameter]
+        public override SwitchParameter Force
+        {
+            get => base.Force;
+            set => base.Force = value;
+        }
+
         #endregion Parameters
 
         #region parameter data

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -93,6 +93,16 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
+        /// <summary>
+        /// Gets or sets the force property.
+        /// </summary>
+        [Parameter]
+        public override SwitchParameter Force
+        {
+            get => base.Force;
+            set => base.Force = value;
+        }
+
         #endregion Parameters
 
         #region parameter data

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -2,17 +2,21 @@
 # Licensed under the MIT License.
 Describe "Convert-Path tests" -Tag CI {
     BeforeAll {
-        $hiddenFilePrefix = [System.Environment]::OSVersion.Platform -eq 'Unix' ? '.' : ''
+        $hiddenFilePrefix = ($IsLinux -or $IsMacOS) ? '.' : ''
 
         $hiddenFilePath1 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test1.txt"
-        $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
-        $hiddenFile1.Attributes = "Hidden"
-        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
-
         $hiddenFilePath2 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test2.txt"
+
+        $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
         $hiddenFile2 = New-Item -Path $hiddenFilePath2 -ItemType File
-        $hiddenFile2.Attributes = "Hidden"
+
+        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
         $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)test2.txt"
+
+        if ($IsWindows) {
+            $hiddenFile1.Attributes = "Hidden"
+            $hiddenFile2.Attributes = "Hidden"
+        }
 
         $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test*.txt"
         $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)test*.txt"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -10,8 +10,8 @@ Describe "Convert-Path tests" -Tag CI {
         $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
         $hiddenFile2 = New-Item -Path $hiddenFilePath2 -ItemType File
 
-        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
-        $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)test2.txt"
+        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)$($hiddenFilePrefix)test1.txt"
+        $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)$($hiddenFilePrefix)test2.txt"
 
         if ($IsWindows) {
             $hiddenFile1.Attributes = "Hidden"
@@ -19,7 +19,7 @@ Describe "Convert-Path tests" -Tag CI {
         }
 
         $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test*.txt"
-        $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)test*.txt"
+        $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)$($hiddenFilePrefix)test*.txt"
     }
 
     It "Convert-Path should handle provider qualified paths" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -2,17 +2,19 @@
 # Licensed under the MIT License.
 Describe "Convert-Path tests" -Tag CI {
     BeforeAll {
-        $hiddenFilePath1 = Join-Path -Path $TestDrive -ChildPath 'test1.txt'
+        $hiddenFilePrefix = [System.Environment]::OSVersion.Platform -eq 'Unix' ? '.' : ''
+
+        $hiddenFilePath1 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test1.txt"
         $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
         $hiddenFile1.Attributes = "Hidden"
         $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
 
-        $hiddenFilePath2 = Join-Path -Path $TestDrive -ChildPath 'test2.txt'
+        $hiddenFilePath2 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test2.txt"
         $hiddenFile2 = New-Item -Path $hiddenFilePath2 -ItemType File
         $hiddenFile2.Attributes = "Hidden"
         $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)test2.txt"
 
-        $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath 'test*.txt'
+        $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test*.txt"
         $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)test*.txt"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -25,8 +25,8 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
         $hiddenFile2 = New-Item -Path $hiddenFilePath2 -ItemType File
 
-        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
-        $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)test2.txt"
+        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)$($hiddenFilePrefix)test1.txt"
+        $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)$($hiddenFilePrefix)test2.txt"
 
         if ($IsWindows) {
             $hiddenFile1.Attributes = "Hidden"
@@ -34,7 +34,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         }
 
         $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test*.txt"
-        $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)test*.txt"
+        $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)$($hiddenFilePrefix)test*.txt"
     }
     AfterAll {
         Remove-PSDrive -Name $driveName -Force

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -17,17 +17,21 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             @{ wd = $testRoot; target = Join-Path $fakeRoot "file.txt"; expected = Join-Path "." "fakeroot" "file.txt" }
         )
 
-        $hiddenFilePrefix = [System.Environment]::OSVersion.Platform -eq 'Unix' ? '.' : ''
+        $hiddenFilePrefix = ($IsLinux -or $IsMacOS) ? '.' : ''
 
         $hiddenFilePath1 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test1.txt"
-        $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
-        $hiddenFile1.Attributes = "Hidden"
-        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
-
         $hiddenFilePath2 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test2.txt"
+
+        $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
         $hiddenFile2 = New-Item -Path $hiddenFilePath2 -ItemType File
-        $hiddenFile2.Attributes = "Hidden"
+
+        $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
         $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)test2.txt"
+
+        if ($IsWindows) {
+            $hiddenFile1.Attributes = "Hidden"
+            $hiddenFile2.Attributes = "Hidden"
+        }
 
         $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test*.txt"
         $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)test*.txt"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -17,17 +17,19 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             @{ wd = $testRoot; target = Join-Path $fakeRoot "file.txt"; expected = Join-Path "." "fakeroot" "file.txt" }
         )
 
-        $hiddenFilePath1 = Join-Path -Path $TestDrive -ChildPath 'test1.txt'
+        $hiddenFilePrefix = [System.Environment]::OSVersion.Platform -eq 'Unix' ? '.' : ''
+
+        $hiddenFilePath1 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test1.txt"
         $hiddenFile1 = New-Item -Path $hiddenFilePath1 -ItemType File
         $hiddenFile1.Attributes = "Hidden"
         $relativeHiddenFilePath1 = ".$([System.IO.Path]::DirectorySeparatorChar)test1.txt"
 
-        $hiddenFilePath2 = Join-Path -Path $TestDrive -ChildPath 'test2.txt'
+        $hiddenFilePath2 = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test2.txt"
         $hiddenFile2 = New-Item -Path $hiddenFilePath2 -ItemType File
         $hiddenFile2.Attributes = "Hidden"
         $relativeHiddenFilePath2 = ".$([System.IO.Path]::DirectorySeparatorChar)test2.txt"
 
-        $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath 'test*.txt'
+        $hiddenFileWildcardPath = Join-Path -Path $TestDrive -ChildPath "$($hiddenFilePrefix)test*.txt"
         $relativeHiddenFileWildcardPath = ".$([System.IO.Path]::DirectorySeparatorChar)test*.txt"
     }
     AfterAll {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after tcmdlts he Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #20929

Added `-Force` parameter to `Resolve-Path` and `Convert-Path` cmdlets to support wildcard hidden files.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Currently it is not possible to use `Resolve-Path` and `Convert-Path` with wildcard hidden paths.

This PR resolves this by adding the missing `-Force` parameter so hidden files can be supported with above cmdlets.

The tests are the same between both cmdlets and differentiate differently between Windows(setting `Hidden` attribute) and Unix(prefixing file with `.`) for hidden files.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/10755
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
