### PR TITLE
[release/v7.2.18] Set the ollForwardOnNoCandidateFx in runtime.config to roll forward only on minor.patch versions

### DIFF
--- a/src/Microsoft.PowerShell.GlobalTool.Shim/runtimeconfig.template.json
+++ b/src/Microsoft.PowerShell.GlobalTool.Shim/runtimeconfig.template.json
@@ -1,4 +1,4 @@
-// This is required to roll forward to runtime 3.x when 2.x is not installed
+// This is required to roll forward to supported minor.patch versions of the runtime.
 {
-  "rollForwardOnNoCandidateFx": 2
+  "rollForwardOnNoCandidateFx": 1
 }

--- a/src/powershell-unix/runtimeconfig.template.json
+++ b/src/powershell-unix/runtimeconfig.template.json
@@ -1,3 +1,4 @@
+// This is required to roll forward to supported minor.patch versions of the runtime.
 {
-  "rollForwardOnNoCandidateFx": 2
+  "rollForwardOnNoCandidateFx": 1
 }

--- a/src/powershell-win-core/runtimeconfig.template.json
+++ b/src/powershell-win-core/runtimeconfig.template.json
@@ -1,3 +1,4 @@
+// This is required to roll forward to supported minor.patch versions of the runtime.
 {
-  "rollForwardOnNoCandidateFx": 2
+  "rollForwardOnNoCandidateFx": 1
 }


### PR DESCRIPTION
Backport #20689