### PR TITLE
Add `ReadOnlyProviders` option for session configuration files

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
@@ -484,6 +484,25 @@ namespace Microsoft.PowerShell.Commands
         private string[] _visibleProviders = Array.Empty<string>();
 
         /// <summary>
+        /// A list of read-only providers.
+        /// </summary>
+        [Parameter]
+        public string[] ReadOnlyProviders
+        {
+            get
+            {
+                return _readOnlyProviders;
+            }
+
+            set
+            {
+                _readOnlyProviders = value;
+            }
+        }
+
+        private string[] _readOnlyProviders = Array.Empty<string>();
+
+        /// <summary>
         /// A list of aliases.
         /// </summary>
         [Parameter]
@@ -915,6 +934,13 @@ namespace Microsoft.PowerShell.Commands
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleProviders, RemotingErrorIdStrings.DISCVisibleProvidersComment,
                         SessionConfigurationUtils.GetVisibilityDefault(_visibleProviders, streamWriter, this), streamWriter, _visibleProviders.Length == 0));
+                }
+
+                // Visible providers
+                if (ShouldGenerateConfigurationSnippet("ReadOnlyProviders"))
+                {
+                    result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.ReadOnlyProviders, RemotingErrorIdStrings.DISCReadOnlyProvidersComment,
+                        SessionConfigurationUtils.GetVisibilityDefault(ReadOnlyProviders, streamWriter, this), streamWriter, ReadOnlyProviders.Length == 0));
                 }
 
                 // Alias definitions
@@ -1372,6 +1398,12 @@ namespace Microsoft.PowerShell.Commands
         private string[] _visibleProviders = Array.Empty<string>();
 
         /// <summary>
+        /// A list of read-only providers.
+        /// </summary>
+        [Parameter]
+        public string[] ReadOnlyProviders { get; set; } = Array.Empty<string>();
+
+        /// <summary>
         /// Scripts to process.
         /// </summary>
         [Parameter]
@@ -1663,6 +1695,10 @@ namespace Microsoft.PowerShell.Commands
                 // Visible providers
                 result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleProviders, RemotingErrorIdStrings.DISCVisibleProvidersComment,
                     SessionConfigurationUtils.GetVisibilityDefault(_visibleProviders, streamWriter, this), streamWriter, _visibleProviders.Length == 0));
+
+                // Read-only providers
+                result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.ReadOnlyProviders, RemotingErrorIdStrings.DISCReadOnlyProvidersComment,
+                    SessionConfigurationUtils.GetVisibilityDefault(ReadOnlyProviders, streamWriter, this), streamWriter, ReadOnlyProviders.Length == 0));
 
                 // Scripts to process
                 string resultData = (_scriptsToProcess.Length > 0) ? SessionConfigurationUtils.CombineStringArray(_scriptsToProcess) : "'C:\\ConfigData\\InitScript1.ps1', 'C:\\ConfigData\\InitScript2.ps1'";

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -2062,7 +2062,6 @@ namespace System.Management.Automation.Remoting
 
                 if (providers != null)
                 {
-                    System.Collections.Generic.HashSet<string> addedProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     foreach (string provider in providers)
                     {
                         if (!string.IsNullOrEmpty(provider))
@@ -2070,13 +2069,9 @@ namespace System.Management.Automation.Remoting
                             // Look up providers from provider name including wildcards.
                             var providersFound = iss.Providers.LookUpByName(provider);
 
-                            foreach (var providerFound in providersFound)
+                            foreach (SessionStateProviderEntry providerFound in providersFound)
                             {
-                                if (!addedProviders.Contains(providerFound.Name))
-                                {
-                                    addedProviders.Add(providerFound.Name);
-                                    providerFound.Visibility = SessionStateEntryVisibility.Public;
-                                }
+                                providerFound.Visibility = SessionStateEntryVisibility.Public;
                             }
                         }
                     }

--- a/src/System.Management.Automation/namespaces/ProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBase.cs
@@ -12,7 +12,6 @@ using System.Management.Automation.Host;
 using System.Resources;
 using System.Diagnostics.CodeAnalysis; // for fxcop
 using System.Security.AccessControl;
-using System.Linq;
 
 namespace System.Management.Automation.Provider
 {
@@ -939,14 +938,19 @@ namespace System.Management.Automation.Provider
                         SessionStateStrings.IContentCmdletProvider_NotSupported);
             }
 
