### PR TITLE
Remove `JetBrains.Annotations` attributes

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -153,25 +153,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 ---------------------------------------------------------
 
-JetBrains.Annotations 2021.2.0 - MIT
-
-
-Copyright (c) 2016 JetBrains http://www.jetbrains.com
-
-MIT License
-
-Copyright (c) <year> <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------------------------
-
----------------------------------------------------------
-
 Json.More.Net 1.9.0 - MIT
 
 

--- a/src/System.Management.Automation/utils/assert.cs
+++ b/src/System.Management.Automation/utils/assert.cs
@@ -120,13 +120,7 @@ namespace System.Management.Automation
         // not expecting these methods to exist.
         [System.Diagnostics.Conditional("DEBUG")]
         [System.Diagnostics.Conditional("ASSERTIONS_TRACE")]
-#if RESHARPER_ATTRIBUTES
-        [JetBrains.Annotations.AssertionMethod]
-#endif
         internal static void Assert(
-#if RESHARPER_ATTRIBUTES
-            [JetBrains.Annotations.AssertionCondition(JetBrains.Annotations.AssertionConditionType.IS_TRUE)]
-#endif
             [DoesNotReturnIf(false)]
             bool condition,
             string whyThisShouldNeverHappen)
@@ -153,17 +147,11 @@ namespace System.Management.Automation
         // not expecting these methods to exist.
         [System.Diagnostics.Conditional("DEBUG")]
         [System.Diagnostics.Conditional("ASSERTIONS_TRACE")]
-#if RESHARPER_ATTRIBUTES
-        [JetBrains.Annotations.AssertionMethod]
-#endif
-        internal static void
-        Assert(
-#if RESHARPER_ATTRIBUTES
-            [JetBrains.Annotations.AssertionCondition(JetBrains.Annotations.AssertionConditionType.IS_TRUE)]
-#endif
+        internal static void Assert(
             [DoesNotReturnIf(false)]
             bool condition,
-            string whyThisShouldNeverHappen, string detailMessage)
+            string whyThisShouldNeverHappen,
+            string detailMessage)
         {
             // Early out avoids some slower code below (mostly the locking done in ThrowInsteadOfAssert).
             if (condition)


### PR DESCRIPTION
`JetBrains.Annotations` package was removed from `cgmanifest.json` in https://github.com/PowerShell/PowerShell/pull/21237
