### PR TITLE
Register the assembly/library resolvers at early stage

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -36,16 +36,19 @@ namespace System.Management.Automation
         /// <summary>
         /// Initialize a singleton of PowerShellAssemblyLoadContext.
         /// </summary>
-        internal static PowerShellAssemblyLoadContext InitializeSingleton(string basePaths)
+        internal static PowerShellAssemblyLoadContext InitializeSingleton(string basePaths, bool throwOnReentry)
         {
             lock (s_syncObj)
             {
-                if (Instance != null)
+                if (Instance is null)
+                {
+                    Instance = new PowerShellAssemblyLoadContext(basePaths);
+                }
+                else if (throwOnReentry)
                 {
                     throw new InvalidOperationException(SingletonAlreadyInitialized);
                 }
 
-                Instance = new PowerShellAssemblyLoadContext(basePaths);
                 return Instance;
             }
         }
@@ -581,7 +584,8 @@ namespace System.Management.Automation
         {
             ArgumentException.ThrowIfNullOrEmpty(basePaths);
 
-            PowerShellAssemblyLoadContext.InitializeSingleton(basePaths);
+            // Disallow calling this method from native code for more than once.
+            PowerShellAssemblyLoadContext.InitializeSingleton(basePaths, throwOnReentry: true);
         }
     }
 

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -26,6 +26,18 @@ namespace System.Management.Automation.Runspaces
         #region constructors
 
         /// <summary>
+        /// Initialize powershell AssemblyLoadContext and register the 'Resolving' event, if it's not done already.
+        /// If powershell is hosted by a native host such as DSC, then PS ALC will be initialized via 'SetPowerShellAssemblyLoadContext' before loading S.M.A.
+        /// </summary>
+        static RunspaceBase()
+        {
+            if (PowerShellAssemblyLoadContext.Instance is null)
+            {
+                PowerShellAssemblyLoadContext.InitializeSingleton(string.Empty);
+            }
+        }
+
+        /// <summary>
         /// Construct an instance of an Runspace using a custom
         /// implementation of PSHost.
         /// </summary>

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -29,6 +29,16 @@ namespace System.Management.Automation.Runspaces
         /// Initialize powershell AssemblyLoadContext and register the 'Resolving' event, if it's not done already.
         /// If powershell is hosted by a native host such as DSC, then PS ALC may be initialized via 'SetPowerShellAssemblyLoadContext' before loading S.M.A.
         /// </summary>
