### PR TITLE
Remove explicit `IDE1005` suppressions

### DIFF
--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRule.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/FilterRules/FilterRule.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Management.UI.Internal
 {
@@ -62,14 +61,12 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         protected void NotifyEvaluationResultInvalidated()
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             var eh = this.EvaluationResultInvalidated;
 
             if (eh != null)
             {
                 eh(this, new EventArgs());
             }
-            #pragma warning restore IDE1005
         }
 
         #endregion

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingSelectorValue.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingSelectorValue.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Windows.Data;
 
@@ -210,14 +209,12 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         protected void NotifySelectedValueChanged(T oldValue, T newValue)
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             EventHandler<PropertyChangedEventArgs<T>> eh = this.SelectedValueChanged;
 
             if (eh != null)
             {
                 eh(this, new PropertyChangedEventArgs<T>(oldValue, newValue));
             }
-            #pragma warning restore IDE1005
         }
 
         #endregion NotifySelectedValueChanged

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValueBase.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterCore/ValidatingValueBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Microsoft.Management.UI.Internal
@@ -252,14 +251,12 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         protected void NotifyPropertyChanged(string propertyName)
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             PropertyChangedEventHandler eh = this.PropertyChanged;
 
             if (eh != null)
             {
                 eh(this, new PropertyChangedEventArgs(propertyName));
             }
-            #pragma warning restore IDE1005
         }
 
         #endregion NotifyPropertyChanged

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/AddFilterRulePickerItem.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/AddFilterRulePickerItem.cs
@@ -70,14 +70,12 @@ namespace Microsoft.Management.UI.Internal
         /// </param>
         protected void NotifyPropertyChanged(string propertyName)
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             PropertyChangedEventHandler eh = this.PropertyChanged;
 
             if (eh != null)
             {
                 eh(this, new PropertyChangedEventArgs(propertyName));
             }
-            #pragma warning restore IDE1005
         }
 
         #endregion NotifyPropertyChanged

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanel.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanel.cs
@@ -204,13 +204,11 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         protected virtual void NotifyFilterExpressionChanged()
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             EventHandler eh = this.FilterExpressionChanged;
             if (eh != null)
             {
                 eh(this, new EventArgs());
             }
-            #pragma warning restore IDE1005
         }
 
         private void Controller_FilterExpressionChanged(object sender, EventArgs e)

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelController.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelController.cs
@@ -260,13 +260,11 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         protected virtual void NotifyFilterExpressionChanged()
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             EventHandler eh = this.FilterExpressionChanged;
             if (eh != null)
             {
                 eh(this, new EventArgs());
             }
-            #pragma warning restore IDE1005
         }
 
         #endregion Notify Filter Expression Changed

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelItem.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/FilterRulePanelItem.cs
@@ -100,15 +100,11 @@ namespace Microsoft.Management.UI.Internal
         {
             Debug.Assert(!string.IsNullOrEmpty(propertyName), "not null");
 
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
-
             PropertyChangedEventHandler eh = this.PropertyChanged;
             if (eh != null)
             {
                 eh(this, new PropertyChangedEventArgs(propertyName));
             }
-
-            #pragma warning restore IDE1005s
         }
 
         #endregion Public Methods

--- a/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchBox.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/FilterProviders/SearchBox.cs
@@ -60,13 +60,11 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         protected virtual void NotifyFilterExpressionChanged()
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             EventHandler eh = this.FilterExpressionChanged;
             if (eh != null)
             {
                 eh(this, new EventArgs());
             }
-            #pragma warning restore IDE1005s
         }
 
         #endregion

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/CommandViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/CommandViewModel.cs
@@ -550,8 +550,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
             return returnValue;
         }
 
-        #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
-
         /// <summary>
         /// Called to trigger the event fired when help is needed for the command.
         /// </summary>
@@ -626,8 +624,6 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
         }
-
-        #pragma warning restore IDE1005
 
         /// <summary>
         /// Called when the PropertyChanged event is triggered on the SelectedParameterSet.

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterSetViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterSetViewModel.cs
@@ -363,13 +363,11 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="propertyName">The changed property.</param>
         private void OnNotifyPropertyChanged(string propertyName)
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             PropertyChangedEventHandler handler = this.PropertyChanged;
             if (handler != null)
             {
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
-            #pragma warning restore IDE1005
         }
 
         /// <summary>

--- a/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterViewModel.cs
+++ b/src/Microsoft.Management.UI.Internal/ShowCommand/ViewModel/ParameterViewModel.cs
@@ -262,13 +262,11 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="propertyName">The changed property.</param>
         private void OnNotifyPropertyChanged(string propertyName)
         {
-            #pragma warning disable IDE1005 // IDE1005: Delegate invocation can be simplified.
             PropertyChangedEventHandler handler = this.PropertyChanged;
             if (handler != null)
             {
                 handler(this, new PropertyChangedEventArgs(propertyName));
             }
-            #pragma warning restore IDE1005
         }
     }
 }


### PR DESCRIPTION
Partially revert changes to `Microsoft.Management.UI.Internal` as analyzers are skipped since #15677
