### PR TITLE
🚧 Prevent Select-Object with ExpandProperty from updating source PSObjects

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -552,7 +552,7 @@ namespace Microsoft.PowerShell.Commands
                     // its members remain the same as before the Select-Object command run.
                     PSObject expandedObject = PSObject.AsPSObject(r.Result, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
-
+                    AddResurrectionProperties(expandedObject);
                     FilteredWriteObject(expandedObject, matchedProperties);
                     return;
                 }
@@ -572,7 +572,7 @@ namespace Microsoft.PowerShell.Commands
                     // its members remain the same as before the Select-Object command run.
                     PSObject expandedObject = PSObject.AsPSObject(expandedValue, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
-
+                    AddResurrectionProperties(expandedObject);
                     FilteredWriteObject(expandedObject, matchedProperties);
                 }
             }
@@ -605,6 +605,17 @@ namespace Microsoft.PowerShell.Commands
                 catch (ExtendedTypeSystemException)
                 {
                     WriteAlreadyExistingPropertyError(noteProperty.Name, inputObject, "AlreadyExistingUserSpecifiedPropertyExpand");
+                }
+            }
+        }
+
+        private void AddResurrectionProperties(PSObject expandedObject)
+        {
+            foreach(PSNoteProperty noteProperty in (expandedObject.PSObject.BaseObject.Properties))
+            {
+                if (expandedObject.Properties[noteProperty.Name] == null)
+                {
+                    expandedObject.Properties.Add(noteProperty);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true, true);
+                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true, true);
+                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, false).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -551,7 +551,7 @@ namespace Microsoft.PowerShell.Commands
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
                     PSObject expandedObject = r.Result is PSObject ? 
