### PR TITLE
Fix the extent of the parser error when a number constant is invalid

### DIFF
--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -3907,7 +3907,8 @@ namespace System.Management.Automation.Language
                     return ScanGenericToken(GetStringBuilder());
                 }
 
-                ReportError(_currentIndex,
+                ReportError(
+                    NewScriptExtent(_tokenStart, _currentIndex),
                     nameof(ParserStrings.BadNumericConstant),
                     ParserStrings.BadNumericConstant,
                     _script.Substring(_tokenStart, _currentIndex - _tokenStart));

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -665,19 +665,32 @@ Describe "Parsing using statement with alias and linebreak and comma" -Tag CI {
     }
 }
 
-It "Should correctly parse array literals for index expressions in method calls" {
-    $tks = $null
-    $ers = $null
-    $Script = '[string]::join(" ", (0, 1, 2)[0, 1])'
-    $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
-    $result.EndBlock.Statements[0].PipelineElements[0].Expression.Arguments[1].Index.Elements.Count | Should -Be 2
-    $ers.Count | Should -Be 0
-}
+Describe "Additional tests" -Tag CI {
+    It "Should correctly parse array literals for index expressions in method calls" {
+        $tks = $null
+        $ers = $null
+        $Script = '[string]::join(" ", (0, 1, 2)[0, 1])'
+        $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $result.EndBlock.Statements[0].PipelineElements[0].Expression.Arguments[1].Index.Elements.Count | Should -Be 2
+        $ers.Count | Should -Be 0
+    }
 
-It "Should correctly parse array types that are used as arguments without brackets in generic type" {
-    $tks = $null
-    $ers = $null
-    $Script = '[System.Tuple[System.String[],System.Int32[]]]'
-    $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
-    $result.EndBlock.Statements[0].PipelineElements[0].Expression.TypeName.FullName | Should -Be 'System.Tuple[System.String[],System.Int32[]]'
+    It "Should correctly parse array types that are used as arguments without brackets in generic type" {
+        $tks = $null
+        $ers = $null
+        $Script = '[System.Tuple[System.String[],System.Int32[]]]'
+        $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $result.EndBlock.Statements[0].PipelineElements[0].Expression.TypeName.FullName | Should -Be 'System.Tuple[System.String[],System.Int32[]]'
+    }
+
+    It "Should get correct offsets for number constant parsing error" {
+        $tks = $null
+        $ers = $null
+        $Script = '$n = 0x10000000000000000'
+        $null = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $ers.Length | Should -BeExactly 1
+        $ers[0].Extent.StartOffset | Should -BeExactly 5
+        $ers[0].Extent.EndOffset | Should -BeExactly 24
+        $ers[0].Extent.Text | Should -BeExactly '0x10000000000000000'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When a number constant is invalid, the offset positions used to create the `Extent` for the generated `ParserError` is incorrect, which caused an exception to happen in PSReadLine (https://github.com/PowerShell/PSReadLine/issues/4064).

`Extent` of the parser error in this case should point to the number token, but today, it points at the end of the token

![image](https://github.com/PowerShell/PowerShell/assets/127450/f115eabc-bed3-4c73-9a86-e0b35bfb0d88)

With this PR, the `Extent` points to the number token as expected:

![image](https://github.com/PowerShell/PowerShell/assets/127450/2834f53a-de33-4391-b2ec-0953586f3a67)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
