### PR TITLE
Revert the PR #17856 (Do not preserve temporary results when no need to do so)

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -2278,25 +2278,26 @@ namespace System.Management.Automation.Language
             switch (context)
             {
                 case CaptureAstContext.AssignmentWithResultPreservation:
-                    result = Expression.Call(CachedReflectionInfo.PipelineOps_PipelineResult, resultList);
-
-                    // PipelineResult might get skipped in some circumstances due to an early return or a FlowControlException thrown out, in which case
-                    // we write to the oldPipe. This can happen in cases like:
-                    //     $(1;2;return 3)
-                    finallyExprs.Add(Expression.Call(CachedReflectionInfo.PipelineOps_FlushPipe, oldPipe, resultList));
-                    break;
                 case CaptureAstContext.AssignmentWithoutResultPreservation:
                     result = Expression.Call(CachedReflectionInfo.PipelineOps_PipelineResult, resultList);
 
                     // Clear the temporary pipe in case of exception, if we are not required to preserve the results
-                    var catchExprs = new List<Expression>
+                    if (context == CaptureAstContext.AssignmentWithoutResultPreservation)
                     {
-                        Expression.Call(CachedReflectionInfo.PipelineOps_ClearPipe, resultList),
-                        Expression.Rethrow(),
-                        Expression.Constant(null, typeof(object))
-                    };
+                        var catchExprs = new List<Expression>
+                        {
+                            Expression.Call(CachedReflectionInfo.PipelineOps_ClearPipe, resultList),
+                            Expression.Rethrow(),
+                            Expression.Constant(null, typeof(object))
+                        };
 
-                    catches.Add(Expression.Catch(typeof(RuntimeException), Expression.Block(typeof(object), catchExprs)));
+                        catches.Add(Expression.Catch(typeof(RuntimeException), Expression.Block(typeof(object), catchExprs)));
+                    }
+
+                    // PipelineResult might get skipped in some circumstances due to an early return or a FlowControlException thrown out,
+                    // in which case we write to the oldPipe. This can happen in cases like:
+                    //     $(1;2;return 3)
+                    finallyExprs.Add(Expression.Call(CachedReflectionInfo.PipelineOps_FlushPipe, oldPipe, resultList));
                     break;
                 case CaptureAstContext.Condition:
                     result = DynamicExpression.Dynamic(PSPipelineResultToBoolBinder.Get(), typeof(bool), resultList);

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -81,28 +81,6 @@ Describe "Scripting.Followup.Tests" -Tags "CI" {
         $result | Should -BeOfType 'System.Collections.Specialized.OrderedDictionary'
     }
 
-    It "Don't preserve result when no need to do so in case of flow-control exception" {
-        function TestFunc1([switch]$p) {
-            ## No need to preserve and flush the results from the IF statement to the outer
-            ## pipeline, because the results are supposed to be assigned to a variable.
-            if ($p) {
-                $null = if ($true) { "one"; return "two" }
-            } else {
-                $a = foreach ($a in 1) { "one"; return; }
-            }
-        }
-
-        function TestFunc2 {
-            ## The results from the sub-expression need to be preserved and flushed to the outer pipeline.
-            $("1";return "2")
-        }
-
-        TestFunc1 | Should -Be $null
-        TestFunc1 -p | Should -Be $null
-
-        TestFunc2 | Should -Be @("1", "2")
-    }
-
     It "'[NullString]::Value' should be treated as string type when resolving .NET method" {
         $testType = 'NullStringTest' -as [type]
         if (-not $testType) {

--- a/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
+++ b/test/powershell/Language/Scripting/Scripting.Followup.Tests.ps1
@@ -125,9 +125,9 @@ public class NullStringTest {
         $result | Should -BeExactly "ibm437"
     }
 
-    It 'Return statement on the right side of an assignment should write the retrun value to outter pipe' {
+    It 'Return statement on the right side of an assignment should write the retrun value to outer pipe' {
         function TestFunc1 {
-            ## The return value are not assigned to the variable but should be written to the outter pipe.
+            ## The return value are not assigned to the variable but should be written to the outer pipe.
             $Global:mylhsvar = if ($true) { return "one" }
         }
 


### PR DESCRIPTION
### PR Summary

Fix #20739 by reverting the PR that caused this regression: #17856

#17856 causes the return value from a `ReturnStatement` to not be preserved too, which breaks an expected behavior.

This is the difference compared with the same code section from v7.3. After this change, the only difference is the updated comments.

![image](https://github.com/PowerShell/PowerShell/assets/127450/65b23d03-51fd-47b6-b4c2-ebe69a82cc94)

Here is the relevant code section in v7.3:

https://github.com/PowerShell/PowerShell/blob/d68aa89daf9b28b23f0675c355b7be0b8795cd82/src/System.Management.Automation/engine/parser/Compiler.cs#L2278-L2310

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
