### PR TITLE
[release/v7.2]Skip build steps that dont have exe packages

### DIFF
--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -215,7 +215,7 @@ jobs:
       Write-Verbose -Verbose "exePath: $exePath"
 
       $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\unsignedEngine' -ChildPath engine.exe
-      Expand-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
+      Expand-ExePackageEngine -ExePath $exePath -EnginePath $enginePath -ProductTargetArchitecture $runtime
     displayName: 'Make exe and expand package'
 
   - task: onebranch.pipeline.signing@1
@@ -227,14 +227,23 @@ jobs:
       search_root: '$(Pipeline.Workspace)'
 
   - pwsh: |
+      $runtime = '$(Runtime)'
+      Write-Verbose -Verbose "runtime = '$(Runtime)'"
       $repoRoot = "$env:REPOROOT"
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
+      $noExeRuntimes = @('fxdependent', 'fxdependentWinDesktop', 'minsize')
+
+      if ($runtime -in $noExeRuntimes) {
+        Write-Verbose -Verbose "No EXE generated for $runtime"
+        return
+      }
+
       $exePath = '$(exePath)'
       $enginePath = Join-Path -Path '$(System.ArtifactsDirectory)\unsignedEngine' -ChildPath engine.exe
       $enginePath | Get-AuthenticodeSignature | out-string | Write-Verbose -verbose
-      Compress-ExePackageEngine -ExePath $exePath -EnginePath $enginePath
+      Compress-ExePackageEngine -ExePath $exePath -EnginePath $enginePath -ProductTargetArchitecture $runtime
     displayName: Compress signed exe package
 
   - task: onebranch.pipeline.signing@1

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3385,7 +3385,12 @@ function Expand-ExePackageEngine {
         # Location to put the expanded engine.
         [Parameter(Mandatory = $true)]
         [string]
-        $EnginePath
+        $EnginePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("x86", "x64", "arm64")]
+        [ValidateNotNullOrEmpty()]
+        [string] $ProductTargetArchitecture
     )
 
     <#
@@ -3393,7 +3398,7 @@ function Expand-ExePackageEngine {
     insignia -ib TestInstaller.exe -o engine.exe
     #>
 
-    $wixPaths = Get-WixPath
+    $wixPaths = Get-WixPath -IsProductArchitectureArm ($ProductTargetArchitecture -eq "arm64")
 
     $resolvedExePath = (Resolve-Path -Path $ExePath).ProviderPath
     $resolvedEnginePath = [System.IO.Path]::GetFullPath($EnginePath)
@@ -3415,7 +3420,12 @@ function Compress-ExePackageEngine {
         # Location of the signed engine
         [Parameter(Mandatory = $true)]
         [string]
-        $EnginePath
+        $EnginePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("x86", "x64", "arm64")]
+        [ValidateNotNullOrEmpty()]
+        [string] $ProductTargetArchitecture
     )
 
 
@@ -3424,7 +3434,7 @@ function Compress-ExePackageEngine {
     insignia -ab engine.exe TestInstaller.exe -o TestInstaller.exe
     #>
 
-    $wixPaths = Get-WixPath
+    $wixPaths = Get-WixPath -IsProductArchitectureArm ($ProductTargetArchitecture -eq "arm64")
 
     $resolvedEnginePath = (Resolve-Path -Path $EnginePath).ProviderPath
     $resolvedExePath = (Resolve-Path -Path $ExePath).ProviderPath


### PR DESCRIPTION
Backport #23945

This pull request includes several changes to the packaging and signing process for exe packages, focusing on adding support for different target architectures and improving the overall build pipeline.

### Pipeline and Packaging Enhancements:

* [`.pipelines/templates/windows-package-build.yml`](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daL213-R247): Enhanced the pipeline to include steps for expanding, signing, and compressing exe packages, with support for multiple target architectures. The `displayName` for the task was updated to reflect the new functionality.
* [`tools/packaging/packaging.psm1`](diffhunk://#diff-8ac11d6f4bbedfce810550a3f8cfd0ee21f8b14085a5764d38577994c7e7c736L3388-R3401): Updated the `Expand-ExePackageEngine` and `Compress-ExePackageEngine` functions to include a mandatory `ProductTargetArchitecture` parameter, which supports "x86", "x64", and "arm64". This ensures the correct paths and commands are used for different architectures. [[1]](diffhunk://#diff-8ac11d6f4bbedfce810550a3f8cfd0ee21f8b14085a5764d38577994c7e7c736L3388-R3401) [[2]](diffhunk://#diff-8ac11d6f4bbedfce810550a3f8cfd0ee21f8b14085a5764d38577994c7e7c736L3418-R3428) [[3]](diffhunk://#diff-8ac11d6f4bbedfce810550a3f8cfd0ee21f8b14085a5764d38577994c7e7c736L3427-R3437)