### PR TITLE
Bump to .NET 9 preview 3

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.1.24101.2"
+    "version": "9.0.100-preview.3.24204.13"
   }
 }

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0-preview.3.24172.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-preview.3.24172.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
-    <PackageReference Include="Markdig.Signed" Version="0.34.0" />
+    <PackageReference Include="Markdig.Signed" Version="0.37.0" />
     <PackageReference Include="Microsoft.PowerShell.MarkdownRender" Version="7.2.1" />
   </ItemGroup>
 
@@ -32,10 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.0-3.final" />
-    <PackageReference Include="System.Threading.AccessControl" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.0-preview.1.24081.2" />
-    <PackageReference Include="JsonSchema.Net" Version="6.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageReference Include="System.Threading.AccessControl" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="JsonSchema.Net" Version="7.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.0-preview.3.24172.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,13 +17,13 @@
   <ItemGroup>
     <!-- This section is to force the version of non-direct dependencies -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.4" />
     <!-- the following package(s) are from https://github.com/dotnet/fxdac -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.IO.Packaging" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0-preview.3.24172.9" />
     <!--
         the following package(s) are from https://github.com/dotnet/wcf
         they are pinned to the version 4.10.x due to a breaking change in newer versions.
@@ -36,7 +36,7 @@
     <PackageReference Include="System.ServiceModel.Security" Version="4.10.3" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.10.3" />
     <!-- the source could not be found for the following package(s) -->
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0-preview.1.24081.3" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0-preview.3.24175.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
+++ b/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
     <ProjectReference Include="..\Microsoft.WSMan.Runtime\Microsoft.WSMan.Runtime.csproj" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-preview.3.24172.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -34,16 +34,16 @@
     <!-- the Application Insights package -->
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.DirectoryServices" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.DirectoryServices" Version="9.0.0-preview.3.24172.9" />
     <!--PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" /-->
-    <PackageReference Include="System.Management" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.0-preview.1.24080.9" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0-preview.1.24080.9" />
+    <PackageReference Include="System.Management" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Security.Permissions" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0-preview.3.24172.9" />
     <!-- the following package(s) are from the powershell org -->
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.PowerShell.Native" Version="7.4.0" />

--- a/test/powershell/Host/Startup.Tests.ps1
+++ b/test/powershell/Host/Startup.Tests.ps1
@@ -33,6 +33,7 @@ Describe "Validate start of console host" -Tag CI {
             'System.Net.Mail.dll'
             'System.Net.NetworkInformation.dll'
             'System.Net.Primitives.dll'
+            'System.Numerics.Vectors.dll'
             'System.ObjectModel.dll'
             'System.Private.CoreLib.dll'
             'System.Private.Uri.dll'

--- a/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
+++ b/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
@@ -238,7 +238,7 @@ Describe 'Generic Method invocation' -Tags 'CI' {
             }
         )
 
-        $result.GetType().Name | Should -BeExactly 'SelectListIterator`2'
+        $result.GetType().Name | Should -BeExactly 'ListSelectIterator`2'
         $typeArgs = $result.GetType().GenericTypeArguments
         $typeArgs[0] | Should -Be ([int])
         $typeArgs[1] | Should -Be ([float])

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -20,6 +20,10 @@
     "FileType": "NonProduct"
   },
   {
+    "Pattern": "clrgcexp.dll",
+    "FileType": "NonProduct"
+  },
+  {
     "Pattern": "clrjit.dll",
     "FileType": "NonProduct"
   },


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Bump the .NET SDK to .NET 9 preview 3 (SDK 9.0.100-preview.3).

Updated 2 tests to address some changes in the new .NET runtime
1. `System.Numerics.Vectors.dll` gets loaded at startup due to dependency changes in .NET runtime.
2. Name of a non-public type changed that is used in our test.
