### PR TITLE
Add PSApplicationOutputEncoding variable

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4527,6 +4527,14 @@ end {
                     ScopedItemOptions.None,
                     new ArgumentTypeConverterAttribute(typeof(System.Text.Encoding))),
 
+                // Variable which controls the encoding for decoding data from a NativeCommand
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSApplicationOutputEncoding,
+                    null,
+                    RunspaceInit.PSApplicationOutputEncodingDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(Encoding))),
+
                 // Preferences
                 //
                 // NTRAID#Windows Out Of Band Releases-931461-2006/03/13

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1645,16 +1645,20 @@ namespace System.Management.Automation
                 startInfo.UseShellExecute = false;
                 startInfo.RedirectStandardInput = redirectInput;
 
+                Encoding outputEncoding = Context.GetVariableValue(
+                    SpecialVariables.PSApplicationOutputEncodingVarPath) as Encoding
+                    ?? Console.OutputEncoding;
+
                 if (redirectOutput)
                 {
                     startInfo.RedirectStandardOutput = true;
-                    startInfo.StandardOutputEncoding = Console.OutputEncoding;
+                    startInfo.StandardOutputEncoding = outputEncoding;
                 }
 
                 if (redirectError)
                 {
                     startInfo.RedirectStandardError = true;
-                    startInfo.StandardErrorEncoding = Console.OutputEncoding;
+                    startInfo.StandardErrorEncoding = outputEncoding;
                 }
             }
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1645,10 +1645,7 @@ namespace System.Management.Automation
                 startInfo.UseShellExecute = false;
                 startInfo.RedirectStandardInput = redirectInput;
 
-                Encoding outputEncoding = Context.GetVariableValue(
-                    SpecialVariables.PSApplicationOutputEncodingVarPath) as Encoding
-                    ?? Console.OutputEncoding;
-
+                Encoding outputEncoding = GetOutputEncoding();
                 if (redirectOutput)
                 {
                     startInfo.RedirectStandardOutput = true;
@@ -1715,6 +1712,20 @@ namespace System.Management.Automation
 
             return startInfo;
         }
+
+#nullable enable
+        /// <summary>
+        /// Gets the encoding to use for a process' output/error pipes.
+        /// </summary>
+        /// <returns>The encoding to use for the process output.</returns>
+        private Encoding GetOutputEncoding()
+        {
+            Encoding? applicationOutputEncoding = Context.GetVariableValue(
+                    SpecialVariables.PSApplicationOutputEncodingVarPath) as Encoding;
+
+            return applicationOutputEncoding ?? Console.OutputEncoding;
+        }
+#nullable disable
 
         /// <summary>
         /// Determine if we have a special file which will change the way native argument passing

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -41,6 +41,10 @@ namespace System.Management.Automation
 
         internal static readonly VariablePath OutputEncodingVarPath = new VariablePath(OutputEncoding);
 
+        internal const string PSApplicationOutputEncoding = nameof(PSApplicationOutputEncoding);
+
+        internal static readonly VariablePath PSApplicationOutputEncodingVarPath = new VariablePath(PSApplicationOutputEncoding);
+
         internal const string VerboseHelpErrors = "VerboseHelpErrors";
 
         internal static readonly VariablePath VerboseHelpErrorsVarPath = new VariablePath(VerboseHelpErrors);
@@ -388,6 +392,7 @@ namespace System.Management.Automation
                     SpecialVariables.NestedPromptLevel,
                     SpecialVariables.pwd,
                     SpecialVariables.Matches,
+                    SpecialVariables.PSApplicationOutputEncoding,
                 },
                 StringComparer.OrdinalIgnoreCase
             );

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -153,6 +153,9 @@
   <data name="OutputEncodingDescription" xml:space="preserve">
     <value>The text encoding used when piping text to a native executable file</value>
   </data>
+  <data name="PSApplicationOutputEncodingDescription" xml:space="preserve">
+    <value>The text encoding used when reading output text from a native executable file</value>
+  </data>
   <data name="PSStyleDescription" xml:space="preserve">
     <value>Configuration controlling how text is rendered.</value>
   </data>