-                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true);
+                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.Result, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -571,8 +571,8 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = r.Result is PSObject ? 
-                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true);
+                    PSObject expandedObject = expandedValue is PSObject ? 
+                        expandedValue.PSObject.Copy() : PSObject.AsPSObject(expandedValue, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true);
+                    PSObject expandedObject = r.Result.PSObject.Copy()
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true);
+                    PSObject expandedObject = r.Result.PSObject.Copy()
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -612,13 +612,19 @@ namespace Microsoft.PowerShell.Commands
         private void AddResurrectionProperties(PSObject expandedObject, PSObject inputObject)
         {
             // Populate an exclusion filter with the names of all ExcludeProperty and properties that currently exist in expandedObject.
-            HashSet<string> fullExclude = new(StringComparer.OrdinalIgnoreCase);
-            foreach (string ep in ExcludeProperty) fullExclude.Add(ep);
-            foreach (string pn in expandedObject.Properties.Name) fullExclude.Add(pn);
+            HashSet<string> fullExclude = new (StringComparer.OrdinalIgnoreCase);
+            foreach (string ep in ExcludeProperty)
+            {
+                fullExclude.Add(ep);
+            }
+            foreach (PSPropertyInfo pi in expandedObject.Properties)
+            {
+                fullExclude.Add(pi.Name);
+            }
             var exclusionFilter = new PSPropertyExpressionFilter(System.Linq.Enumerable.ToArray(fullExclude));
 
             TerminatingErrorContext invocationContext = new (this);
-            ParameterProcessor processor = new (new SelectObjectExpressionParameterDefinition());
+            ParameterProcessor processor = new(new SelectObjectExpressionParameterDefinition());
             List<MshParameter> propertyList = processor.ProcessParameters(new object[] { "*" }, invocationContext);
 
             foreach (MshParameter p in propertyList)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -612,18 +612,20 @@ namespace Microsoft.PowerShell.Commands
         private void AddResurrectionProperties(PSObject expandedObject, PSObject inputObject)
         {
             // Populate an exclusion filter with the names of all ExcludeProperty and properties that currently exist in expandedObject.
-            HashSet<string> fullExclude = new (StringComparer.OrdinalIgnoreCase);
+            HashSet<string> fullExclude = new(StringComparer.OrdinalIgnoreCase);
             foreach (string ep in ExcludeProperty)
             {
                 fullExclude.Add(ep);
             }
+
             foreach (PSPropertyInfo pi in expandedObject.Properties)
             {
                 fullExclude.Add(pi.Name);
             }
+
             var exclusionFilter = new PSPropertyExpressionFilter(System.Linq.Enumerable.ToArray(fullExclude));
 
-            TerminatingErrorContext invocationContext = new (this);
+            TerminatingErrorContext invocationContext = new(this);
             ParameterProcessor processor = new(new SelectObjectExpressionParameterDefinition());
             List<MshParameter> propertyList = processor.ProcessParameters(new object[] { "*" }, invocationContext);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,8 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = r.Result.PSObject.Copy()
+                    PSObject expandedObject = r.Result is PSObject ? 
+                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true)
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -570,7 +571,8 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = r.Result.PSObject.Copy()
+                    PSObject expandedObject = r.Result is PSObject ? 
+                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true)
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(r.Result, false).Copy();
+                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, false).Copy();
+                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(r.Result, false).Copy();
+                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true).Copy();
+                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true).Copy();
+                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -639,9 +639,7 @@ namespace Microsoft.PowerShell.Commands
                         foreach (PSPropertyExpressionResult mshExpRes in tempExprResults)
                         {
                             // filter the exclusions, if any
-                            if (_exclusionFilter.IsMatch(mshExpRes.ResolvedExpression))
-                                continue;
-                            else
+                            if (!exclusionFilter.IsMatch(mshExpRes.ResolvedExpression))
                             {
                                 PSNoteProperty mshProp = new PSNoteProperty(name, mshExpRes.Result);
                                 expandedObject.Properties.Add(mshProp);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -644,7 +644,7 @@ namespace Microsoft.PowerShell.Commands
                             else
                             {
                                 PSNoteProperty mshProp = new PSNoteProperty(name, mshExpRes.Result);
-                                expandedObject.Properties.Add(mshProp)
+                                expandedObject.Properties.Add(mshProp);
                             }
                         }
                     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -613,15 +613,15 @@ namespace Microsoft.PowerShell.Commands
         {
             // Populate an exclusion filter with the names of all ExcludeProperty and properties that currently exist in expandedObject.
             HashSet<string> fullExclude = new(StringComparer.OrdinalIgnoreCase);
-            foreach (string ep in ExcludeProperty) { fullExclude.Add(ep); }
-            foreach (string pn in expandedObject.Properties.Name) { fullExclude.Add(pn); }
-            exclusionFilter = new PSPropertyExpressionFilter(fullExclude.ToArray());
+            foreach (string ep in ExcludeProperty) fullExclude.Add(ep);
+            foreach (string pn in expandedObject.Properties.Name) fullExclude.Add(pn);
+            var exclusionFilter = new PSPropertyExpressionFilter(System.Linq.Enumerable.ToArray(fullExclude));
 
-            TerminatingErrorContext invocationContext = new(this);
-            ParameterProcessor processor = new(new SelectObjectExpressionParameterDefinition());
-            List<MshParameter> propertyList = processor.ProcessParameters(new object[] {"*"}, invocationContext);
+            TerminatingErrorContext invocationContext = new (this);
+            ParameterProcessor processor = new (new SelectObjectExpressionParameterDefinition());
+            List<MshParameter> propertyList = processor.ProcessParameters(new object[] { "*" }, invocationContext);
 
-            foreach (MshParameter prop in propertyList)
+            foreach (MshParameter p in propertyList)
             {
                 string name = p.GetEntry(NameEntryDefinition.NameEntryKey) as string;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true).Copy();
+                    PSObject expandedObject = PSObject.AsPSObject(r.Result, false).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, false).Copy();
+                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -551,7 +551,7 @@ namespace Microsoft.PowerShell.Commands
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
                     PSObject expandedObject = r.Result is PSObject ? 
-                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.Result, true);
+                        r.Result.Copy() : PSObject.AsPSObject(r.Result, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -572,7 +572,7 @@ namespace Microsoft.PowerShell.Commands
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
                     PSObject expandedObject = expandedValue is PSObject ? 
-                        expandedValue.PSObject.Copy() : PSObject.AsPSObject(expandedValue, true);
+                        expandedValue.Copy() : PSObject.AsPSObject(expandedValue, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -551,7 +551,7 @@ namespace Microsoft.PowerShell.Commands
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
                     PSObject expandedObject = r.Result is PSObject ? 
-                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true)
+                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -572,7 +572,7 @@ namespace Microsoft.PowerShell.Commands
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
                     PSObject expandedObject = r.Result is PSObject ? 
-                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true)
+                        r.Result.PSObject.Copy() : PSObject.AsPSObject(r.result, true);
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -611,11 +611,14 @@ namespace Microsoft.PowerShell.Commands
 
         private void AddResurrectionProperties(PSObject expandedObject)
         {
-            foreach(PSNoteProperty noteProperty in (expandedObject.PSObject.BaseObject.Properties))
+            if (PSObject.HasInstanceMembers(expandedObject, out PSMemberInfoInternalCollection<PSMemberInfo> instanceMembers))
             {
-                if (expandedObject.Properties[noteProperty.Name] == null)
+                foreach (PSMemberInfo memberInfo in instanceMembers)
                 {
-                    expandedObject.Properties.Add(noteProperty);
+                    if (expandedObject.Members[memberInfo.Name] == null)
+                    {
+                        expandedObject.Members.Add(memberInfo);
+                    }
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,8 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = r.Result is PSObject ? 
-                        r.Result.Copy() : PSObject.AsPSObject(r.Result, true);
+                    PSObject expandedObject = PSObject.AsPSObject(r.Result, false).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -571,8 +570,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = expandedValue is PSObject ? 
-                        expandedValue.Copy() : PSObject.AsPSObject(expandedValue, true);
+                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, false).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1039,7 +1039,7 @@ namespace System.Management.Automation
         /// <param name="storeTypeNameAndInstanceMembersLocally"></param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "AsPSObject is shipped as part of V1. This is a new overload method.")]
-        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally)
+        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally, bool AsNew)
         {
             if (obj == null)
             {
@@ -1048,7 +1048,14 @@ namespace System.Management.Automation
 
             if (obj is PSObject so)
             {
-                return so;
+                if(AsNew)
+                {
+                    return so.Copy();
+                }
+                else
+                {
+                    return so;
+                }
             }
 
             return new PSObject(obj) { StoreTypeNameAndInstanceMembersLocally = storeTypeNameAndInstanceMembersLocally };

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1076,13 +1076,19 @@ namespace System.Management.Automation
             }
 
             if (psObjectAboveBase.ImmediateBaseObject is PSCustomObject
-                || psObjectAboveBase.ImmediateBaseObject is string
-                || pso.StoreTypeNameAndInstanceMembersLocally)
+                || psObjectAboveBase.ImmediateBaseObject is string)
             {
                 return psObjectAboveBase;
             }
