### PR TITLE
[release/v7.2.19] Add dotenv install as latest version does not work with current Ruby version (#21239)

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -2089,6 +2089,7 @@ function Start-PSBootstrap {
 
             # Install [fpm](https://github.com/jordansissel/fpm) and [ronn](https://github.com/rtomayko/ronn)
             if ($Package) {
+                Install-GlobalGem -Sudo $sudo -GemName "dotenv" -GemVersion "2.8.1"
                 Install-GlobalGem -Sudo $sudo -GemName "ffi" -GemVersion "1.12.0"
                 Install-GlobalGem -Sudo $sudo -GemName "fpm" -GemVersion "1.11.0"
                 Install-GlobalGem -Sudo $sudo -GemName "ronn" -GemVersion "0.7.3"


### PR DESCRIPTION

Backport #21239