### PR TITLE
Stop replacing variables in path tab completion

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -984,7 +984,7 @@ namespace System.Management.Automation
                             }
                         }
                     }
-                    }
+                }
                 else if (expressionAst.Parent is ArrayLiteralAst && expressionAst.Parent.Parent is CommandAst)
                 {
                     commandAst = (CommandAst)expressionAst.Parent.Parent;
@@ -4405,6 +4405,10 @@ namespace System.Management.Automation
             @"(^Microsoft\.PowerShell\.Core\\FileSystem::|^FileSystem::|^)(?:\\\\|//)(?![.|?])([^\\/]+)(?:\\|/)([^\\/]*)$",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        /// <summary>
+        /// Contains the value of an expression + script text of the expression itself.
+        /// Used by the File path completion code to store nested expressions in expandable strings so the variables can be reinserted into the completion text.
+        /// </summary>
         internal sealed class ExpressionValue
         {
             internal string expression;

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1443,6 +1443,19 @@ class InheritedClassTest : System.Attribute
         }
     }
 
+    It 'Should be able to use subexpressions in path completion' {
+        $TempDir = Join-Path $TestDrive "FileCompletionTest\$($PSVersionTable.PSEdition)\Test"
+        $null = New-Item -Path $TempDir -Force -ItemType Directory
+        $InputText = $TempDir.Replace($PSVersionTable.PSEdition, '$($PSVersionTable.PSEdition)')
+        $Res = TabExpansion2 -inputScript $InputText
+        $Res.CompletionMatches[0].CompletionText | Should -BeLike "*$InputText*"
+    }
+
+    It 'Should add quotes and ampersand to command expression with variable' {
+        $Res = TabExpansion2 -inputScript '$PSHOME\pwsh'
+        $Res.CompletionMatches[0].CompletionText | Should -BeLike "& `"`$PSHOME*`""
+    }
+
     It 'Should correct slashes in UNC path completion' -Skip:(!$IsWindows) {
         $Res = TabExpansion2 -inputScript 'Get-ChildItem //localhost/c$/Windows'
         $Res.CompletionMatches[0].CompletionText | Should -Be "\\localhost\c$\Windows"

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1246,7 +1246,7 @@ class InheritedClassTest : System.Attribute
                 @{ inputStr = "bbbbbbb"; name = "bbbbbbb}"; localExpected = "& '.${separator}bbbbbbb}'"; oneSubExpected = "& '..${separator}bbbbbbb}'"; twoSubExpected = "& '..${separator}..${separator}bbbbbbb}'" }
                 @{ inputStr = "bbbbbb"; name = "bbbbbb("; localExpected = "& '.${separator}bbbbbb('"; oneSubExpected = "& '..${separator}bbbbbb('"; twoSubExpected = "& '..${separator}..${separator}bbbbbb('" }
                 @{ inputStr = "bbbbb"; name = "bbbbb)"; localExpected = "& '.${separator}bbbbb)'"; oneSubExpected = "& '..${separator}bbbbb)'"; twoSubExpected = "& '..${separator}..${separator}bbbbb)'" }
-                @{ inputStr = "bbbb"; name = "bbbb$"; localExpected = "& '.${separator}bbbb$'"; oneSubExpected = "& '..${separator}bbbb$'"; twoSubExpected = "& '..${separator}..${separator}bbbb$'" }
+                @{ inputStr = "bbbb"; name = "bbbb$"; localExpected = ".${separator}bbbb$"; oneSubExpected = "..${separator}bbbb$"; twoSubExpected = "..${separator}..${separator}bbbb$" }
                 @{ inputStr = "bbb"; name = "bbb'"; localExpected = "& '.${separator}bbb'''"; oneSubExpected = "& '..${separator}bbb'''"; twoSubExpected = "& '..${separator}..${separator}bbb'''" }
                 @{ inputStr = "bb"; name = "bb,"; localExpected = "& '.${separator}bb,'"; oneSubExpected = "& '..${separator}bb,'"; twoSubExpected = "& '..${separator}..${separator}bb,'" }
                 @{ inputStr = "b"; name = "b;"; localExpected = "& '.${separator}b;'"; oneSubExpected = "& '..${separator}b;'"; twoSubExpected = "& '..${separator}..${separator}b;'" }
@@ -1390,7 +1390,7 @@ class InheritedClassTest : System.Attribute
 
             $res = TabExpansion2 -ast $scriptAst -tokens $tokens -positionOfCursor $cursorPosition
             $res.CompletionMatches | Should -HaveCount 1
-            $expectedPath = Join-Path $PSScriptRoot -ChildPath BugFix.Tests.ps1
+            $expectedPath = Join-Path '$PSScriptRoot' -ChildPath BugFix.Tests.ps1
             $res.CompletionMatches[0].CompletionText | Should -Be "`"$expectedPath`""
         }
 
@@ -1415,9 +1415,9 @@ class InheritedClassTest : System.Attribute
             @{LiteralPath = 'BacktickTest[';   BacktickSingle = 1; BacktickDouble = 2;  LiteralBacktickSingle = 0; LiteralBacktickDouble = 0}
             @{LiteralPath = 'BacktickTest`[';  BacktickSingle = 3; BacktickDouble = 6;  LiteralBacktickSingle = 1; LiteralBacktickDouble = 2}
             @{LiteralPath = 'BacktickTest``['; BacktickSingle = 5; BacktickDouble = 10; LiteralBacktickSingle = 2; LiteralBacktickDouble = 4}
-            @{LiteralPath = 'BacktickTest$';   BacktickSingle = 0; BacktickDouble = 1;  LiteralBacktickSingle = 0; LiteralBacktickDouble = 1}
-            @{LiteralPath = 'BacktickTest`$';  BacktickSingle = 2; BacktickDouble = 3;  LiteralBacktickSingle = 1; LiteralBacktickDouble = 3}
-            @{LiteralPath = 'BacktickTest``$'; BacktickSingle = 4; BacktickDouble = 7;  LiteralBacktickSingle = 2; LiteralBacktickDouble = 5}
+            @{LiteralPath = 'BacktickTest$A';   BacktickSingle = 0; BacktickDouble = 1;  LiteralBacktickSingle = 0; LiteralBacktickDouble = 1}
+            @{LiteralPath = 'BacktickTest`$A';  BacktickSingle = 2; BacktickDouble = 3;  LiteralBacktickSingle = 1; LiteralBacktickDouble = 3}
+            @{LiteralPath = 'BacktickTest``$A'; BacktickSingle = 4; BacktickDouble = 7;  LiteralBacktickSingle = 2; LiteralBacktickDouble = 5}
         ) {
             param($LiteralPath, $BacktickSingle, $BacktickDouble, $LiteralBacktickSingle, $LiteralBacktickDouble)
             $NewPath = Join-Path -Path $TestDrive -ChildPath $LiteralPath
@@ -1445,7 +1445,7 @@ class InheritedClassTest : System.Attribute
 
     It 'Should correct slashes in UNC path completion' -Skip:(!$IsWindows) {
         $Res = TabExpansion2 -inputScript 'Get-ChildItem //localhost/c$/Windows'
-        $Res.CompletionMatches[0].CompletionText | Should -Be "'\\localhost\c$\Windows'"
+        $Res.CompletionMatches[0].CompletionText | Should -Be "\\localhost\c$\Windows"
     }
 
     It 'Should keep custom drive names when completing file paths' {
@@ -1582,12 +1582,9 @@ class InheritedClassTest : System.Attribute
                 @{ inputStr = '$global:max'; expected = '$global:MaximumHistoryCount'; setup = $null }
                 @{ inputStr = '$PSMod'; expected = '$PSModuleAutoLoadingPreference'; setup = $null }
                 ## tab completion for variable in path
-                ## if $PSHOME contains a space tabcompletion adds ' around the path
-                @{ inputStr = 'cd $PSHOME\Modu'; expected = if($PSHOME.Contains(' ')) { "'$(Join-Path $PSHOME 'Modules')'" } else { Join-Path $PSHOME 'Modules' }; setup = $null }
-                @{ inputStr = 'cd "$PSHOME\Modu"'; expected = "`"$(Join-Path $PSHOME 'Modules')`""; setup = $null }
-                @{ inputStr = '$PSHOME\System.Management.Au'; expected = if($PSHOME.Contains(' ')) { "`& '$(Join-Path $PSHOME 'System.Management.Automation.dll')'" }  else { Join-Path $PSHOME 'System.Management.Automation.dll'}; Setup = $null }
-                @{ inputStr = '"$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
-                @{ inputStr = '& "$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
+                @{ inputStr = 'cd "$PSHOME\Modu"'; expected = "`"$(Join-Path '$PSHOME' 'Modules')`""; setup = $null }
+                @{ inputStr = '"$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path '$PSHOME' 'System.Management.Automation.dll')`""; setup = $null }
+                @{ inputStr = '& "$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path '$PSHOME' 'System.Management.Automation.dll')`""; setup = $null }
                 ## tab completion AST-based tests
                 @{ inputStr = 'get-date | ForEach-Object { $PSItem.h'; expected = 'Hour'; setup = $null }
                 @{ inputStr = '$a=gps;$a[0].h'; expected = 'Handle'; setup = $null }
@@ -1615,7 +1612,7 @@ class InheritedClassTest : System.Attribute
 
         It "Tab completion UNC path" -Skip:(!$IsWindows) {
             $beforeTab = "\\localhost\ADMIN$\boo"
-            $afterTab = "& '\\localhost\ADMIN$\Boot'"
+            $afterTab = "\\localhost\ADMIN$\Boot"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
             $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Improves tab completion so variables don't get replaced when tab completing paths, for example: `ls $env:windir\System3<Tab>` will tab complete to: `ls $env:windir\System32` instead of `ls C:\Windows\System32`.  
The way it works is that the variables are resolved, and the resulting string is used to find valid path completions, then the variable text is inserted back into the discovered paths. Because of this implementation it's not perfect, you can trick it to insert the variable into the wrong place, for example:
```
$Var = "C"
ls C:\Windows\System32\${Var}onfi<Tab>
```
turns into `${Var}:\Windows\System32\config\` instead of the expected: `C:\Windows\System32\${Var}onfig\`
in practice it shouldn't be an issue because people usually use variables to define the root of a path, or to define entire path segments with more unique names.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/5350
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
