### PR TITLE
Fix Global tool config generation

### DIFF
--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -292,7 +292,7 @@ jobs:
       $config.Add("Microsoft.PowerShell:ExecutionPolicy", "RemoteSigned")
       $config.Add("WindowsPowerShellCompatibilityModuleDenyList", @("PSScheduledJob", "BestPractices", "UpdateServices"))
 
-      $configPublishPath = Join-Path "$outputPath" 'temp' 'tools' 'net8.0' 'any' "powershell.config.json"
+      $configPublishPath = Join-Path "$outputPath" 'temp' 'tools' 'net9.0' 'any' "powershell.config.json"
       Set-Content -Path $configPublishPath -Value ($config | ConvertTo-Json) -Force -ErrorAction Stop
 
       Compress-Archive -Path "$outputPath\temp\*" -DestinationPath "$outputPath\$nupkgName" -Force


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes a change to the `jobs:` section in the `.pipelines/templates/windows-hosted-build.yml` file to update the PowerShell configuration path. 

* `jobs:` section in `.pipelines/templates/windows-hosted-build.yml`: Updated the `$configPublishPath` to use `net9.0` instead of `net8.0` for the PowerShell configuration file.


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
