### PR TITLE
Fix `Get`/`Set-Clipboard` on Linux/Wayland with wl-clipboard

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
@@ -76,8 +76,18 @@ namespace Microsoft.PowerShell.Commands.Internal
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                tool = "xclip";
-                args = "-selection clipboard -out";
+                string sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+
+                if (sessionType == "wayland")
+                {
+                    tool = "wl-paste";
+                }
+                else
+                {
+                    // Previous behavior: use xclip regardless of XDG_SESSION_TYPE
+                    tool = "xclip";
+                    args = "-selection clipboard -out";
+                }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -109,14 +119,25 @@ namespace Microsoft.PowerShell.Commands.Internal
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                tool = "xclip";
-                if (string.IsNullOrEmpty(text))
+                string sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+
+                if (sessionType == "wayland")
                 {
-                    args = "-selection clipboard /dev/null";
+                    tool = "wl-copy";
                 }
                 else
                 {
-                    args = "-selection clipboard -in";
+                    // Previous behavior: use xclip regardless of XDG_SESSION_TYPE
+                    tool = "xclip";
+
+                    if (string.IsNullOrEmpty(text))
+                    {
+                        args = "-selection clipboard /dev/null";
+                    }
+                    else
+                    {
+                        args = "-selection clipboard -in";
+                    }
                 }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
@@ -76,15 +76,16 @@ namespace Microsoft.PowerShell.Commands.Internal
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                string sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+                string waylandEnv = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY");
+                bool isWayland = !(string.IsNullOrEmpty(waylandEnv));
 
-                if (sessionType == "wayland")
+                if (isWayland)
                 {
                     tool = "wl-paste";
                 }
                 else
                 {
-                    // Previous behavior: use xclip regardless of XDG_SESSION_TYPE
+                    // Previous behavior: use xclip regardless of env:WAYLAND_DISPLAY
                     tool = "xclip";
                     args = "-selection clipboard -out";
                 }
@@ -119,15 +120,16 @@ namespace Microsoft.PowerShell.Commands.Internal
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                string sessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+                string waylandEnv = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY");
+                bool isWayland = !(string.IsNullOrEmpty(waylandEnv));
 
-                if (sessionType == "wayland")
+                if (isWayland)
                 {
                     tool = "wl-copy";
                 }
                 else
                 {
-                    // Previous behavior: use xclip regardless of XDG_SESSION_TYPE
+                    // Previous behavior: use xclip regardless of env:WAYLAND_DISPLAY
                     tool = "xclip";
 
                     if (string.IsNullOrEmpty(text))

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using Microsoft.PowerShell.Commands.Internal;
@@ -55,7 +56,7 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                textContent = Clipboard.GetText();
+                textContent = Clipboard.GetText((Hashtable)GetVariableValue("PSClipboardActions"));
             }
             catch (PlatformNotSupportedException)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/SetClipboardCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/SetClipboardCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -90,6 +91,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="append">If true, appends to clipboard instead of overwriting.</param>
         private void SetClipboardContent(List<string> contentList, bool append)
         {
+            Hashtable clipboardActions = (Hashtable)GetVariableValue("PSClipboardActions");
             string setClipboardShouldProcessTarget;
 
             if ((contentList == null || contentList.Count == 0) && !append)
@@ -97,7 +99,7 @@ namespace Microsoft.PowerShell.Commands
                 setClipboardShouldProcessTarget = string.Format(CultureInfo.InvariantCulture, ClipboardResources.ClipboardCleared);
                 if (ShouldProcess(setClipboardShouldProcessTarget, "Set-Clipboard"))
                 {
-                    Clipboard.SetText(string.Empty);
+                    Clipboard.SetText(clipboardActions, string.Empty);
                 }
 
                 return;
@@ -106,7 +108,7 @@ namespace Microsoft.PowerShell.Commands
             StringBuilder content = new();
             if (append)
             {
-                content.AppendLine(Clipboard.GetText());
+                content.AppendLine(Clipboard.GetText(clipboardActions));
             }
 
             if (contentList != null)
@@ -148,7 +150,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (!AsOSC52)
             {
-                Clipboard.SetText(content);
+                Clipboard.SetText((Hashtable)GetVariableValue("PSClipboardActions"), content);
                 return;
             }
 

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -37,6 +37,10 @@ namespace System.Management.Automation
 
         internal static readonly VariablePath PSStyleVarPath = new VariablePath(PSStyle);
 
+        internal const string PSClipboardActions = "PSClipboardActions";
+
+        internal static readonly VariablePath PSClipboardActionsVarPath = new VariablePath(PSClipboardActions);
+
         internal const string OutputEncoding = "OutputEncoding";
 
         internal static readonly VariablePath OutputEncodingVarPath = new VariablePath(OutputEncoding);

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -123,6 +123,9 @@
   <data name="PSHOMEDescription" xml:space="preserve">
     <value>Parent folder of the host application of the current runspace</value>
   </data>
+  <data name="PSClipboardActions" xml:space="preserve">
+    <value>replaceme Commands used to control Get-Clipboard and Set-Clipboard commands</value>
+  </data>
   <data name="HOMEDescription" xml:space="preserve">
     <value>Folder containing the current user's profile</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
@@ -4,12 +4,14 @@
 Describe 'Clipboard cmdlet tests' -Tag CI {
     BeforeAll {
         $xclip = Get-Command xclip -CommandType Application -ErrorAction Ignore
+        $wlcopy = Get-Command wl-copy -CommandType Application -ErrorAction Ignore
+        $wlpaste = Get-Command wl-paste -CommandType Application -ErrorAction Ignore
     }
 
     Context 'Text' {
         BeforeAll {
             $defaultParamValues = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = ($IsWindows -and $env:PROCESSOR_ARCHITECTURE.Contains("arm")) -or ($IsLinux -and $xclip -eq $null)
+            $PSDefaultParameterValues["it:skip"] = ($IsWindows -and $env:PROCESSOR_ARCHITECTURE.Contains("arm")) -or ($IsLinux -and ($xclip -eq $null) -and ($wlcopy -eq $null) -and ($wlpaste -eq $null) )
         }
 
         AfterAll {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Uses `wl-copy`/`wl-paste` from [wl-clipboard](https://github.com/bugaevc/wl-clipboard) if a Wayland session is in use ([`$env:XDG_SESSION_TYPE` is `wayland`](https://www.freedesktop.org/software/systemd/man/latest/pam_systemd.html#type=)), otherwise fallback to previous default `xclip`

## PR Context

Fixes #17561
Supersedes #18227

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/pull/11267
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