+        /// <remarks>
+        /// We do this both here and during the initialization of the 'ClrFacade' type.
+        /// This is because we want to make sure the assembly/library resolvers are:
+        ///  1. registered before any script/cmdlet can run.
+        ///  2. registered before 'ClrFacade' gets used for assembly related operations.
+        ///
+        /// The 'ClrFacade' type may be used without a Runspace created, for example, by calling type conversion methods in the 'LanguagePrimitive' type.
+        /// And at the mean time, script or cmdlet may run without the 'ClrFacade' type initialized.
+        /// That's why we attempt to create the singleton of 'PowerShellAssemblyLoadContext' at both places.
+        /// </remarks>
         static RunspaceBase()
         {
             if (PowerShellAssemblyLoadContext.Instance is null)

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -27,13 +27,13 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Initialize powershell AssemblyLoadContext and register the 'Resolving' event, if it's not done already.
-        /// If powershell is hosted by a native host such as DSC, then PS ALC will be initialized via 'SetPowerShellAssemblyLoadContext' before loading S.M.A.
+        /// If powershell is hosted by a native host such as DSC, then PS ALC may be initialized via 'SetPowerShellAssemblyLoadContext' before loading S.M.A.
         /// </summary>
         static RunspaceBase()
         {
             if (PowerShellAssemblyLoadContext.Instance is null)
             {
-                PowerShellAssemblyLoadContext.InitializeSingleton(string.Empty);
+                PowerShellAssemblyLoadContext.InitializeSingleton(string.Empty, throwOnReentry: false);
             }
         }
 

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -20,6 +20,18 @@ namespace System.Management.Automation
     /// </summary>
     internal static class ClrFacade
     {
+        /// <summary>
+        /// Initialize powershell AssemblyLoadContext and register the 'Resolving' event, if it's not done already.
+        /// If powershell is hosted by a native host such as DSC, then PS ALC may be initialized via 'SetPowerShellAssemblyLoadContext' before loading S.M.A.
+        /// </summary>
+        static ClrFacade()
+        {
+            if (PowerShellAssemblyLoadContext.Instance is null)
+            {
+                PowerShellAssemblyLoadContext.InitializeSingleton(string.Empty, throwOnReentry: false);
+            }
+        }
+
         #region Assembly
 
         internal static IEnumerable<Assembly> GetAssemblies(TypeResolutionState typeResolutionState, TypeName typeName)

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -24,6 +24,16 @@ namespace System.Management.Automation
         /// Initialize powershell AssemblyLoadContext and register the 'Resolving' event, if it's not done already.
         /// If powershell is hosted by a native host such as DSC, then PS ALC may be initialized via 'SetPowerShellAssemblyLoadContext' before loading S.M.A.
         /// </summary>
+        /// <remarks>
+        /// We do this both here and during the initialization of the 'RunspaceBase' type.
+        /// This is because we want to make sure the assembly/library resolvers are:
+        ///  1. registered before any script/cmdlet can run.
+        ///  2. registered before 'ClrFacade' gets used for assembly related operations.
+        ///
+        /// The 'ClrFacade' type may be used without a Runspace created, for example, by calling type conversion methods in the 'LanguagePrimitive' type.
+        /// And at the mean time, script or cmdlet may run without the 'ClrFacade' type initialized.
+        /// That's why we attempt to create the singleton of 'PowerShellAssemblyLoadContext' at both places.
+        /// </remarks>
         static ClrFacade()
         {
             if (PowerShellAssemblyLoadContext.Instance is null)

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -20,18 +20,6 @@ namespace System.Management.Automation
     /// </summary>
     internal static class ClrFacade
     {
-        /// <summary>
-        /// Initialize powershell AssemblyLoadContext and register the 'Resolving' event, if it's not done already.
-        /// If powershell is hosted by a native host such as DSC, then PS ALC might be initialized via 'SetPowerShellAssemblyLoadContext' before loading S.M.A.
-        /// </summary>
-        static ClrFacade()
-        {
-            if (PowerShellAssemblyLoadContext.Instance == null)
-            {
-                PowerShellAssemblyLoadContext.InitializeSingleton(string.Empty);
-            }
-        }
-
         #region Assembly
 
         internal static IEnumerable<Assembly> GetAssemblies(TypeResolutionState typeResolutionState, TypeName typeName)

--- a/test/powershell/engine/Basic/RegisterAssemblyResolverEarly.ps1
+++ b/test/powershell/engine/Basic/RegisterAssemblyResolverEarly.ps1
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Assembly resolvers should be registered early at startup" -Tags "CI" {
+
+    ## The PKI module requires loading an assembly from GAC, and thus depends on the PowerShell assembly resolver to work.
+    It "Can load the PKI module with 'pwsh -ExecutionPolicy bypass -NoProfile -c `"Import-Module PKI`"'" -Skip:(!$IsWindows) {
+        $pwsh = Join-Path $PSHOME "pwsh.exe"
+        $out = & $pwsh -ExecutionPolicy bypass -NoProfile -c "Import-Module PKI; Get-Module | % name"
+        $out | Should -BeExactly "PKI"
+    }
+}

--- a/test/powershell/engine/Basic/RegisterAssemblyResolverEarly.ps1
+++ b/test/powershell/engine/Basic/RegisterAssemblyResolverEarly.ps1
@@ -5,8 +5,9 @@ Describe "Assembly resolvers should be registered early at startup" -Tags "CI" {
 
     ## The PKI module requires loading an assembly from GAC, and thus depends on the PowerShell assembly resolver to work.
     It "Can load the PKI module with 'pwsh -ExecutionPolicy bypass -NoProfile -c `"Import-Module PKI`"'" -Skip:(!$IsWindows) {
-        $pwsh = Join-Path $PSHOME "pwsh.exe"
-        $out = & $pwsh -ExecutionPolicy bypass -NoProfile -c "Import-Module PKI; Get-Module | % name"
+        ## Use 'Bypass' execution policy so that it doesn't trigger 'AuthorizationManager' which would trigger 'ClrFacade' initialization.
+        ## We want to make sure even if 'ClrFacade' is not hit during startup, the resolvers are still registered early enough.
+        $out = pwsh -ExecutionPolicy bypass -NoProfile -c "Import-Module PKI; Get-Module | % name"
         $out | Should -BeExactly "PKI"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #20740, Fix #21319

This is an unexpected regression caused by #18356, specifically [this line of change](https://github.com/PowerShell/PowerShell/commit/1688b0fc356af9f2f9f8bae1e8304bc0929d51a5#diff-20df6f18d8f50364843dfabc414eaed80bbc46ea342e042baaac6a888867f380L518) in `ExternalScriptInfo`.
The native lib resolver and GAC assembly resolvers are registered within the static constructor of `ClrFacade`, and that change reduced the reference surface of `ClrFacade`, which caused them to not be registered when running `pwsh -exe bypass -nop -c "ipmo pki"`.

The fix is to do the registration to an early stage. `PowerShellAssemblyLoadContext.InitializeSingleton(string.Empty)` is added to the static constructor of `RunspaceBase`, which will run as soon as anything in the startup code path references `LocalRunspace` or `RunspaceBase`. This is to make sure we register the resolvers before PowerShell is ready to run any scripts/cmdlets.

However, we still need to keep the singleton initialization in `ClrFacade` because `ClrFacade` can be used without a Runspace created, for example, by calling the type conversion methods in `LanguagePrimitive`. So, we attempt to do the singleton initialization at both places.

Many thanks to @SeeminglyScience for the help in investigation and validation.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [x] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - **_We have considered the VSCode extension, which already register a handler to the `Resolving` event of the default ALC. It's verified that after this change, the behavior (order of the registered handler) is the same as in PowerShell v7.3 -- PowerShell's handler is registered first and then the VSCode extension's handler._**