### PR TITLE
Fix Get-Error serialization of array values

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -946,10 +946,18 @@ namespace System.Management.Automation.Runspaces
                                                 $isFirstElement = $true
                                                 foreach ($value in $prop.Value) {
                                                     $null = $output.Append($newline)
-                                                    if (!$isFirstElement) {
-                                                        $null = $output.Append($newline)
+
+                                                    if ($value -is [Type] -or $value -is [string] -or $value.GetType().IsPrimitive) {
+                                                        # We want to display the primitive value, also includes strings and
+                                                        # types values, the latter containing a lot of uneeded properties.
+                                                        $null = $output.Append(""${prefix}$(' ' * $indent)${value}"")
                                                     }
-                                                    $null = $output.Append((Show-ErrorRecord $value $newIndent ($depth + 1)))
+                                                    else {
+                                                        if (!$isFirstElement) {
+                                                            $null = $output.Append($newline)
+                                                        }
+                                                        $null = $output.Append((Show-ErrorRecord $value $newIndent ($depth + 1)))
+                                                    }
                                                     $isFirstElement = $false
                                                 }
                                             }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -946,11 +946,14 @@ namespace System.Management.Automation.Runspaces
                                                 $isFirstElement = $true
                                                 foreach ($value in $prop.Value) {
                                                     $null = $output.Append($newline)
+                                                    $valueIndent = ' ' * ($newIndent + 2)
 
-                                                    if ($value -is [Type] -or $value -is [string] -or $value.GetType().IsPrimitive) {
-                                                        # We want to display the primitive value, also includes strings and
-                                                        # types values, the latter containing a lot of uneeded properties.
-                                                        $null = $output.Append(""${prefix}$(' ' * $indent)${value}"")
+                                                    if ($value -is [Type]) {
+                                                        # Just show the typename instead of it as an object
+                                                        $null = $output.Append(""${prefix}${valueIndent}[${value}]"")
+                                                    }
+                                                    elseif ($value -is [string] -or $value.GetType().IsPrimitive) {
+                                                        $null = $output.Append(""${prefix}${valueIndent}${value}"")
                                                     }
                                                     else {
                                                         if (!$isFirstElement) {

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -950,7 +950,7 @@ namespace System.Management.Automation.Runspaces
 
                                                     if ($value -is [Type]) {
                                                         # Just show the typename instead of it as an object
-                                                        $null = $output.Append(""${prefix}${valueIndent}[${value}]"")
+                                                        $null = $output.Append(""${prefix}${valueIndent}[$($value.ToString())]"")
                                                     }
                                                     elseif ($value -is [string] -or $value.GetType().IsPrimitive) {
                                                         $null = $output.Append(""${prefix}${valueIndent}${value}"")
@@ -964,6 +964,10 @@ namespace System.Management.Automation.Runspaces
                                                     $isFirstElement = $false
                                                 }
                                             }
+                                        }
+                                        elseif ($prop.Value -is [Type]) {
+                                            # Just show the typename instead of it as an object
+                                            $null = $output.Append(""[$($prop.Value.ToString())]"")
                                         }
                                         # Anything else, we convert to string.
                                         # ToString() can throw so we use LanguagePrimitives.TryConvertTo() to hide a convert error

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Error.Tests.ps1
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Get-Error" -Tags "CI" {
+    It "Does not hang when serializing exception with array with type instances" {
+        $ps = [PowerShell]::Create()
+        $null = $ps.AddScript(@'
+            class GetErrorWithTypeArray : Exception {
+                [type[]]$Values
+
+                GetErrorWithTypeArray ([string]$Message) : base($Message) {
+                    $this.Values = [type[]]@([string], [type])
+                }
+            }
+            try { throw [GetErrorWithTypeArray]::new("") } catch {}
+            Get-Error | Out-String
+'@)
+
+        $task = $ps.BeginInvoke()
+        if (-not $task.AsyncWaitHandle.WaitOne(5000)) {
+            $null = $ps.BeginStop($null, $null)
+            throw "Timed out waiting for Get-Error to serialize"
+        }
+
+        $result = $ps.EndInvoke($task)
+        $result.Count | Should -Be 1
+        $result[0] | Should -BeOfType ([string])
+
+        $formattedError = (@(
+            $result[0] -split "\r?\n" | ForEach-Object {
+                $_.TrimEnd()
+            }
+        ) -join ([Environment]::NewLine)).Trim()
+
+        $formattedError | Should -Be @'
+Exception        :
+    Type    : GetErrorWithTypeArray
+    Values  :
+        string
+        type
+    HResult : -2146233088
+CategoryInfo     : OperationStopped: (:) [], GetErrorWithTypeArray
+InvocationInfo   :
+    ScriptLineNumber : 8
+    OffsetInLine     : 19
+    HistoryId        : 1
+    Line             : try { throw [GetErrorWithTypeArray]::new("") } catch {}
+
+    Statement        : throw [GetErrorWithTypeArray]::new("")
+    PositionMessage  : At line:8 char:19
+                       +             try { throw [GetErrorWithTypeArray]::new("") } catch {}
+                       +                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    CommandOrigin    : Internal
+ScriptStackTrace : at <ScriptBlock>, <No file>: line 8
+'@.Trim()
+    }
+
+    It "Formats strings and primitive types in an array" {
+        $ps = [PowerShell]::Create()
+        $null = $ps.AddScript(@'
+            class GetErrorPrimitiveArray : Exception {
+                [object[]]$Values
+
+                GetErrorPrimitiveArray ([string]$Message) : base($Message) {
+                    $this.Values = @(1, "2", 0.5)
+                }
+            }
+            try { throw [GetErrorPrimitiveArray]::new("") } catch {}
+            Get-Error | Out-String
+'@)
+
+        $result = $ps.Invoke()
+        $result.Count | Should -Be 1
+        $result[0] | Should -BeOfType ([string])
+
+        $formattedError = (@(
+            $result[0] -split "\r?\n" | ForEach-Object {
+                $_.TrimEnd()
+            }
+        ) -join ([Environment]::NewLine)).Trim()
+
+        $formattedError | Should -Be @'
+Exception        :
+    Type    : GetErrorPrimitiveArray
+    Values  :
+        1
+        2
+        0.5
+    HResult : -2146233088
+CategoryInfo     : OperationStopped: (:) [], GetErrorPrimitiveArray
+InvocationInfo   :
+    ScriptLineNumber : 8
+    OffsetInLine     : 19
+    HistoryId        : 1
+    Line             : try { throw [GetErrorPrimitiveArray]::new("") } catch {}
+
+    Statement        : throw [GetErrorPrimitiveArray]::new("")
+    PositionMessage  : At line:8 char:19
+                       +             try { throw [GetErrorPrimitiveArray]::new("") } catch {}
+                       +                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    CommandOrigin    : Internal
+ScriptStackTrace : at <ScriptBlock>, <No file>: line 8
+'@.Trim()
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Error.Tests.ps1
@@ -7,9 +7,11 @@ Describe "Get-Error" -Tags "CI" {
         $null = $ps.AddScript(@'
             class GetErrorWithTypeArray : Exception {
                 [type[]]$Values
+                [type]$Type
 
                 GetErrorWithTypeArray ([string]$Message) : base($Message) {
-                    $this.Values = [type[]]@([string], [type])
+                    $this.Values = [type[]]@([string], [int])
+                    $this.Type = [bool]
                 }
             }
             try { throw [GetErrorWithTypeArray]::new("") } catch {}
@@ -34,24 +36,24 @@ Describe "Get-Error" -Tags "CI" {
 
         $formattedError | Should -Be @'
 Exception        :
-    Type    : GetErrorWithTypeArray
     Values  :
-        string
-        type
+              [System.String]
+              [System.Int32]
+    Type    : [System.Boolean]
     HResult : -2146233088
 CategoryInfo     : OperationStopped: (:) [], GetErrorWithTypeArray
 InvocationInfo   :
-    ScriptLineNumber : 8
+    ScriptLineNumber : 10
     OffsetInLine     : 19
     HistoryId        : 1
     Line             : try { throw [GetErrorWithTypeArray]::new("") } catch {}
 
     Statement        : throw [GetErrorWithTypeArray]::new("")
-    PositionMessage  : At line:8 char:19
+    PositionMessage  : At line:10 char:19
                        +             try { throw [GetErrorWithTypeArray]::new("") } catch {}
                        +                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     CommandOrigin    : Internal
-ScriptStackTrace : at <ScriptBlock>, <No file>: line 8
+ScriptStackTrace : at <ScriptBlock>, <No file>: line 10
 '@.Trim()
     }
 
@@ -62,7 +64,7 @@ ScriptStackTrace : at <ScriptBlock>, <No file>: line 8
                 [object[]]$Values
 
                 GetErrorPrimitiveArray ([string]$Message) : base($Message) {
-                    $this.Values = @(1, "2", 0.5)
+                    $this.Values = @(1, "alpha", 0.5)
                 }
             }
             try { throw [GetErrorPrimitiveArray]::new("") } catch {}
@@ -83,9 +85,9 @@ ScriptStackTrace : at <ScriptBlock>, <No file>: line 8
 Exception        :
     Type    : GetErrorPrimitiveArray
     Values  :
-        1
-        2
-        0.5
+              1
+              alpha
+              0.5
     HResult : -2146233088
 CategoryInfo     : OperationStopped: (:) [], GetErrorPrimitiveArray
 InvocationInfo   :


### PR DESCRIPTION
# PR Summary
Ensure Get-Error does not hang when attempting to serialize an exception that contains a property whose type is an array of System.Type instances. Also ensures that primitive types like System.Int32, System.Boolean as well as System.String is formatted as a string rather than an object with properties.

This will no longer hang

```powershell
class ExceptionWithArrayType : Exception {
    [Type[]]$Types

    ExceptionWithArrayType ([string]$Message) : base($Message) {
        $this.Types = @([string], [int])
    }
}

try { throw  [ExceptionWithArrayType]::new("") } catch {}
Get-Error 
```

It also ensures that exception with a property containing an array of primitive types (+ `[string]`) is formatted as that primitive type. For example this exception

```powershell
class ExceptionWithArrayPrimitive : Exception {
    [object[]]$Values

    ExceptionWithArrayPrimitive ([string]$Message) : base($Message) {
        $this.Values = @(1, "value")
    }
}

try { throw  [ExceptionWithArrayPrimitive]::new("") } catch {}
Get-Error 
```

Currently this looks like

```
Exception        :
    Type    : ExceptionWithArrayPrimitive
    Values  :


        Length : 5
    HResult : -2146233088
CategoryInfo     : OperationStopped: (:) [], ExceptionWithArrayPrimitive
InvocationInfo   :
    ScriptLineNumber : 1
    OffsetInLine     : 7
    HistoryId        : 2
    Line             : try { throw  [ExceptionWithArrayPrimitive]::new("") } catch {}
    Statement        : throw  [ExceptionWithArrayPrimitive]::new("")
    PositionMessage  : At line:1 char:7
                       + try { throw  [ExceptionWithArrayPrimitive]::new("") } catch {}
                       +       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CommandOrigin    : Internal
ScriptStackTrace : at <ScriptBlock>, <No file>: line 1
```

With these changes it now looks like (note `Values :` in the `Exception`).

```
Exception        :
    Type    : ExceptionWithArrayPrimitive
    Values  :
        1
        value
    HResult : -2146233088
CategoryInfo     : OperationStopped: (:) [], ExceptionWithArrayPrimitive
InvocationInfo   :
    ScriptLineNumber : 1
    OffsetInLine     : 7
    HistoryId        : 2
    Line             : try { throw  [ExceptionWithArrayPrimitive]::new("") } catch {}
    Statement        : throw  [ExceptionWithArrayPrimitive]::new("")
    PositionMessage  : At line:1 char:7
                       + try { throw  [ExceptionWithArrayPrimitive]::new("") } catch {}
                       +       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    CommandOrigin    : Internal
ScriptStackTrace : at <ScriptBlock>, <No file>: line 1
```

## PR Context

Fixes: https://github.com/PowerShell/PowerShell/issues/21083

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
