### PR TITLE
Update the URLs used in `nuget.config` files

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -105,7 +105,7 @@ extends:
         ignoreDirectories: '.devcontainer,demos,docker,docs,src,test,tools/packaging'
       asyncSdl:
         enabled: true
-        forStages: [prep, macos, linux, windows, SignFiles, test_and_release_artifacts]
+        forStages: [prep, macos, linux, windows, test_and_release_artifacts]
         credscan:
           enabled: true
           scanFolder:  $(Build.SourcesDirectory)

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-dotnet-9/nuget/v3/index.json" />
+    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell-7-5-preview-test-2/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/src/Modules/nuget.config
+++ b/src/Modules/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-dotnet-9/nuget/v3/index.json" />
+    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell-7-5-preview-test-2/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update the URLs used in `nuget.config` files per the discussion with Travis.

@TravisEz13 There are 2 more `nuget.config` files in the repo:
- `PowerShell\test\tools\Modules\nuget.config`
- `PowerShell\tools\wix\nuget.config`

Should they be changed too?