### PR TITLE
Add OutFile property in WebResponseObject

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the output file path.
         /// </summary>
-        public string? OutFile { get; set; }
+        public string? OutFile { get; internal set; }
 
         #endregion Properties
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -70,6 +70,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public string StatusDescription => WebResponseHelper.GetStatusDescription(BaseResponse);
 
+        /// <summary>
+        /// Gets or sets the output file path.
+        /// </summary>
+        public string? OutFile { get; set; }
+
         #endregion Properties
 
         #region Protected Fields

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (ShouldSaveToOutFile)
             {
-                WriteVerbose(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"File Name: {Path.GetFileName(outFilePath)}"));
+                WriteVerbose($"File Name: {Path.GetFileName(outFilePath)}");
 
                 // ContentLength is always the partial length, while ContentRange is the full length
                 // Without Request.Range set, ContentRange is null and partial length (ContentLength) equals to full length

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -38,6 +38,8 @@ namespace Microsoft.PowerShell.Commands
             ArgumentNullException.ThrowIfNull(response);
             TimeSpan perReadTimeout = ConvertTimeoutSecondsToTimeSpan(OperationTimeoutSeconds);
             Stream responseStream = StreamHelper.GetResponseStream(response, _cancelToken.Token);
+            string outFilePath = WebResponseHelper.GetOutFilePath(response, _qualifiedOutFile);
+
             if (ShouldWriteToPipeline)
             {
                 // Creating a MemoryStream wrapper to response stream here to support IsStopping.
@@ -50,6 +52,7 @@ namespace Microsoft.PowerShell.Commands
                     _cancelToken.Token);
                 WebResponseObject ro = WebResponseHelper.IsText(response) ? new BasicHtmlWebResponseObject(response, responseStream, perReadTimeout, _cancelToken.Token) : new WebResponseObject(response, responseStream, perReadTimeout, _cancelToken.Token);
                 ro.RelationLink = _relationLink;
+                ro.OutFile = outFilePath;
                 WriteObject(ro);
 
                 // Use the rawcontent stream from WebResponseObject for further
@@ -61,9 +64,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (ShouldSaveToOutFile)
             {
-                string outFilePath = WebResponseHelper.GetOutFilePath(response, _qualifiedOutFile);
-
-                WriteVerbose(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"File Name: {Path.GetFileName(_qualifiedOutFile)}"));
+                WriteVerbose(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"File Name: {Path.GetFileName(outFilePath)}"));
 
                 // ContentLength is always the partial length, while ContentRange is the full length
                 // Without Request.Range set, ContentRange is null and partial length (ContentLength) equals to full length

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -786,6 +786,28 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $content.Content.Length
     }
 
+    It "Invoke-WebRequest -PassThru -OutFile <directory> saves the downloaded file path as a property in WebResponseObject"{
+        $uri = Get-WebListenerUrl -Test 'Get'
+        $content = Invoke-WebRequest -Uri $uri -PassThru -OutFile $TestDrive
+        $content.OutFile | Should -exist
+        $content.OutFile | Should -Be (Join-Path $TestDrive 'Get')
+    }
+
+    It "Invoke-WebRequest -PassThru -OutFile <file> saves the downloaded file path as a property in WebResponseObject"{
+        $uri = Get-WebListenerUrl -Test 'Get'
+        $filePath = Join-Path $TestDrive "pestertest-outfile"
+        $content = Invoke-WebRequest -Uri $uri -PassThru -OutFile $filePath
+        $content.OutFile | Should -exist
+        $content.OutFile | Should -Be $filePath
+    }
+
+    It "Invoke-WebRequest -PassThru -OutFile -Verbose File Name reflects the downloaded file name" {
+        $uri = Get-WebListenerUrl -Test 'Get'
+        $filePath = Join-Path $TestDrive "pestertest-outfile"
+        $content = Invoke-WebRequest -Verbose -Uri $uri -PassThru -OutFile $filePath 4>variable:verbo
+        $verbo[-1].Message | Should -Match "pestertest-outfile"
+    }
+
     It "Invoke-WebRequest should fail if -OutFile is <Name>." -TestCases @(
         @{ Name = "empty"; Value = [string]::Empty }
         @{ Name = "null"; Value = $null }
@@ -4637,7 +4659,6 @@ Describe 'Invoke-WebRequest and Invoke-RestMethod support OperationTimeoutSecond
         RunWithNetworkTimeout -Command Invoke-RestMethod -Uri $uri -OperationTimeoutSeconds 2 -WillTimeout -Arguments '-SkipCertificateCheck'
     }
 }
-
 
 Describe "Invoke-RestMethod should run in the default synchronization context (threadpool)" -Tag "CI" {
     BeforeAll {


### PR DESCRIPTION
# PR Summary

Fixes: #21082 

Added OutFile as a property in WebResponseObject. OutFile will save whenever writing to pipe line.
Refactored one line to reduce redundancy.

## PR Context

PR extends WebObjectResponse with a property that stores the installed file's path. It makes sense to have this as a built in property since we have access to it.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