-            if (Context.ExecutionContext.InitialSessionState.Providers[Context.ProviderInstance.ProviderInfo.Name]
-                .Any(static sspe => sspe.Options.HasFlag(ScopedItemOptions.ReadOnly)))
+            Collection<SessionStateProviderEntry> providerEntries =
+                Context.ExecutionContext.InitialSessionState.Providers[Context.ProviderInstance.ProviderInfo.Name];
+
+            foreach (SessionStateProviderEntry providerEntry in providerEntries)
             {
-                throw new SessionStateUnauthorizedAccessException(
-                    Context.ProviderInstance.ProviderInfo.Name,
-                    SessionStateCategory.CmdletProvider,
-                    nameof(SessionStateStrings.ProviderNotWritable),
-                    SessionStateStrings.ProviderNotWritable);
+                if (providerEntry.Options.HasFlag(ScopedItemOptions.ReadOnly))
+                {
+                    throw new SessionStateUnauthorizedAccessException(
+                        Context.ProviderInstance.ProviderInfo.Name,
+                        SessionStateCategory.CmdletProvider,
+                        nameof(SessionStateStrings.ProviderNotWritable),
+                        SessionStateStrings.ProviderNotWritable);
+                }
             }
 
             // Call interface method

--- a/src/System.Management.Automation/namespaces/ProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBase.cs
@@ -12,6 +12,7 @@ using System.Management.Automation.Host;
 using System.Resources;
 using System.Diagnostics.CodeAnalysis; // for fxcop
 using System.Security.AccessControl;
+using System.Linq;
 
 namespace System.Management.Automation.Provider
 {
@@ -936,6 +937,16 @@ namespace System.Management.Automation.Provider
                 throw
                     PSTraceSource.NewNotSupportedException(
                         SessionStateStrings.IContentCmdletProvider_NotSupported);
+            }
+
+            if (Context.ExecutionContext.InitialSessionState.Providers[Context.ProviderInstance.ProviderInfo.Name]
+                .Any(static sspe => sspe.Options.HasFlag(ScopedItemOptions.ReadOnly)))
+            {
+                throw new SessionStateUnauthorizedAccessException(
+                    Context.ProviderInstance.ProviderInfo.Name,
+                    SessionStateCategory.CmdletProvider,
+                    nameof(SessionStateStrings.ProviderNotWritable),
+                    SessionStateStrings.ProviderNotWritable);
             }
 
             // Call interface method
@@ -1984,4 +1995,3 @@ namespace System.Management.Automation.Provider
 }
 
 #pragma warning restore 56506
-

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1062,6 +1062,9 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
   <data name="DISCVisibleProvidersComment" xml:space="preserve">
     <value>Providers to make visible when applied to a session</value>
   </data>
+  <data name="DISCReadOnlyProvidersComment" xml:space="preserve">
+    <value>Providers to make read-only when applied to a session</value>
+  </data>
   <data name="DISCVisibleExternalCommandsComment" xml:space="preserve">
     <value>External commands (scripts and applications) to make visible when applied to a session</value>
   </data>

--- a/src/System.Management.Automation/resources/SessionStateStrings.resx
+++ b/src/System.Management.Automation/resources/SessionStateStrings.resx
@@ -342,6 +342,9 @@
   <data name="AliasNotWritable" xml:space="preserve">
     <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
   </data>
+  <data name="ProviderNotWritable" xml:space="preserve">
+    <value>Cannot write to provider {0} because it is read-only.</value>
+  </data>
   <data name="FunctionNotWritable" xml:space="preserve">
     <value>Cannot write to function {0} because it is read-only or constant.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -842,50 +842,50 @@ namespace PowershellTestConfigNamespace
             $matchedEndpoint | Should -Not -BeNullOrEmpty
         }
     }
