### PR TITLE
Improve Array BinaryAdd Method for object[]

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -39,6 +39,9 @@ namespace System.Management.Automation.Language
         internal static readonly MethodInfo ObjectList_ToArray =
             typeof(List<object>).GetMethod(nameof(List<object>.ToArray), Type.EmptyTypes);
 
+        internal static readonly MethodInfo ArrayOps_AddObject =
+            typeof(ArrayOps).GetMethod(nameof(ArrayOps.AddObjectArray), StaticFlags);
+
         internal static readonly MethodInfo ArrayOps_GetMDArrayValue =
             typeof(ArrayOps).GetMethod(nameof(ArrayOps.GetMDArrayValue), StaticFlags);
 

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -2717,6 +2717,14 @@ namespace System.Management.Automation.Language
                                            lhsEnumerator.Expression.Cast(typeof(IEnumerator)),
                                            rhsEnumerator.Expression.Cast(typeof(IEnumerator)));
                 }
+                else if (target.Value is object[] targetArray)
+                {
+                    // Adding 1 item to an object[]
+                    // This is an optimisation over the default EnumerableOps_AddObject.
+                    call = Expression.Call(CachedReflectionInfo.ArrayOps_AddObject,
+                                           target.Expression.Cast(typeof(object[])),
+                                           arg.Expression.Cast(typeof(object)));
+                }
                 else
                 {
                     // Adding 1 item to a list

--- a/src/System.Management.Automation/engine/runtime/Operations/ArrayOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/ArrayOps.cs
@@ -12,6 +12,15 @@ namespace System.Management.Automation
 {
     internal static class ArrayOps
     {
+        internal static object AddObjectArray(object[] lhs, object rhs)
+        {
+            int newIdx = lhs.Length;
+            Array.Resize(ref lhs, newIdx + 1);
+            lhs[newIdx] = rhs;
+
+            return lhs;
+        }
+
         internal static object[] SlicingIndex(object target, object[] indexes, Func<object, object, object> indexer)
         {
             var result = new object[indexes.Length];


### PR DESCRIPTION
# PR Summary

Use Array.Resize when doing += on an array type. This is more efficient than the default BinaryAdd done on other enumerable types. As adding to an array is a common operation done by people new to PowerShell this should reduce some of the issues which come with that type of code.

An example of dramatic difference this can make is reflected by this code

```powershell
$s = [gc]::GetTotalAllocatedBytes($true)

Measure-Command {
    & {
        $val = @()
        for ($i = 0; $i -lt 20000; $i++) {
            $val += $i
        }
    }
}

$e = [gc]::GetTotalAllocatedBytes($true);

Write-Host "Allocated Bytes $($e-$s)"
```

When run with the new code (`TEST=true`) you can see it is 8 seconds faster and requires less memory to allocate. As the arrays get larger the differences are even more profound.

```bash
jborean:~/dev/PowerShell$ TEST=true debug/pwsh -File jordan.ps1

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 795
Ticks             : 7950790
TotalDays         : 9.20230324074074E-06
TotalHours        : 0.000220855277777778
TotalMinutes      : 0.0132513166666667
TotalSeconds      : 0.795079
TotalMilliseconds : 795.079

Allocated Bytes 1604712232
jborean:~/dev/PowerShell$ debug/pwsh -File jordan.ps1

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 9
Milliseconds      : 145
Ticks             : 91453429
TotalDays         : 0.000105848876157407
TotalHours        : 0.00254037302777778
TotalMinutes      : 0.152422381666667
TotalSeconds      : 9.1453429
TotalMilliseconds : 9145.3429

Allocated Bytes 6372367600
```

This doesn't negate the existing performance impacts of adding to an array, it just removes extra work that wasn't needed in the first place (which was pretty inefficient) making it slower than it has to. People should still use an alternative like capturing the output from the pipeline or use `List<T>`.


## PR Context

Partially Fixes: https://github.com/PowerShell/PowerShell/issues/23899

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [X] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
