### PR TITLE
[release/v7.4.3] When generating `OutputType` don't cast to `Type[]`

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1565,7 +1565,15 @@ namespace System.Management.Automation.Language
 
                 if (args[0] is Type)
                 {
-                    result = new OutputTypeAttribute(LanguagePrimitives.ConvertTo<Type[]>(args));
+                    // We avoid `ConvertTo<Type[]>(args)` here as CLM would throw due to `Type[]`
+                    // being a "non-core" type. NOTE: This doesn't apply to `string[]`.
+                    Type[] types = new Type[args.Length];
+                    for (int i = 0; i < args.Length; i++)
+                    {
+                        types[i] = LanguagePrimitives.ConvertTo<Type>(args[i]);
+                    }
+
+                    result = new OutputTypeAttribute(types);
                 }
                 else
                 {


### PR DESCRIPTION
Backport #21605