### PR TITLE
WIP: Add Microsoft.WinGet.CommandNotFound module to PSGalleryModules

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -815,6 +815,10 @@ function Restore-PSPackage
         if ($Options.Runtime -like 'win*') {
             $RestoreArguments += "/property:EnableWindowsTargeting=True"
             $RestoreArguments += "/property:UseRidGraph=True"
+            $RestoreArguments += "/property:IsWindows=True"
+        }
+        else {
+            $RestoreArguments += "/property:IsWindows=False"
         }
 
         if ($InteractiveAuth) {
@@ -2639,11 +2643,19 @@ function Copy-PSGalleryModules
         throw "Can't find nuget global cache"
     }
 
+    $windowsOnlyModules = @("Microsoft.Winget.Client", "Microsoft.Winget.CommandNotFound")
+
     $psGalleryProj = [xml](Get-Content -Raw $CsProjPath)
 
     foreach ($m in $psGalleryProj.Project.ItemGroup.PackageReference) {
         $name = $m.Include
         $version = $m.Version
+
+        if ($name -in $windowsOnlyModules -and $Options.Runtime -notlike "win*") {
+            Write-Log -message "Skipping $name because it is Windows only"
+            continue
+        }
+
         Write-Log -message "Name='$Name', Version='$version', Destination='$Destination'"
 
         # Remove the build revision from the src (nuget drops it).

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
-  <Import Project="..\..\PowerShell.Common.props" />
   <PropertyGroup>
     <Product>PowerShell</Product>
     <Company>Microsoft Corporation</Company>

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -8,6 +8,7 @@
     <TargetFramework>net9.0</TargetFramework>
 
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <IsWindows Condition="'$(IsWindows)' =='true' or ( '$(IsWindows)' == '' and '$(OS)' == 'Windows_NT')">true</IsWindows>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,8 +18,8 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.5" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
-    <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4" />
-    <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1911" />
+    <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4" Condition=" '$(IsWindows)' != 'true' "/>
+    <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1911" Condition=" '$(IsWindows)' != 'true' "/>
   </ItemGroup>
 
 </Project>

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -17,7 +17,11 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.5" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsWindows)' == 'true' ">
     <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4" />
+    <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1791" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.5" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
-    <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.3" />
+    <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -17,9 +17,6 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.5" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(IsWindows)' == 'true' ">
     <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4" />
     <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1911" />
   </ItemGroup>

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
-
+  <Import Project="..\..\PowerShell.Common.props" />
   <PropertyGroup>
     <Product>PowerShell</Product>
     <Company>Microsoft Corporation</Company>
@@ -8,7 +8,6 @@
     <TargetFramework>net9.0</TargetFramework>
 
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <IsWindows Condition="'$(IsWindows)' =='true' or ( '$(IsWindows)' == '' and '$(OS)' == 'Windows_NT')">true</IsWindows>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,8 +17,11 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.5" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
-    <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4" Condition=" '$(IsWindows)' != 'true' "/>
-    <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1911" Condition=" '$(IsWindows)' != 'true' "/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsWindows)' == 'true' ">
+    <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4"/>
+    <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1911"/>
   </ItemGroup>
 
 </Project>

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.5" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
+    <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup Condition=" '$(IsWindows)' == 'true' ">
     <PackageReference Include="Microsoft.WinGet.CommandNotFound" Version="1.0.4" />
-    <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1791" />
+    <PackageReference Include="Microsoft.WinGet.Client" Version="1.8.1911" />
   </ItemGroup>
 
 </Project>

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -8,8 +8,8 @@ Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
     }
 
     Context "Windows only" {
-        # Microsoft.WinGet.CommandNotFound relies on winget being available
-        Mock Get-Command -ParameterFilter { $cmd -eq "winget" }
+        # Microsoft.WinGet.CommandNotFound relies on winget "being available" by checking if Get-Command returns a result
+        Mock Get-Command -ParameterFilter { $cmd -eq "winget" } -MockWith { return Get-Command * }
 
         It "Should import the module correctly" -Skip:(-not $IsWindows) {
             try {

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
 
     Context "Windows only" {
         # Microsoft.WinGet.CommandNotFound relies on winget being available
-        Mock -CommandName winget -MockWith {}
+        Mock -CommandName winget
 
         It "Should import the module correctly" -Skip:(-not $IsWindows) {
             try {

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
+
+    Context "Windows only" -Skip:(-not $IsWindows) {
+        It "Should import the module correctly" {
+            Import-Module -Name Microsoft.WinGet.CommandNotFound
+            $module = Get-Module Microsoft.WinGet.CommandNotFound
+            $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
+            $module.Version | Should -Match '^1.0.4$'
+        }
+
+        It "Should be installed to `$PSHOME" {
+            $module = Get-Module (Join-Path -Path $PSHOME -ChildPath "Modules" -AdditionalChildPath "Microsoft.WinGet.CommandNotFound") -ListAvailable
+            $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
+            $module.Version | Should -Match '^1.0.4$'
+            $module.Path | Should -Be (Join-Path -Path $PSHOME -ChildPath "Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.psd1")
+        }
+    }
+
+    Context "Linux and macOS only" -Skip:($IsWindows) {
+        It "Should not be installed to `$PSHOME" {
+            Test-Path (Join-Path -Path $PSHOME -ChildPath "Modules" -AdditionalChildPath "Microsoft.WinGet.CommandNotFound") | Should -Be $False
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -1,16 +1,21 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
+    BeforeAll {
+        if (Get-Module Microsoft.WinGet.CommandNotFound) {
+            Remove-Module Microsoft.WinGet.CommandNotFound
+        }
+    }
 
-    Context "Windows only" -Skip:(-not $IsWindows) {
-        It "Should import the module correctly" {
+    Context "Windows only" {
+        It "Should import the module correctly" -Skip:(-not $IsWindows) {
             Import-Module -Name Microsoft.WinGet.CommandNotFound
             $module = Get-Module Microsoft.WinGet.CommandNotFound
             $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
             $module.Version | Should -Match '^1.0.4$'
         }
 
-        It "Should be installed to `$PSHOME" {
+        It "Should be installed to `$PSHOME" -Skip:(-not $IsWindows) {
             $module = Get-Module (Join-Path -Path $PSHOME -ChildPath "Modules" -AdditionalChildPath "Microsoft.WinGet.CommandNotFound") -ListAvailable
             $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
             $module.Version | Should -Match '^1.0.4$'
@@ -18,9 +23,13 @@ Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
         }
     }
 
-    Context "Linux and macOS only" -Skip:($IsWindows) {
-        It "Should not be installed to `$PSHOME" {
+    Context "Linux and macOS only" {
+        It "Should not be installed to `$PSHOME" -Skip:($IsWindows) {
             Test-Path (Join-Path -Path $PSHOME -ChildPath "Modules" -AdditionalChildPath "Microsoft.WinGet.CommandNotFound") | Should -Be $False
         }
+    }
+
+    AfterAll {
+        Remove-Module Microsoft.WinGet.CommandNotFound
     }
 }

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -9,27 +9,27 @@ Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
 
     Context "Windows only" {
         It "Should import the module correctly" -Skip:(-not $IsWindows) {
-            Import-Module -Name Microsoft.WinGet.CommandNotFound
-            $module = Get-Module Microsoft.WinGet.CommandNotFound
-            $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
-            $module.Version | Should -Match '^1.0.4$'
+            try {
+                $module = Import-Module -Name Microsoft.WinGet.CommandNotFound -PassThru
+                $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
+                $module.Version | Should -BeGreaterThan "1.0.4"
+            }
+            finally {
+                Get-Module -Name Microsoft.WinGet.CommandNotFound | Remove-Module -Force
+            }
         }
 
         It "Should be installed to `$PSHOME" -Skip:(-not $IsWindows) {
             $module = Get-Module (Join-Path -Path $PSHOME -ChildPath "Modules" -AdditionalChildPath "Microsoft.WinGet.CommandNotFound") -ListAvailable
             $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
-            $module.Version | Should -Match '^1.0.4$'
+            $module.Version | Should -BeGreaterThan "1.0.4"
             $module.Path | Should -Be (Join-Path -Path $PSHOME -ChildPath "Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.psd1")
         }
     }
 
     Context "Linux and macOS only" {
-        It "Should not be installed to `$PSHOME" -Skip:($IsWindows) {
-            Test-Path (Join-Path -Path $PSHOME -ChildPath "Modules" -AdditionalChildPath "Microsoft.WinGet.CommandNotFound") | Should -Be $False
+        It "Should not be installed" -Skip:($IsWindows) {
+            Get-Module -Name Microsoft.WinGet.CommandNotFound -ListAvailable | Should -BeNullOrEmpty
         }
-    }
-
-    AfterAll {
-        Remove-Module Microsoft.WinGet.CommandNotFound
     }
 }

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -8,6 +8,9 @@ Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
     }
 
     Context "Windows only" {
+        # Microsoft.WinGet.CommandNotFound relies on winget being available
+        Mock -CommandName winget -MockWith {}
+
         It "Should import the module correctly" -Skip:(-not $IsWindows) {
             try {
                 $module = Import-Module -Name Microsoft.WinGet.CommandNotFound -PassThru

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
 
     Context "Windows only" {
         # Microsoft.WinGet.CommandNotFound relies on winget being available
-        Mock -CommandName winget
+        Mock Get-Command -ParameterFilter { $cmd -eq "winget" }
 
         It "Should import the module correctly" -Skip:(-not $IsWindows) {
             try {

--- a/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.Tests.ps1
@@ -13,6 +13,8 @@ Describe "Microsoft.WinGet.CommandNotFound" -tags "CI" {
 
         It "Should import the module correctly" -Skip:(-not $IsWindows) {
             try {
+                # define an alias to simulate winget being available on the system
+                New-Alias -Name winget -Value Get-ChildItem
                 $module = Import-Module -Name Microsoft.WinGet.CommandNotFound -PassThru
                 $module.Name | Should -BeExactly 'Microsoft.WinGet.CommandNotFound'
                 $module.Version | Should -BeGreaterThan "1.0.4"

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -836,6 +836,22 @@
     "FileType": "NonProduct"
   },
   {
+    "Pattern": "Modules/Microsoft.WinGet.CommandNotFound/LICENSE",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.CommandNotFound/Microsoft.WinGet.CommandNotFound.psd1",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.CommandNotFound/ValidateOS.psm1",
+    "FileType": "NonProduct"
+  },
+  {
     "Pattern": "Modules/PackageManagement/*.dll",
     "FileType": "NonProduct"
   },

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -836,6 +836,10 @@
     "FileType": "NonProduct"
   },
   {
+    "Pattern": "Modules/Microsoft.WinGet.CommandNotFound/.signature.p7s",
+    "FileType": "NonProduct"
+  },
+  {
     "Pattern": "Modules/Microsoft.WinGet.CommandNotFound/LICENSE",
     "FileType": "NonProduct"
   },

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -836,6 +836,90 @@
     "FileType": "NonProduct"
   },
   {
+    "Pattern": "Modules/Microsoft.WinGet.Client/Format.ps1xml",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/Microsoft.WinGet.Client.psd1",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/Microsoft.WinGet.Client.Cmdlets.dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/Microsoft.WinGet.Client.Cmdlets.dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/DirectDependencies/Microsoft.WinGet.Client.Engine.dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/SharedDependencies/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/SharedDependencies/arm64/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/SharedDependencies/arm64/Microsoft.Management.Deployment.winmd",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/SharedDependencies/x64/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/SharedDependencies/x64/Microsoft.Management.Deployment.winmd",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/SharedDependencies/x86/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net48/SharedDependencies/x86/Microsoft.Management.Deployment.winmd",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/Microsoft.WinGet.Client.Cmdlets.dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/DirectDependencies/Microsoft.WinGet.Client.Engine.dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/SharedDependencies/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/SharedDependencies/arm64/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/SharedDependencies/arm64/Microsoft.Management.Deployment.winmd",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/SharedDependencies/x64/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/SharedDependencies/x64/Microsoft.Management.Deployment.winmd",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/SharedDependencies/x86/*dll",
+    "FileType": "NonProduct"
+  },
+  {
+    "Pattern": "Modules/Microsoft.WinGet.Client/net6.0-windows10.0.22000.0/SharedDependencies/x86/Microsoft.Management.Deployment.winmd",
+    "FileType": "NonProduct"
+  },
+  {
     "Pattern": "Modules/Microsoft.WinGet.CommandNotFound/.signature.p7s",
     "FileType": "NonProduct"
   },


### PR DESCRIPTION
# PR Summary
Adds the [Microsoft.WinGet.CommandNotFound](https://github.com/microsoft/winget-command-not-found) module to PSGalleryModules.

## PR Context
This automatically enables users to get winget suggestions for packages when PowerShell detects that a command wasn't found.

## PR Checklist
- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
