### PR TITLE
Option 2 - Change parameter type of `-PropertyType` to `RegistryValueKind`  for `New-ItemProperty`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -114,10 +114,10 @@ namespace Microsoft.PowerShell.Commands
         {
             if (Path != null && Path.Length > 0)
             {
-                return InvokeProvider.Property.NewPropertyDynamicParameters(Path[0], Name, PropertyType.ToString(), Value, context);
+                return InvokeProvider.Property.NewPropertyDynamicParameters(Path[0], Name, PropertyType, Value, context);
             }
 
-            return InvokeProvider.Property.NewPropertyDynamicParameters(".", Name, PropertyType.ToString(), Value, context);
+            return InvokeProvider.Property.NewPropertyDynamicParameters(".", Name, PropertyType, Value, context);
         }
 
         #endregion Parameters
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    InvokeProvider.Property.New(path, Name, PropertyType.ToString(), Value, CmdletProviderContext);
+                    InvokeProvider.Property.New(path, Name, PropertyType, Value, CmdletProviderContext);
                 }
                 catch (PSNotSupportedException notSupported)
                 {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Management.Automation;
+using Microsoft.Win32;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -63,7 +64,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         [Alias("Type")]
-        public string PropertyType { get; set; }
+        public RegistryValueKind PropertyType { get; set; }
 
         /// <summary>
         /// The value of the property to create on the item.
@@ -113,10 +114,10 @@ namespace Microsoft.PowerShell.Commands
         {
             if (Path != null && Path.Length > 0)
             {
-                return InvokeProvider.Property.NewPropertyDynamicParameters(Path[0], Name, PropertyType, Value, context);
+                return InvokeProvider.Property.NewPropertyDynamicParameters(Path[0], Name, PropertyType.ToString(), Value, context);
             }
 
-            return InvokeProvider.Property.NewPropertyDynamicParameters(".", Name, PropertyType, Value, context);
+            return InvokeProvider.Property.NewPropertyDynamicParameters(".", Name, PropertyType.ToString(), Value, context);
         }
 
         #endregion Parameters
@@ -136,7 +137,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    InvokeProvider.Property.New(path, Name, PropertyType, Value, CmdletProviderContext);
+                    InvokeProvider.Property.New(path, Name, PropertyType.ToString(), Value, CmdletProviderContext);
                 }
                 catch (PSNotSupportedException notSupported)
                 {

--- a/src/System.Management.Automation/engine/PropertyCmdletProviderInterfaces.cs
+++ b/src/System.Management.Automation/engine/PropertyCmdletProviderInterfaces.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.ObjectModel;
-
+using Microsoft.Win32;
 using Dbg = System.Management.Automation;
 
 namespace System.Management.Automation
@@ -668,7 +668,7 @@ namespace System.Management.Automation
         /// <param name="propertyName">
         /// The name of the property that should be created.
         /// </param>
-        /// <param name="propertyTypeName">
+        /// <param name="propertyType">
         /// The type of the property that should be created.
         /// </param>
         /// <param name="value">
@@ -701,7 +701,7 @@ namespace System.Management.Automation
         public Collection<PSObject> New(
             string path,
             string propertyName,
-            string propertyTypeName,
+            RegistryValueKind propertyType,
             object value)
         {
             Dbg.Diagnostics.Assert(
@@ -710,7 +710,7 @@ namespace System.Management.Automation
 
             // Parameter validation is done in the session state object
 
-            return _sessionState.NewProperty(new string[] { path }, propertyName, propertyTypeName, value, false, false);
+            return _sessionState.NewProperty(new string[] { path }, propertyName, propertyType, value, false, false);
         }
 
         /// <summary>
@@ -722,7 +722,7 @@ namespace System.Management.Automation
         /// <param name="propertyName">
         /// The name of the property that should be created.
         /// </param>
-        /// <param name="propertyTypeName">
+        /// <param name="propertyType">
         /// The type of the property that should be created.
         /// </param>
         /// <param name="value">
@@ -761,7 +761,7 @@ namespace System.Management.Automation
         public Collection<PSObject> New(
             string[] path,
             string propertyName,
-            string propertyTypeName,
+            RegistryValueKind propertyType,
             object value,
             bool force,
             bool literalPath)
@@ -772,7 +772,7 @@ namespace System.Management.Automation
 
             // Parameter validation is done in the session state object
 
-            return _sessionState.NewProperty(path, propertyName, propertyTypeName, value, force, literalPath);
+            return _sessionState.NewProperty(path, propertyName, propertyType, value, force, literalPath);
         }
 
         /// <summary>
@@ -821,7 +821,7 @@ namespace System.Management.Automation
         internal void New(
             string path,
             string propertyName,
-            string type,
+            RegistryValueKind type,
             object value,
             CmdletProviderContext context)
         {
@@ -876,7 +876,7 @@ namespace System.Management.Automation
         internal object NewPropertyDynamicParameters(
             string path,
             string propertyName,
-            string type,
+            RegistryValueKind type,
             object value,
             CmdletProviderContext context)
         {

--- a/src/System.Management.Automation/engine/SessionStateDynamicProperty.cs
+++ b/src/System.Management.Automation/engine/SessionStateDynamicProperty.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.ObjectModel;
 using System.Management.Automation.Provider;
-
+using Microsoft.Win32;
 using Dbg = System.Management.Automation;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
@@ -63,7 +63,7 @@ namespace System.Management.Automation
         internal Collection<PSObject> NewProperty(
             string[] paths,
             string property,
-            string type,
+            RegistryValueKind type,
             object value,
             bool force,
             bool literalPath)
@@ -135,7 +135,7 @@ namespace System.Management.Automation
         internal void NewProperty(
             string[] paths,
             string property,
-            string type,
+            RegistryValueKind type,
             object value,
             CmdletProviderContext context)
         {
@@ -208,7 +208,7 @@ namespace System.Management.Automation
             CmdletProvider providerInstance,
             string path,
             string property,
-            string type,
+            RegistryValueKind type,
             object value,
             CmdletProviderContext context)
         {
@@ -302,7 +302,7 @@ namespace System.Management.Automation
         internal object NewPropertyDynamicParameters(
              string path,
             string propertyName,
-            string type,
+            RegistryValueKind type,
             object value,
             CmdletProviderContext context)
         {
@@ -377,7 +377,7 @@ namespace System.Management.Automation
             CmdletProvider providerInstance,
             string path,
             string propertyName,
-            string type,
+            RegistryValueKind type,
             object value,
             CmdletProviderContext context)
         {

--- a/src/System.Management.Automation/namespaces/IDynamicPropertyProvider.cs
+++ b/src/System.Management.Automation/namespaces/IDynamicPropertyProvider.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #nullable enable
+using Microsoft.Win32;
+
 namespace System.Management.Automation.Provider
 {
     #region IDynamicPropertyCmdletProvider
@@ -36,7 +38,7 @@ namespace System.Management.Automation.Provider
         /// <param name="propertyName">
         /// The name of the property that should be created.
         /// </param>
-        /// <param name="propertyTypeName">
+        /// <param name="propertyType">
         /// The type of the property that should be created.
         /// </param>
         /// <param name="value">
@@ -60,7 +62,7 @@ namespace System.Management.Automation.Provider
         void NewProperty(
             string path,
             string propertyName,
-            string propertyTypeName,
+            RegistryValueKind propertyType,
             object? value);
 
         /// <summary>
@@ -74,7 +76,7 @@ namespace System.Management.Automation.Provider
         /// <param name="propertyName">
         /// The name of the property that should be created.
         /// </param>
-        /// <param name="propertyTypeName">
+        /// <param name="propertyType">
         /// The type of the property that should be created.
         /// </param>
         /// <param name="value">
@@ -90,7 +92,7 @@ namespace System.Management.Automation.Provider
         object? NewPropertyDynamicParameters(
             string path,
             string propertyName,
-            string propertyTypeName,
+            RegistryValueKind propertyType,
             object? value);
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/ProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBase.cs
@@ -12,6 +12,7 @@ using System.Management.Automation.Host;
 using System.Resources;
 using System.Diagnostics.CodeAnalysis; // for fxcop
 using System.Security.AccessControl;
+using Microsoft.Win32;
 
 namespace System.Management.Automation.Provider
 {
@@ -457,7 +458,7 @@ namespace System.Management.Automation.Provider
         /// <param name="propertyName">
         /// The name of the property that should be created.
         /// </param>
-        /// <param name="propertyTypeName">
+        /// <param name="propertyType">
         /// The type of the property that should be created.
         /// </param>
         /// <param name="value">
@@ -473,7 +474,7 @@ namespace System.Management.Automation.Provider
         internal void NewProperty(
             string path,
             string propertyName,
-            string propertyTypeName,
+            RegistryValueKind propertyType,
             object value,
             CmdletProviderContext cmdletProviderContext)
         {
@@ -488,7 +489,7 @@ namespace System.Management.Automation.Provider
 
             // Call interface method
 
-            propertyProvider.NewProperty(path, propertyName, propertyTypeName, value);
+            propertyProvider.NewProperty(path, propertyName, propertyType, value);
         }
 
         /// <summary>
@@ -502,7 +503,7 @@ namespace System.Management.Automation.Provider
         /// <param name="propertyName">
         /// The name of the property that should be created.
         /// </param>
-        /// <param name="propertyTypeName">
+        /// <param name="propertyType">
         /// The type of the property that should be created.
         /// </param>
         /// <param name="value">
@@ -518,7 +519,7 @@ namespace System.Management.Automation.Provider
         internal object NewPropertyDynamicParameters(
             string path,
             string propertyName,
-            string propertyTypeName,
+            RegistryValueKind propertyType,
             object value,
             CmdletProviderContext cmdletProviderContext)
         {
@@ -529,7 +530,7 @@ namespace System.Management.Automation.Provider
                 return null;
             }
 
-            return propertyProvider.NewPropertyDynamicParameters(path, propertyName, propertyTypeName, value);
+            return propertyProvider.NewPropertyDynamicParameters(path, propertyName, propertyType, value);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/RegistryProvider.cs
+++ b/src/System.Management.Automation/namespaces/RegistryProvider.cs
@@ -2121,7 +2121,7 @@ namespace Microsoft.PowerShell.Commands
         public void NewProperty(
             string path,
             string propertyName,
-            string type,
+            RegistryValueKind type,
             object value)
         {
             if (path == null)
@@ -2156,14 +2156,6 @@ namespace Microsoft.PowerShell.Commands
 
             if (ShouldProcess(resource, action))
             {
-                // convert the type to a RegistryValueKind
-                RegistryValueKind kind;
-                if (!ParseKind(type, out kind))
-                {
-                    key.Close();
-                    return;
-                }
-
                 try
                 {
                     // Check to see if the property already exists
@@ -2171,7 +2163,7 @@ namespace Microsoft.PowerShell.Commands
                     if (Force || key.GetValue(propertyName) == null)
                     {
                         // Create the value
-                        SetRegistryValue(key, propertyName, value, kind, path);
+                        SetRegistryValue(key, propertyName, value, type, path);
                     }
                     else
                     {
@@ -2725,7 +2717,7 @@ namespace Microsoft.PowerShell.Commands
         public object NewPropertyDynamicParameters(
             string path,
             string propertyName,
-            string type,
+            RegistryValueKind type,
             object value)
         {
             return null;

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -911,6 +911,30 @@ ConstructorTestClass(int i, bool b)
         }
     }
 
+    Context 'New-ItemProperty -PropertyType parameter completion' {
+        BeforeAll {
+            $allRegistryValueKinds = 'Binary DWord ExpandString MultiString None QWord String Unknown'
+            $dwordValueKind = 'DWord'
+            $qwordValueKind = 'QWord'
+            $binaryValueKind = 'Binary'
+            $multiStringValueKind = 'MultiString'
+        }
+
+        It "Should complete Property Type for '<TextInput>'" -Skip:(!$IsWindows) -TestCases @(
+            @{ TextInput = "New-ItemProperty -PropertyType "; ExpectedPropertyTypes = $allRegistryValueKinds }
+            @{ TextInput = "New-ItemProperty -PropertyType d"; ExpectedPropertyTypes = $dwordValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType q"; ExpectedPropertyTypes = $qwordValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType bin"; ExpectedPropertyTypes = $binaryValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType multi"; ExpectedPropertyTypes = $multiStringValueKind }
+            @{ TextInput = "New-ItemProperty -PropertyType invalidproptype"; ExpectedPropertyTypes = '' }
+        ) {
+            param($TextInput, $ExpectedPropertyTypes)
+            $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
+            $completionText = $res.CompletionMatches.CompletionText | Sort-Object -Unique
+            $completionText -join ' ' | Should -BeExactly $ExpectedPropertyTypes
+        }
+    }
+
     Context "Format cmdlet's View paramter completion" {
         BeforeAll {
             $viewDefinition = @'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #21116

This PR contains the code changes required for Option 2 described in linked issue.

Changed parameter type of `-PropertyType` to `RegistryValueKind`  for `New-ItemProperty` command.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

This type change enables tab completion automatically on this parameter, instead having to create an argument completer, like in Option 1 implementation #21117.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
