### PR TITLE
Add `-PropertyType` argument completer for `New-ItemProperty`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 
@@ -245,6 +243,34 @@ namespace Microsoft.PowerShell.Commands
                 yield break;
             }
 
+            if (!IsRegistryProvider(fakeBoundParameters))
+            {
+                yield break;
+            }
+
+            var propertyTypePattern = WildcardPattern.Get(wordToComplete.Trim(QuoteChars) + "*", WildcardOptions.IgnoreCase);
+
+            foreach (string propertyType in s_RegistryPropertyTypes)
+            {
+                if (propertyTypePattern.IsMatch(propertyType))
+                {
+                    yield return new CompletionResult(
+                        propertyType,
+                        propertyType,
+                        CompletionResultType.ParameterValue,
+                        GetRegistryPropertyTypeToolTip(propertyType));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if parameter paths are from Registry provider.
+        /// </summary>
+        /// <param name="fakeBoundParameters">The fake bound parameters.</param>
+        /// <returns>Boolean indicating if paths are from Registry Provider</returns>
+        private static bool IsRegistryProvider(IDictionary fakeBoundParameters)
+
+        {
             Collection<PathInfo> paths;
 
             if (fakeBoundParameters.Contains("Path"))
@@ -260,22 +286,7 @@ namespace Microsoft.PowerShell.Commands
                 paths = ResolvePath(@".\", isLiteralPath: false);
             }
 
-            if (paths.Count > 0 && paths[0].Provider.NameEquals("Registry"))
-            {
-                var propertyTypePattern = WildcardPattern.Get(wordToComplete.Trim(QuoteChars) + "*", WildcardOptions.IgnoreCase);
-
-                foreach (string propertyType in s_RegistryPropertyTypes)
-                {
-                    if (propertyTypePattern.IsMatch(propertyType))
-                    {
-                        yield return new CompletionResult(
-                            propertyType,
-                            propertyType,
-                            CompletionResultType.ParameterValue,
-                            GetRegistryPropertyTypeToolTip(propertyType));
-                    }
-                }
-            }
+            return paths.Count > 0 && paths[0].Provider.NameEquals("Registry");
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -225,25 +225,19 @@ namespace Microsoft.PowerShell.Commands
 
             Collection<PathInfo> paths;
 
-            // Completion: New-ItemProperty -Path <path> -PropertyType <wordToComplete>
             if (fakeBoundParameters.Contains("Path"))
             {
                 paths = ResolvePaths(ConvertParameterPathsToArray(fakeBoundParameters["Path"]), isLiteralPath: false);
             }
-
-            // Completion: New-ItemProperty -LiteralPath <path> -PropertyType <wordToComplete>
             else if (fakeBoundParameters.Contains("LiteralPath"))
             {
                 paths = ResolvePaths(ConvertParameterPathsToArray(fakeBoundParameters["LiteralPath"]), isLiteralPath: true);
             }
-
-            // Just exit since we need to be sure we are completing for registry provider
             else
             {
                 yield break;
             }
 
-            // Perform completion if path is using registry provider
             if (paths.Count > 0 && paths[0].Provider.NameEquals("Registry"))
             {
                 var propertyTypePattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
@@ -292,7 +286,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 return new string[] { parameterPath.ToString() };
             }
-
             else if (parameterType.IsArray && parameterType.GetElementType() == typeof(object))
             {
                 return Array.ConvertAll((object[])parameterPath, path => path.ToString());

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -9,8 +9,6 @@ using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 
-using Microsoft.Win32;
-
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -282,7 +282,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Converts object path to array of paths.
         /// </summary>
-        /// <param name="parameterPath">The object parameter path</param>
+        /// <param name="parameterPath">The object parameter path.</param>
         /// <returns>Array of path strings.</returns>
         private static string[] ConvertParameterPathsToArray(object parameterPath)
         {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -183,6 +183,7 @@ namespace Microsoft.PowerShell.Commands
 
     }
 
+#if !UNIX
     /// <summary>
     /// Provides argument completion for PropertyType parameter.
     /// </summary>
@@ -302,4 +303,5 @@ namespace Microsoft.PowerShell.Commands
             return output;
         }
     }
+#endif
 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -225,11 +225,15 @@ namespace Microsoft.PowerShell.Commands
 
             if (fakeBoundParameters.Contains("Path"))
             {
-                paths = ResolvePaths(ConvertParameterPathsToArray(fakeBoundParameters["Path"]), isLiteralPath: false);
+                paths = ResolvePaths(
+                    ConvertParameterPathsToArray(fakeBoundParameters["Path"]),
+                    isLiteralPath: false);
             }
             else if (fakeBoundParameters.Contains("LiteralPath"))
             {
-                paths = ResolvePaths(ConvertParameterPathsToArray(fakeBoundParameters["LiteralPath"]), isLiteralPath: true);
+                paths = ResolvePaths(
+                    ConvertParameterPathsToArray(fakeBoundParameters["LiteralPath"]),
+                    isLiteralPath: true);
             }
             else
             {
@@ -247,7 +251,11 @@ namespace Microsoft.PowerShell.Commands
 
                     if (propertyTypePattern.IsMatch(completionText))
                     {
-                        yield return new CompletionResult(completionText, completionText, CompletionResultType.ParameterValue, toolTip);
+                        yield return new CompletionResult(
+                            completionText,
+                            completionText,
+                            CompletionResultType.ParameterValue,
+                            toolTip);
                     }
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -260,7 +260,7 @@ namespace Microsoft.PowerShell.Commands
                 paths = ResolvePath(@".\", isLiteralPath: false);
             }
 
-            if (paths[0].Provider.NameEquals("Registry"))
+            if (paths.Count > 0 && paths[0].Provider.NameEquals("Registry"))
             {
                 var propertyTypePattern = WildcardPattern.Get(wordToComplete.Trim(QuoteChars) + "*", WildcardOptions.IgnoreCase);
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Management.Automation;
-using System.Management.Automation.Language;
-using Microsoft.Win32;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using Microsoft.Win32;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -182,7 +182,7 @@ namespace Microsoft.PowerShell.Commands
 
     }
 
-    // <summary>
+    /// <summary>
     /// Provides argument completion for PropertyType parameter.
     /// </summary>
     public class PropertyTypeArgumentCompleter : IArgumentCompleter

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -211,19 +211,6 @@ namespace Microsoft.PowerShell.Commands
             _ => TabCompletionStrings.RegistryUnknownToolTip
         };
 
-        private static readonly char[] QuoteChars = new char[]
-        {
-            '\'',
-            '"',
-            '\u2018', // left single quotation mark
-            '\u2019', // right single quotation mark
-            '\u201a', // single low-9 quotation mark
-            '\u201b', // single high-reversed-9 quotation mark
-            '\u201c', // left double quotation mark
-            '\u201d', // right double quotation mark
-            '\u201E'  // low double left quote used in german
-        };
-
         /// <summary>
         /// Returns completion results for PropertyType parameter.
         /// </summary>
@@ -245,14 +232,19 @@ namespace Microsoft.PowerShell.Commands
                 yield break;
             }
 
-            var propertyTypePattern = WildcardPattern.Get(wordToComplete.Trim(QuoteChars) + "*", WildcardOptions.IgnoreCase);
+            string quote = CompletionCompleters.HandleDoubleAndSingleQuote(ref wordToComplete);
+            var propertyTypePattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
 
             foreach (string propertyType in s_RegistryPropertyTypes)
             {
                 if (propertyTypePattern.IsMatch(propertyType))
                 {
+                    string completionText = quote == string.Empty
+                        ? propertyType
+                        : quote + propertyType + quote;
+
                     yield return new CompletionResult(
-                        propertyType,
+                        completionText,
                         propertyType,
                         CompletionResultType.ParameterValue,
                         GetRegistryPropertyTypeToolTip(propertyType));

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Language;
+
 using Microsoft.Win32;
 
 namespace Microsoft.PowerShell.Commands

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -67,7 +67,9 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [Alias("Type")]
+#if !UNIX
         [ArgumentCompleter(typeof(PropertyTypeArgumentCompleter))]
+#endif
         public string PropertyType { get; set; }
 
         /// <summary>
@@ -237,12 +239,6 @@ namespace Microsoft.PowerShell.Commands
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
         {
-            // -PropertyType parameter is only supported on Windows
-            if (!Platform.IsWindows)
-            {
-                yield break;
-            }
-
             if (!IsRegistryProvider(fakeBoundParameters))
             {
                 yield break;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -210,13 +210,13 @@ namespace Microsoft.PowerShell.Commands
 
             var propertyTypePattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
 
-            foreach (RegistryValueKind registryValueType in Enum.GetValues(typeof(RegistryValueKind)))
+            foreach (RegistryValueKind registryValue in Enum.GetValues(typeof(RegistryValueKind)))
             {
-                string registryValueTypeString = registryValueType.ToString();
+                string registryValueString = registryValue.ToString();
 
-                if (propertyTypePattern.IsMatch(registryValueTypeString))
+                if (propertyTypePattern.IsMatch(registryValueString))
                 {
-                    yield return new CompletionResult(registryValueTypeString);
+                    yield return new CompletionResult(registryValueString);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -267,9 +267,8 @@ namespace Microsoft.PowerShell.Commands
         /// Checks if parameter paths are from Registry provider.
         /// </summary>
         /// <param name="fakeBoundParameters">The fake bound parameters.</param>
-        /// <returns>Boolean indicating if paths are from Registry Provider</returns>
+        /// <returns>Boolean indicating if paths are from Registry Provider.</returns>
         private static bool IsRegistryProvider(IDictionary fakeBoundParameters)
-
         {
             Collection<PathInfo> paths;
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Management.Automation;
+using System.Management.Automation.Language;
+using Microsoft.Win32;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -63,6 +68,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [Alias("Type")]
+        [ArgumentCompleter(typeof(PropertyTypeArgumentCompleter))]
         public string PropertyType { get; set; }
 
         /// <summary>
@@ -174,5 +180,45 @@ namespace Microsoft.PowerShell.Commands
         }
         #endregion Command code
 
+    }
+
+    // <summary>
+    /// Provides argument completion for PropertyType parameter.
+    /// </summary>
+    public class PropertyTypeArgumentCompleter : IArgumentCompleter
+    {
+        /// <summary>
+        /// Returns completion results for PropertyType parameter.
+        /// </summary>
+        /// <param name="commandName">The command name.</param>
+        /// <param name="parameterName">The parameter name.</param>
+        /// <param name="wordToComplete">The word to complete.</param>
+        /// <param name="commandAst">The command AST.</param>
+        /// <param name="fakeBoundParameters">The fake bound parameters.</param>
+        /// <returns>List of Completion Results.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters)
+        {
+            if (!Platform.IsWindows)
+            {
+                yield break;
+            }
+
+            var propertyTypePattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
+
+            foreach (RegistryValueKind registryValueType in Enum.GetValues(typeof(RegistryValueKind)))
+            {
+                string registryValueTypeString = registryValueType.ToString();
+
+                if (propertyTypePattern.IsMatch(registryValueTypeString))
+                {
+                    yield return new CompletionResult(registryValueTypeString);
+                }
+            }
+        }
     }
 }

--- a/src/System.Management.Automation/resources/TabCompletionStrings.resx
+++ b/src/System.Management.Automation/resources/TabCompletionStrings.resx
@@ -353,4 +353,25 @@ using namespace &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
 
 using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
   </data>
+  <data name="RegistryStringToolTip" xml:space="preserve">
+    <value>A normal string.</value>
+  </data>
+  <data name="RegistryExpandStringToolTip" xml:space="preserve">
+    <value>A string that contains unexpanded references to environment variables that are expanded when the value is retrieved.</value>
+  </data>
+  <data name="RegistryBinaryToolTip" xml:space="preserve">
+    <value>Binary data in any form.</value>
+  </data>
+  <data name="RegistryDWordToolTip" xml:space="preserve">
+    <value>A 32-bit binary number.</value>
+  </data>
+  <data name="RegistryMultiStringToolTip" xml:space="preserve">
+    <value>An array of strings.</value>
+  </data>
+  <data name="RegistryQWordToolTip" xml:space="preserve">
+    <value>A 64-bit binary number.</value>
+  </data>
+  <data name="RegistryUnknownToolTip" xml:space="preserve">
+    <value>An unsupported registry data type.</value>
+  </data>
 </root>

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -940,7 +940,7 @@ ConstructorTestClass(int i, bool b)
             $multiStringValueKind = 'MultiString'
         }
 
-        It "Should complete Property Type for '<TextInput>'" -Skip:(!([System.Management.Automation.Platform]::IsWindows)) -TestCases @(
+        It "Should complete Property Type for '<TextInput>'" -Skip:(!$IsWindows) -TestCases @(
             @{ TextInput = "New-ItemProperty -PropertyType "; ExpectedPropertyTypes = $allRegistryValueKinds }
             @{ TextInput = "New-ItemProperty -PropertyType d"; ExpectedPropertyTypes = $dwordValueKind }
             @{ TextInput = "New-ItemProperty -PropertyType q"; ExpectedPropertyTypes = $qwordValueKind }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -935,6 +935,7 @@ ConstructorTestClass(int i, bool b)
         BeforeAll {
             if ($IsWindows) {
                 $allRegistryValueKinds = 'String ExpandString Binary DWord MultiString QWord Unknown'
+                $allRegistryValueKindsWithQuotes = "'String' 'ExpandString' 'Binary' 'DWord' 'MultiString' 'QWord' 'Unknown'"
                 $dwordValueKind = 'DWord'
                 $qwordValueKind = 'QWord'
                 $binaryValueKind = 'Binary'
@@ -979,8 +980,8 @@ ConstructorTestClass(int i, bool b)
             @{ TextInput = "New-ItemProperty -PropertyType invalidproptype"; ExpectedPropertyTypes = '' }
 
             # All of these should return completion even with quotes included
-            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType '"; ExpectedPropertyTypes = $allRegistryValueKinds }
-            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType 'bin"; ExpectedPropertyTypes = $binaryValueKind }
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType '"; ExpectedPropertyTypes = $allRegistryValueKindsWithQuotes }
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType 'bin"; ExpectedPropertyTypes = "'$binaryValueKind'" }
         ) {
             param($TextInput, $ExpectedPropertyTypes)
             $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -933,14 +933,14 @@ ConstructorTestClass(int i, bool b)
 
     Context 'New-ItemProperty -PropertyType parameter completion' {
         BeforeAll {
-            $allRegistryValueKinds = ([Enum]::GetValues([Microsoft.Win32.RegistryValueKind]) | ForEach-Object { $_.ToString() } | Sort-Object -Unique) -join ' '
+            $allRegistryValueKinds = 'Binary DWord ExpandString MultiString None QWord String Unknown'
             $dwordValueKind = 'DWord'
             $qwordValueKind = 'QWord'
             $binaryValueKind = 'Binary'
             $multiStringValueKind = 'MultiString'
         }
 
-        It "Should complete Property Type for '<TextInput>'" -TestCases @(
+        It "Should complete Property Type for '<TextInput>'" -Skip:(!([System.Management.Automation.Platform]::IsWindows)) -TestCases @(
             @{ TextInput = "New-ItemProperty -PropertyType "; ExpectedPropertyTypes = $allRegistryValueKinds }
             @{ TextInput = "New-ItemProperty -PropertyType d"; ExpectedPropertyTypes = $dwordValueKind }
             @{ TextInput = "New-ItemProperty -PropertyType q"; ExpectedPropertyTypes = $qwordValueKind }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -931,6 +931,30 @@ ConstructorTestClass(int i, bool b)
         }
     }
 
+    Context 'New-ItemProperty -PropertyType parameter completion' {
+        BeforeAll {
+            $allRegistryValueKinds = ([Enum]::GetValues([Microsoft.Win32.RegistryValueKind]) | ForEach-Object { $_.ToString() } | Sort-Object -Unique) -join ' '
+            $dwordValueKind = 'DWord'
+            $qwordValueKind = 'QWord'
+            $binaryValueKind = 'Binary'
+            $multiStringValueKind = 'MultiString'
+        }
+
+        It "Should complete Property Type for '<TextInput>'" -TestCases @(
+            @{ TextInput = "New-ItemProperty -PropertyType "; ExpectedPropertyTypes = $allRegistryValueKinds }
+            @{ TextInput = "New-ItemProperty -PropertyType d"; ExpectedPropertyTypes = $dwordValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType q"; ExpectedPropertyTypes = $qwordValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType bin"; ExpectedPropertyTypes = $binaryValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType multi"; ExpectedPropertyTypes = $multiStringValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType invalidproptype"; ExpectedPropertyTypes = '' }
+        ) {
+            param($TextInput, $ExpectedPropertyTypes)
+            $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
+            $completionText = $res.CompletionMatches.CompletionText | Sort-Object -Unique
+            $completionText -join ' ' | Should -BeExactly $ExpectedPropertyTypes
+        }
+    }
+
     Context "Format cmdlet's View paramter completion" {
         BeforeAll {
             $viewDefinition = @'

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -933,25 +933,64 @@ ConstructorTestClass(int i, bool b)
 
     Context 'New-ItemProperty -PropertyType parameter completion' {
         BeforeAll {
-            $allRegistryValueKinds = 'Binary DWord ExpandString MultiString None QWord String Unknown'
-            $dwordValueKind = 'DWord'
-            $qwordValueKind = 'QWord'
-            $binaryValueKind = 'Binary'
-            $multiStringValueKind = 'MultiString'
+            if ($IsWindows) {
+                $allRegistryValueKinds = 'String ExpandString Binary DWord MultiString QWord Unknown'
+                $dwordValueKind = 'DWord'
+                $qwordValueKind = 'QWord'
+                $binaryValueKind = 'Binary'
+                $multiStringValueKind = 'MultiString'
+                $registryPath = "HKCU:\test1\sub"
+                New-Item -Path $registryPath -Force
+                $registryLiteralPath = "HKCU:\test2\*\sub"
+                New-Item -Path $registryLiteralPath -Force
+                $fileSystemPath = "TestDrive:\test1.txt"
+                New-Item -Path $fileSystemPath -Force
+                $fileSystemLiteralPathDir = "TestDrive:\[]"
+                $fileSystemLiteralPath = "$fileSystemLiteralPathDir\test2.txt"
+                New-Item -Path $fileSystemLiteralPath -Force
+            }
         }
 
         It "Should complete Property Type for '<TextInput>'" -Skip:(!$IsWindows) -TestCases @(
-            @{ TextInput = "New-ItemProperty -PropertyType "; ExpectedPropertyTypes = $allRegistryValueKinds }
-            @{ TextInput = "New-ItemProperty -PropertyType d"; ExpectedPropertyTypes = $dwordValueKind }
-            @{ TextInput = "New-ItemProperty -PropertyType q"; ExpectedPropertyTypes = $qwordValueKind }
-            @{ TextInput = "New-ItemProperty -PropertyType bin"; ExpectedPropertyTypes = $binaryValueKind }
-            @{ TextInput = "New-ItemProperty -PropertyType multi"; ExpectedPropertyTypes = $multiStringValueKind }
+            # -Path completions
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType "; ExpectedPropertyTypes = $allRegistryValueKinds }
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType d"; ExpectedPropertyTypes = $dwordValueKind }
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType q"; ExpectedPropertyTypes = $qwordValueKind }
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType bin"; ExpectedPropertyTypes = $binaryValueKind }
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType multi"; ExpectedPropertyTypes = $multiStringValueKind }
+            @{ TextInput = "New-ItemProperty -Path $registryPath -PropertyType invalidproptype"; ExpectedPropertyTypes = '' }
+            @{ TextInput = "New-ItemProperty -Path $fileSystemPath -PropertyType "; ExpectedPropertyTypes = '' }
+
+            # -LiteralPath completions
+            @{ TextInput = "New-ItemProperty -LiteralPath $registryLiteralPath -PropertyType "; ExpectedPropertyTypes = $allRegistryValueKinds }
+            @{ TextInput = "New-ItemProperty -LiteralPath $registryLiteralPath -PropertyType d"; ExpectedPropertyTypes = $dwordValueKind }
+            @{ TextInput = "New-ItemProperty -LiteralPath $registryLiteralPath -PropertyType q"; ExpectedPropertyTypes = $qwordValueKind }
+            @{ TextInput = "New-ItemProperty -LiteralPath $registryLiteralPath -PropertyType bin"; ExpectedPropertyTypes = $binaryValueKind }
+            @{ TextInput = "New-ItemProperty -LiteralPath $registryLiteralPath -PropertyType multi"; ExpectedPropertyTypes = $multiStringValueKind }
+            @{ TextInput = "New-ItemProperty -LiteralPath $registryLiteralPath -PropertyType invalidproptype"; ExpectedPropertyTypes = '' }
+            @{ TextInput = "New-ItemProperty -LiteralPath $fileSystemLiteralPath -PropertyType "; ExpectedPropertyTypes = '' }
+
+            # All of these should return no completion since they don't specify -Path/-LiteralPath
+            @{ TextInput = "New-ItemProperty -PropertyType "; ExpectedPropertyTypes = '' }
+            @{ TextInput = "New-ItemProperty -PropertyType d"; ExpectedPropertyTypes = '' }
+            @{ TextInput = "New-ItemProperty -PropertyType q"; ExpectedPropertyTypes = '' }
+            @{ TextInput = "New-ItemProperty -PropertyType bin"; ExpectedPropertyTypes = '' }
+            @{ TextInput = "New-ItemProperty -PropertyType multi"; ExpectedPropertyTypes = '' }
             @{ TextInput = "New-ItemProperty -PropertyType invalidproptype"; ExpectedPropertyTypes = '' }
         ) {
             param($TextInput, $ExpectedPropertyTypes)
             $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
-            $completionText = $res.CompletionMatches.CompletionText | Sort-Object -Unique
+            $completionText = $res.CompletionMatches.CompletionText
             $completionText -join ' ' | Should -BeExactly $ExpectedPropertyTypes
+        }
+
+        AfterAll {
+            if ($IsWindows) {
+                Remove-Item -Path $registryPath -Force
+                Remove-Item -LiteralPath $registryLiteralPath -Force
+                Remove-Item -Path $fileSystemPath -Force
+                Remove-Item -LiteralPath $fileSystemLiteralPathDir -Recurse -Force
+            }
         }
     }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -988,7 +988,7 @@ ConstructorTestClass(int i, bool b)
             $completionText -join ' ' | Should -BeExactly $ExpectedPropertyTypes
         }
 
-        It "Test fallback to provider of current location if no path specified" {
+        It "Test fallback to provider of current location if no path specified" -Skip:(!$IsWindows) {
             try {
                 Push-Location HKCU:\
                 $textInput = "New-ItemProperty -PropertyType "


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #21116

This PR adds an argument completer for Option 1 described in linked issue.

Add `-PropertyType` argument completer for `New-ItemProperty` command.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Currently you cannot tab complete registry value kinds for `New-ItemProperty -PropertyType`. This PR adds a `PropertyTypeArgumentCompleter` which matches `wordToComplete` against the possible enum values of `RegistryValueKind`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