-
-    Describe 'Test configuration options' -Tags CI {
-        BeforeAll {
-            $ConfigFilePath = Join-Path $TestDrive "TestPSSessionConfigurationFile.pssc"
-            $PSFileName = $IsWindows ? 'pwsh.exe' : 'pwsh'
-            $PSPath = Join-Path -Path $PSHOME -ChildPath $psFileName
-        }
-
-        It 'ReadOnlyProviders cannot be written to.' {
-            $configParams = @{
-                SchemaVersion = '2.0.0.0'
-                GUID = [guid]::NewGuid()
-                Author = 'User'
-                SessionType = 'RestrictedRemoteServer'
-                LanguageMode = 'ConstrainedLanguage'
-                VisibleAliases = '*'
-                VisibleCmdlets = '*'
-                VisibleFunctions = '*'
-                VisibleExternalCommands = '*'
-                VisibleProviders = 'FileSystem', 'Registry', 'Environment', 'Function'
-                ReadOnlyProviders = 'Environment'
-            }
-
-            if (Test-Path -LiteralPath $ConfigFilePath) {
-                Remove-Item -LiteralPath $ConfigFilePath
-            }
-
-            try {
-                { New-PSSessionConfigurationFile @configParams -Path $ConfigFilePath } | Should -Not -Throw
-                $env:READONLY_PROVIDER_TESTING_VALUE = '1'
-                $result = { & $PSPath -NonInteractive -NoProfile -ConfigurationFile $ConfigFilePath { $env:READONLY_PROVIDER_TESTING_VALUE = '2' } }
-                    | Should -Throw -ErrorId ProviderNotWritable
-            } finally {
-                $env:READONLY_PROVIDER_TESTING_VALUE = ''
-                if (Test-Path -LiteralPath $ConfigFilePath) {
-                    Remove-Item -LiteralPath $ConfigFilePath
-                }
-            }
-
-        }
-    }
 }
 finally
 {
     Pop-DefaultParameterValueStack
     $WarningPreference = $originalWarningPreference
+}
+
+Describe 'Test PSSession configuration file options' -Tags CI {
+    BeforeAll {
+        $ConfigFilePath = Join-Path $TestDrive "TestPSSessionConfigurationFile.pssc"
+        $PSFileName = $IsWindows ? 'pwsh.exe' : 'pwsh'
+        $PSPath = Join-Path -Path $PSHOME -ChildPath $psFileName
+    }
+
+    It 'ReadOnlyProviders cannot be written to.' {
+        $configParams = @{
+            SchemaVersion = '2.0.0.0'
+            GUID = [guid]::NewGuid()
+            Author = 'User'
+            SessionType = 'RestrictedRemoteServer'
+            LanguageMode = 'ConstrainedLanguage'
+            VisibleAliases = '*'
+            VisibleCmdlets = '*'
+            VisibleFunctions = '*'
+            VisibleExternalCommands = '*'
+            VisibleProviders = 'FileSystem', 'Registry', 'Environment', 'Function'
+            ReadOnlyProviders = 'Environment'
+        }
+
+        if (Test-Path -LiteralPath $ConfigFilePath) {
+            Remove-Item -LiteralPath $ConfigFilePath
+        }
+
+        try {
+            { New-PSSessionConfigurationFile @configParams -Path $ConfigFilePath } | Should -Not -Throw
+            $env:READONLY_PROVIDER_TESTING_VALUE = '1'
+            $result = { & $PSPath -NonInteractive -NoProfile -ConfigurationFile $ConfigFilePath { $env:READONLY_PROVIDER_TESTING_VALUE = '2' } }
+                | Should -Throw -ErrorId ProviderNotWritable
+        } finally {
+            $env:READONLY_PROVIDER_TESTING_VALUE = ''
+            if (Test-Path -LiteralPath $ConfigFilePath) {
+                Remove-Item -LiteralPath $ConfigFilePath
+            }
+        }
+
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -880,7 +880,7 @@ Describe 'Test PSSession configuration file options' -Tags CI {
             $env:READONLY_PROVIDER_TESTING_VALUE = '1'
 
             {
-                $results = & $PSPath -NonInteractive -NoProfile -ConfigurationFile $ConfigFilePath { $env:READONLY_PROVIDER_TESTING_VALUE = '2' } } 2>&1
+                $results = & $PSPath -NonInteractive -NoProfile -ConfigurationFile $ConfigFilePath { $env:READONLY_PROVIDER_TESTING_VALUE = '2' } 2>&1
                 foreach ($result in $results) {
                     if ($result -is [System.Management.Automation.ErrorRecord]) {
                         throw $result


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adds option in a session configuration file to make a provider visible, but not able to be written to.

## PR Context

~~Keeping this as WIP only because I expect issues with the test. Will take it out of draft after getting that working.~~

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
