### PR TITLE
Fix a null reference exception when 'Runspace.DefaultRunspace' is null

### DIFF
--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -8,6 +8,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Internal;
+using System.Management.Automation.Runspaces;
 using System.Management.Automation.Tracing;
 using System.Runtime.InteropServices;
 
@@ -91,9 +92,8 @@ namespace System.Management.Automation.Security
             string messageToWrite = message;
 
             // Augment the log message with current script information from the script debugger, if available.
-            context ??= System.Management.Automation.Runspaces.LocalPipeline.GetExecutionContextFromTLS();
+            context ??= LocalPipeline.GetExecutionContextFromTLS();
             bool debuggerAvailable = context is not null &&
-                                     context._debugger is not null &&
                                      context._debugger is ScriptDebugger;
 
             if (debuggerAvailable)
@@ -108,10 +108,9 @@ namespace System.Management.Automation.Security
             PSEtwLog.LogWDACAuditEvent(title, messageToWrite, fqid);
 
             // We drop into the debugger only if requested and we are running in the interactive host session runspace (Id == 1).
-            if (debuggerAvailable &&
-                dropIntoDebugger is true && 
+            if (debuggerAvailable && dropIntoDebugger &&
                 context._debugger.DebugMode.HasFlag(DebugModes.LocalScript) &&
-                System.Management.Automation.Runspaces.Runspace.DefaultRunspace.Id == 1 &&
+                Runspace.DefaultRunspace?.Id == 1 &&
                 context.DebugPreferenceVariable.HasFlag(ActionPreference.Break) &&
                 context.InternalHost?.UI is not null)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix https://github.com/PowerShell/PowerShell/issues/21253

Fix a null reference exception when `Runspace.DefaultRunspace == null`.
This issue happens when the `WDAC Audit` feature is enabled on the client machine.

`Enter-PSSession` will push a `RemoteRunspace` to the `RunspaceRef` in `ConsoleHost`, then the next input loop will use the `RemoteRunspace` to create a pipeline. The call to `LogWDACAuditMessage` happens when creating that pipeline, and at that point, we are still in the starting thread of `pwsh`, not a `Pipeline Execution Thread`, so the local-thread-storage property `Runspace.DefaultRunspace` is `null`.

The fix is to check on `Runspace.DefaultRunspace?.Id == 1`. This PR also does some cleanup of the code.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.