### PR TITLE
Validate the value for `using namespace` during semantic checks to prevent declaring invalid namespaces

### DIFF
--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 
 using Microsoft.PowerShell;
 using System.Management.Automation.Security;
@@ -17,7 +18,7 @@ using Microsoft.PowerShell.DesiredStateConfiguration.Internal;
 
 namespace System.Management.Automation.Language
 {
-    internal sealed class SemanticChecks : AstVisitor2, IAstPostVisitHandler
+    internal sealed partial class SemanticChecks : AstVisitor2, IAstPostVisitHandler
     {
         private readonly Parser _parser;
 
@@ -1319,19 +1320,50 @@ namespace System.Management.Automation.Language
 
         public override AstVisitAction VisitUsingStatement(UsingStatementAst usingStatementAst)
         {
-            bool usingKindSupported = usingStatementAst.UsingStatementKind == UsingStatementKind.Namespace ||
-                                      usingStatementAst.UsingStatementKind == UsingStatementKind.Assembly ||
-                                      usingStatementAst.UsingStatementKind == UsingStatementKind.Module;
-            if (!usingKindSupported ||
-                usingStatementAst.Alias != null)
+            UsingStatementKind kind = usingStatementAst.UsingStatementKind;
+            bool usingKindSupported = kind is UsingStatementKind.Namespace or UsingStatementKind.Assembly or UsingStatementKind.Module;
+            if (!usingKindSupported || usingStatementAst.Alias != null)
             {
-                _parser.ReportError(usingStatementAst.Extent,
+                _parser.ReportError(
+                    usingStatementAst.Extent,
                     nameof(ParserStrings.UsingStatementNotSupported),
                     ParserStrings.UsingStatementNotSupported);
             }
 
+            if (kind is UsingStatementKind.Namespace)
+            {
+                Regex nsPattern = NamespacePattern();
+                string name = usingStatementAst.Name.Value;
+                if (!nsPattern.IsMatch(usingStatementAst.Name.Value))
+                {
+                    _parser.ReportError(
+                        usingStatementAst.Extent,
+                        nameof(ParserStrings.InvalidNamespaceValue),
+                        ParserStrings.InvalidNamespaceValue);
+                }
+            }
+
             return AstVisitAction.Continue;
         }
+
+        /// <summary>
+        /// This regular expression is for validating if a namespace string is valid.
+        ///
+        /// In C#, a legit namespace is defined as `identifier ('.' identifier)*` [see https://learn.microsoft.com/dotnet/csharp/language-reference/language-specification/namespaces#143-namespace-declarations].
+        /// And `identifier` is defined in https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/identifier-names#naming-rules, summarized below:
+        ///   - Identifiers must start with a letter or underscore (_).
+        ///   - Identifiers can contain
+        ///     * Unicode letter characters (categories: Lu, Ll, Lt, Lm, Lo or Nl);
+        ///     * decimal digit characters (category: Nd);
+        ///     * Unicode connecting characters (category: Pc);
+        ///     * Unicode combining characters (categories: Mn, Mc);
+        ///     * Unicode formatting characters (category: Cf).
+        ///
+        /// For details about how Unicode categories are represented in regular expression, see the "Unicode Categories" section in the following article:
+        ///   - https://www.regular-expressions.info/unicode.html
+        /// </summary>
+        [GeneratedRegex(@"^[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Pc}\p{Mn}\p{Mc}\p{Cf}_]*(?:\.[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Pc}\p{Mn}\p{Mc}\p{Cf}_]*)*$")]
+        private static partial Regex NamespacePattern();
 
         public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst)
         {

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1333,7 +1333,6 @@ namespace System.Management.Automation.Language
             if (kind is UsingStatementKind.Namespace)
             {
                 Regex nsPattern = NamespacePattern();
-                string name = usingStatementAst.Name.Value;
                 if (!nsPattern.IsMatch(usingStatementAst.Name.Value))
                 {
                     _parser.ReportError(

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1336,7 +1336,7 @@ namespace System.Management.Automation.Language
                 if (!nsPattern.IsMatch(usingStatementAst.Name.Value))
                 {
                     _parser.ReportError(
-                        usingStatementAst.Extent,
+                        usingStatementAst.Name.Extent,
                         nameof(ParserStrings.InvalidNamespaceValue),
                         ParserStrings.InvalidNamespaceValue);
                 }

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1229,6 +1229,9 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="UsingStatementNotSupported" xml:space="preserve">
     <value>This syntax of the 'using' statement is not supported.</value>
   </data>
+  <data name="InvalidNamespaceValue" xml:space="preserve">
+    <value>The specified namespace in the 'using' statement contains invalid characters.</value>
+  </data>
   <data name="InformationStream" xml:space="preserve">
     <value>information stream</value>
   </data>

--- a/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
+++ b/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
@@ -131,7 +131,7 @@ Describe "Using Namespace" -Tags "CI" {
     ShouldBeParseError "using namespace ''" InvalidNamespaceValue 16
     ShouldBeParseError "using namespace [System]" InvalidNamespaceValue 16
     ShouldBeParseError "using namespace ',System'" InvalidNamespaceValue 16
-    ShouldBeParseError "using namespace ]System" InvalidNamespaceValue 16
+    ShouldBeParseError "using namespace ']System'" InvalidNamespaceValue 16
     # TODO: add diagnostic (low pri)
     # ShouldBeParseError "using namespace System; using namespace System" UsingNamespaceAlreadySpecified 24
 }

--- a/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
+++ b/test/powershell/Language/Parser/UsingNamespace.Tests.ps1
@@ -128,7 +128,10 @@ Describe "Using Namespace" -Tags "CI" {
 
     ShouldBeParseError "1; using namespace System" UsingMustBeAtStartOfScript 3
     ShouldBeParseError "using namespace Foo = System" UsingStatementNotSupported 0
+    ShouldBeParseError "using namespace ''" InvalidNamespaceValue 16
+    ShouldBeParseError "using namespace [System]" InvalidNamespaceValue 16
+    ShouldBeParseError "using namespace ',System'" InvalidNamespaceValue 16
+    ShouldBeParseError "using namespace ]System" InvalidNamespaceValue 16
     # TODO: add diagnostic (low pri)
     # ShouldBeParseError "using namespace System; using namespace System" UsingNamespaceAlreadySpecified 24
 }
-


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/17113
Validate the value for `using namespace` during semantic checks to prevent declaring invalid namespaces.

This PR is to supersede #19134. Thanks @MartinGC94 and @iSazonov for the initial investigation of the regular expression used to validate the namespace values!

I think the right place for doing the check should be in `SemanticChecks`, so that the AST generated from `using` statement is unchanged, so there is no need to make changes to tab completion code.

**_Parsing error thrown at the semantic check stage_**

![image](https://github.com/PowerShell/PowerShell/assets/127450/eadae5f4-3268-4b27-99b1-314fbf99354c)

**_AST is unchanged from the parsing_**

![image](https://github.com/PowerShell/PowerShell/assets/127450/a8eaf62d-e8d7-464c-bea7-09d210989b15)

About @JamesWTruher's concern expressed in https://github.com/PowerShell/PowerShell/pull/19134#issuecomment-1548708709, the relevant code is as follows.
The variable `typeName` is of the type `TypeName`, so `typeName.Name` must be a valid type name. Therefore, as long as `ns`, the namespace value, is valid, the `newTypeNameToSearch` should be valid. By preventing the declaration of any invalid namespace names, we can guarantee `new TypeName(...)` won't throw here, so I think we don't need to make any changes here.

https://github.com/PowerShell/PowerShell/blob/4f02a89906a92f684ff4511ae74958f602edf800/src/System.Management.Automation/engine/parser/TypeResolver.cs#L396-L399

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