--- a/test/powershell/engine/Basic/NativeCommandEncoding.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandEncoding.Tests.ps1
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Native command output encoding tests' -Tags 'CI' {
+    BeforeAll {
+        $WriteConsoleOutPath = Join-Path $PSScriptRoot assets WriteConsoleOut.ps1
+        $defaultEncoding = [Console]::OutputEncoding.WebName
+    }
+
+    BeforeEach {
+        Clear-Variable -Name PSApplicationOutputEncoding
+    }
+
+    AfterEach {
+        Clear-Variable -Name PSApplicationOutputEncoding
+    }
+
+    It 'Defaults to [Console]::OutputEncoding if not set' {
+        $actual = pwsh -File $WriteConsoleOutPath -Value café -Encoding $defaultEncoding
+        $actual | Should -Be café
+    }
+
+    It 'Defaults to [Console]::OutputEncoding if set to $null' {
+        $PSApplicationOutputEncoding = $null
+        $actual = pwsh -File $WriteConsoleOutPath -Value café -Encoding $defaultEncoding
+        $actual | Should -Be café
+    }
+
+    It 'Uses scoped $PSApplicationOutputEncoding value' {
+        $PSApplicationOutputEncoding = [System.Text.Encoding]::Unicode
+        $actual = & {
+            $PSApplicationOutputEncoding = [System.Text.UTF8Encoding]::new()
+            pwsh -File $WriteConsoleOutPath -Value café -Encoding utf-8
+        }
+
+        $actual | Should -Be café
+
+        # Will use UTF-16-LE hence the different values
+        $actual = pwsh -File $WriteConsoleOutPath -Value café -Encoding Unicode
+        $actual | Should -Be café
+    }
+
+    It 'Uses variable in class method' {
+        class NativeEncodingTestClass {
+            static [string] RunTest([string]$Script) {
+                $PSApplicationOutputEncoding = [System.Text.Encoding]::Unicode
+                return pwsh -File $Script -Value café -Encoding unicode
+            }
+        }
+
+        $actual = [NativeEncodingTestClass]::RunTest($WriteConsoleOutPath)
+        $actual | Should -Be café
+    }
+
+    It 'Fails to set variable with invalid encoding object' {
+        $ps = [PowerShell]::Create()
+        $ps.AddScript('$PSApplicationOutputEncoding = "utf-8"').Invoke()
+
+        $ps.Streams.Error.Count | Should -Be 1
+        [string]$ps.Streams.Error[0] | Should -Be 'Cannot convert the "utf-8" value of type "System.String" to type "System.Text.Encoding".'
+    }
+}

--- a/test/powershell/engine/Basic/assets/WriteConsoleOut.ps1
+++ b/test/powershell/engine/Basic/assets/WriteConsoleOut.ps1
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [string]
+    $Value,
+
+    [Parameter(Mandatory)]
+    [string]
+    $Encoding
+)
+
+$enc = [System.Text.Encoding]::GetEncoding($Encoding)
+$data = $enc.GetBytes($Value)
+
+$outStream = [System.Console]::OpenStandardOutput()
+try {
+    $outStream.Write($data, 0, $data.Length)
+} finally {
+    $outStream.Dispose()
+}


### PR DESCRIPTION
# PR Summary
Adds the `$PSApplicationOutputEncoding` variable that can be used to control the encoding PowerShell uses when reading the raw bytes to a string of an external application. This provides a scoped option to control the encoding used without resorting to the process wide setting of `[Console]::OutputEncoding`.

If the variable is unset (the default) or `$null`, the `[Console]::OutputEncoding` value is used to preserve the existing behaviour.

I ended up with `$PSApplicationOutputEncoding` to reflect that this is for the "Application" commands in PowerShell (`Get-Command ... -CommandType Application`) and `$OutputEncoding` is already taken as the confusingly named option for controlling how PowerShell encodes input to an application.

While not covered in this PR this could potentially be expanded in the future with:

+ Argument converters to support setting from a string/integer `$PSApplicationOutputEncoding = 'utf-8'`
+ A custom "raw/byte" encoding to have PowerShell output the `byte[]` without any encoding

## PR Context
https://github.com/PowerShell/PowerShell/issues/16868 for this specific ask but there are many related issues to this.

Currently PowerShell uses the value of `[Console]::OutputEncoding` to control what encoding is used when reading the output from a native application. This can be problematic as:

+ It's set process wide, multithreading code can impact each other
+ You need an annoying try/finally to temporarily set it to another value
+ It also changes how the current process itself might write the output if the end user forgets to reset back to the default

A very common example is using `wsl.exe` which is hardcoded to output as UTF-16-LE/Unicode. To do this in PowerShell you would need to do:

```powershell
$origEncoding = [Console]::OutputEncoding
try {
    [Console]::OutputEncoding = [System.Text.Encoding]::Unicode
    $res = wsl.exe status
}
finally {
    [Console]::OutputEncoding = $origEncoding
}
```

With this PR you can now do

```powershell
$res = & {
    $PSApplicationOutputEncoding = [System.Text.Encoding]::Unicode
    wsl.exe status
}
```

Not only is this less lines, it is thread safe so you can run this in parallel in multiple runspaces at the same time and it also won't change how PowerShell might output it's strings to the console. The scriptblock can even be omitted if already running in a child scope that doesn't need to go back to the default.

Other known examples of external applications that don't follow the value of `[Console]::OutputEncoding` and typically need the user to set it when calling

+ `winget.exe` - always uses UTF-8
+ `python.exe` - uses the Windows locale encoding (WinPS called this ANSI), or can be UTF-8 if an env var or argument is set to force it

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/pull/10876
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
