### PR TITLE
Fix Windows local build issue #24124

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1029,6 +1029,12 @@ function New-PSOptions {
         elseif ($Runtime -like 'fxdependent*') {
             $Output = [IO.Path]::Combine($Top, "bin", $Configuration, $Framework, "publish", $Executable)
         }
+        elseif ( -not $CI -and $Runtime.Contains("win7-")) {
+            $Output = [IO.Path]::Combine($Top, "bin", $Runtime.Replace("win7-", $null), $Configuration, $Framework, $Runtime, "publish", $Executable)
+        }
+        elseif ( -not $CI -and $Runtime.Contains("win-")) {
+            $Output = [IO.Path]::Combine($Top, "bin", $Runtime.Replace("win-", $null), $Configuration, $Framework, $Runtime, "publish", $Executable)
+        }
         else {
             $Output = [IO.Path]::Combine($Top, "bin", $Configuration, $Framework, $Runtime, "publish", $Executable)
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes issue #24124 

Account for OutDir path used by dotnet msbuild during local builds on Windows machines.

This fixes local build issues as CI does not have these problems.