### PR TITLE
Fix `Resolve-Path -Relative` with path starting with period

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -223,7 +223,8 @@ namespace Microsoft.PowerShell.Commands
                             // Do not insert './' if result path is not relative
                             if (!adjustedPath.StartsWith(
                                     currentPath.Drive?.Root ?? currentPath.Path, StringComparison.OrdinalIgnoreCase) &&
-                                !adjustedPath.StartsWith("." + currentPath.Provider.ItemSeparator, StringComparison.OrdinalIgnoreCase))
+                                !adjustedPath.StartsWith("." + currentPath.Provider.ItemSeparator, StringComparison.OrdinalIgnoreCase) &&
+                                !adjustedPath.StartsWith(".." + currentPath.Provider.ItemSeparator, StringComparison.OrdinalIgnoreCase))
                             {
                                 adjustedPath = SessionState.Path.Combine(".", adjustedPath);
                             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -221,8 +221,7 @@ namespace Microsoft.PowerShell.Commands
                             string adjustedPath = SessionState.Path.NormalizeRelativePath(currentPath.Path, _relativeBasePath);
 
                             // Do not insert './' if result path is not relative
-                            if (!adjustedPath.StartsWith(
-                                    currentPath.Drive?.Root ?? currentPath.Path, StringComparison.OrdinalIgnoreCase) &&
+                            if (!adjustedPath.StartsWith(currentPath.Drive?.Root ?? currentPath.Path, StringComparison.OrdinalIgnoreCase) &&
                                 !adjustedPath.StartsWith("." + currentPath.Provider.ItemSeparator, StringComparison.OrdinalIgnoreCase) &&
                                 !adjustedPath.StartsWith(".." + currentPath.Provider.ItemSeparator, StringComparison.OrdinalIgnoreCase))
                             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         public string RelativeBasePath
-        { 
+        {
             get
             {
                 return _relativeBasePath;
@@ -223,7 +223,7 @@ namespace Microsoft.PowerShell.Commands
                             // Do not insert './' if result path is not relative
                             if (!adjustedPath.StartsWith(
                                     currentPath.Drive?.Root ?? currentPath.Path, StringComparison.OrdinalIgnoreCase) &&
-                                !adjustedPath.StartsWith('.'))
+                                !adjustedPath.StartsWith("." + currentPath.Provider.ItemSeparator, StringComparison.OrdinalIgnoreCase))
                             {
                                 adjustedPath = SessionState.Path.Combine(".", adjustedPath);
                             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         }
     ) -Test {
         param($Path, $BasePath, $Expected, $CD)
-        
+
         if ($null -eq $Expected)
         {
             {Resolve-Path -Path $Path -RelativeBasePath $BasePath -ErrorAction Stop} | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
@@ -112,6 +112,19 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
                     Set-Location $OldLocation
                 }
             }
+        }
+    }
+
+    It 'returns filenames starting with period correctly' {
+        $testFile = Join-Path $TestDrive ".testfile"
+        $null = New-Item -Path $testFile -ItemType File -Force
+        try {
+            Push-Location $TestDrive
+            $result = Resolve-Path -Path ".testfile" -Relative
+            $result | Should -BeExactly (Join-Path '.' '.testfile')
+        }
+        finally {
+            Pop-Location
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -127,4 +127,19 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             Pop-Location
         }
     }
+
+    It 'does not return path containing both current and parent directory' {
+        $testDir = Join-Path $TestDrive "testDir"
+        $null = New-Item -Path $testDir -ItemType Directory -Force
+        $testFile = Join-Path $testDrive "testfile"
+        $null = New-Item -Path $testFile -ItemType File -Force
+        try {
+            Push-Location $testDir
+            $result = Resolve-Path -Path "..\testfile" -Relative
+            $result | Should -BeExactly (Join-Path '..' 'testfile')
+        }
+        finally {
+            Pop-Location
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Original code has a check if the resolved path for local location already started with a period to determine if it should add `./` in front.  However, this meant that files/folders that start with a period didn't get returned as relative.  The change is to check if the resolved path starts with a period and directory separator.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/21144

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
