### PR TITLE
If SMA.dll location is not found, use host exe to determine `$PSHOME` location

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,6 +482,8 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase(string shellId)
         {
+            // Use the location of SMA.dll as the application base if it exists,
+            // otherwise, use the base directory from `AppContext`.
             var baseDirectory = Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
             if (string.IsNullOrEmpty(baseDirectory))
             {

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -485,7 +485,7 @@ namespace System.Management.Automation
             var baseDirectory = Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
             if (string.IsNullOrEmpty(baseDirectory))
             {
-                // need to remove any trailing directory separator characters
+                // Need to remove any trailing directory separator characters
                 baseDirectory = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
             }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,9 +482,7 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase(string shellId)
         {
-            // Use the location of SMA.dll as the application base.
-            Assembly assembly = typeof(PSObject).Assembly;
-            return Path.GetDirectoryName(assembly.Location);
+            return AppContext.BaseDirectory;
         }
 
         private static string[] s_productFolderDirectories;
@@ -1536,8 +1534,8 @@ namespace System.Management.Automation
                 // if import-module is visible, then the session is not restricted,
                 // because the user can load arbitrary code.
                 if (cmdletInfo != null && cmdletInfo.Visibility == SessionStateEntryVisibility.Public)
-                {        
-                   return false; 
+                {
+                   return false;
                 }
                 return true;
         }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,16 +482,11 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase(string shellId)
         {
-            var baseDirectory = AppContext.BaseDirectory;
-            if (!string.IsNullOrEmpty(baseDirectory))
+            var baseDirectory = Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
+            if (string.IsNullOrEmpty(baseDirectory))
             {
                 // need to remove any trailing directory separator characters
-                baseDirectory = baseDirectory.TrimEnd(Path.DirectorySeparatorChar);
-            }
-            else
-            {
-                // host path can be empty if hosted in WinRM, so fallback to using SMA.dll location
-                baseDirectory = Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
+                baseDirectory = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
             }
 
             return baseDirectory;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,7 +482,8 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase(string shellId)
         {
-            return AppContext.BaseDirectory;
+            // Try the host exe first, then fall back to SMA location.  Host exe can be null if hosted in WinRM.
+            return AppContext.BaseDirectory ?? Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,8 +482,14 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase(string shellId)
         {
-            // Try the host exe first, then fall back to SMA location.  Host exe can be null if hosted in WinRM.
-            return AppContext.BaseDirectory ?? Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
+            // Try the host exe first, then fall back to SMA location.  Host exe can be empty if hosted in WinRM.
+            var baseDirectory = AppContext.BaseDirectory;
+            if (string.IsNullOrEmpty(baseDirectory))
+            {
+                baseDirectory = Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
+            }
+
+            return baseDirectory;
         }
 
         private static string[] s_productFolderDirectories;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -482,10 +482,15 @@ namespace System.Management.Automation
 
         internal static string GetApplicationBase(string shellId)
         {
-            // Try the host exe first, then fall back to SMA location.  Host exe can be empty if hosted in WinRM.
             var baseDirectory = AppContext.BaseDirectory;
-            if (string.IsNullOrEmpty(baseDirectory))
+            if (!string.IsNullOrEmpty(baseDirectory))
             {
+                // need to remove any trailing directory separator characters
+                baseDirectory = baseDirectory.Trim(Path.DirectorySeparatorChar);
+            }
+            else
+            {
+                // host path can be empty if hosted in WinRM, so fallback to using SMA.dll location
                 baseDirectory = Path.GetDirectoryName(typeof(PSObject).Assembly.Location);
             }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -486,7 +486,7 @@ namespace System.Management.Automation
             if (!string.IsNullOrEmpty(baseDirectory))
             {
                 // need to remove any trailing directory separator characters
-                baseDirectory = baseDirectory.Trim(Path.DirectorySeparatorChar);
+                baseDirectory = baseDirectory.TrimEnd(Path.DirectorySeparatorChar);
             }
             else
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -92,11 +92,10 @@ Describe "Get-Process" -Tags "CI" {
     }
 
     It "Should return CommandLine property" -Skip:($IsMacOS) {
-        $pwshPath = (Get-Command pwsh).Source
         if ($IsWindows) {
             # Windows will convert the bound parameters and quote them if it
             # contains whitespace. Any inner double quotes are escaped with \".
-            $expected = "`"$pwshPath`" -NoProfile -NoLogo -NonInteractive -Command `"(Get-Process -Id \`"`$pid\`").CommandLine`""
+            $expected = "`"$PSHOME\pwsh.exe`" -NoProfile -NoLogo -NonInteractive -Command `"(Get-Process -Id \`"`$pid\`").CommandLine`""
 
             $actual = & {
                 $PSNativeCommandArgumentPassing = 'Windows'
@@ -106,7 +105,7 @@ Describe "Get-Process" -Tags "CI" {
             # Linux passes arguments as they are bound. As there is no actual
             # command line string, pwsh just joins each array with a space
             # without attempting to use some sort of quoting rule.
-            $expected = "$pwshPath -NoProfile -NoLogo -NonInteractive -Command (Get-Process -Id `"`$pid`").CommandLine"
+            $expected = "$PSHOME/pwsh -NoProfile -NoLogo -NonInteractive -Command (Get-Process -Id `"`$pid`").CommandLine"
 
             $actual = & "$PSHOME/pwsh" -NoProfile -NoLogo -NonInteractive -Command '(Get-Process -Id "$pid").CommandLine'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -92,10 +92,11 @@ Describe "Get-Process" -Tags "CI" {
     }
 
     It "Should return CommandLine property" -Skip:($IsMacOS) {
+        $pwshPath = (Get-Command pwsh).Source
         if ($IsWindows) {
             # Windows will convert the bound parameters and quote them if it
             # contains whitespace. Any inner double quotes are escaped with \".
-            $expected = "`"$PSHOME\pwsh.exe`" -NoProfile -NoLogo -NonInteractive -Command `"(Get-Process -Id \`"`$pid\`").CommandLine`""
+            $expected = "`"$pwshPath`" -NoProfile -NoLogo -NonInteractive -Command `"(Get-Process -Id \`"`$pid\`").CommandLine`""
 
             $actual = & {
                 $PSNativeCommandArgumentPassing = 'Windows'
@@ -105,7 +106,7 @@ Describe "Get-Process" -Tags "CI" {
             # Linux passes arguments as they are bound. As there is no actual
             # command line string, pwsh just joins each array with a space
             # without attempting to use some sort of quoting rule.
-            $expected = "$PSHOME/pwsh -NoProfile -NoLogo -NonInteractive -Command (Get-Process -Id `"`$pid`").CommandLine"
+            $expected = "$pwshPath -NoProfile -NoLogo -NonInteractive -Command (Get-Process -Id `"`$pid`").CommandLine"
 
             $actual = & "$PSHOME/pwsh" -NoProfile -NoLogo -NonInteractive -Command '(Get-Process -Id "$pid").CommandLine'
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

PowerShell uses the SMA.dll file location to determine it's base location.  However, if a hosted app is built as a single exe, that location is empty which causes PowerShell init to fail.

Change is if SMA.dll file location is empty, use the host exe location instead.

Tested manually building pwsh as singleexe.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/24070
Fix https://github.com/PowerShell/PowerShell/issues/23797

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
