### PR TITLE
Enable reproducible builds

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -1,4 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Sdk Name="DotNet.ReproducibleBuilds.Isolated" Version="1.1.1" />
+
   <Import Project=".\Analyzers.props" />
 
   <!--
@@ -140,7 +142,8 @@
 
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
-
+  
+    <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -192,4 +195,11 @@
   <PropertyGroup>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
[Reproducible builds](https://github.com/dotnet/reproducible-builds) are an important way to improve the integrity of binary releases.