### PR TITLE
Fix argument passing in GlobalToolShim, fix #11747

### DIFF
--- a/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
+++ b/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
@@ -30,9 +30,10 @@ namespace Microsoft.PowerShell.GlobalTool.Shim
 
             string platformFolder = isWindows ? WinFolderName : UnixFolderName;
 
-            string argsString = args.Length > 0 ? string.Join(" ", args) : null;
+            var arguments = new List<string>(args.Length + 1);
             var pwshPath = Path.Combine(currentPath, platformFolder, PwshDllName);
-            string processArgs = string.IsNullOrEmpty(argsString) ? $"\"{pwshPath}\"" : $"\"{pwshPath}\" {argsString}";
+            arguments.Add(pwshPath);
+            arguments.AddRange(args);
 
             if (File.Exists(pwshPath))
             {
@@ -41,7 +42,7 @@ namespace Microsoft.PowerShell.GlobalTool.Shim
                     e.Cancel = true;
                 };
 
-                var process = System.Diagnostics.Process.Start("dotnet", processArgs);
+                var process = System.Diagnostics.Process.Start("dotnet", arguments);
                 process.WaitForExit();
                 return process.ExitCode;
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR fixes #11747 by properly passing the arguments to a child process from the .NET global tool shim.

The previous approach was losing the quotes around the arguments, and could easily mess up the arguments with spaces or embedded quotes.

The new approach is more robust since it relies on .NET Process API properly re-packing the arguments to be passed to a child process.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

While working on PowerShell-related tooling, I have noted that there are several issues with the current implementation of .NET tool shim, and the parsing in the PowerShell instance installed via `dotnet tool install` works differently than to the instance installed natively (on any system, though the issue I was initially investigating was reported from Linux).

After putting some thought, I have eventually figured out that the reason should be in how PowerShell's global tool behaves, and discovered #11747.

I believe that this PR should strictly improve the behavior in all cases, and make it closer to what happens when `pwsh.exe` gets called natively: if .NET's `Process` API is able to round-trip the arguments to the called binary properly, then this should be an ideal implementation.

Notably, there's still some room for improvement on Windows, because of how process argument parsing works on this OS, but for now I've decided to follow the naivety (if you will) of the existing implementation, and not to introduce platform-dependent branches.

In all known cases, this is strict improvement.

An example test case I was playing with while testing this fix:
```
PS> pwsh -c "echo `"123 123`""
```

I expect this example to reliably print `123 123` in one line in all cases.

The old shim implementation was failing this expectation: it was passing the command as `-c echo "123 123"`, losing the quotes aroung the command body along the way (and something additional tricky happening that was splitting the string into two arguments for `echo`).

The native PowerShell executable on all available systems behaves as I expect: prints `123 123` in one line.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively

      (sadly, I think that there are no tests for this shim module so far; if there are tests then please direct me to them and I'm ready to improve the tests as well)
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
