### PR TITLE
Improve .NET overload definition of generics

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -4441,7 +4441,7 @@ namespace System.Management.Automation
             }
 
             builder.Append(memberName ?? methodEntry.Name);
-            if (methodEntry.IsGenericMethodDefinition)
+            if (methodEntry.IsGenericMethodDefinition || methodEntry.IsGenericMethod)
             {
                 builder.Append('[');
 


### PR DESCRIPTION
# PR Summary

This change ensures that generic methods created with MakeGenericMethod() will include the generic type information in the overload definition string so that consumers can easily see it is from a generic overload rather than another overload.

## PR Context

This is related to https://github.com/PowerShell/PowerShell/pull/21320 where I found that doing `[System.Runtime.InteropServices.Marshal]::SizeOf([int])` was selecting the `SizeOf<T>()` overload but as the output from  `GetMethodInfoOverloadDefinition()` didn't include the generic type block it was hard to determine the overload chosen was this. This PR aligns the behaviour with other generic types.

Using the following, this is what this PR changes:

```powershell
Add-Type -TypeDefinition @"
using System.Management.Automation;

namespace TestCodeMethodDefinition;

public static class TestClass1
{
    public static T Generic1<T>(PSObject obj, T val) => val;

    public static T1 Generic2<T1, T2>(PSObject obj, T1 val, T2 dummy) => val;
}
"@

$mi1 = [TestCodeMethodDefinition.TestClass1].GetMethod("Generic1")
$mi2 = [TestCodeMethodDefinition.TestClass1].GetMethod("Generic2")
$obj = [PSCustomObject]@{}
$obj | Add-Member -MemberType CodeMethod -Name FromGeneric1 -Value $mi1.MakeGenericMethod(@([int]))
$obj | Add-Member -MemberType CodeMethod -Name FromGeneric2 -Value $mi2.MakeGenericMethod(@([string], [int]))

$obj.FromGeneric1.OverloadDefinitions
$obj.FromGeneric2.OverloadDefinitions

# Before
static int Generic1(psobject obj, int val)
static string Generic2(psobject obj, string val, int dummy)

# After
static int Generic1[int](psobject obj, int val)
static string Generic2[string, int](psobject obj, string val, int dummy)
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
