### PR TITLE
Delay progress bar in Copy-Item and Remove-Item cmdlets

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3115,9 +3115,9 @@ namespace Microsoft.PowerShell.Commands
                         {
                             _removedFiles++;
                             _removedBytes += fileBytesSize;
-                            double speed = _removedBytes / 1024 / 1024 / _removeStopwatch.Elapsed.TotalSeconds;
                             if (_removeStopwatch.Elapsed.TotalSeconds > ProgressBarDurationThreshold)
                             {
+                                double speed = _removedBytes / 1024 / 1024 / _removeStopwatch.Elapsed.TotalSeconds;
                                 var progress = new ProgressRecord(
                                     REMOVE_FILE_ACTIVITY_ID,
                                     StringUtil.Format(FileSystemProviderStrings.RemovingLocalFileActivity, _removedFiles, _totalFiles),
@@ -3997,9 +3997,9 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 _copiedFiles++;
                                 _copiedBytes += file.Length;
-                                double speed = (double)(_copiedBytes / 1024 / 1024) / _copyStopwatch.Elapsed.TotalSeconds;
                                 if (_copyStopwatch.Elapsed.TotalSeconds > ProgressBarDurationThreshold)
                                 {
+                                    double speed = (double)(_copiedBytes / 1024 / 1024) / _copyStopwatch.Elapsed.TotalSeconds;
                                     var progress = new ProgressRecord(
                                         COPY_FILE_ACTIVITY_ID,
                                         StringUtil.Format(FileSystemProviderStrings.CopyingLocalFileActivity, _copiedFiles, _totalFiles),
@@ -4951,7 +4951,7 @@ namespace Microsoft.PowerShell.Commands
         private long _removedFiles;
         private readonly Stopwatch _removeStopwatch = new();
 
-        private const double ProgressBarDurationThreshold = 3.0;
+        private const double ProgressBarDurationThreshold = 2.0;
         #endregion CopyItem
 
         #endregion ContainerCmdletProvider members

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2878,7 +2878,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Context != null
                     && Context.ExecutionContext.SessionState.PSVariable.Get(SpecialVariables.ProgressPreferenceVarPath.UserPath).Value is ActionPreference progressPreference
-                    && progressPreference == ActionPreference.Continue && _totalFiles >= 5)
+                    && progressPreference == ActionPreference.Continue)
                 {
                     {
                         Task.Run(() =>
@@ -2953,7 +2953,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (_totalFiles >= 5 && (Stopping || _removedFiles == _totalFiles))
+                if (Stopping || _removedFiles == _totalFiles)
                 {
 
                     _removeStopwatch.Stop();
@@ -3112,7 +3112,7 @@ namespace Microsoft.PowerShell.Commands
                             RemoveFileSystemItem(file, force);
                         }
 
-                        if (_totalFiles > 0)
+                        if (_removeStopwatch.Elapsed.TotalSeconds > 0.6 && _totalFiles > 0)
                         {
                             _removedFiles++;
                             _removedBytes += fileBytesSize;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3112,11 +3112,14 @@ namespace Microsoft.PowerShell.Commands
                             RemoveFileSystemItem(file, force);
                         }
 
-                        if (_removeStopwatch.Elapsed.TotalSeconds > 0.2 && _totalFiles > 0)
+                        if (_totalFiles > 0)
                         {
                             _removedFiles++;
                             _removedBytes += fileBytesSize;
                             double speed = _removedBytes / 1024 / 1024 / _removeStopwatch.Elapsed.TotalSeconds;
+
+                            if (_removeStopwatch.Elapsed.TotalSeconds > progressBarDurationThreshold)
+                            {
                             var progress = new ProgressRecord(
                                 REMOVE_FILE_ACTIVITY_ID,
                                 StringUtil.Format(FileSystemProviderStrings.RemovingLocalFileActivity, _removedFiles, _totalFiles),
@@ -3126,6 +3129,7 @@ namespace Microsoft.PowerShell.Commands
                             progress.PercentComplete = percentComplete;
                             progress.RecordType = ProgressRecordType.Processing;
                             WriteProgress(progress);
+                            }
                         }
                     }
                 }
@@ -3991,11 +3995,14 @@ namespace Microsoft.PowerShell.Commands
                             FileInfo result = new FileInfo(destinationPath);
                             WriteItemObject(result, destinationPath, false);
 
-                            if (_copyStopwatch.Elapsed.TotalSeconds > 0.2 && _totalFiles > 0)
+                            if (_totalFiles > 0)
                             {
                                 _copiedFiles++;
                                 _copiedBytes += file.Length;
                                 double speed = (double)(_copiedBytes / 1024 / 1024) / _copyStopwatch.Elapsed.TotalSeconds;
+
+                                if (_copyStopwatch.Elapsed.TotalSeconds > progressBarDurationThreshold)
+                                {
                                 var progress = new ProgressRecord(
                                     COPY_FILE_ACTIVITY_ID,
                                     StringUtil.Format(FileSystemProviderStrings.CopyingLocalFileActivity, _copiedFiles, _totalFiles),
@@ -4005,6 +4012,7 @@ namespace Microsoft.PowerShell.Commands
                                 progress.PercentComplete = percentComplete;
                                 progress.RecordType = ProgressRecordType.Processing;
                                 WriteProgress(progress);
+                                }
                             }
                         }
                         else
@@ -4945,7 +4953,8 @@ namespace Microsoft.PowerShell.Commands
         private long _removedBytes;
         private long _removedFiles;
         private readonly Stopwatch _removeStopwatch = new();
-
+        
+        private const double progressBarDurationThreshold = 3.0;
         #endregion CopyItem
 
         #endregion ContainerCmdletProvider members

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2878,7 +2878,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Context != null
                     && Context.ExecutionContext.SessionState.PSVariable.Get(SpecialVariables.ProgressPreferenceVarPath.UserPath).Value is ActionPreference progressPreference
-                    && progressPreference == ActionPreference.Continue)
+                    && progressPreference == ActionPreference.Continue && _totalFiles >= 5)
                 {
                     {
                         Task.Run(() =>
@@ -2953,8 +2953,9 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (Stopping || _removedFiles == _totalFiles)
+                if (_totalFiles >= 5 && (Stopping || _removedFiles == _totalFiles))
                 {
+
                     _removeStopwatch.Stop();
                     var progress = new ProgressRecord(REMOVE_FILE_ACTIVITY_ID, " ", " ")
                     {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3112,7 +3112,7 @@ namespace Microsoft.PowerShell.Commands
                             RemoveFileSystemItem(file, force);
                         }
 
-                        if (_removeStopwatch.Elapsed.TotalSeconds > 0.6 && _totalFiles > 0)
+                        if (_removeStopwatch.Elapsed.TotalSeconds > 0.2 && _totalFiles > 0)
                         {
                             _removedFiles++;
                             _removedBytes += fileBytesSize;
@@ -3991,7 +3991,7 @@ namespace Microsoft.PowerShell.Commands
                             FileInfo result = new FileInfo(destinationPath);
                             WriteItemObject(result, destinationPath, false);
 
-                            if (_totalFiles > 0)
+                            if (_copyStopwatch.Elapsed.TotalSeconds > 0.2 && _totalFiles > 0)
                             {
                                 _copiedFiles++;
                                 _copiedBytes += file.Length;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3118,15 +3118,15 @@ namespace Microsoft.PowerShell.Commands
                             double speed = _removedBytes / 1024 / 1024 / _removeStopwatch.Elapsed.TotalSeconds;
                             if (_removeStopwatch.Elapsed.TotalSeconds > ProgressBarDurationThreshold)
                             {
-                            var progress = new ProgressRecord(
-                                REMOVE_FILE_ACTIVITY_ID,
-                                StringUtil.Format(FileSystemProviderStrings.RemovingLocalFileActivity, _removedFiles, _totalFiles),
-                                StringUtil.Format(FileSystemProviderStrings.RemovingLocalBytesStatus, Utils.DisplayHumanReadableFileSize(_removedBytes), Utils.DisplayHumanReadableFileSize(_totalBytes), speed)
-                            );
-                            var percentComplete = _totalBytes != 0 ? (int)Math.Min(_removedBytes * 100 / _totalBytes, 100) : 100;
-                            progress.PercentComplete = percentComplete;
-                            progress.RecordType = ProgressRecordType.Processing;
-                            WriteProgress(progress);
+                                var progress = new ProgressRecord(
+                                    REMOVE_FILE_ACTIVITY_ID,
+                                    StringUtil.Format(FileSystemProviderStrings.RemovingLocalFileActivity, _removedFiles, _totalFiles),
+                                    StringUtil.Format(FileSystemProviderStrings.RemovingLocalBytesStatus, Utils.DisplayHumanReadableFileSize(_removedBytes), Utils.DisplayHumanReadableFileSize(_totalBytes), speed)
+                                );
+                                var percentComplete = _totalBytes != 0 ? (int)Math.Min(_removedBytes * 100 / _totalBytes, 100) : 100;
+                                progress.PercentComplete = percentComplete;
+                                progress.RecordType = ProgressRecordType.Processing;
+                                WriteProgress(progress);
                             }
                         }
                     }
@@ -4000,15 +4000,15 @@ namespace Microsoft.PowerShell.Commands
                                 double speed = (double)(_copiedBytes / 1024 / 1024) / _copyStopwatch.Elapsed.TotalSeconds;
                                 if (_copyStopwatch.Elapsed.TotalSeconds > ProgressBarDurationThreshold)
                                 {
-                                var progress = new ProgressRecord(
-                                    COPY_FILE_ACTIVITY_ID,
-                                    StringUtil.Format(FileSystemProviderStrings.CopyingLocalFileActivity, _copiedFiles, _totalFiles),
-                                    StringUtil.Format(FileSystemProviderStrings.CopyingLocalBytesStatus, Utils.DisplayHumanReadableFileSize(_copiedBytes), Utils.DisplayHumanReadableFileSize(_totalBytes), speed)
-                                );
-                                var percentComplete = _totalBytes != 0 ? (int)Math.Min(_copiedBytes * 100 / _totalBytes, 100) : 100;
-                                progress.PercentComplete = percentComplete;
-                                progress.RecordType = ProgressRecordType.Processing;
-                                WriteProgress(progress);
+                                    var progress = new ProgressRecord(
+                                        COPY_FILE_ACTIVITY_ID,
+                                        StringUtil.Format(FileSystemProviderStrings.CopyingLocalFileActivity, _copiedFiles, _totalFiles),
+                                        StringUtil.Format(FileSystemProviderStrings.CopyingLocalBytesStatus, Utils.DisplayHumanReadableFileSize(_copiedBytes), Utils.DisplayHumanReadableFileSize(_totalBytes), speed)
+                                    );
+                                    var percentComplete = _totalBytes != 0 ? (int)Math.Min(_copiedBytes * 100 / _totalBytes, 100) : 100;
+                                    progress.PercentComplete = percentComplete;
+                                    progress.RecordType = ProgressRecordType.Processing;
+                                    WriteProgress(progress);
                                 }
                             }
                         }
@@ -4950,7 +4950,7 @@ namespace Microsoft.PowerShell.Commands
         private long _removedBytes;
         private long _removedFiles;
         private readonly Stopwatch _removeStopwatch = new();
-        
+
         private const double ProgressBarDurationThreshold = 3.0;
         #endregion CopyItem
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2955,7 +2955,6 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Stopping || _removedFiles == _totalFiles)
                 {
-
                     _removeStopwatch.Stop();
                     var progress = new ProgressRecord(REMOVE_FILE_ACTIVITY_ID, " ", " ")
                     {
@@ -3117,8 +3116,7 @@ namespace Microsoft.PowerShell.Commands
                             _removedFiles++;
                             _removedBytes += fileBytesSize;
                             double speed = _removedBytes / 1024 / 1024 / _removeStopwatch.Elapsed.TotalSeconds;
-
-                            if (_removeStopwatch.Elapsed.TotalSeconds > progressBarDurationThreshold)
+                            if (_removeStopwatch.Elapsed.TotalSeconds > ProgressBarDurationThreshold)
                             {
                             var progress = new ProgressRecord(
                                 REMOVE_FILE_ACTIVITY_ID,
@@ -4000,8 +3998,7 @@ namespace Microsoft.PowerShell.Commands
                                 _copiedFiles++;
                                 _copiedBytes += file.Length;
                                 double speed = (double)(_copiedBytes / 1024 / 1024) / _copyStopwatch.Elapsed.TotalSeconds;
-
-                                if (_copyStopwatch.Elapsed.TotalSeconds > progressBarDurationThreshold)
+                                if (_copyStopwatch.Elapsed.TotalSeconds > ProgressBarDurationThreshold)
                                 {
                                 var progress = new ProgressRecord(
                                     COPY_FILE_ACTIVITY_ID,
@@ -4954,7 +4951,7 @@ namespace Microsoft.PowerShell.Commands
         private long _removedFiles;
         private readonly Stopwatch _removeStopwatch = new();
         
-        private const double progressBarDurationThreshold = 3.0;
+        private const double ProgressBarDurationThreshold = 3.0;
         #endregion CopyItem
 
         #endregion ContainerCmdletProvider members


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
I've optimized the Progress Bar of the Copy and Remove commands to display only after the operation lasts more then 200ms, otherwise do the operation without a Progress Bar, I've done this by adding to the IF conditional of IF _copyStopwatch or _removeStopwatch Elapsed time is higher then 0.2 seconds(200ms) add the Progress Bar to the process.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fix #23831
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
