### PR TITLE
[release/v7.2.18] Remove the `ref` folder before running compliance

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/compliance/apiscan.yml
+++ b/tools/releaseBuild/azureDevOps/templates/compliance/apiscan.yml
@@ -59,6 +59,11 @@ jobs:
 
         $OutputFolder = Split-Path (Get-PSOutput)
         Write-Host "##vso[task.setvariable variable=BinDir]$OutputFolder"
+
+        Write-Verbose -Verbose -Message "Deleting ref folder from output folder"
+        if (Test-Path $OutputFolder/ref) {
+          Remove-Item -Recurse -Force $OutputFolder/ref
+        }
       workingDirectory: '$(Build.SourcesDirectory)'
       displayName: 'Build PowerShell Source'
 


### PR DESCRIPTION
Backport https://github.com/PowerShell/PowerShell/pull/20373