### PR TITLE
fix package build to not check some files for a signature.

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -941,13 +941,21 @@ function Update-PSSignedBuildFolder
             if ($signature.Status -ne 'Valid') {
                 Write-Error "Invalid signature for $signedFilePath"
             }
+
         }
         else
         {
             Write-Verbose -Verbose "Skipping certificate check of $signedFilePath on non-Windows"
         }
 
+
+        # completely skip replacing pwsh on non-windows systems (there is no .exe extension here)
+        if ($signedFileObject.Name -eq "pwsh") {
+            continue
+        }
+
         Copy-Item -Path $signedFilePath -Destination $destination -Force
+
     }
 
     foreach($filter in $RemoveFilter) {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -912,7 +912,7 @@ function Update-PSSignedBuildFolder
         
         # The Shim will not be signed in CI.
         
-        if ($signedFileObject.Name -eq "pwsh" -or ($signedFileObject.Name -eq "Microsoft.PowerShell.GlobalTool.Shim.exe" -and $env:TF_BUILD)) {
+        if ($signedFileObject.Name -eq "pwsh" -or ($signedFileObject.Name -eq "Microsoft.PowerShell.GlobalTool.Shim.exe" -and $env:BUILD_REASON -eq 'PullRequest')) {
             Write-Verbose -Verbose "Skipping $signedFileObject"
             continue
         }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -909,7 +909,10 @@ function Update-PSSignedBuildFolder
     foreach ($signedFileObject in $signedFilesList) {
         # completely skip replacing pwsh on non-windows systems (there is no .exe extension here)
         # and it may not be signed correctly
-        if ($signedFileObject.Name -eq "pwsh" -or $signedFileObject.Name -eq "Microsoft.PowerShell.GlobalTool.Shim.exe") {
+        
+        # The Shim will not be signed in CI.
+        
+        if ($signedFileObject.Name -eq "pwsh" -or ($signedFileObject.Name -eq "Microsoft.PowerShell.GlobalTool.Shim.exe" -and $env:TF_BUILD)) {
             Write-Verbose -Verbose "Skipping $signedFileObject"
             continue
         }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -905,20 +905,22 @@ function Update-PSSignedBuildFolder
     $signedFilesFilter = Join-Path -Path $SignedFilesPathNormalized -ChildPath '*'
     Write-Verbose -Verbose "signedFilesFilter = $signedFilesFilter"
 
-    Get-ChildItem -Path $signedFilesFilter -Recurse -File | Select-Object -ExpandProperty FullName | ForEach-Object -Process {
-        Write-Verbose -Verbose "Processing $_"
+    $signedFilesList = Get-ChildItem -Path $signedFilesFilter -Recurse -File
+    foreach ($signedFileObject in $signedFilesList) {
+        $signedFilePath = $signedFileObject.FullName
+        Write-Verbose -Verbose "Processing $signedFilePath"
 
         # Agents seems to be on a case sensitive file system
         if ($IsLinux) {
-            $relativePath = $_.Replace($SignedFilesPathNormalized, '')
+            $relativePath = $signedFilePath.Replace($SignedFilesPathNormalized, '')
         } else {
-            $relativePath = $_.ToLowerInvariant().Replace($SignedFilesPathNormalized.ToLowerInvariant(), '')
+            $relativePath = $signedFilePath.ToLowerInvariant().Replace($SignedFilesPathNormalized.ToLowerInvariant(), '')
         }
 
         Write-Verbose -Verbose "relativePath = $relativePath"
         $destination = (Get-Item (Join-Path -Path $BuildPathNormalized -ChildPath $relativePath)).FullName
         Write-Verbose -Verbose "destination = $destination"
-        Write-Log "replacing $destination with $_"
+        Write-Log "replacing $destination with $signedFilePath"
 
         if (-not (Test-Path $destination)) {
             $parent = Split-Path -Path $destination -Parent
@@ -932,13 +934,20 @@ function Update-PSSignedBuildFolder
             Write-Error "File not found: $destination, parent - $parent exists: $exists"
         }
 
-        $signature = Get-AuthenticodeSignature -FilePath $_
-
-        if ($signature.Status -ne 'Valid') {
-            Write-Error "Invalid signature for $_"
+        # Get-AuthenticodeSignature will only work on Windows
+        if ($IsWindows)
+        {
+            $signature = Get-AuthenticodeSignature -FilePath $signedFilePath
+            if ($signature.Status -ne 'Valid') {
+                Write-Error "Invalid signature for $signedFilePath"
+            }
+        }
+        else
+        {
+            Write-Verbose -Verbose "Skipping certificate check of $signedFilePath on non-Windows"
         }
 
-        Copy-Item -Path $_ -Destination $destination -Force
+        Copy-Item -Path $signedFilePath -Destination $destination -Force
     }
 
     foreach($filter in $RemoveFilter) {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -909,8 +909,8 @@ function Update-PSSignedBuildFolder
     foreach ($signedFileObject in $signedFilesList) {
         # completely skip replacing pwsh on non-windows systems (there is no .exe extension here)
         # and it may not be signed correctly
-        if ($signedFileObject.Name -eq "pwsh") {
-            Write-Verbose -Verbose "Skipping pwsh"
+        if ($signedFileObject.Name -eq "pwsh" -or $signedFileObject.Name -eq "Microsoft.PowerShell.GlobalTool.Shim.exe") {
+            Write-Verbose -Verbose "Skipping $signedFileObject"
             continue
         }
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -907,6 +907,13 @@ function Update-PSSignedBuildFolder
 
     $signedFilesList = Get-ChildItem -Path $signedFilesFilter -Recurse -File
     foreach ($signedFileObject in $signedFilesList) {
+        # completely skip replacing pwsh on non-windows systems (there is no .exe extension here)
+        # and it may not be signed correctly
+        if ($signedFileObject.Name -eq "pwsh") {
+            Write-Verbose -Verbose "Skipping pwsh"
+            continue
+        }
+
         $signedFilePath = $signedFileObject.FullName
         Write-Verbose -Verbose "Processing $signedFilePath"
 
@@ -941,17 +948,10 @@ function Update-PSSignedBuildFolder
             if ($signature.Status -ne 'Valid') {
                 Write-Error "Invalid signature for $signedFilePath"
             }
-
         }
         else
         {
             Write-Verbose -Verbose "Skipping certificate check of $signedFilePath on non-Windows"
-        }
-
-
-        # completely skip replacing pwsh on non-windows systems (there is no .exe extension here)
-        if ($signedFileObject.Name -eq "pwsh") {
-            continue
         }
 
         Copy-Item -Path $signedFilePath -Destination $destination -Force


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Our coordinated packaging build has been failing for some time.
This change skips those checks for files named `pwsh`
Additionally, the global tool `shim.exe` is created in a different way, and needs no signature at this point in the build.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
