### PR TITLE
[release/v7.2]Use correct signing certificates for RPM and DEBs

### DIFF
--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -169,7 +169,7 @@ extends:
           signedDrop: 'drop_linux_sign_linux_fxd_x64_mariner'
           packageType: rpm-fxdependent  #mariner-x64
           jobName: mariner_x64
-          signingProfile: 'CP-459159-pgpdetached'
+          signingProfile: 'CP-459159-Pgp'
 
       - template: /.pipelines/templates/linux-package-build.yml@self
         parameters:
@@ -177,7 +177,7 @@ extends:
           signedDrop: 'drop_linux_sign_linux_fxd_arm64_mariner'
           packageType: rpm-fxdependent-arm64 #mariner-arm64
           jobName: mariner_arm64
-          signingProfile: 'CP-459159-pgpdetached'
+          signingProfile: 'CP-459159-Pgp'
 
       - template: /.pipelines/templates/linux-package-build.yml@self
         parameters:

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -3,7 +3,7 @@ parameters:
   signedeDrop: 'drop_linux_sign_linux_x64'
   packageType: deb
   jobName: 'deb'
-  signingProfile: 'CP-450779-pgpdetached'
+  signingProfile: 'CP-450779-Pgp'
 
 jobs:
 - job: ${{ parameters.jobName }}


### PR DESCRIPTION
Backport #21522

This pull request includes changes to the signing profiles in the CI pipeline configuration files to ensure consistency in naming conventions.

Changes to signing profiles:

* [`.pipelines/PowerShell-Packages-Official.yml`](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L172-R180): Updated the `signingProfile` parameter for `mariner_x64` and `mariner_arm64` jobs to use 'CP-459159-Pgp' instead of 'CP-459159-pgpdetached'.
* [`.pipelines/templates/linux-package-build.yml`](diffhunk://#diff-c4deeac235a73bb18401801ffa4dbcba3977cfb09599cd432e2a5940de12734eL6-R6): Updated the `signingProfile` parameter for `deb` job to use 'CP-450779-Pgp' instead of 'CP-450779-pgpdetached'.