### PR TITLE
 InitialSessionState: Add support for configuring initial working directory

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1678,6 +1678,7 @@ namespace System.Management.Automation.Runspaces
             ss.ThreadOptions = this.ThreadOptions;
             ss.ThrowOnRunspaceOpenError = this.ThrowOnRunspaceOpenError;
             ss.ApartmentState = this.ApartmentState;
+            ss.Location = this.Location;
 
             foreach (ModuleSpecification modSpec in this.ModuleSpecificationsToImport)
             {
@@ -1830,6 +1831,12 @@ namespace System.Management.Automation.Runspaces
         /// be in an inconsistent state.
         /// </summary>
         public bool ThrowOnRunspaceOpenError { get; set; } = false;
+
+        /// <summary>
+        /// If not null, the working location of the runspace is set to this path. If null,
+        /// the <see cref="Environment.CurrentDirectory">process working directory</see> is used as a default.
+        /// </summary>
+        public string Location { get; set; } = null;
 
         /// <summary>
         /// This property will be set only if we are refreshing the Type/Format settings by calling UpdateTypes/UpdateFormats directly.
@@ -2231,7 +2238,7 @@ namespace System.Management.Automation.Runspaces
                 }
             }
 
-            SetSessionStateDrive(context, setLocation: setLocation);
+            SetSessionStateDrive(context, setLocation);
         }
 
         private void Bind_SetVariables(SessionStateInternal ss)
@@ -3412,10 +3419,16 @@ namespace System.Management.Automation.Runspaces
             }
         }
 
-        internal static void SetSessionStateDrive(ExecutionContext context, bool setLocation)
+        private void SetSessionStateDrive(ExecutionContext context, bool setLocation)
         {
             if (context.EngineSessionState.ProviderCount == 0)
             {
+                // If there are no defined providers, but a custom location was set, the location cannot exist, throw an error.
+                if (setLocation && Location != null)
+                {
+                    throw new ItemNotFoundException(Location, "PathNotFound", SessionStateStrings.PathNotFound);
+                }
+
                 return;
             }
 
@@ -3425,7 +3438,7 @@ namespace System.Management.Automation.Runspaces
             if (context.EngineSessionState.CurrentDrive == null && !TryInitSessionStateCurrentDrive(context))
             {
                 // FIXME: this is a wrong exception to throw, we don't yet know that the path was not found
-                ItemNotFoundException itemNotFound = new(Environment.CurrentDirectory, "PathNotFound", SessionStateStrings.PathNotFound);
+                ItemNotFoundException itemNotFound = new(Location ?? Environment.CurrentDirectory, "PathNotFound", SessionStateStrings.PathNotFound);
                 context.ReportEngineStartupError(itemNotFound);
                 return;
             }
@@ -3437,7 +3450,16 @@ namespace System.Management.Automation.Runspaces
 
             var providerContext = new CmdletProviderContext(context) { SuppressWildcardExpansion = true };
 
-            // Set the starting location to the current process working directory
+            // User set a custom initial working location.
+            if (Location != null)
+            {
+                // If the location is invalid or does not exist, let the exception bubble up; since the user explicitly
+                // configured the working directory, he probably wants to get notified on failure.
+                context.EngineSessionState.SetLocation(Location, providerContext);
+                return;
+            }
+
+            // As a fallback, set the starting location to the current process working directory.
             // Ignore any errors as the file system provider may not be loaded or
             // a drive with the same name as the real file system drive may not have
             // been mounted.

--- a/test/xUnit/csharp/test_InitialSessionState.cs
+++ b/test/xUnit/csharp/test_InitialSessionState.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using Xunit;
+using DriveNotFoundException = System.Management.Automation.DriveNotFoundException;
+
+namespace PSTests.Parallel;
+
+public class InitialSessionStateTests
+{
+    [Fact]
+    public void TestDefaultLocation()
+    {
+        var wd = GetResultingLocation(null);
+        Assert.Equal(Environment.CurrentDirectory, wd.Path);
+    }
+
+    [Fact]
+    public void TestCustomFileSystemLocation()
+    {
+        // any path different from the process working directory would work here
+        var location = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+
+        // sanity check to ensure the test is not running from the tmp dir
+        Assert.NotEqual(location, Environment.CurrentDirectory);
+
+        var wd = GetResultingLocation(location);
+        Assert.Equal(location, wd.Path);
+    }
+
+    [Fact]
+    public void TestCustomEnvLocation()
+    {
+        var wd = GetResultingLocation("Env:");
+        Assert.Equal("Env:" + Path.DirectorySeparatorChar, wd.Path);
+    }
+
+    [Fact]
+    public void TestCustomLocation_NonExistentDrive()
+    {
+        Assert.Throws<DriveNotFoundException>(() => { GetResultingLocation("NonExistentDrive:"); });
+    }
+
+    [Fact]
+    public void TestCustomLocation_NonExistentPath()
+    {
+        Assert.Throws<ItemNotFoundException>(() => { GetResultingLocation("Temp:/nonexistent test directory"); });
+    }
+
+    private static PathInfo GetResultingLocation(string issLocation)
+    {
+        var iss = InitialSessionState.CreateDefault2();
+        iss.Location = issLocation;
+
+        using var runspace = RunspaceFactory.CreateRunspace(iss);
+        runspace.Open();
+
+        using var ps = PowerShell.Create(runspace);
+        return ps.AddCommand("pwd").Invoke<PathInfo>().Single();
+    }
+}


### PR DESCRIPTION
# PR Summary

Add support for configuring the initial working location of a `Runspace` using a new ~`WorkingDirectory`~`Location` property on `InitialSessionState`.

I recommend reviewing the 2 commits separately, first one refactors the method without major changes in behavior, second one implements the feature.

## PR Context

Resolves #17603.

## Design questions

@vexx32 I have 2 questions about the design of the feature and related functionality:

1\) If the working directory is invalid (does not exist, unknown drive,...), I propagate the exception back to the caller, without checking `ThrowOnRunspaceOpenError`. Should I add a check and suppress the exception if it's not set? My reasoning is that if a caller explicitly sets a custom working directory, he probably expects it to be valid and get notified when it's not, even when he's not interested in other initialization errors, but it's inconsistent with how other errors are handled.

2\) In the original implementation, there's a check for `if (context.EngineSessionState.ProviderCount > 0)` and if there are no providers, the function does not do anything, leaving the current drive and location unset. However, this results in subsequent accesses to the location throwing confusing internal errors (even from scripts running inside the `Runspace`):
```powershell
$iss = [initialsessionstate]::CreateDefault2()
$iss.ThrowOnRunspaceOpenError = $true
# remove all providers
$iss.Providers.RemoveItem(0, $iss.Providers.Count)

$r = [runspacefactory]::CreateRunspace($Host, $iss)
$r.Open()
[powershell]::Create($r).AddCommand("pwd").Invoke()
# Exception calling "Invoke" with "0" argument(s): "Cannot perform operation because operation "get_CurrentLocation" is not valid. Remove operation "get_CurrentLocation", or investigate why it is not valid."
```

For now, I've kept the original behavior, but it seems cleaner to me to throw an exception if there are no providers defined to avoid the confusing errors later on. I can either modify the behavior in a subsequent commit, or I can create a new PR after this one is done, just wanted to hear your opinion.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
