### PR TITLE
Added Tab Completion for pwsh

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1157,6 +1157,102 @@ namespace System.Management.Automation
                 }
             }
 
+            if (result == null || result.Count == 0)
+            {
+                // Handles the following scenario: pwsh -<tab>
+                result = CompletePwshCommands(completionContext);
+            }
+
+            return result;
+        }
+
+        private static List<CompletionResult> CompletePwshCommands(CompletionContext completionContext)
+        {
+            if (!completionContext.CursorPosition.Line.Contains("pwsh -"))
+            {
+                return null;
+            }
+            List<CompletionResult> result = new List<CompletionResult>();
+            string parameterToComplete = completionContext.RelatedAsts[^1].Extent.Text;
+            List<string> parameters = new List<string>()
+            {
+                "-File",
+                "-Command",
+                "-CommandWithArgs",
+                "-ConfigurationName",
+                "-ConfigurationFile",
+                "-CustomPipeName",
+                "-EncodedCommand",
+                "-ExecutionPolicy",
+                "-InputFormat",
+                "-Interactive",
+                "-Login",
+                "-MTA",
+                "-NoExit",
+                "-NoLogo",
+                "-NonInteractive",
+                "-NoProfile",
+                "-NoProfileLoadTime",
+                "-OutputFormat",
+                "-SettingsFile",
+                "-SSHServerMode",
+                "-STA",
+                "-Version",
+                "-WindowStyle",
+                "-WorkingDirectory",
+                "-Help"
+            };
+            List<string> alias = new List<string>()
+            {
+                "-f",
+                "-c",
+                "-cwa",
+                "-config",
+                "-e",
+                "-ec",
+                "-ex",
+                "-ep",
+                "-i",
+                "-l",
+                "-noe",
+                "-nol",
+                "-noni",
+                "-nop",
+                "-of",
+                "-settings",
+                "-sshs",
+                "-v",
+                "-w",
+                "-wd",
+                "-?"
+            };
+            if (parameterToComplete.Equals("-"))
+            {
+                foreach (string parameter in parameters)
+                {
+                    result.Add(new CompletionResult(parameter, parameter, CompletionResultType.ParameterName, parameter));
+                }
+            }
+            else
+            {
+                foreach (string parameter in parameters)
+                {
+                    if (parameter.StartsWith(parameterToComplete, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Add(new CompletionResult(parameter, parameter, CompletionResultType.ParameterName, parameter));
+                    }
+                }
+                if (result.Count == 0)
+                {
+                    foreach (string parameter in alias)
+                    {
+                        if (parameter.StartsWith(parameterToComplete, StringComparison.OrdinalIgnoreCase))
+                        {
+                            result.Add(new CompletionResult(parameter, parameter, CompletionResultType.ParameterName, parameter));
+                        }
+                    }
+                }
+            }
             return result;
         }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -2348,6 +2348,12 @@ namespace System.Management.Automation
                 }
             }
 
+            if (completionContext.RelatedAsts[0].Extent.Text.Contains("-Command")
+                && completionContext.RelatedAsts[0].Extent.Text.Contains("pwsh"))
+            {
+                return CompletionCompleters.CompleteCommand(completionContext);
+            }
+
             bool needFileCompletion = false;
             if (lastAst.Parent is FileRedirectionAst || CompleteAgainstSwitchFile(lastAst, completionContext.TokenBeforeCursor))
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1348,6 +1348,14 @@ namespace System.Management.Automation
                     }
                 }
 
+                if (commandName == "pwsh")
+                {
+                    if (commandAst.CommandElements[^1].Extent.Text.Equals("-Command"))
+                    {
+                        return CompleteCommand(context);
+                    }
+                }
+
                 var clearLiteralPathKey = false;
                 if (pseudoBinding == null)
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes: #14808

Adds tab completion for pwsh parameters and arguments

**This is a draft PR. I don't know if this is the best approach.**

## PR Context

@Liturgist brought up the fact that pwsh/pwsh.exe doesn't have supporting tab completion for its parameters.
 
## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
