### PR TITLE
Get-Help may report parameters with `ValueFromRemainingArguments` attribute as pipeline-able

### DIFF
--- a/src/System.Management.Automation/help/DefaultCommandHelpObjectBuilder.cs
+++ b/src/System.Management.Automation/help/DefaultCommandHelpObjectBuilder.cs
@@ -605,9 +605,7 @@ namespace System.Management.Automation.Help
 
                     foreach (ParameterAttribute attrib in attribs)
                     {
-                        if (attrib.ValueFromPipeline ||
-                            attrib.ValueFromPipelineByPropertyName ||
-                            attrib.ValueFromRemainingArguments)
+                        if (attrib.ValueFromPipeline || attrib.ValueFromPipelineByPropertyName)
                         {
                             if (!inputs.Contains(parameter.Value.ParameterType.FullName))
                             {

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -695,3 +695,21 @@ Describe 'Update-Help allows partial culture matches' -Tags 'CI' {
         Test-UpdateHelpAux $null $Pass
     }
 }
+
+Describe 'InputTypes accurately describe pipelinable input' {
+    BeforeAll {
+        function invoke-inputtypetest {
+            [CmdletBinding()]
+            param (
+            [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$true)][string]$a,
+            [Parameter(Position=1,ValueFromRemainingArguments=$true)][object[]]$c)
+            Process { "$a $c" }
+        }
+    }
+
+    It 'Should have only 1 input type' {
+        $inputTypes = (Get-Help -full invoke-inputtypetest).inputtypes.inputtype.type.name.trim().split("`n")
+        $inputTypes.Count | Should -Be 1
+        $inputTypes | Should -Be "System.String"
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When calculating the `InputTypes` property of the help object, it includes those parameters which have the `ValueFromRemainingArguments` attribute. This is not correct.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

as this demonstrates, VFRA does not allow pipeline binding:

```powershell
function test-vfra {        
[CmdletBinding()]
param ([Parameter(ValueFromRemainingArguments=$true)][object[]]$c)
Process { "$c" }
}

PS> test-vfra 1 2 3                                                                  
1 2 3
PS> 1 | test-vfra
test-vfra: The input object cannot be bound to any parameters for the command either because the command does not take pipeline input or the input and its properties do not match any of the parameters that take pipeline input.

PS> (get-help -full test-vfra).inputtypes.inputtype.type.name
System.Object[]
```

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
