### PR TITLE
PowerShell: Use correct command in examples for AddScript xml doc

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -948,7 +948,9 @@ namespace System.Management.Automation
         /// Add a cmdlet to construct a command pipeline.
         /// For example, to construct a command string "get-process | sort-object",
         ///     <code>
-        ///         PowerShell shell = PowerShell.Create("get-process").AddCommand("sort-object");
+        ///         PowerShell shell = PowerShell.Create()
+        ///             .AddCommand("get-process")
+        ///             .AddCommand("sort-object");
         ///     </code>
         /// </summary>
         /// <param name="cmdlet">
@@ -986,7 +988,9 @@ namespace System.Management.Automation
         /// Add a cmdlet to construct a command pipeline.
         /// For example, to construct a command string "get-process | sort-object",
         ///     <code>
-        ///         PowerShell shell = PowerShell.Create("get-process").AddCommand("sort-object");
+        ///         PowerShell shell = PowerShell.Create()
+        ///             .AddCommand("get-process", true)
+        ///             .AddCommand("sort-object", true);
         ///     </code>
         /// </summary>
         /// <param name="cmdlet">
@@ -1027,8 +1031,8 @@ namespace System.Management.Automation
         /// Add a piece of script to construct a command pipeline.
         /// For example, to construct a command string "get-process | foreach { $_.Name }"
         ///     <code>
-        ///         PowerShell shell = PowerShell.Create("get-process").
-        ///                                     AddScript("foreach { $_.Name }");
+        ///         PowerShell shell = PowerShell.Create()
+        ///             .AddScript("get-process | foreach { $_.Name }");
         ///     </code>
         /// </summary>
         /// <param name="script">
@@ -1066,8 +1070,8 @@ namespace System.Management.Automation
         /// Add a piece of script to construct a command pipeline.
         /// For example, to construct a command string "get-process | foreach { $_.Name }"
         ///     <code>
-        ///         PowerShell shell = PowerShell.Create("get-process").
-        ///                                     AddScript("foreach { $_.Name }", true);
+        ///         PowerShell shell = PowerShell.Create()
+        ///             .AddScript("get-process | foreach { $_.Name }", true);
         ///     </code>
         /// </summary>
         /// <param name="script">
@@ -1175,8 +1179,9 @@ namespace System.Management.Automation
         /// Add a parameter to the last added command.
         /// For example, to construct a command string "get-process | select-object -property name"
         ///     <code>
-        ///         PowerShell shell = PowerShell.Create("get-process").
-        ///                                     AddCommand("select-object").AddParameter("property","name");
+        ///         PowerShell shell = PowerShell.Create()
+        ///             .AddCommand("get-process")
+        ///             .AddCommand("select-object").AddParameter("property", "name");
         ///     </code>
         /// </summary>
         /// <param name="parameterName">
@@ -1380,8 +1385,9 @@ namespace System.Management.Automation
         /// Adds an argument to the last added command.
         /// For example, to construct a command string "get-process | select-object name"
         ///     <code>
-        ///         PowerShell shell = PowerShell.Create("get-process").
-        ///                                     AddCommand("select-object").AddParameter("name");
+        ///         PowerShell shell = PowerShell.Create()
+        ///             .AddCommand("get-process")
+        ///             .AddCommand("select-object").AddArgument("name");
         ///     </code>
         /// This will add the value "name" to the positional parameter list of "select-object"
         /// cmdlet. When the command is invoked, this value will get bound to positional parameter 0

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -1028,7 +1028,7 @@ namespace System.Management.Automation
         /// For example, to construct a command string "get-process | foreach { $_.Name }"
         ///     <code>
         ///         PowerShell shell = PowerShell.Create("get-process").
-        ///                                     AddCommand("foreach { $_.Name }", true);
+        ///                                     AddScript("foreach { $_.Name }");
         ///     </code>
         /// </summary>
         /// <param name="script">
@@ -1067,7 +1067,7 @@ namespace System.Management.Automation
         /// For example, to construct a command string "get-process | foreach { $_.Name }"
         ///     <code>
         ///         PowerShell shell = PowerShell.Create("get-process").
-        ///                                     AddCommand("foreach { $_.Name }", true);
+        ///                                     AddScript("foreach { $_.Name }", true);
         ///     </code>
         /// </summary>
         /// <param name="script">


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

PowerShell.AddScript's xml doc was using AddCommand in its example (probably a copy-paste mistake). One overload was also using a parameter only defined for the other overload.

## PR Context

I'm hosting PowerShell with the pythonnet library in a custom Robot Framework library, and noticed the example was wrong.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
