### PR TITLE
Prevent Select-Object with ExpandProperty from updating source PSObjects

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true);
+                    PSObject expandedObject = PSObject.AsPSObject(r.Result, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell.Commands
                     // directly with it. We want the NoteProperty to be associated only with this
                     // particular PSObject, so that when the user uses the base object else where,
                     // its members remain the same as before the Select-Object command run.
-                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true);
+                    PSObject expandedObject = PSObject.AsPSObject(expandedValue, true).Copy();
                     AddNoteProperties(expandedObject, inputObject, matchedProperties);
 
                     FilteredWriteObject(expandedObject, matchedProperties);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

When using `Select-Object` to select from a `PSObject` with both `-Property` and `-ExpandedProperty` arguments specified, the source object will be copied instead of referenced.

<!-- Summarize your PR between here and the checklist. -->

This PR addresses issue #21308.  It ensures that when a `PSObject` is selected from with both the `-ExpandProperty` and `-Property` arguments specified, the source object will not be updated.  While technically preventing the source object from being modified is a breaking change, it breaks things in a manner [previously approved](https://github.com/PowerShell/PowerShell/issues/7768#issuecomment-459158766) by the @Powershell/powershell-committee.  This PR is needed because the previous attempt at fixing this only works for non-PSObject inputs.

In particular, for operations matching the aforementioned restrictions, this PR does the following: Within the `ProcessExpandParameter` method, the `expandedObject` is now set to a copy of the resulting `PSObject` instead of a reference.

Additionally, Pester tests have been added.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [X] Yes - In a manner [previously approved](https://github.com/PowerShell/PowerShell/issues/7768#issuecomment-459158766) by the @Powershell/powershell-committee
- **User-facing changes**
    - [X] Not Applicable
- **Testing - New and feature**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.