### PR TITLE
Fix Hyper-V Remoting when using remoting import

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -471,7 +471,7 @@ namespace Microsoft.PowerShell.Commands
             // Unknown scenario, this should not happen.
             string message = PSRemotingErrorInvariants.FormatResourceString(
                 RemotingErrorIdStrings.HyperVFailedToGetStateUnknownType,
-                    rawState?.GetType()?.FullName ?? "null");
+                rawState?.GetType()?.FullName ?? "null");
             throw new InvalidOperationException(message);
         }
 #nullable disable

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -445,6 +445,40 @@ namespace Microsoft.PowerShell.Commands
             FastSavingCritical,
         }
 
+#nullable enable
+        /// <summary>
+        /// Get the State property from Get-VM result.
+        /// </summary>
+        /// <param name="value">The raw PSObject as returned by Get-VM.</param>
+        /// <returns>The VMState value of the State property if present and parsable, otherwise null.</returns>
+        internal VMState? GetVMStateProperty(PSObject value)
+        {
+            ReadOnlyPSMemberInfoCollection<PSPropertyInfo> stateProps = value.Properties.Match("State");
+            if (stateProps.Count == 0)
+            {
+                return null;
+            }
+
+            object? rawState = stateProps[0].Value;
+            if (rawState is Enum enumState)
+            {
+                // If the Hyper-V module was directly importable we have the VMState enum
+                // value which we can just cast to our VMState type.
+                return (VMState)enumState;
+            }
+            else if (rawState is string stringState && Enum.TryParse(stringState, true, out VMState result))
+            {
+                // If the Hyper-V module was imported through implicit remoting on old
+                // Windows versions we get a string back which we will try and parse
+                // as the enum label.
+                return result;
+            }
+
+            // Unknown scenario, this should not happen.
+            return null;
+        }
+#nullable disable
+
         #endregion
 
         #region Tracer
@@ -1658,7 +1692,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         this.VMName[index] = (string)results[0].Properties["VMName"].Value;
 
-                        if ((VMState)results[0].Properties["State"].Value == VMState.Running)
+                        if (GetVMStateProperty(results[0]) == VMState.Running)
                         {
                             vmIsRunning[index] = true;
                         }
@@ -1707,7 +1741,7 @@ namespace Microsoft.PowerShell.Commands
                         this.VMId[index] = (Guid)results[0].Properties["VMId"].Value;
                         this.VMName[index] = (string)results[0].Properties["VMName"].Value;
 
-                        if ((VMState)results[0].Properties["State"].Value == VMState.Running)
+                        if (GetVMStateProperty(results[0]) == VMState.Running)
                         {
                             vmIsRunning[index] = true;
                         }

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -453,13 +453,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>The VMState value of the State property if present and parsable, otherwise null.</returns>
         internal VMState? GetVMStateProperty(PSObject value)
         {
-            ReadOnlyPSMemberInfoCollection<PSPropertyInfo> stateProps = value.Properties.Match("State");
-            if (stateProps.Count == 0)
-            {
-                return null;
-            }
-
-            object? rawState = stateProps[0].Value;
+            object? rawState = value.Properties["State"].Value;
             if (rawState is Enum enumState)
             {
                 // If the Hyper-V module was directly importable we have the VMState enum
@@ -475,7 +469,10 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Unknown scenario, this should not happen.
-            return null;
+            string message = PSRemotingErrorInvariants.FormatResourceString(
+                RemotingErrorIdStrings.HyperVFailedToGetStateUnknownType,
+                    rawState?.GetType()?.FullName ?? "null");
+            throw new InvalidOperationException(message);
         }
 #nullable disable
 

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1025,7 +1025,7 @@ namespace Microsoft.PowerShell.Commands
             //
             // VM should be in running state.
             //
-            if ((VMState)results[0].Properties["State"].Value != VMState.Running)
+            if (GetVMStateProperty(results[0]) != VMState.Running)
             {
                 WriteError(
                     new ErrorRecord(

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -932,7 +932,7 @@ namespace Microsoft.PowerShell.Commands
                     //
                     // VM should be in running state.
                     //
-                    if ((VMState)results[0].Properties["State"].Value != VMState.Running)
+                    if (GetVMStateProperty(results[0]) != VMState.Running)
                     {
                         WriteError(
                             new ErrorRecord(

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1720,4 +1720,7 @@ SSH client process terminated before connection could be established.</value>
   <data name="WDACGetPowerShellLogMessage" xml:space="preserve">
     <value>Creating a PowerShell object from a script block may require evaluating some expressions within the script block. The expression evaluation will silently fail and return 'null' in Constrained Language mode, unless the expression represents a constant value.</value>
   </data>
+  <data name="HyperVFailedToGetStateUnknownType" xml:space="preserve">
+    <value>Failed to get Hyper-V VM State. The value was of the type {0} but was expected to be Microsoft.HyperV.PowerShell.VMState or System.String.</value>
+  </data>
 </root>


### PR DESCRIPTION
# PR Summary
When on a Windows version that cannot load the Hyper-V module the State property will be of the string type. This change ensures that PowerShell can still parse this value to the VMState type as expected when the module was loaded natively. This should allow PSRemoting cmdlets that call Get-VM to properly get the VM State property.

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/issues/24014

I don't have a Server 2016 host to test against but it seems like the only other props used from `Get-VM` are a `String` and `Guid` types which should work without any issues in an implicitly remoted module import.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
