### PR TITLE
Fix up buffer management getting network roots

### DIFF
--- a/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
@@ -26,56 +26,53 @@ internal static partial class Interop
 
             uint bufferSize = MAX_PATH;
 
-#if DEBUG
-            // In Debug mode buffer size is initially set to 3 and if additional buffer is required, the
-            // required buffer size is allocated and the WNetGetConnection API is executed with the newly
-            // allocated buffer size.
-            bufferSize = 3;
-#endif
-
             ReadOnlySpan<char> driveName = stackalloc char[] { drive, ':', '\0' };
             Span<char> uncBuffer = stackalloc char[(int)bufferSize];
-            int errorCode = ERROR_NO_NETWORK;
 
+            char[]? rentedArray = null;
             try
             {
-                errorCode = WNetGetConnection(driveName, uncBuffer, ref bufferSize);
-            }
-            catch (System.DllNotFoundException)
-            {
-                s_WNetApiNotAvailable = true;
-                return ERROR_NOT_SUPPORTED;
-            }
-
-            if (errorCode == ERROR_SUCCESS)
-            {
-                // exclude null terminator
-                uncPath = uncBuffer.Slice(0, (int)bufferSize - 1).ToString();
-            }
-            else if (errorCode == ERROR_MORE_DATA)
-            {
-                char[]? rentedArray = null;
-                try
+                while (true)
                 {
-                    uncBuffer = rentedArray = ArrayPool<char>.Shared.Rent((int)bufferSize);
-                    errorCode = WNetGetConnection(driveName, uncBuffer, ref bufferSize);
-
-                    if (errorCode == ERROR_SUCCESS)
+                    int errorCode;
+                    try
                     {
-                        // exclude null terminator
-                        uncPath = uncBuffer.Slice(0, (int)bufferSize - 1).ToString();
+                        errorCode = WNetGetConnection(driveName, uncBuffer, ref bufferSize);
+                    }
+                    catch (System.DllNotFoundException)
+                    {
+                        s_WNetApiNotAvailable = true;
+                        return ERROR_NOT_SUPPORTED;
+                    }
+
+                    if (errorCode == ERROR_MORE_DATA)
+                    {
+                        uncBuffer = rentedArray = ArrayPool<char>.Shared.Rent((int)bufferSize);
+                    }
+                    else
+                    {
+                        if (errorCode == ERROR_SUCCESS)
+                        {
+                            // Cannot rely on bufferSize as it's only set if
+                            // the first call ended with ERROR_MORE_DATA,
+                            // instead slice at the null terminator.
+                            int nullIdx = uncBuffer.IndexOf('\0');
+                            uncPath = uncBuffer.Slice(
+                                0,
+                                nullIdx == -1 ? uncBuffer.Length : nullIdx).ToString();
+                        }
+
+                        return errorCode;
                     }
                 }
-                finally
+            }
+            finally
+            {
+                if (rentedArray is not null)
                 {
-                    if (rentedArray is not null)
-                    {
-                        ArrayPool<char>.Shared.Return(rentedArray);
-                    }
+                    ArrayPool<char>.Shared.Return(rentedArray);
                 }
             }
-
-            return errorCode;
         }
     }
 }


### PR DESCRIPTION
# PR Summary
Fixes the logic used when getting the PSDrive DisplayRoot for network PSDrive paths to exclude null terminators.

There are no tests added because the original issue was that we ran with DEBUG mode that didn't go across the problematic code. In this case we are now testing the problematic scenario which is the more common of the two.

## PR Context

Fixes: https://github.com/PowerShell/PowerShell/issues/21064

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
