### PR TITLE
Enable CA1868: Unnecessary call to 'Contains' for sets

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -510,6 +510,10 @@ dotnet_diagnostic.CA1846.severity = warning
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
 dotnet_diagnostic.CA1847.severity = warning
 
+# CA1868: Unnecessary call to 'Contains' for sets
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1868
+dotnet_diagnostic.CA1868.severity = warning
+
 # CA2000: Dispose objects before losing scope
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
 dotnet_diagnostic.CA2000.severity = none

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -535,9 +535,8 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             {
                 if (this.curCimSessionsById.ContainsKey(id))
                 {
-                    if (!sessionIds.Contains(id))
+                    if (sessionIds.Add(id))
                     {
-                        sessionIds.Add(id);
                         sessions.Add(this.curCimSessionsById[id].GetPSObject());
                     }
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-SddlString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-SddlString.cs
@@ -81,9 +81,8 @@ namespace Microsoft.PowerShell.Commands
                 foreach (string memberName in Enum.GetNames(accessRightType))
                 {
                     int memberValue = (int)Enum.Parse(accessRightType, memberName);
-                    if (!foundAccessRightValues.Contains(memberValue))
+                    if (foundAccessRightValues.Add(memberValue))
                     {
-                        foundAccessRightValues.Add(memberValue);
                         if ((accessMask & memberValue) == memberValue)
                         {
                             foundAccessRightNames.Add(memberName);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1419,11 +1419,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         if (!string.IsNullOrEmpty(currentHeader))
                         {
-                            if (!headers.Contains(currentHeader))
-                            {
-                                headers.Add(currentHeader);
-                            }
-                            else
+                            if (!headers.Add(currentHeader))
                             {
                                 // throw a terminating error as there are duplicate headers in the input.
                                 string memberAlreadyPresentMsg =

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -792,9 +792,8 @@ namespace Microsoft.PowerShell.Commands
 
                     if (ShouldProcess(formattedTarget, action))
                     {
-                        if (!fullFileNameHash.Contains(resolvedPath))
+                        if (fullFileNameHash.Add(resolvedPath))
                         {
-                            fullFileNameHash.Add(resolvedPath);
                             newTypes.Add(new SessionStateTypeEntry(prependPathTotal[i]));
                         }
                     }
@@ -806,9 +805,8 @@ namespace Microsoft.PowerShell.Commands
                     if (entry.FileName != null)
                     {
                         string resolvedPath = ModuleCmdletBase.ResolveRootedFilePath(entry.FileName, Context) ?? entry.FileName;
-                        if (!fullFileNameHash.Contains(resolvedPath))
+                        if (fullFileNameHash.Add(resolvedPath))
                         {
-                            fullFileNameHash.Add(resolvedPath);
                             newTypes.Add(entry);
                         }
                     }
@@ -825,9 +823,8 @@ namespace Microsoft.PowerShell.Commands
 
                     if (ShouldProcess(formattedTarget, action))
                     {
-                        if (!fullFileNameHash.Contains(resolvedPath))
+                        if (fullFileNameHash.Add(resolvedPath))
                         {
-                            fullFileNameHash.Add(resolvedPath);
                             newTypes.Add(new SessionStateTypeEntry(appendPathTotalItem));
                         }
                     }
@@ -971,9 +968,8 @@ namespace Microsoft.PowerShell.Commands
 
                     if (ShouldProcess(formattedTarget, action))
                     {
-                        if (!fullFileNameHash.Contains(appendPathTotalItem))
+                        if (fullFileNameHash.Add(appendPathTotalItem))
                         {
-                            fullFileNameHash.Add(appendPathTotalItem);
                             newFormats.Add(new SessionStateFormatEntry(appendPathTotalItem));
                         }
                     }

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
@@ -601,8 +601,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // if it is a type reference, just add the type name
                 if (r is TypeReference tr)
                 {
-                    if (!allTypes.Contains(tr.name))
-                        allTypes.Add(tr.name);
+                    allTypes.Add(tr.name);
                 }
                 else
                 {
@@ -619,8 +618,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // we found the group, go over it
                     foreach (TypeReference x in tgd.typeReferenceList)
                     {
-                        if (!allTypes.Contains(x.name))
-                            allTypes.Add(x.name);
+                        allTypes.Add(x.name);
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1151,10 +1151,8 @@ namespace System.Management.Automation
                 case "ActivePostCommand": currentActionSet = _activePostCommand; break;
             }
 
-            if (currentActionSet.Contains(command))
+            if (!currentActionSet.Add(command))
                 throw new InvalidOperationException();
-            else
-                currentActionSet.Add(command);
         }
 
         internal void UnregisterLookupCommandInfoAction(string currentAction, string command)
@@ -1168,8 +1166,7 @@ namespace System.Management.Automation
                 case "ActivePostCommand": currentActionSet = _activePostCommand; break;
             }
 
-            if (currentActionSet.Contains(command))
-                currentActionSet.Remove(command);
+            currentActionSet.Remove(command);
         }
 
         private readonly HashSet<string> _activePreLookup = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1569,13 +1569,9 @@ namespace System.Management.Automation.Runspaces
                 string assembly = ss.Assemblies[i].FileName;
                 if (!string.IsNullOrEmpty(assembly))
                 {
-                    if (assemblyList.Contains(assembly))
+                    if (!assemblyList.Add(assembly))
                     {
                         ss.Assemblies.RemoveItem(i);
-                    }
-                    else
-                    {
-                        assemblyList.Add(assembly);
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1047,9 +1047,8 @@ namespace Microsoft.PowerShell.Commands
                             PSModuleInfo module = CreateModuleInfoForGetModule(resolvedModulePath, refresh);
                             if (module != null)
                             {
-                                if (!modules.Contains(resolvedModulePath))
+                                if (modules.Add(resolvedModulePath))
                                 {
-                                    modules.Add(resolvedModulePath);
                                     yield return module;
                                 }
                             }
@@ -1078,9 +1077,8 @@ namespace Microsoft.PowerShell.Commands
                                         foundModule = true;
                                         // We need to list all versions of the module.
                                         string subModulePath = Path.GetDirectoryName(file);
-                                        if (!modules.Contains(subModulePath))
+                                        if (modules.Add(subModulePath))
                                         {
-                                            modules.Add(subModulePath);
                                             yield return module;
                                         }
                                     }

--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -1321,9 +1321,8 @@ namespace System.Management.Automation.Language
             foreach (var typeDefinitionAst in typeDefinitions)
             {
                 var typeName = GetClassNameInAssembly(typeDefinitionAst);
-                if (!definedTypes.Contains(typeName))
+                if (definedTypes.Add(typeName))
                 {
-                    definedTypes.Add(typeName);
                     if ((typeDefinitionAst.TypeAttributes & TypeAttributes.Class) == TypeAttributes.Class)
                     {
                         defineTypeHelpers.Add(new DefineTypeHelper(parser, module, typeDefinitionAst, typeName));

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -90,16 +90,12 @@ namespace System.Management.Automation.Language
                 foreach (var parameter in parameters)
                 {
                     string parameterName = parameter.Name.VariablePath.UserPath;
-                    if (parametersSet.Contains(parameterName))
+                    if (!parametersSet.Add(parameterName))
                     {
                         _parser.ReportError(parameter.Name.Extent,
                             nameof(ParserStrings.DuplicateFormalParameter),
                             ParserStrings.DuplicateFormalParameter,
                             parameterName);
-                    }
-                    else
-                    {
-                        parametersSet.Add(parameterName);
                     }
 
                     var voidConstraint =
@@ -242,7 +238,7 @@ namespace System.Management.Automation.Language
             foreach (var namedArg in attributeAst.NamedArguments)
             {
                 string name = namedArg.ArgumentName;
-                if (names.Contains(name))
+                if (!names.Add(name))
                 {
                     _parser.ReportError(namedArg.Extent,
                         nameof(ParserStrings.DuplicateNamedArgument),
@@ -251,8 +247,6 @@ namespace System.Management.Automation.Language
                 }
                 else
                 {
-                    names.Add(name);
-
                     if (!namedArg.ExpressionOmitted && !IsValidAttributeArgument(namedArg.Argument, constantValueVisitor))
                     {
                         var error = GetNonConstantAttributeArgErrorExpr(constantValueVisitor);
@@ -1124,7 +1118,7 @@ namespace System.Management.Automation.Language
                 if (keyStrAst != null)
                 {
                     var keyStr = keyStrAst.Value.ToString();
-                    if (keys.Contains(keyStr))
+                    if (!keys.Add(keyStr))
                     {
                         string errorId;
                         string errorMsg;
@@ -1140,10 +1134,6 @@ namespace System.Management.Automation.Language
                         }
 
                         _parser.ReportError(entry.Item1.Extent, errorId, errorMsg, keyStr);
-                    }
-                    else
-                    {
-                        keys.Add(keyStr);
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -797,10 +797,7 @@ namespace System.Management.Automation.Internal
                     return;
                 }
 
-                if (_preparingForDisconnectList.Contains(bcmdTM))
-                {
-                    _preparingForDisconnectList.Remove(bcmdTM);
-                }
+                _preparingForDisconnectList.Remove(bcmdTM);
 
                 if (_preparingForDisconnectList.Count == 0)
                 {

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -1081,10 +1081,7 @@ namespace System.Management.Automation
                         {
                             // this command is not visible to the user (from CommandOrigin) so
                             // dont show help topic for it.
-                            if (!hiddenCommands.Contains(helpName))
-                            {
-                                hiddenCommands.Add(helpName);
-                            }
+                            hiddenCommands.Add(helpName);
 
                             continue;
                         }

--- a/src/System.Management.Automation/help/HelpFileHelpProvider.cs
+++ b/src/System.Management.Automation/help/HelpFileHelpProvider.cs
@@ -170,11 +170,7 @@ namespace System.Management.Automation
             {
                 string fileName = Path.GetFileName(file);
 
-                if (!fileNameHash.Contains(fileName))
-                {
-                    fileNameHash.Add(fileName);
-                }
-                else
+                if (!fileNameHash.Add(fileName))
                 {
                     // If the file need to be removed, add it to matchedFilesToRemove, if not already present.
                     if (!matchedFilesToRemove.Contains(file))

--- a/src/System.Management.Automation/security/CatalogHelper.cs
+++ b/src/System.Management.Automation/security/CatalogHelper.cs
@@ -220,9 +220,8 @@ namespace System.Management.Automation
                 relativePath = fileToHash.Name;
             }
 
-            if (!relativePaths.Contains(relativePath))
+            if (relativePaths.Add(relativePath))
             {
-                relativePaths.Add(relativePath);
                 if (fileToHash.Length != 0)
                 {
                     cdfFilesContent += "<HASH>" + fileToHash.FullName + "=" + fileToHash.FullName + Environment.NewLine;


### PR DESCRIPTION
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1868

Fix applied to concrete types `HashSet<T>` and `List<T>`.