-
-            return psObjectAboveBase.ImmediateBaseObject;
+            // Do a deeper copy.
+            else if (pso.StoreTypeNameAndInstanceMembersLocally)
+            {
+                return psObjectAboveBase.Copy();
+            }
+            else
+            {
+                return psObjectAboveBase.ImmediateBaseObject;
+            }
         }
 
         #endregion static methods

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1076,19 +1076,13 @@ namespace System.Management.Automation
             }
 
             if (psObjectAboveBase.ImmediateBaseObject is PSCustomObject
-                || psObjectAboveBase.ImmediateBaseObject is string)
+                || psObjectAboveBase.ImmediateBaseObject is string
+                || pso.StoreTypeNameAndInstanceMembersLocally)
             {
                 return psObjectAboveBase;
             }
-            else if (pso.StoreTypeNameAndInstanceMembersLocally)
-            {
-                // Do a deeper copy.
-                return psObjectAboveBase.Copy();
-            }
-            else
-            {
-                return psObjectAboveBase.ImmediateBaseObject;
-            }
+            
+            return psObjectAboveBase.ImmediateBaseObject;
         }
 
         #endregion static methods

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -899,7 +899,7 @@ namespace System.Management.Automation
         #endregion properties
 
         #region static methods
-        public static bool HasInstanceMembers(object obj, out PSMemberInfoInternalCollection<PSMemberInfo> instanceMembers)
+        internal static bool HasInstanceMembers(object obj, out PSMemberInfoInternalCollection<PSMemberInfo> instanceMembers)
         {
             if (obj is PSObject psobj)
             {

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1081,7 +1081,6 @@ namespace System.Management.Automation
             {
                 return psObjectAboveBase;
             }
-            
             return psObjectAboveBase.ImmediateBaseObject;
         }
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -899,7 +899,7 @@ namespace System.Management.Automation
         #endregion properties
 
         #region static methods
-        internal static bool HasInstanceMembers(object obj, out PSMemberInfoInternalCollection<PSMemberInfo> instanceMembers)
+        public static bool HasInstanceMembers(object obj, out PSMemberInfoInternalCollection<PSMemberInfo> instanceMembers)
         {
             if (obj is PSObject psobj)
             {

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1039,7 +1039,7 @@ namespace System.Management.Automation
         /// <param name="storeTypeNameAndInstanceMembersLocally"></param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "AsPSObject is shipped as part of V1. This is a new overload method.")]
-        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally, bool AsNew)
+        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally, bool AsNew = false)
         {
             if (obj == null)
             {

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1080,9 +1080,9 @@ namespace System.Management.Automation
             {
                 return psObjectAboveBase;
             }
-            // Do a deeper copy.
             else if (pso.StoreTypeNameAndInstanceMembersLocally)
             {
+                // Do a deeper copy.
                 return psObjectAboveBase.Copy();
             }
             else

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1081,6 +1081,7 @@ namespace System.Management.Automation
             {
                 return psObjectAboveBase;
             }
+
             return psObjectAboveBase.ImmediateBaseObject;
         }
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1037,10 +1037,9 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="storeTypeNameAndInstanceMembersLocally"></param>
-        /// <param name="asNew"></param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "AsPSObject is shipped as part of V1. This is a new overload method.")]
-        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally, bool asNew = false)
+        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally)
         {
             if (obj == null)
             {
@@ -1049,14 +1048,7 @@ namespace System.Management.Automation
 
             if (obj is PSObject so)
             {
-                if (asNew)
-                {
-                    return so.Copy();
-                }
-                else
-                {
-                    return so;
-                }
+                return so;
             }
 
             return new PSObject(obj) { StoreTypeNameAndInstanceMembersLocally = storeTypeNameAndInstanceMembersLocally };

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1037,9 +1037,10 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="storeTypeNameAndInstanceMembersLocally"></param>
+        /// <param name="asNew"></param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "AsPSObject is shipped as part of V1. This is a new overload method.")]
-        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally, bool AsNew = false)
+        internal static PSObject AsPSObject(object obj, bool storeTypeNameAndInstanceMembersLocally, bool asNew = false)
         {
             if (obj == null)
             {
@@ -1048,7 +1049,7 @@ namespace System.Management.Automation
 
             if (obj is PSObject so)
             {
-                if(AsNew)
+                if (asNew)
                 {
                     return so.Copy();
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -395,15 +395,12 @@ Describe "Select-Object with ExpandProperty and Property" -Tags "CI" {
             $obj | Add-Member resurrectTableProp 1
             # Now embed the object inside another object and it via -ExpandProperty,
             # while also decorating it via another property using -Property.
-            $results = [PSCustomObject] @{ psobjectWrapperProp = 2; prop = $obj; prop2 = $obj } |
-                Select-Object -ExpandProperty prop -Property psobjectWrapperProp, prop2
+            $results = [PSCustomObject] @{ psobjectWrapperProp = 2; prop = $obj } |
+                Select-Object -ExpandProperty prop -Property psobjectWrapperProp
         }
 
         It "Resurection Table member is present" {
             $results.resurrectTableProp | Should -BeExactly 1
-        }
-        It "Selected property has Resurection Table member" {
-            $results.prop2.resurrectTableProp | Should -BeExactly 1
         }
         It "PSObject-attached member is present" {
             $results.psobjectWrapperProp | Should -BeExactly 2
@@ -413,9 +410,6 @@ Describe "Select-Object with ExpandProperty and Property" -Tags "CI" {
         }
         It "PSObject-attached member has not become a resurection-table member" {
             $results.PSObject.BaseObject.psobjectWrapperProp | Should -BeNullOrEmpty
-        }
-        It "PSObject-attached member preserves ressurection table member" {
-            $results.PSObject.BaseObject.prop2.resurrectTableProp | Should -BeExactly 1
         }
         # Issue #21308
         It "Original object remains unchanged" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -406,7 +406,7 @@ Describe "Select-Object with ExpandProperty and Property" -Tags "CI" {
             $results.psobjectWrapperProp | Should -BeExactly 2
         }
         It "Resurrection-table member has not become a PSObject-attached member" {
-            $results.psobject.BaseObject.resurrectTableProp | Should -BeExactly 1
+            $results.PSObject.BaseObject.resurrectTableProp | Should -BeExactly 1
         }
         It "PSObject-attached member has not become a resurection-table member" {
             $results.PSObject.BaseObject.psobjectWrapperProp | Should -BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -250,12 +250,12 @@ Describe "Select-Object DRT basic functionality" -Tags "CI" {
         $results.Count | Should -Be 1
         $results[0] | Should -BeExactly "2"
     }
-    
+
     It "Select-Object with Skip and SkipLast should work with Skip overlapping SkipLast" {
         $results = "1", "2" | Select-Object -Skip 2 -SkipLast 1
         $results. Count | Should -Be 0
     }
-    
+
     It "Select-Object with Skip and SkipLast should work with skiplast overlapping skip" {
         $results = "1", "2" | Select-Object -Skip 1 -SkipLast 2
         $results. Count | Should -Be 0
@@ -361,6 +361,13 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
         $results = [pscustomobject]@{Thing = "thing1"; Param2 = "param2" } | Select-Object -Property * -ExcludeProperty Param2
         $results.Param2 | Should -BeNullOrEmpty
         $results.Thing | Should -BeExactly "thing1"
+    }
+
+    # Issue #21308
+    It "Select-Object with ExpandProperty and Property does not modify source object" {
+        $obj = [PSCustomObject]@{"name"="admin1";"children"=[PSCustomObject]@{"name"="admin2"}}
+        $obj | Select-Object @{N="country";E={$_.name}} -ExpandProperty children | Out-Null
+        $obj.children.country | Should -BeNullOrEmpty
     }
 
     It "Select-Object with ExpandProperty and Property don't skip processing ExcludeProperty" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -363,13 +363,6 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
         $results.Thing | Should -BeExactly "thing1"
     }
 
-    # Issue #21308
-    It "Select-Object with ExpandProperty and Property does not modify source object" {
-        $obj = [PSCustomObject]@{"name"="admin1";"children"=[PSCustomObject]@{"name"="admin2"}}
-        $obj | Select-Object @{N="country";E={$_.name}} -ExpandProperty children | Out-Null
-        $obj.children.country | Should -BeNullOrEmpty
-    }
-
     It "Select-Object with ExpandProperty and Property don't skip processing ExcludeProperty" {
         $p = Get-Process -Id $PID | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
         $p[0].psobject.Properties.Item("ProcessorAffinity") | Should -BeNullOrEmpty
@@ -390,7 +383,25 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
     }
 }
 
-Describe 'Select-Object behaviour with hashtable entries and actual members' -Tags CI {
+Describe "Select-Object with ExpandProperty" -Tags "CI" {
+
+    # Issue #7937
+    It "Select-Object with ExpandProperty preserves ETS instance members" {
+        $obj = [DateTime]::Now
+        $obj | Add-Member myProp myPropValue
+        $results =  [PSCustomObject] @{ prop = $obj } | Select-Object -ExpandProperty prop
+        $results.myProp | Should -BeExactly "myPropValue"
+    }
+
+    # Issue #21308
+    It "Select-Object with ExpandProperty and Calculated Property does not modify source object" {
+        $obj = [PSCustomObject]@{"name"="admin1";"children"=[PSCustomObject]@{"name"="admin2"}}
+        $obj | Select-Object -Property @{N="country";E={$_.name}} -ExpandProperty children | Out-Null
+        $obj.children.country | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Select-Object behaviour with hashtable entries and actual members' -Tags "CI" {
 
     It 'can retrieve a hashtable entry as a property' {
         $hashtable = @{ Entry = 100 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -395,12 +395,15 @@ Describe "Select-Object with ExpandProperty and Property" -Tags "CI" {
             $obj | Add-Member resurrectTableProp 1
             # Now embed the object inside another object and it via -ExpandProperty,
             # while also decorating it via another property using -Property.
-            $results = [PSCustomObject] @{ psobjectWrapperProp = 2; prop = $obj } |
-                Select-Object -ExpandProperty prop -Property psobjectWrapperProp
+            $results = [PSCustomObject] @{ psobjectWrapperProp = 2; prop = $obj; prop2 = $obj } |
+                Select-Object -ExpandProperty prop -Property psobjectWrapperProp, prop2
         }
 
         It "Resurection Table member is present" {
             $results.resurrectTableProp | Should -BeExactly 1
+        }
+        It "Selected property has Resurection Table member" {
+            $results.prop2.resurrectTableProp | Should -BeExactly 1
         }
         It "PSObject-attached member is present" {
             $results.psobjectWrapperProp | Should -BeExactly 2
@@ -410,6 +413,9 @@ Describe "Select-Object with ExpandProperty and Property" -Tags "CI" {
         }
         It "PSObject-attached member has not become a resurection-table member" {
             $results.PSObject.BaseObject.psobjectWrapperProp | Should -BeNullOrEmpty
+        }
+        It "PSObject-attached member preserves ressurection table member" {
+            $results.PSObject.BaseObject.prop2.resurrectTableProp | Should -BeExactly 1
         }
         # Issue #21308
         It "Original object remains unchanged" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -386,7 +386,7 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
 Describe "Select-Object with ExpandProperty and Property" -Tags "CI" {
 
     # Issue #7937
-    Context "Select-Object with ExpandProperty preserves ETS instance members" {
+    Context "Preserves ETS instance members" {
         BeforeAll {
             # Use a .NET reference type, because the copy semantics of value types
             # could hide some behaviors.
@@ -418,7 +418,7 @@ Describe "Select-Object with ExpandProperty and Property" -Tags "CI" {
     }
 
     # Issue #21308
-    It "Select-Object with ExpandProperty and Calculated Property does not modify source object" {
+    It "Does not modify source object" {
         $obj = [PSCustomObject]@{"name"="admin1";"children"=[PSCustomObject]@{"name"="admin2"}}
         $obj | Select-Object -Property @{N="country";E={$_.name}} -ExpandProperty children | Out-Null
         $obj.children.country | Should -BeNullOrEmpty


### PR DESCRIPTION
### Supersceeded by #21328
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

When using `Select-Object` to select from a `PSObject` with both `-Property` and `-ExpandedProperty` arguments specified, the source object will be copied instead of referenced.

<!-- Summarize your PR between here and the checklist. -->

This PR addresses issue #21308 and #7937.  It ensures that when a `PSObject` is selected from with both the `-ExpandProperty` and `-Property` arguments specified, the source object will not be updated.  While technically preventing the source object from being modified is a breaking change, it breaks things in a manner [previously approved](https://github.com/PowerShell/PowerShell/issues/7768#issuecomment-459158766) by the @Powershell/powershell-committee.  This PR is needed because the previous attempt at fixing this only works for non-PSObject inputs.

In particular, for operations matching the aforementioned restrictions, this PR does the following:

- The `PSObject.AsPSObject()` method is now invoked with `StoreTypeNameAndInstanceMembersLocally` set to `true`. (Resolves #7937)
- The resulting `PSObject` is now copied using the `.Copy()` method before that copy is assigned to the `expandedObject` variable. (Resolves #21308)

Additionally, Pester tests for both issues have been added.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] Yes - In a manner [previously approved](https://github.com/PowerShell/PowerShell/issues/7768#issuecomment-459158766) by the @Powershell/powershell-committee
- **User-facing changes**
    - [X] Not Applicable
- **Testing - New and feature**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
