### PR TITLE
Fix `Test-ModuleManifest` so it can use a UNC path

### DIFF
--- a/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
@@ -374,7 +374,8 @@ namespace Microsoft.PowerShell.Commands
                     ThrowTerminatingError(er);
                 }
 
-                // This should be the FileSystemProvider path and not the provider path
+                // `Path` returns the PSProviderPath which is fully qualified to the provider and the filesystem APIs
+                // don't understand this.  Instead `ProviderPath` returns the path that the FileSystemProvider understands.
                 path = pathInfos[0].ProviderPath;
 
                 // First, we validate if the path does exist.

--- a/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
@@ -374,7 +374,8 @@ namespace Microsoft.PowerShell.Commands
                     ThrowTerminatingError(er);
                 }
 
-                path = pathInfos[0].Path;
+                // This should be the FileSystemProvider path and not the provider path
+                path = pathInfos[0].ProviderPath;
 
                 // First, we validate if the path does exist.
                 if (!File.Exists(path) && !Directory.Exists(path))

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -151,6 +151,16 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         $module.NestedModules | Should -HaveCount 1
         $module.NestedModules.Name | Should -BeExactly "Foo"
     }
+
+    It 'Works for manifest specified as UNC path' -Skip:(!$IsWindows) {
+        # chance the testdrive path to a UNC path
+
+        $testModulePath = '\\localhost\' + "$testDrive\test.psd1".Replace(':', '$')
+        New-Item -ItemType File -Path testdrive:/foo.psm1 > $null
+        New-ModuleManifest -Path $testModulePath -RootModule "foo.psm1"
+        $module = Test-ModuleManifest -Path $testModulePath
+        $module.RootModule | Should -Be "foo.psm1"
+    }
 }
 
 Describe "Tests for circular references in required modules" -tags "CI" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The cmdlet resolves the path to correct the slashes, but then uses the `PathInfo.Path` which is the fully qualified provider path which is not a valid file system path, so when it tries to use .NET `File` and `Directory` to check if the root module exists, it fails as it doesn't understand provider paths.  Instead, use the `ProviderPath` property (which despite the naming returns the path from the provider which is the filesystem path).

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/24114

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
