### PR TITLE
Bump PackageManagement to 1.4.8.1

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
-    <PackageReference Include="PackageManagement" Version="1.4.7" />
+    <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.1.0" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />


### PR DESCRIPTION
This pull request includes an update to the `src/Modules/PSGalleryModules.csproj` file to ensure compatibility with the latest version of the `PackageManagement` package.

Dependency updates:

* [`src/Modules/PSGalleryModules.csproj`](diffhunk://#diff-c5607631ae8e51c58ed12c063bb5d26ed89bc04b8bafc882c83f11ee0ee68273L15-R15): Updated the `PackageManagement` package reference from version `1.4.7` to `1.4.8.1` for improved compatibility and bug fixes.