### PR TITLE
Fix `[semver]` type to pass semver.org tests

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -336,7 +336,7 @@ namespace System.Management.Automation
     {
         private const string VersionSansRegEx = @"^(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?$";
         private const string LabelRegEx = @"^((?<preLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?(\+(?<buildLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?$";
-        private const string LabelUnitRegEx = @"^[0-9A-Za-z][0-9A-Za-z\-\.]*$";
+        private const string LabelUnitRegEx = @"^[0-9A-Za-z-][0-9A-Za-z\-\.]*$";
         private const string PreLabelPropertyName = "PSSemVerPreReleaseLabel";
         private const string BuildLabelPropertyName = "PSSemVerBuildLabel";
         private const string TypeNameForVersionWithLabel = "System.Version#IncludeLabel";
@@ -410,7 +410,7 @@ namespace System.Management.Automation
         public SemanticVersion(int major, int minor, int patch, string label)
             : this(major, minor, patch)
         {
-            // We presume the SymVer :
+            // We presume the SemVer :
             // 1) major.minor.patch-label
             // 2) 'label' starts with letter or digit.
             if (!string.IsNullOrEmpty(label))
@@ -447,7 +447,7 @@ namespace System.Management.Automation
                 throw PSTraceSource.NewArgumentException(nameof(minor));
             }
 
-            if (patch < 0) 
+            if (patch < 0)
             {
                 throw PSTraceSource.NewArgumentException(nameof(patch));
             }
@@ -568,12 +568,12 @@ namespace System.Management.Automation
         public int Patch { get; }
 
         /// <summary>
-        /// PreReleaseLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// PreReleaseLabel position in the SemVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
         /// </summary>
         public string PreReleaseLabel { get; }
 
         /// <summary>
-        /// BuildLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// BuildLabel position in the SemVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
         /// </summary>
         public string BuildLabel { get; }
 
@@ -643,7 +643,7 @@ namespace System.Management.Automation
             string preLabel = null;
             string buildLabel = null;
 
-            // We parse the SymVer 'version' string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+            // We parse the SemVer 'version' string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
             var dashIndex = version.IndexOf('-');
             var plusIndex = version.IndexOf('+');
 
@@ -804,7 +804,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Implement <see cref="IComparable{T}.CompareTo"/>.
-        /// Meets SymVer 2.0 p.11 https://semver.org/
+        /// Meets SemVer 2.0 p.11 https://semver.org/
         /// </summary>
         public int CompareTo(SemanticVersion value)
         {
@@ -820,7 +820,7 @@ namespace System.Management.Automation
             if (Patch != value.Patch)
                 return Patch > value.Patch ? 1 : -1;
 
-            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            // SemVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
             return ComparePreLabel(this.PreReleaseLabel, value.PreReleaseLabel);
         }
 
@@ -837,7 +837,7 @@ namespace System.Management.Automation
         /// </summary>
         public bool Equals(SemanticVersion other)
         {
-            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            // SemVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
             return other != null &&
                    (Major == other.Major) && (Minor == other.Minor) && (Patch == other.Patch) &&
                    string.Equals(PreReleaseLabel, other.PreReleaseLabel, StringComparison.Ordinal);
@@ -906,7 +906,7 @@ namespace System.Management.Automation
 
         private static int ComparePreLabel(string preLabel1, string preLabel2)
         {
-            // Symver 2.0 standard p.9
+            // SemVer 2.0 standard p.9
             // Pre-release versions have a lower precedence than the associated normal version.
             // Comparing each dot separated identifier from left to right
             // until a difference is found as follows:

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -335,8 +335,9 @@ namespace System.Management.Automation
     public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>
     {
         private const string VersionSansRegEx = @"^(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?$";
-        private const string LabelRegEx = @"^((?<preLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?(\+(?<buildLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?$";
-        private const string LabelUnitRegEx = @"^[0-9A-Za-z-][0-9A-Za-z\-\.]*$";
+        private const string LabelRegEx = @"^(?<preLabel>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(?:\+(?<buildLabel>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
+        private const string LabelUnitRegEx = @"^((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)$";
+        private const string BuildUnitRegEx = @"^([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)$";
         private const string PreLabelPropertyName = "PSSemVerPreReleaseLabel";
         private const string BuildLabelPropertyName = "PSSemVerBuildLabel";
         private const string TypeNameForVersionWithLabel = "System.Version#IncludeLabel";
@@ -370,7 +371,7 @@ namespace System.Management.Automation
         /// <param name="buildLabel">The build metadata for the version.</param>
         /// <exception cref="FormatException">
         /// If <paramref name="preReleaseLabel"/> don't match 'LabelUnitRegEx'.
-        /// If <paramref name="buildLabel"/> don't match 'LabelUnitRegEx'.
+        /// If <paramref name="buildLabel"/> don't match 'BuildUnitRegEx'.
         /// </exception>
         public SemanticVersion(int major, int minor, int patch, string preReleaseLabel, string buildLabel)
             : this(major, minor, patch)
@@ -387,7 +388,7 @@ namespace System.Management.Automation
 
             if (!string.IsNullOrEmpty(buildLabel))
             {
-                if (!Regex.IsMatch(buildLabel, LabelUnitRegEx))
+                if (!Regex.IsMatch(buildLabel, BuildUnitRegEx))
                 {
                     throw new FormatException(nameof(buildLabel));
                 }
@@ -729,7 +730,7 @@ namespace System.Management.Automation
             }
 
             if (preLabel != null && !Regex.IsMatch(preLabel, LabelUnitRegEx) ||
-               (buildLabel != null && !Regex.IsMatch(buildLabel, LabelUnitRegEx)))
+               (buildLabel != null && !Regex.IsMatch(buildLabel, BuildUnitRegEx)))
             {
                 result.SetFailure(ParseFailureKind.FormatException);
                 return false;

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -304,7 +304,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
 '@
 
             $validVersions = @()
-            foreach ($version in $valid.Split("`n", [System.StringSplitOptions]::RemoveEmptyEntries)) {
+            foreach ($version in $valid.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)) {
                 $validVersions += @{version = $version}
             }
 
@@ -352,7 +352,7 @@ beta
 '@
 
             $invalidVersions = @()
-            foreach ($version in $invalid.Split("`n", [System.StringSplitOptions]::RemoveEmptyEntries)) {
+            foreach ($version in $invalid.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)) {
                 $invalidVersions += @{version = $version}
             }
         }

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -267,4 +267,105 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             { $PSVersionTable.PSVersion | Format-Table | Out-String } | Should -Not -Throw
         }
     }
+
+    Context 'Semver official tests' {
+        BeforeAll {
+            $valid = @'
+0.0.4
+1.2.3
+10.20.30
+1.1.2-prerelease+meta
+1.1.2+meta
+1.1.2+meta-valid
+1.0.0-alpha
+1.0.0-beta
+1.0.0-alpha.beta
+1.0.0-alpha.beta.1
+1.0.0-alpha.1
+1.0.0-alpha0.valid
+1.0.0-alpha.0valid
+1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
+1.0.0-rc.1+build.1
+2.0.0-rc.1+build.123
+1.2.3-beta
+10.2.3-DEV-SNAPSHOT
+1.2.3-SNAPSHOT-123
+1.0.0
+2.0.0
+1.1.7
+2.0.0+build.1848
+2.0.1-alpha.1227
+1.0.0-alpha+beta
+1.2.3----RC-SNAPSHOT.12.9.1--.12+788
+1.2.3----R-S.12.9.1--.12+meta
+1.2.3----RC-SNAPSHOT.12.9.1--.12
+1.0.0+0.build.1-rc.10000aaa-kk-0.1
+1.0.0-0A.is.legal
+'@
+
+            $validVersions = @()
+            foreach ($version in $valid.Split("`n", [System.StringSplitOptions]::RemoveEmptyEntries)) {
+                $validVersions += @{version = $version}
+            }
+
+            $invalid = @'
+1
+1.2
+1.2.3-0123
+1.2.3-0123.0123
+1.1.2+.123
++invalid
+-invalid
+-invalid+invalid
+-invalid.01
+alpha
+alpha.beta
+alpha.beta.1
+alpha.1
+alpha+beta
+alpha_beta
+alpha.
+alpha..
+beta
+1.0.0-alpha_beta
+-alpha.
+1.0.0-alpha..
+1.0.0-alpha..1
+1.0.0-alpha...1
+1.0.0-alpha....1
+1.0.0-alpha.....1
+1.0.0-alpha......1
+1.0.0-alpha.......1
+01.1.1
+1.01.1
+1.1.01
+1.2
+1.2.3.DEV
+1.2-SNAPSHOT
+1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788
+1.2-RC-SNAPSHOT
+-1.0.3-gamma+b7718
++justmeta
+9.8.7+meta+meta
+9.8.7-whatever+meta+meta
+99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12
+'@
+
+            $invalidVersions = @()
+            foreach ($version in $invalid.Split("`n", [System.StringSplitOptions]::RemoveEmptyEntries)) {
+                $invalidVersions += @{version = $version}
+            }
+        }
+
+        It 'Should parse valid versions: <version>' -TestCases $validVersions {
+            param($version)
+            $v = [SemanticVersion]::new($version)
+            $v.ToString() | Should -Be $version
+        }
+
+        It 'Should not parse invalid versions: <version>' -TestCases $invalidVersions {
+            { [SemanticVersion]::new($version) } | Should -Throw
+        }
+    }
+
 }

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -359,12 +359,12 @@ beta
 
         It 'Should parse valid versions: <version>' -TestCases $validVersions {
             param($version)
-            $v = [SemanticVersion]::new($version)
+            $v = [semver]"$version"
             $v.ToString() | Should -Be $version
         }
 
         It 'Should not parse invalid versions: <version>' -TestCases $invalidVersions {
-            { [SemanticVersion]::new($version) } | Should -Throw
+            { [semver]"$version" } | Should -Throw
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- replaced existing regex with slightly modified one from semver.org matching C# syntax
- added separate regex for buildLabel validation as it differs from the preLabel validation
- Fix some misspellings of `semver` in the comments
- Added all the valid and invalid tests from semver.org except the one where the version numbers exceed an int

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/21383

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
