### PR TITLE
Fix up .NET method invocation with Optional arg

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7167,6 +7167,13 @@ namespace System.Management.Automation.Language
                     {
                         argExprs[i] = Expression.Default(parameterType);
                     }
+                    else if (!parameters[i].HasDefaultValue && parameterType != typeof(object) && argValue == Type.Missing)
+                    {
+                        // If the method contains just [Optional] without a default value set then we cannot use
+                        // Type.Missing as a placeholder. Instead we use the default value for that type. Only
+                        // exception to this rule is when the parameter type is object.
+                        argExprs[i] = Expression.Default(parameterType);
+                    }
                     else
                     {
                         // We don't specify the parameter type in the constant expression. Normally the default

--- a/test/powershell/engine/Basic/CLRBinding.Tests.ps1
+++ b/test/powershell/engine/Basic/CLRBinding.Tests.ps1
@@ -1,0 +1,151 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe ".NET Method Binding Tests" -tags CI {
+    BeforeAll {
+        Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+namespace CLRBindingTests;
+
+public class TestClass
+{
+    public int Prop { get; }
+
+    public TestClass(int value = 1)
+    {
+        Prop = value;
+    }
+
+    public static string StaticWithDefaultExpected() => StaticWithDefault();
+    public static string StaticWithDefault(string value = "foo") => value;
+
+    public static string StaticWithOptionalAndValueExpected() => StaticWithOptionalAndValue();
+    public static string StaticWithOptionalAndValue([Optional, DefaultParameterValue("bar")] string value) => value;
+
+    public static string StaticWithOptionalExpected() => StaticWithOptional();
+    public static string StaticWithOptional([Optional] string value) => value;
+
+    public object InstanceWithDefaultExpected() => InstanceWithDefault();
+    public object InstanceWithDefault(object value = null) => value;
+
+    public object InstanceWithOptionalAndValueExpected() => InstanceWithOptionalAndValue();
+    public object InstanceWithOptionalAndValue([Optional, DefaultParameterValue("foo")] object value) => value;
+
+    public object InstanceWithOptionalExpected() => InstanceWithOptional();
+    public object InstanceWithOptional([Optional] object value) => value;
+
+    public string MultipleArgsWithDefaultExpected(string prefix) => MultipleArgsWithDefault(prefix);
+    public string MultipleArgsWithDefault(string prefix, string extra = "abc") => $"{prefix}{extra}";
+
+    public string MultipleArgsWithOptionalAndValueExpected(string prefix) => MultipleArgsWithOptionalAndValue(prefix);
+    public string MultipleArgsWithOptionalAndValue(string prefix, [Optional, DefaultParameterValue("def")] string extra) => $"{prefix}{extra}";
+
+    public string MultipleArgsWithOptionalExpected(string prefix) => MultipleArgsWithOptional(prefix);
+    public string MultipleArgsWithOptional(string prefix, [Optional] string extra) => $"{prefix}{extra}";
+}
+
+public class TestClassCstorWithOptionalAndValue
+{
+    public int Prop { get; }
+
+    public TestClassCstorWithOptionalAndValue([Optional, DefaultParameterValue(2)] int value)
+    {
+        Prop = value;
+    }
+}
+
+public class TestClassCstorWithOptional
+{
+    public int Prop { get; }
+
+    public TestClassCstorWithOptional([Optional] int value)
+    {
+        Prop = value;
+    }
+}
+'@
+    }
+
+    It "Binds to constructor with default argument" {
+        $c = [CLRBindingTests.TestClass]::new()
+        $c.Prop | Should -Be 1
+    }
+
+    It "Binds to constructor with Optional with DefaultValue argument" {
+        $c = [CLRBindingTests.TestClassCstorWithOptionalAndValue]::new()
+        $c.Prop | Should -Be 2
+    }
+
+    It "Binds to constructor with Optional argument" {
+        $c = [CLRBindingTests.TestClassCstorWithOptional]::new()
+        $c.Prop | Should -Be 0
+    }
+
+    It "Binds to static method with default argument" {
+        $expected = [CLRBindingTests.TestClass]::StaticWithDefaultExpected()
+        $actual = [CLRBindingTests.TestClass]::StaticWithDefault()
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to static method with Optional with DefaultValue argument" {
+        $expected = [CLRBindingTests.TestClass]::StaticWithOptionalAndValueExpected()
+        $actual = [CLRBindingTests.TestClass]::StaticWithOptionalAndValue()
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to static method with Optional argument" {
+        $expected = [CLRBindingTests.TestClass]::StaticWithOptionalExpected()
+        $actual = [CLRBindingTests.TestClass]::StaticWithOptional()
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to instance method with default argument" {
+        $c = [CLRBindingTests.TestClass]::new()
+
+        $expected = $c.InstanceWithDefaultExpected()
+        $actual = $c.InstanceWithDefault()
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to instance method with Optional with DefaultValue argument" {
+        $c = [CLRBindingTests.TestClass]::new()
+
+        $expected = $c.InstanceWithOptionalAndValueExpected()
+        $actual = $c.InstanceWithOptionalAndValue()
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to instance method with Optional argument" {
+        $c = [CLRBindingTests.TestClass]::new()
+
+        $expected = $c.InstanceWithOptionalExpected()
+        $actual = $c.InstanceWithOptional()
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to instance method with normal arg and default argument" {
+        $c = [CLRBindingTests.TestClass]::new()
+
+        $expected = $c.MultipleArgsWithDefaultExpected("prefix")
+        $actual = $c.MultipleArgsWithDefault("prefix")
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to instance method with Optional with normal arg and DefaultValue argument" {
+        $c = [CLRBindingTests.TestClass]::new()
+
+        $expected = $c.MultipleArgsWithOptionalAndValueExpected("prefix")
+        $actual = $c.MultipleArgsWithOptionalAndValue("prefix")
+        $actual | Should -Be $expected
+    }
+
+    It "Binds to instance method with normal arg and Optional argument" {
+        $c = [CLRBindingTests.TestClass]::new()
+
+        $expected = $c.MultipleArgsWithOptionalExpected("prefix")
+        $actual = $c.MultipleArgsWithOptional("prefix")
+        $actual | Should -Be $expected
+    }
+}


### PR DESCRIPTION
# PR Summary
Fix .NET method invocation with an argument that has an [Optional] attribute but no default value.

Fixes: https://github.com/PowerShell/PowerShell/issues/21372

## PR Context
While not common .NET has the ability to set an optional argument but no explicit value https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#optional-arguments

> You can also declare optional parameters by using the .NET [OptionalAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.optionalattribute) class. OptionalAttribute parameters do not require a default value. However, if a default value is desired, take a look at [DefaultParameterValueAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.defaultparametervalueattribute) class.

The docs for F# even recommend this attribute when it comes to F# assemblies that could be used in C# and other .NET languages https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/parameters-and-arguments#optional-parameters

> For the purposes of C# and Visual Basic interop you can use the attributes [<Optional; DefaultParameterValue<(...)>] in F#, so that callers will see an argument as optional. This is equivalent to defining the argument as optional in C# as in MyMethod(int i = 3).

When it comes to the compiled assembly the `ParameterInfo.DefaultValue` for an argument with only `[Optional]` is [System.Reflection.Missing](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.missing?view=net-8.0) but this value cannot be passed as an argument unless the type is `object` because it cannot be casted to the argument type. Instead using `null` or the `default` value for that type should be used.

This is a good candidate to backport.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
