### PR TITLE
Set-Acl: Do not fail on untranslatable SID

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemSecurity.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemSecurity.cs
@@ -168,13 +168,15 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // Get the security descriptor of the destination path
                     ObjectSecurity existingDescriptor = new FileInfo(path).GetAccessControl();
-                    Type ntAccountType = typeof(System.Security.Principal.NTAccount);
+                    // Use SecurityIdentifier to avoid having the below comparison steps
+                    // fail when dealing with an untranslatable SID in the SD
+                    Type identityType = typeof(System.Security.Principal.SecurityIdentifier);
 
                     AccessControlSections sections = AccessControlSections.All;
 
                     // If they didn't modify any audit information, don't try to set
                     // the audit section.
-                    int auditRuleCount = sd.GetAuditRules(true, true, ntAccountType).Count;
+                    int auditRuleCount = sd.GetAuditRules(true, true, identityType).Count;
                     if ((auditRuleCount == 0) &&
                         (sd.AreAuditRulesProtected == existingDescriptor.AreAccessRulesProtected))
                     {
@@ -182,13 +184,13 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     // If they didn't modify the owner, don't try to set that section.
-                    if (sd.GetOwner(ntAccountType) == existingDescriptor.GetOwner(ntAccountType))
+                    if (sd.GetOwner(identityType) == existingDescriptor.GetOwner(identityType))
                     {
                         sections &= ~AccessControlSections.Owner;
                     }
 
                     // If they didn't modify the group, don't try to set that section.
-                    if (sd.GetGroup(ntAccountType) == existingDescriptor.GetGroup(ntAccountType))
+                    if (sd.GetGroup(identityType) == existingDescriptor.GetGroup(identityType))
                     {
                         sections &= ~AccessControlSections.Group;
                     }


### PR DESCRIPTION
# PR Summary
Fix up error when attempting to set a SecurityDescriptor that contains a SACL, Owner, or Group entry with a SecurityIdentifier that cannot be translated. For example the existing SD or SD to set owner has a SecurityIdentifier set to a user that doesn't exist on the current machine or is a domain account where the host isn't domain joined.

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/issues/21095

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
