### PR TITLE
Add ability to capture MSBuild Binary logs when restore fails

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -130,8 +130,6 @@ extends:
               value: true
           - name: ob_outputDirectory
             value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT/BuildJson'
-          - name: ob_signing_setup_enabled
-            value: false
 
         steps:
         - checkout: self

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -22,6 +22,10 @@ parameters:
     displayName: Enable Windows Stage
     type: boolean
     default: true
+  - name: ENABLE_MSBUILD_BINLOGS
+    displayName: Enable MSBuild Binary Logs
+    type: boolean
+    default: false
 
 resources:
   repositories:
@@ -68,6 +72,8 @@ variables:
     value: ${{ parameters.SKIP_SIGNING }}
   - group: 'AzDevOpsArtifacts'
   - group: 'mscodehub-feed-read-akv'
+  - name: ENABLE_MSBUILD_BINLOGS
+    value: ${{ parameters.ENABLE_MSBUILD_BINLOGS }}
 
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
@@ -124,6 +130,8 @@ extends:
               value: true
           - name: ob_outputDirectory
             value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT/BuildJson'
+          - name: ob_signing_setup_enabled
+            value: false
 
         steps:
         - checkout: self


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces changes to enable MSBuild binary logging and improve the handling of build artifacts in the pipeline configuration and build scripts.

### Pipeline Configuration Changes:

* [`.pipelines/PowerShell-Coordinated_Packages-Official.yml`](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR25-R28): Added a new parameter `ENABLE_MSBUILD_BINLOGS` to enable or disable MSBuild binary logs.
* [`.pipelines/PowerShell-Coordinated_Packages-Official.yml`](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR75-R76): Updated `variables` section to include the new `ENABLE_MSBUILD_BINLOGS` parameter.


### Build Script Enhancements:

* [`build.psm1`](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR856-R859): Modified the `Restore-PSPackage` function to append the `-bl` argument for binary logging if `ENABLE_MSBUILD_BINLOGS` is set.
* [`build.psm1`](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR877-R893): Enhanced the `Restore-PSPackage` function to handle and upload MSBuild binary logs if a restore operation fails and `ENABLE_MSBUILD_BINLOGS` is enabled.

## PR Context

Binary logs are much more readable but are too big to use all the time.  

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
