### PR TITLE
[release/v7.2]Fix exe signing with third party signing for WiX engine

### DIFF
--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -143,6 +143,7 @@ jobs:
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: 1
   - group: DotNetPrivateBuildAccess
+  - group: certificate_logical_to_actual
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: ob_sdl_codeSignValidation_enabled

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -88,6 +88,7 @@ jobs:
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - group: DotNetPrivateBuildAccess
+  - group: certificate_logical_to_actual
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: ob_sdl_codeSignValidation_enabled

--- a/.pipelines/templates/obp-file-signing.yml
+++ b/.pipelines/templates/obp-file-signing.yml
@@ -128,7 +128,7 @@ steps:
   displayName: Sign 3rd Party files
   inputs:
     command: 'sign'
-    signing_profile: 135020002
+    signing_profile: $(msft_3rd_party_cert_id)
     files_to_sign: '**\*.dll;**\*.exe'
     search_root: $(Pipeline.Workspace)/thirdPartyToBeSigned
 

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -17,6 +17,7 @@ jobs:
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: 1
   - group: DotNetPrivateBuildAccess
+  - group: certificate_logical_to_actual
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: ob_sdl_codeSignValidation_enabled

--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -18,6 +18,7 @@ jobs:
     - name: skipNugetSecurityAnalysis
       value: true
     - group: DotNetPrivateBuildAccess
+    - group: certificate_logical_to_actual
     - name: ob_outputDirectory
       value: '$(Build.ArtifactStagingDirectory)\ONEBRANCH_ARTIFACT'
     - name: ob_sdl_binskim_enabled
@@ -209,11 +210,35 @@ jobs:
       Set-Location $repoRoot
 
       $exePath = New-ExePackage -ProductVersion $version -ProductTargetArchitecture $runtime -MsiLocationPath $msiLocation
+      Write-Verbose -Verbose "setting vso[task.setvariable variable=exePath]$exePath"
+      Write-Host "##vso[task.setvariable variable=exePath]$exePath"
       Write-Verbose -Verbose "exePath: $exePath"
-    displayName: 'Make exe package'
+
+      $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\unsignedEngine' -ChildPath engine.exe
+      Expand-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
+    displayName: 'Make exe and expand package'
 
   - task: onebranch.pipeline.signing@1
-    displayName: Sign MSI packages
+    displayName: Sign exe engine
+    inputs:
+      command: 'sign'
+      signing_profile: $(msft_3rd_party_cert_id)
+      files_to_sign: '$(System.ArtifactsDirectory)\unsignedEngine\*.exe'
+      search_root: '$(Pipeline.Workspace)'
+
+  - pwsh: |
+      $repoRoot = "$env:REPOROOT"
+      Import-Module "$repoRoot\build.psm1"
+      Import-Module "$repoRoot\tools\packaging"
+
+      $exePath = '$(exePath)'
+      $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\unsignedEngine' -ChildPath engine.exe
+      $enginePath | Get-AuthenticodeSignature | out-string | Write-Verbose -verbose
+      Compress-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
+    displayName: Compress signed exe package
+
+  - task: onebranch.pipeline.signing@1
+    displayName: Sign exe packages
     inputs:
       command: 'sign'
       signing_profile: external_distribution


### PR DESCRIPTION
Backport #23878

This pull request includes several updates to the pipeline configuration files to improve the build and signing process. The most important changes include adding a new group for certificate management, updating the signing profile to use a variable, and enhancing the Windows package build process.

### Pipeline Configuration Updates:

* `.pipelines/templates/linux.yml`, `.pipelines/templates/mac.yml`, `.pipelines/templates/windows-hosted-build.yml`, `.pipelines/templates/windows-package-build.yml`: Added `certificate_logical_to_actual` group to manage certificate mapping. [[1]](diffhunk://#diff-d57c933d863854f9d912e16e721ee4f97370454f265d73be75d62448be712056R146) [[2]](diffhunk://#diff-36df43c9f4f3a05ba28d68446fe703429dd357f723690b0e1f9e47e50ff4ecdcR91) [[3]](diffhunk://#diff-75adb3400c53c5cbe183c86d9d543a4cda81cd7664b45c4bf3ce77478e8ff098R20) [[4]](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daR21)

### Signing Profile Updates:

* [`.pipelines/templates/obp-file-signing.yml`](diffhunk://#diff-0e1172506a7cf796d69b4c947235541c05a4c9c26697030ff024b8bc8568c218L131-R131): Changed `signing_profile` to use `$(msft_3rd_party_cert_id)` variable for better flexibility.

### Windows Package Build Enhancements:

* [`.pipelines/templates/windows-package-build.yml`](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daR213-R241): Enhanced the build process to include steps for creating, expanding, signing, and compressing the exe package.