### PR TITLE
Fix `Test-Path -IsValid` to check for invalid path and filename characters

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1080,6 +1080,13 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
+            // .NET introduced a change where invalid characters are accepted https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
+            // We need to check for invalid characters ourselves
+            if (path.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.PowerShell.Commands
 
             // .NET introduced a change where invalid characters are accepted https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
             // We need to check for invalid characters ourselves
-            if (path.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+            if (path.IndexOfAny(Path.GetInvalidPathChars()) != -1 || Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
             {
                 return false;
             }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1085,10 +1085,11 @@ namespace Microsoft.PowerShell.Commands
 
             // Remove drive root first
             string pathWithoutDriveRoot = path.Substring(Path.GetPathRoot(path).Length);
+            char[] invalidFileChars = Path.GetInvalidFileNameChars();
 
             foreach (string segment in pathWithoutDriveRoot.Split(Path.DirectorySeparatorChar))
             {
-                if (segment.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
+                if (segment.IndexOfAny(invalidFileChars) != -1)
                 {
                     return false;
                 }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1090,11 +1090,15 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // now validate each segment of the path
-            foreach (string segment in Path.GetDirectoryName(path).Split(Path.DirectorySeparatorChar))
+            var directory = Path.GetDirectoryName(path);
+            if (directory is not null)
             {
-                if (segment.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+                foreach (string segment in directory.Split(Path.DirectorySeparatorChar))
                 {
-                    return false;
+                    if (segment.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1095,7 +1095,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (string segment in directory.Split(Path.DirectorySeparatorChar))
                 {
-                    if (segment.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+                    if (segment.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
                     {
                         return false;
                     }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1081,7 +1081,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // .NET introduced a change where invalid characters are accepted https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
-            // We need to check for invalid characters ourselves
+            // We need to check for invalid characters ourselves.  `Path.GetInvalidFileNameChars()` is a supserset of `Path.GetInvalidPathChars()`
 
             // Remove drive root first
             string pathWithoutDriveRoot = path.Substring(Path.GetPathRoot(path).Length);

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1082,23 +1082,11 @@ namespace Microsoft.PowerShell.Commands
 
             // .NET introduced a change where invalid characters are accepted https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
             // We need to check for invalid characters ourselves
-
-            // validate the filename portion first
-            if (Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
+            foreach (string segment in path.Split(Path.DirectorySeparatorChar))
             {
-                return false;
-            }
-
-            // now validate each segment of the path
-            var directory = Path.GetDirectoryName(path);
-            if (directory is not null)
-            {
-                foreach (string segment in directory.Split(Path.DirectorySeparatorChar))
+                if (segment.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
                 {
-                    if (segment.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1082,9 +1082,20 @@ namespace Microsoft.PowerShell.Commands
 
             // .NET introduced a change where invalid characters are accepted https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
             // We need to check for invalid characters ourselves
-            if (Path.GetDirectoryName(path).IndexOfAny(Path.GetInvalidPathChars()) != -1 || Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
+
+            // validate the filename portion first
+            if (Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
             {
                 return false;
+            }
+
+            // now validate each segment of the path
+            foreach (string segment in Path.GetDirectoryName(path).Split(Path.DirectorySeparatorChar))
+            {
+                if (segment.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+                {
+                    return false;
+                }
             }
 
             return true;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.PowerShell.Commands
 
             // .NET introduced a change where invalid characters are accepted https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
             // We need to check for invalid characters ourselves
-            if (path.IndexOfAny(Path.GetInvalidPathChars()) != -1 || Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
+            if (Path.GetDirectoryName(path).IndexOfAny(Path.GetInvalidPathChars()) != -1 || Path.GetFileName(path).IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
             {
                 return false;
             }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1082,7 +1082,11 @@ namespace Microsoft.PowerShell.Commands
 
             // .NET introduced a change where invalid characters are accepted https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
             // We need to check for invalid characters ourselves
-            foreach (string segment in path.Split(Path.DirectorySeparatorChar))
+
+            // Remove drive root first
+            string pathWithoutDriveRoot = path.Substring(Path.GetPathRoot(path).Length);
+
+            foreach (string segment in pathWithoutDriveRoot.Split(Path.DirectorySeparatorChar))
             {
                 if (segment.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -140,10 +140,10 @@ Describe "Test-Path" -Tags "CI" {
         Test-Path -Path $path -IsValid | Should -BeTrue
     }
 
-    It 'Windows paths should be inavlid: <path>' -Skip:(!$IsWindows) -TestCases @(
-        @{ path = "C:\Program Files\foo*" }
-        @{ path = "C:\Program Files|p\foo" }
-        @{ path = "C:\Win`u{0000}dows\System32" }
+    It 'Windows paths should be inavlid: <variant>' -Skip:(!$IsWindows) -TestCases @(
+        @{ variant = "wildcard"; path = "C:\Program Files\foo*" }
+        @{ variant = "pipe symbol"; path = "C:\Program Files|p\foo" }
+        @{ variant = "null char"; path = "C:\Win`u{0000}dows\System32" }
     ) {
         param($path)
         Test-Path -Path $path -IsValid | Should -BeFalse
@@ -162,9 +162,9 @@ Describe "Test-Path" -Tags "CI" {
         Test-Path -Path $path -IsValid | Should -BeTrue
     }
 
-    It 'Unix paths should be invalid: <path>' -Skip:($IsWindows) -TestCases @(
-        @{ path = "/usr/bi`u{0000}n/test" }
-        @{ path = "/usr/bin/t`u{0000}est" }
+    It 'Unix paths should be invalid: <variant>' -Skip:($IsWindows) -TestCases @(
+        @{ variant = "null in path"; path = "/usr/bi`u{0000}n/test" }
+        @{ variant = "null in filename"; path = "/usr/bin/t`u{0000}est" }
     ) {
         param($path)
         Test-Path -Path $path -IsValid | Should -BeFalse

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -128,6 +128,14 @@ Describe "Test-Path" -Tags "CI" {
         Test-Path -Path $badPath -IsValid | Should -BeFalse
     }
 
+    It "Should return appropriate result for wildcard" {
+        if ($IsWindows) {
+            Test-Path -Path "C:\Program Files\*" -IsValid | Should -BeFalse
+        } else {
+            Test-Path -Path "/usr/*" | Should -BeTrue
+        }
+    }
+
     It "Should return true on paths containing spaces when the path is surrounded in quotes" {
         Test-Path -Path "/totally a valid/path" -IsValid | Should -BeTrue
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Due to intentional [breaking change in .NET](https://learn.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters), `Test-Path -IsValid` no longer fails for some filenames which used to fail.

Fix is to use .NET GetInvalidPathChars() and GetInvalidFilenameChars() to perform additional check within the FileSystemProvider to validate if the path is valid for the current OS.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/20847

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
