### PR TITLE
Fix tilde expansion to handle implicit quotes due to escaped whitespace

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -287,7 +287,7 @@ namespace System.Management.Automation
                         if (NeedQuotes(arg))
                         {
                             _arguments.Append('"');
-                            AddToArgumentList(parameter, arg);
+                            PossiblyGlobArg(arg, parameter, usedQuotes: false);
 
                             // need to escape all trailing backslashes so the native command receives it correctly
                             // according to http://www.daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULESDOC
@@ -500,7 +500,7 @@ namespace System.Management.Automation
             afterPrev -= arrayExtent.StartOffset;
             beforeNext -= arrayExtent.StartOffset;
 
-            if (arrayText[afterPrev] == ',') 
+            if (arrayText[afterPrev] == ',')
             {
                 return ", ";
             }
@@ -509,7 +509,7 @@ namespace System.Management.Automation
             {
                 return " ,";
             }
-            
+
             return " , ";
         }
 

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -291,7 +291,6 @@ namespace System.Management.Automation
 
                             // need to escape all trailing backslashes so the native command receives it correctly
                             // according to http://www.daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULESDOC
-                            _arguments.Append(arg);
                             for (int i = arg.Length - 1; i >= 0 && arg[i] == '\\'; i--)
                             {
                                 _arguments.Append('\\');

--- a/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
@@ -132,4 +132,7 @@ Describe 'Native UNIX globbing tests' -tags "CI" {
 		/bin/echo '~/foo' | Should -BeExactly '~/foo'
 		/bin/echo "~/foo" | Should -BeExactly '~/foo'
 	}
+    It '~ should be expanded when used with implicit quotes' {
+        /bin/echo ~/a` b | Should -BeExactly "$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)/a b"
+    }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
@@ -30,6 +30,6 @@ Describe 'Native Windows tilde expansion tests' -tags "CI" {
 		cmd /c echo "~\foo" | Should -BeExactly '~\foo'
 	}
     It '~ should be expanded with implicit quotes' {
-        cmd /c echo ~\a` b | Should -BeExactly "$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)\a b"
+        cmd /c echo ~\a` b | Should -BeExactly "`"$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)\a `""
     }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
@@ -30,6 +30,6 @@ Describe 'Native Windows tilde expansion tests' -tags "CI" {
 		cmd /c echo "~\foo" | Should -BeExactly '~\foo'
 	}
     It '~ should be expanded with implicit quotes' {
-        cmd /c echo ~\a` b | Should -BeExactly "`"$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)\a `""
+        cmd /c echo ~\a` b | Should -BeExactly "`"$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)\a b`""
     }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeWindowsTildeExpansion.Tests.ps1
@@ -29,4 +29,7 @@ Describe 'Native Windows tilde expansion tests' -tags "CI" {
         cmd /c echo '~\foo' | Should -BeExactly '~\foo'
 		cmd /c echo "~\foo" | Should -BeExactly '~\foo'
 	}
+    It '~ should be expanded with implicit quotes' {
+        cmd /c echo ~\a` b | Should -BeExactly "$($ExecutionContext.SessionState.Provider.Get("FileSystem").Home)\a b"
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This affects with Windows and non-Windows so not directly related to the tilde expansion experimental feature.  The code logic doesn't apply the tilde expansion if there are implicit quotes (meaning escaped whitespace).  The fix is to re-use the possible globbing helper which does the tilde expansion within this code path.

Note that in Windows case, the quotes are expected while on non-Windows they don't have the quotes and this is how `echo` works differently on the two systems:

`cmd /c echo "a b"` will echo `"a b"`, but `/bin/echo "a b"` will echo `a b`.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/21276

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
