### PR TITLE
Fix progress rendering when using double-wide unicode

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -427,7 +427,7 @@ namespace Microsoft.PowerShell
 
             sb.Append(secRemain);
 
-            if (PercentComplete >= 0 && PercentComplete < 100 && barWidth > 0)
+            if (PercentComplete >= 0 && barWidth > 0)
             {
                 int barLength = PercentComplete * barWidth / 100;
                 if (barLength >= barWidth)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -417,7 +417,7 @@ namespace Microsoft.PowerShell
             else
             {
                 sb.Append(StatusDescription);
-            }   
+            }
 
             int emptyPadLength = barWidth - rawUI.LengthInBufferCells(sb.ToString()) - secRemainLength;
             if (emptyPadLength > 0)
@@ -437,7 +437,7 @@ namespace Microsoft.PowerShell
 
                 if (barLength < rawUI.LengthInBufferCells(sb.ToString()))
                 {
-                    sb.Insert(barLength + PSStyle.Instance.Reverse.Length, PSStyle.Instance.ReverseOff);
+                    sb.Insert(barLength, PSStyle.Instance.ReverseOff);
                 }
             }
             else

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressNode.cs
@@ -422,7 +422,7 @@ namespace Microsoft.PowerShell
             int emptyPadLength = barWidth - rawUI.LengthInBufferCells(sb.ToString()) - secRemainLength;
             if (emptyPadLength > 0)
             {
-                sb.Append(string.Empty.PadRight(emptyPadLength));
+                sb.Append(' ', emptyPadLength);
             }
 
             sb.Append(secRemain);

--- a/src/System.Management.Automation/engine/ProgressRecord.cs
+++ b/src/System.Management.Automation/engine/ProgressRecord.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Management.Automation.Internal;
 using System.Runtime.Serialization;
 
 using Dbg = System.Management.Automation.Diagnostics;
@@ -44,19 +45,9 @@ namespace System.Management.Automation
                 throw PSTraceSource.NewArgumentOutOfRangeException(nameof(activityId), activityId, ProgressRecordStrings.ArgMayNotBeNegative, "activityId");
             }
 
-            if (string.IsNullOrEmpty(activity))
-            {
-                throw PSTraceSource.NewArgumentException(nameof(activity), ProgressRecordStrings.ArgMayNotBeNullOrEmpty, "activity");
-            }
-
-            if (string.IsNullOrEmpty(statusDescription))
-            {
-                throw PSTraceSource.NewArgumentException(nameof(activity), ProgressRecordStrings.ArgMayNotBeNullOrEmpty, "statusDescription");
-            }
-
             this.id = activityId;
-            this.activity = activity;
-            this.status = statusDescription;
+            this.Activity = activity;
+            this.StatusDescription = statusDescription;
         }
 
         /// <summary>
@@ -166,6 +157,11 @@ namespace System.Management.Automation
                     throw PSTraceSource.NewArgumentException("value", ProgressRecordStrings.ArgMayNotBeNullOrEmpty, "value");
                 }
 
+                if (new ValueStringDecorated(value).IsDecorated)
+                {
+                    throw PSTraceSource.NewArgumentException("value", ProgressRecordStrings.StringMayNotBeDecorated);
+                }
+
                 activity = value;
             }
         }
@@ -187,6 +183,11 @@ namespace System.Management.Automation
                 if (string.IsNullOrEmpty(value))
                 {
                     throw PSTraceSource.NewArgumentException("value", ProgressRecordStrings.ArgMayNotBeNullOrEmpty, "value");
+                }
+
+                if (new ValueStringDecorated(value).IsDecorated)
+                {
+                    throw PSTraceSource.NewArgumentException("value", ProgressRecordStrings.StringMayNotBeDecorated);
                 }
 
                 status = value;

--- a/src/System.Management.Automation/resources/ProgressRecordStrings.resx
+++ b/src/System.Management.Automation/resources/ProgressRecordStrings.resx
@@ -129,4 +129,7 @@
   <data name="ParentActivityIdCantBeActivityId" xml:space="preserve">
     <value>ParentActivityId cannot be the same as the ActivityId.</value>
   </data>
+  <data name="StringMayNotBeDecorated" xml:space="preserve">
+    <value>String may not contain VT escape sequences.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Progress.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Progress.Tests.ps1
@@ -33,4 +33,12 @@ Describe "Write-Progress DRT Unit Tests" -Tags "CI" {
     It 'Should be able to complete a progress record with no activity specified' {
         { Write-Progress -Completed } | Should -Not -Throw
     }
+
+    It 'Activity cannot contain VT' {
+        { Write-Progress -Activity "`e[1m" } | Should -Throw -ErrorId 'Argument,Microsoft.PowerShell.Commands.WriteProgressCommand'
+    }
+
+    It 'Status cannot contain VT' {
+        { Write-Progress -Activity 1 -Status "`e[1m" } | Should -Throw -ErrorId 'Argument,Microsoft.PowerShell.Commands.WriteProgressCommand'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The previous minimal progress rendering code was using the string length which counts characters and not the buffer cells required.  This means that double-wide east asian characters counted as 1 when it should be counted as 2 so that it renders correctly in the console.  The fix is to change all usage of getting the length to using a helper function that returns the number of buffer cells for a string.

Here's what it looked like before and after the change:

https://github.com/PowerShell/PowerShell/assets/11859881/1ee484d9-dc57-4deb-8b61-51ca6ed2a5a3

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/21293

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
