### PR TITLE
WIP: Maintain http persistence where possible

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2381,6 +2381,30 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             return $session
         }
 
+        function RunWithNoSession {
+            param(
+                [uri]$Uri,
+                [object]$Session,
+                [string]$Command,
+                [switch]$ExpectConnectionRecreated
+            )
+            $defaultSession = 'global:PSDefaultWebSession'
+            $pwsh = [PowerShell]::Create()
+            $pwsh.Runspace.SessionStateProxy.SetVariable('uri', $Uri)
+            if ($Session) {
+                $pwsh.Runspace.SessionStateProxy.SetVariable($defaultSession, $Session)
+            }
+            $script = "`$null = $command -Verbose"
+            $pwsh.AddScript($script).Invoke()
+
+            $expectedConnRecreatedCount = if ($ExpectConnectionRecreated) { 1 } else { 0 }
+            ($pwsh.Streams.Verbose | Where-Object { $matchConnRecreatedMessage.Matches($_.Message) }).Count | Should -Be $expectedConnRecreatedCount
+            $session = $pwsh.Runspace.SessionStateProxy.GetVariable($defaultSession)
+            $pwsh.Dispose()
+            return $session
+
+        }
+
         It 'Connection persistence maintained' {
             $uri = Get-WebListenerUrl
             $Session = RunCheckingPersistence -Uri $uri -Command 'Invoke-WebRequest -Uri $uri' -CaptureSession
@@ -2485,6 +2509,21 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri -proxy $proxy" -Session $session -ExpectConnectionRecreated
             # No proxy specified - connection retained
             $session = RunCheckingPersistence -Uri $uri -Command "Invoke-WebRequest -Uri $uri" -Session $session
+        }
+
+        It 'Opportunistic persistence is used when no WebSession is specified' {
+            $uri = Get-WebListenerUrl
+            $defaultSession = $null
+            $defaultSession = RunWithNoSession -session $defaultSession -Uri $uri -Command 'Invoke-WebRequest -Uri $uri'
+            $defaultSession = RunWithNoSession -session $defaultSession -Uri $uri -Command 'Invoke-WebRequest -Uri $uri'
+
+            $defaultSession = $null
+            $defaultSession = RunWithNoSession -session $defaultSession -Uri $uri -Command 'Invoke-WebRequest -Uri $uri'
+            # Skip certificate check prevents re-use
+            $defaultSession = RunWithNoSession -session $defaultSession -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -SkipCertificateCheck' -ExpectConnectionRecreated
+            # Using same parameter again has re-use
+            $defaultSession = RunWithNoSession -session $defaultSession -Uri $uri -Command 'Invoke-WebRequest -Uri $uri -SkipCertificateCheck'
+
         }
     }
 }


### PR DESCRIPTION
A default web session is created whenever the user doesn't provide a session or request it to be saved somewhere.

When the default session is re-used, any changes made to it are reset so the request will behave predictably. The reset process tries to ensure maximum opportunities for persistent http requests by avoiding recreating the http client when subsequent invocations use compatible parameters.

The default web session is saved as a global session state variable called PSDefaultWebSession. This approach is used so that each run space will get its own default web session to avoid problems when running requests in parallel.

Please provide feedback on this approach and whether there is an alternative way to save per runspace web session that would be more suitable. I would prefer a way to save the variable in the run space that doesn't expose it to users, though this implementation detail is currently used by the test case.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

The following script demonstrates performance improvement:

```pwsh
(Measure-Command {
    1..10 | ForEach-Object {
        Invoke-WebRequest https://postman-echo.com/get?i=$_
    }
}).TotalMilliseconds
```

PWSH 7.4.0
12520.8165

With patch:
4269.2125

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
