### PR TITLE
Adding hex format for native command exit codes

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -133,7 +133,7 @@ namespace System.Management.Automation
         }
     }
 
-    #nullable enable
+#nullable enable
     /// <summary>
     /// This exception is used by the NativeCommandProcessor to indicate an error
     /// when a native command returns a non-zero exit code.
@@ -187,7 +187,7 @@ namespace System.Management.Automation
         public int ProcessId { get; }
 
     }
-    #nullable restore
+#nullable restore
 
     /// <summary>
     /// Provides way to create and execute native commands.
@@ -972,11 +972,17 @@ namespace System.Management.Automation
                     }
 
                     const string errorId = nameof(CommandBaseStrings.ProgramExitedWithNonZeroCode);
+#if UNIX
+                    string hexFormatStr = "0x{0:X2}";
+#else
+                    string hexFormatStr = "0x{0:X8}";
+#endif
 
                     string errorMsg = StringUtil.Format(
                         CommandBaseStrings.ProgramExitedWithNonZeroCode,
                         NativeCommandName,
-                        _nativeProcess.ExitCode);
+                        _nativeProcess.ExitCode,
+                        string.Format(CultureInfo.InvariantCulture, hexFormatStr, _nativeProcess.ExitCode));
 
                     var exception = new NativeCommandExitException(
                         Path,

--- a/src/System.Management.Automation/resources/CommandBaseStrings.resx
+++ b/src/System.Management.Automation/resources/CommandBaseStrings.resx
@@ -163,7 +163,7 @@
       however that is used for ApplicationFailedExceptions thrown when the NativeCommandProcessor fails in an unexpected way.
       In this case, we have a more specific error for the native command scenario, so the two are not conflated.
     -->
-    <value>Program "{0}" ended with non-zero exit code: {1}.</value>
+    <value>Program "{0}" ended with non-zero exit code: {1} ({2}).</value>
   </data>
   <data name="ShouldProcessMessage" xml:space="preserve">
     <value>Performing the operation "{0}" on target "{1}".</value>

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
             $error[0].TargetObject | Should -BeExactly $exePath
-            $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
+            $stderr[1].Exception.Message | Should -BeExactly ("Program `"$exeName`" ended with non-zero exit code: 1 ({0})." -f ($IsWindows ? '0x00000001' : '0x01'))
         }
 
         It "Non-boolean value should not cause type casting error when the native command exited with non-zero code" {
@@ -61,7 +61,7 @@ Describe 'Native command error handling tests' -Tags 'CI' {
 
             $error[0].FullyQualifiedErrorId | Should -BeExactly 'ProgramExitedWithNonZeroCode'
             $error[0].TargetObject | Should -BeExactly $exePath
-            $stderr[1].Exception.Message | Should -BeExactly "Program `"$exeName`" ended with non-zero exit code: 1."
+            $stderr[1].Exception.Message | Should -BeExactly ("Program `"$exeName`" ended with non-zero exit code: 1 ({0})." -f ($IsWindows ? '0x00000001' : '0x01'))
         }
 
         It 'Non-zero exit code generates a non-teminating error for $ErrorActionPreference = ''SilentlyContinue''' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This implementation adds the hex-format version of the native command exit code message (#19886)


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X ] Issue filed: <!-- Number/link of that issue here --> 19886

- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
