### PR TITLE
Fix PSModulePath with multiple paths

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1275,11 +1275,13 @@ namespace System.Management.Automation
             if (!string.IsNullOrEmpty(pathToAdd))
             {
                 path = AddToPath(path, pathToAdd, insertIndex);
-                insertIndex = path.IndexOf(Path.PathSeparator, PathContainsSubstring(path, pathToAdd));
-                if (insertIndex != -1)
+                foreach (string addedSubPath in pathToAdd.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    // advance past the path separator
-                    insertIndex++;
+                    int newInsertIndex = PathContainsSubstring(path, addedSubPath) + addedSubPath.Length + 1;
+                    if (newInsertIndex > insertIndex)
+                    {
+                        insertIndex = newInsertIndex;
+                    }
                 }
             }
             return path;


### PR DESCRIPTION
# PR Summary

Allows PSModulePath when present in `powershell.config.json` to have multiple paths. This worked up to pwsh 7.3, and stopped working on 7.4+.
Fix #20706.

## PR Context

PowerShell Core can't start if PSModulePath has multiple paths in the json config file.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
