### PR TITLE
Change type of LineNumber to ulong in Select-String

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the number of the matching line.
         /// </summary>
         /// <value>The number of the matching line.</value>
-        public uint64 LineNumber { get; set; }
+        public ulong LineNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the text of the matching line.
@@ -277,7 +277,7 @@ namespace Microsoft.PowerShell.Commands
             // Otherwise, render the full context.
             List<string> lines = new(Context.DisplayPreContext.Length + Context.DisplayPostContext.Length + 1);
 
-            uint64 displayLineNumber = this.LineNumber - Context.DisplayPreContext.Length;
+            ulong displayLineNumber = this.LineNumber - (ulong)Context.DisplayPreContext.Length;
             foreach (string contextLine in Context.DisplayPreContext)
             {
                 lines.Add(FormatLine(contextLine, displayLineNumber++, displayPath, ContextPrefix));
@@ -356,7 +356,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="displayPath">The file path, formatted for display.</param>
         /// <param name="prefix">The match prefix.</param>
         /// <returns>The formatted line as a string.</returns>
-        private string FormatLine(string lineStr, uint64 displayLineNumber, string displayPath, string prefix)
+        private string FormatLine(string lineStr, ulong displayLineNumber, string displayPath, string prefix)
         {
             return _pathSet
                        ? StringUtil.Format(MatchFormat, prefix, displayPath, displayLineNumber, lineStr)
@@ -1417,7 +1417,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private bool _doneProcessing;
 
-        private uint64 _inputRecordNumber;
+        private ulong _inputRecordNumber;
 
         /// <summary>
         /// Read command line parameters.
@@ -1595,7 +1595,7 @@ namespace Microsoft.PowerShell.Commands
                     using (StreamReader sr = new(fs, Encoding))
                     {
                         string line;
-                        uint64 lineNo = 0;
+                        ulong lineNo = 0;
 
                         // Read and display lines from the file until the end of
                         // the file is reached.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the number of the matching line.
         /// </summary>
         /// <value>The number of the matching line.</value>
-        public int LineNumber { get; set; }
+        public uint64 LineNumber { get; set; }
 
         /// <summary>
         /// Gets or sets the text of the matching line.
@@ -277,7 +277,7 @@ namespace Microsoft.PowerShell.Commands
             // Otherwise, render the full context.
             List<string> lines = new(Context.DisplayPreContext.Length + Context.DisplayPostContext.Length + 1);
 
-            int displayLineNumber = this.LineNumber - Context.DisplayPreContext.Length;
+            uint64 displayLineNumber = this.LineNumber - Context.DisplayPreContext.Length;
             foreach (string contextLine in Context.DisplayPreContext)
             {
                 lines.Add(FormatLine(contextLine, displayLineNumber++, displayPath, ContextPrefix));
@@ -356,7 +356,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="displayPath">The file path, formatted for display.</param>
         /// <param name="prefix">The match prefix.</param>
         /// <returns>The formatted line as a string.</returns>
-        private string FormatLine(string lineStr, int displayLineNumber, string displayPath, string prefix)
+        private string FormatLine(string lineStr, uint64 displayLineNumber, string displayPath, string prefix)
         {
             return _pathSet
                        ? StringUtil.Format(MatchFormat, prefix, displayPath, displayLineNumber, lineStr)
@@ -1417,7 +1417,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private bool _doneProcessing;
 
-        private int _inputRecordNumber;
+        private uint64 _inputRecordNumber;
 
         /// <summary>
         /// Read command line parameters.
@@ -1595,7 +1595,7 @@ namespace Microsoft.PowerShell.Commands
                     using (StreamReader sr = new(fs, Encoding))
                     {
                         string line;
-                        int lineNo = 0;
+                        uint64 lineNo = 0;
 
                         // Read and display lines from the file until the end of
                         // the file is reached.


### PR DESCRIPTION
Very long files could overflow the LineNumber, leading to negative line numbers in output of Select-String. Changing to UInt64 should fix this for the forseeable future

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

See Commit message: Fix for negative LineNumbers in Output of Select-String
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
See Issue #24027 

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [X] N/A or can only be tested interactively - I've tested locally
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
