### PR TITLE
Add remote runspace check for PushRunspace

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -629,8 +629,7 @@ namespace Microsoft.PowerShell
                 return;
             }
 
-            RemoteRunspace remoteRunspace = runspace as RemoteRunspace;
-            if (remoteRunspace is not RemoteRunspace remoteRunspace)
+            if (runspace is not RemoteRunspace remoteRunspace)
             {
                 throw new ArgumentException(ConsoleHostStrings.PushRunspaceNotRemote, nameof(runspace));
             }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -630,12 +630,11 @@ namespace Microsoft.PowerShell
             }
 
             RemoteRunspace remoteRunspace = runspace as RemoteRunspace;
-            if (remoteRunspace is null)
+            if (remoteRunspace is not RemoteRunspace remoteRunspace)
             {
                 throw new ArgumentException(ConsoleHostStrings.PushRunspaceNotRemote, nameof(runspace));
             }
 
-            Dbg.Assert(remoteRunspace != null, "Expected remoteRunspace != null");
             remoteRunspace.StateChanged += HandleRemoteRunspaceStateChanged;
 
             // Unsubscribe the local session debugger.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -622,14 +622,19 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// See base class.
         /// </summary>
-        public void PushRunspace(Runspace newRunspace)
+        public void PushRunspace(Runspace runspace)
         {
             if (_runspaceRef == null)
             {
                 return;
             }
 
-            RemoteRunspace remoteRunspace = newRunspace as RemoteRunspace;
+            RemoteRunspace remoteRunspace = runspace as RemoteRunspace;
+            if (remoteRunspace is null)
+            {
+                throw new ArgumentException(ConsoleHostStrings.PushRunspaceNotRemote, nameof(runspace));
+            }
+
             Dbg.Assert(remoteRunspace != null, "Expected remoteRunspace != null");
             remoteRunspace.StateChanged += HandleRemoteRunspaceStateChanged;
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -182,4 +182,7 @@ The current session does not support debugging; execution will continue.
   <data name="RunAsAdministrator" xml:space="preserve">
     <value>Run as Administrator</value>
   </data>
+  <data name="PushRunspaceNotRemote" xml:space="preserve">
+    <value>PushRunspace can only push a remote runspace.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/engine/hostifaces/MshHost.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHost.cs
@@ -296,6 +296,11 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Called by the engine to notify the host that a runspace push has been requested.
         /// </summary>
+        /// <param name="runspace">
+        /// The runspace to push. This runspace must be a remote runspace and
+        /// not a locally created runspace.
+        /// </param>
+        /// <exception cref="ArgumentException">The specified runspace is not a remote runspace.</exception>
         /// <seealso cref="System.Management.Automation.Host.IHostSupportsInteractiveSession.PushRunspace"/>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Runspace")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "runspace")]

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -81,3 +81,18 @@ Describe 'PromptForCredential' -Tags "CI" {
         $out.UserName | Should -BeExactly 'myDomain\myUser'
     }
 }
+
+Describe 'PushRunspaceLocalFailure' -Tags 'CI' {
+    It 'Should throw an exception when pushing a local runspace' {
+        $runspace = [RunspaceFactory]::CreateRunspace()
+        try {
+            $runspace.Open()
+            $exc = { $Host.PushRunspace($runspace) } | Should -Throw -PassThru
+            $exc.Exception.InnerException | Should -BeOfType ([System.ArgumentException])
+            [string]$exc | Should -BeLike "*PushRunspace can only push a remote runspace. (Parameter 'runspace')*"
+        }
+        finally {
+            $runspace.Dispose()
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary
Add explicit exception when attempting to call PushRunspace on a runspace that is not remote. Instead of failing with a hard to understand NullReferenceException an ArgumentException is raised with information about what went wrong.

Fixes: https://github.com/PowerShell/PowerShell/issues/5735

## PR Context
Someone in the PS Discord was trying to get this working and didn't know why it was failing. The issue #5735 was auto closed by the bot but I think this should still be in place.

While the `RemoteRunspace` check is in place on the default ConsoleHost I am not aware of any other implementations that work with a local `Runspace` so thought it best to just update the doc string to clearly indicate that the runspace should be a remote one.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
