### PR TITLE
Tee object can now store received error records to a variable.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -155,7 +155,6 @@ namespace Microsoft.PowerShell.Commands
                 if (this._inputObject.BaseObject is ErrorRecord er)
                 {
                     this.errorCommandWrapper.Process(_inputObject);
-                    return;
                 }
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Tee-Object.cs
@@ -95,20 +95,20 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// ErrorRecordVariable parameter.
+        /// Gets or Sets the name of the variable used to store ErrorRecords.
         /// <summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
         [Alias("ERV")]
         public string ErrorRecordVariable
         {
-            get { return _errorRecordVariable; }
+            get { return this.errorRecordVariable; }
 
-            set { _errorRecordVariable = value; }
+            set { this.errorRecordVariable = value; }
         }
 
         private string _variable;
-        private string _errorRecordVariable;
+        private string errorRecordVariable;
 
         /// <summary>
         /// </summary>
@@ -138,11 +138,11 @@ namespace Microsoft.PowerShell.Commands
                 // the values to be written
             }
 
-            if (!string.IsNullOrEmpty(_errorRecordVariable))
+            if (!string.IsNullOrEmpty(this.errorRecordVariable))
             {
-                _errorCommandWrapper = new CommandWrapper();
-                _errorCommandWrapper.Initialize(Context, "set-variable", typeof(SetVariableCommand));
-                _errorCommandWrapper.AddNamedParameter("name", _errorRecordVariable);
+                this.errorCommandWrapper = new CommandWrapper();
+                this.errorCommandWrapper.Initialize(Context, "set-variable", typeof(SetVariableCommand));
+                this.errorCommandWrapper.AddNamedParameter("name", this.errorRecordVariable);
             }
         }
 
@@ -150,11 +150,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            if (_errorCommandWrapper is not null)
+            if (this.errorCommandWrapper is not null)
             {
-                if (_inputObject.BaseObject is ErrorRecord er)
+                if (this._inputObject.BaseObject is ErrorRecord er)
                 {
-                    _errorCommandWrapper.Process(_inputObject);
+                    this.errorCommandWrapper.Process(_inputObject);
                     return;
                 }
             }
@@ -167,11 +167,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-            // _commandWrapper is always created, but _errorCommandWrapper may not be.
+            // _commandWrapper is always created, but errorCommandWrapper may not be.
             _commandWrapper.ShutDown();
-            if (_errorCommandWrapper is not null)
+            if (this.errorCommandWrapper is not null)
             {
-                _errorCommandWrapper.ShutDown();
+                errorCommandWrapper.ShutDown();
             }
         }
 
@@ -186,10 +186,10 @@ namespace Microsoft.PowerShell.Commands
                     _commandWrapper = null;
                 }
 
-                if (isDisposing && _errorCommandWrapper is not null)
+                if (isDisposing && this.errorCommandWrapper is not null)
                 {
-                    _errorCommandWrapper.Dispose();
-                    _errorCommandWrapper = null;
+                    this.errorCommandWrapper.Dispose();
+                    errorCommandWrapper = null;
                 }
             }
         }
@@ -205,7 +205,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region private
         private CommandWrapper _commandWrapper;
-        private CommandWrapper _errorCommandWrapper;
+        private CommandWrapper errorCommandWrapper;
         private bool _alreadyDisposed;
         #endregion private
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
@@ -92,4 +92,18 @@ Describe "Tee-Object DRT Unit Tests" -Tags "CI" {
         $results | Should -Be $expected
     }
 
