### PR TITLE
Add error for Get-PSSession -ComputerName on Unix

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
@@ -343,7 +343,7 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
 #if UNIX
-            if (ComputerName.Length > 0)
+            if (ComputerName?.Length > 0)
             {
                 ErrorRecord err = new(
                     new NotImplementedException(

--- a/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
@@ -8,6 +8,7 @@ using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Runspaces;
+using System.Runtime.InteropServices;
 
 using Dbg = System.Management.Automation.Diagnostics;
 
@@ -341,8 +342,22 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            base.BeginProcessing();
+#if UNIX
+            if (ComputerName.Length > 0)
+            {
+                ErrorRecord err = new(
+                    new NotImplementedException(
+                        PSRemotingErrorInvariants.FormatResourceString(
+                            RemotingErrorIdStrings.UnsupportedOSForRemoteEnumeration,
+                            RuntimeInformation.OSDescription)),
+                    "PSSessionComputerNameUnix",
+                    ErrorCategory.NotImplemented,
+                    null);
+                ThrowTerminatingError(err);
+            }
+#endif
 
+            base.BeginProcessing();
             ConfigurationName ??= string.Empty;
         }
 

--- a/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
+++ b/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
@@ -18,6 +18,7 @@ namespace System.Management.Automation.Remoting
         // OS related 1-9
         DefaultRemotingExceptionMessage = 0,
         OutOfMemory = 1,
+        UnsupportedOSForRemoteEnumeration = 2,
 
         // Pipeline related range: 10-99
         PipelineIdsDoNotMatch = 10,

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -123,6 +123,9 @@
   <data name="OutOfMemory" xml:space="preserve">
     <value>Out of process memory.</value>
   </data>
+  <data name="UnsupportedOSForRemoteEnumeration" xml:space="preserve">
+    <value>Remote PSSession enumeration with -ComputerName is only supported on Windows and not "{0}".</value>
+  </data>
   <data name="PipelineIdsDoNotMatch" xml:space="preserve">
     <value>Pipeline ID "{0}" does not match the InstanceId of the pipeline that is currently running, "{1}".</value>
   </data>


### PR DESCRIPTION
# PR Summary
Emit an exception when attempting to use Get-PSSession -ComputerName on a non-Windows platform that makes it clear it cannot be used on those platforms. Now when running this on non-Windows it will emit the following error.

```powershell
PS /home/jborean/dev/PowerShell> Get-PSSession -ComputerName foo
Get-PSSession: Remote PSSession enumeration with -ComputerName is only supported on Windows and not "Arch Linux".
```

## PR Context
I don't think this feature will ever be implemented, even if it is it would be nice to error with a proper message not the current

> Get-PSSession: The term 'New-WSManSessionOption' is not recognized as a name of a cmdlet, function, script file, or executable program.
> Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

Fixes: https://github.com/PowerShell/PowerShell/issues/20995

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
