### PR TITLE
Fix PowerShell class to support deriving from an abstract class with abstract properties

### DIFF
--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -628,3 +628,33 @@ class Derived : Base
         $sb.Invoke() | Should -Be 200
     }
 }
+
+Describe 'Base type has abstract properties' -Tags "CI" {
+    It 'can derive from `FileSystemInfo`' {
+        ## FileSystemInfo has 3 abstract members that a derived type needs to implement
+        ##  - public abstract bool Exists { get; }
+        ##  - public abstract string Name { get; }
+        ##  - public abstract void Delete ();
+
+        class myFileSystemInfo : System.IO.FileSystemInfo
+        {
+            [string] $Name
+            [bool] $Exists
+
+            myFileSystemInfo([string]$path)
+            {
+                # ctor
+                $this.Name = $path
+                $this.Exists = $true
+            }
+
+            [void] Delete()
+            {
+            }
+        }
+
+        $myFile = [myFileSystemInfo]::new('Hello')
+        $myFile.Name | Should -Be 'Hello'
+        $myFile.Exists | Should -BeTrue
+    }
+}

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -657,4 +657,18 @@ Describe 'Base type has abstract properties' -Tags "CI" {
         $myFile.Name | Should -Be 'Hello'
         $myFile.Exists | Should -BeTrue
     }
+
+    It 'deriving from `FileSystemInfo` will fail when the abstract property `Exists` is not implemented' {
+        $script = [scriptblock]::Create('class WillFail : System.IO.FileSystemInfo { [string] $Name }')
+        $failure = $null
+        try {
+            & $script
+        } catch {
+            $failure = $_
+        }
+
+        $failure | Should -Not -BeNullOrEmpty
+        $failure.FullyQualifiedErrorId | Should -BeExactly "TypeCreationError"
+        $failure.Exception.Message | Should -BeLike "*'get_Exists'*"
+    }
 }


### PR DESCRIPTION
# PR Summary

Fix PowerShell class to support deriving from an abstract class with abstract properties.
The fix is to detect that we are deriving from an abstract base type, and the property is an implementation of an abstract property from that base type.

## PR Context

The following PowerShell class stops working in PowerShell v7.4.1, because .NET 8 enforces stricter validation on the dynamically emitted IL code. Previously, for a property that is supposed to be the implementation of an abstract property in base type, we don't set the `Reflection.MethodAttributes.Virtual` attribute when creating the property. That actually makes the created property have nothing to do with the abstract property in base type. Prior to .NET 8, the IL emitting library doesn't detect this error even though the abstract property is not implemented. However, starting from .NET 8, it detects the issue and throw exception in this case.

Running the following PowerShell class will result in an error in v7.4.1

```powershell
class nxFileSystemInfo : System.IO.FileSystemInfo
{
    [string] $Name
    [bool] $Exists

    [void] Delete()
    {
    }
}
```
```none
ParserError:
Line |
   1 |  class nxFileSystemInfo : System.IO.FileSystemInfo
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Error during creation of type "nxFileSystemInfo". Error message: Method 'get_Name' in type 'nxFileSystemInfo' from assembly 'PowerShell Class
     | Assembly, Version=1.0.0.2, Culture=neutral, PublicKeyToken=null' does not have an implementation.
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
