### PR TITLE
[release/v7.4.3] Expand `~` to `$home` on Windows with tab completion

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4892,12 +4892,15 @@ namespace System.Management.Automation
 
             for (int i = 0; i < path.Length; i++)
             {
+                // on Windows, we need to preserve the expanded home path as native commands don't understand it
+#if UNIX                
                 if (i == homeIndex)
                 {
                     _ = sb.Append('~');
                     i += homePath.Length - 1;
                     continue;
                 }
+#endif
 
                 EscapeCharIfNeeded(sb, path, i, stringType, literalPath, useSingleQuoteEscapeRules, ref quotesAreNeeded);
                 _ = sb.Append(path[i]);

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1227,12 +1227,16 @@ class InheritedClassTest : System.Attribute
             $res.CompletionMatches[0].CompletionText | Should -Be "`"$expectedPath`""
         }
 
-        It "Should keep '~' in completiontext when it's used to refer to home in input" {
+        It "Should handle '~' in completiontext when it's used to refer to home in input" {
             $res = TabExpansion2 -inputScript "~$separator"
             # select the first answer which does not have a space in the completion (those completions look like & '3D Objects')
             $observedResult = $res.CompletionMatches.Where({$_.CompletionText.IndexOf("&") -eq -1})[0].CompletionText
             $completedText = $res.CompletionMatches.CompletionText -join ","
-            $observedResult | Should -BeLike "~$separator*" -Because "$completedText"
+            if ($IsWindows) {
+                $observedResult | Should -BeLike "$home$separator*" -Because "$completedText"
+            } else {
+                $observedResult | Should -BeLike "~$separator*" -Because "$completedText"
+            }
         }
 
         It "Should use '~' as relative filter text when not followed by separator" {


### PR DESCRIPTION
Backport #21529