+    It "Positive Variable/ErrorRecordVariable Test" {
+        $results = Get-Item $PSHOME,doesnotexist1,$PWD,doesnotexist2 2>&1 | Tee-Object -Variable outputVar -ErrorRecordVariable errVar
+        $results.Length | Should -Be 2
+        $outputVar.Length | Should -Be 2
+        $errVar.Length | Should -Be 2
+    }
+
+    It "Positive File/ErrorRecordVariable Test" {
+        $results = Get-Item $PSHOME,doesnotexist1,$PWD,doesnotexist2 2>&1 | Tee-Object -File $tempFile -ErrorRecordVariable errVar
+        $results.Length | Should -Be 2
+        (Get-Content $tempFile).Length | Should -BeGreaterThan 2
+        $errVar.Length | Should -Be 2
+    }
+
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
@@ -107,7 +107,7 @@ Describe "Tee-Object DRT Unit Tests" -Tags "CI" {
     }
 
 	It "Positive native process test" {
-		$results = .{ TestExe -echoargs a; TestExe } 2>&1 | Tee-Object -Variable outputVar -ErrorRecordVariable errVar
+		$results = .{ testexe -echoargs a; testexe } 2>&1 | Tee-Object -Variable outputVar -ErrorRecordVariable errVar
         $expectedResults = 'Arg 0 is <a>','Test not specified'
 		$results | Should -Be $expectedResults
 		$outputVar | Should -Be $expectedResults

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
@@ -106,4 +106,11 @@ Describe "Tee-Object DRT Unit Tests" -Tags "CI" {
         $errVar.Length | Should -Be 2
     }
 
+	It "Positive native process test" {
+		$results = .{ TestExe -echoargs a; TestExe } 2>&1 | Tee-Object -Variable outputVar -ErrorRecordVariable errVar
+		$results | Should -Be 'Arg 0 is <a>'
+		$outputVar | Should -Be 'Arg 0 is <a>'
+		$errVar | Should -Be "Test not specified"
+	}
+
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Tee-Object.Tests.ps1
@@ -94,22 +94,23 @@ Describe "Tee-Object DRT Unit Tests" -Tags "CI" {
 
     It "Positive Variable/ErrorRecordVariable Test" {
         $results = Get-Item $PSHOME,doesnotexist1,$PWD,doesnotexist2 2>&1 | Tee-Object -Variable outputVar -ErrorRecordVariable errVar
-        $results.Length | Should -Be 2
-        $outputVar.Length | Should -Be 2
+        $results.Length | Should -Be 4
+        $outputVar.Length | Should -Be 4
         $errVar.Length | Should -Be 2
     }
 
     It "Positive File/ErrorRecordVariable Test" {
         $results = Get-Item $PSHOME,doesnotexist1,$PWD,doesnotexist2 2>&1 | Tee-Object -File $tempFile -ErrorRecordVariable errVar
-        $results.Length | Should -Be 2
-        (Get-Content $tempFile).Length | Should -BeGreaterThan 2
+        $results.Length | Should -Be 4
+        (Get-Content $tempFile).Length | Should -BeGreaterThan 4
         $errVar.Length | Should -Be 2
     }
 
 	It "Positive native process test" {
 		$results = .{ TestExe -echoargs a; TestExe } 2>&1 | Tee-Object -Variable outputVar -ErrorRecordVariable errVar
-		$results | Should -Be 'Arg 0 is <a>'
-		$outputVar | Should -Be 'Arg 0 is <a>'
+        $expectedResults = 'Arg 0 is <a>','Test not specified'
+		$results | Should -Be $expectedResults
+		$outputVar | Should -Be $expectedResults
 		$errVar | Should -Be "Test not specified"
 	}
 


### PR DESCRIPTION
This addresses an aspect of issue #5184 

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This adds the parameter `-ErrorRecordVariable` (Alias `ERV`) to `Tee-Object`
if `Tee-Object` receives an ErrorRecord in the input stream and `-ErrorRecordVariable` is included,
`Tee-Object` will assign those error records to the variable. This enables the following scenario:

```powershell
PS> Get-Item $PSHOME,doesnotexist 2>&1 | Tee-Object -var out -ERV ee

    Directory: /Users/james/src/github/forks/jameswtruher/PowerShell-1/src/powershell-unix/bin/Debug/net9.0/osx-x64

UnixMode         User Group         LastWriteTime         Size Name
--------         ---- -----         -------------         ---- ----
drwxr-xr-x      james staff        5/1/2024 11:34         9024 publish

PS> $out

    Directory: /Users/james/src/github/forks/jameswtruher/PowerShell-1/src/powershell-unix/bin/Debug/net9.0/osx-x64

UnixMode         User Group         LastWriteTime         Size Name
--------         ---- -----         -------------         ---- ----
drwxr-xr-x      james staff        5/1/2024 11:34         9024 publish

PS> $ee
Get-Item: Cannot find path '/Users/james/src/github/forks/jameswtruher/PowerShell-1/src/Microsoft.PowerShell.Commands.Utility/commands/utility/doesnotexist' because it does not exist.
PS>
```

It works with file, literalfile, and variable parameter sets.
This works with native executables as well, as when stderr is written, we create an error record.
Errors created by `Tee-Object` are emitted in the normal way, it is only the input object which is inspected and handled by this new behavior.
Note: the `2>&1` is required to ensure that the error stream is emitted into the output stream

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [x] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
