### PR TITLE
Fix progress calculation on Remove-Item

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3121,7 +3121,7 @@ namespace Microsoft.PowerShell.Commands
                                 StringUtil.Format(FileSystemProviderStrings.RemovingLocalFileActivity, _removedFiles, _totalFiles),
                                 StringUtil.Format(FileSystemProviderStrings.RemovingLocalBytesStatus, Utils.DisplayHumanReadableFileSize(_removedBytes), Utils.DisplayHumanReadableFileSize(_totalBytes), speed)
                             );
-                            var percentComplete = (int)Math.Min(_removedBytes * 100 / _totalBytes, 100);
+                            var percentComplete = _totalBytes != 0 ? (int)Math.Min(_removedBytes * 100 / _totalBytes, 100) : 100;
                             progress.PercentComplete = percentComplete;
                             progress.RecordType = ProgressRecordType.Processing;
                             WriteProgress(progress);


### PR DESCRIPTION
# PR Summary
Fix the percentage completion calculation for Remove-Item when deleting a directory or file that have no size. As the size calculation is done in a background thread this may or may not happen due to a race condition of when it is calculated.

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/issues/23868

I can't write a test for this as the `_totalFiles` and `_totalBytes` calculation is done in a background thread and will most likely run after the progress check is done in the main thread. The changes are consistent in what is done in https://github.com/PowerShell/PowerShell/pull/19038 for a similar problem.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
