### PR TITLE
Get-Process: Remove admin for IncludeUserName

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -752,7 +752,7 @@ namespace Microsoft.PowerShell.Commands
 
                 var tokenUser = Marshal.PtrToStructure<Win32Native.TOKEN_USER>(tokenUserInfo);
                 SecurityIdentifier sid = new SecurityIdentifier(tokenUser.User.Sid);
-                return sid.Translate(typeof(System.Security.Principal.NTAccount)).Value;
+                userName = sid.Translate(typeof(System.Security.Principal.NTAccount)).Value;
             }
             catch (NotSupportedException)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -752,18 +752,15 @@ namespace Microsoft.PowerShell.Commands
 
                 var tokenUser = Marshal.PtrToStructure<Win32Native.TOKEN_USER>(tokenUserInfo);
                 SecurityIdentifier sid = new SecurityIdentifier(tokenUser.User.Sid);
-                try
-                {
-                    return sid.Translate(typeof(System.Security.Principal.NTAccount)).Value;
-                }
-                catch (IdentityNotMappedException)
-                {
-                    return null;
-                }
+                return sid.Translate(typeof(System.Security.Principal.NTAccount)).Value;
             }
             catch (NotSupportedException)
             {
                 // The Process not started yet, or it's a process from a remote machine.
+            }
+            catch (IdentityNotMappedException)
+            {
+                // SID cannot be mapped to a user
             }
             catch (InvalidOperationException)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -758,7 +758,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 catch (IdentityNotMappedException)
                 {
-                    return sid.Value;
+                    return null;
                 }
             }
             catch (NotSupportedException)

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
@@ -204,9 +204,6 @@
   <data name="ContradictParametersSpecified" xml:space="preserve">
     <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
   </data>
-  <data name="IncludeUserNameRequiresElevation" xml:space="preserve">
-    <value>The 'IncludeUserName' parameter requires elevated user rights. Try running the command again in a session that has been opened with elevated user rights (that is, Run as Administrator).</value>
-  </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
     <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Get-Process for admin" -Tags @('CI', 'RequireAdminOnWindows') {
-    It "Should support -IncludeUserName" {
-        (Get-Process -Id $PID -IncludeUserName).UserName | Should -Match $env:USERNAME
-    }
-
     It "Should support -Module" -Pending:$IsMacOS {
         $modules = Get-Process -Id $PID -Module
         $modules.GetType() | Should -BeExactly "System.Object[]"
@@ -78,12 +74,8 @@ Describe "Get-Process" -Tags "CI" {
         (Get-Process -Id $PID).Id | Should -BeExactly $PID
     }
 
-    It "Should fail to run Get-Process with -IncludeUserName without admin" -Skip:(!$IsWindows) {
-        if (Test-IsElevated) {
-            Set-ItResult -Skipped -Because "must NOT be run as admin"
-        }
-
-        { Get-Process -IncludeUserName } | Should -Throw -ErrorId "IncludeUserNameRequiresElevation,Microsoft.PowerShell.Commands.GetProcessCommand"
+    It "Should support -IncludeUserName" {
+        (Get-Process -Id $PID -IncludeUserName).UserName | Should -Match $env:USERNAME
     }
 
     It "Should fail to run Get-Process with -Module without admin" -Skip:(!$IsWindows) {


### PR DESCRIPTION
# PR Summary

Removes the administrator requirements checked on Get-Process -IncludeUserName as it can be used to get the username on processes you currently own. The check was unecessary and the value can be set to null on processes the current user does not have access to.

This also changes the logic for translating the SecurityIdentifier in the access token to use the builtin .NET class which handles more scenarios (like Font Driver Host users), and is simpler.

## PR Context

Fixes: https://github.com/PowerShell/PowerShell/issues/21055
Fixes: https://github.com/PowerShell/PowerShell/issues/21300

While #21055 was closed by the bot it seems like the general consensus is that there shouldn't be an access check and to just return `$null` for the property if it failed to retrieve the username.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
