### PR TITLE
Get-Service Ignore common errors

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -682,11 +682,11 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>ServiceController as PSObject with UserName, Description and StartupType added.</returns>
         private static PSObject AddProperties(nint scManagerHandle, ServiceController service)
         {
-            NakedWin32Handle hService = IntPtr.Zero;
+            NakedWin32Handle hService = nint.Zero;
 
             // As these are optional values, a failure due to permissions or
             // other problem is ignored and the properties are set to null.
-            bool isDelayedAutoStart = false;
+            bool? isDelayedAutoStart = null;
             string? binPath = null;
             string? description = null;
             string? startName = null;
@@ -724,9 +724,12 @@ namespace Microsoft.PowerShell.Commands
                     {
                         binPath = serviceInfo.lpBinaryPathName;
                         startName = serviceInfo.lpServiceStartName;
-                        startupType = NativeMethods.GetServiceStartupType(
-                            (ServiceStartMode)serviceInfo.dwStartType,
-                            isDelayedAutoStart);
+                        if (isDelayedAutoStart.HasValue)
+                        {
+                            startupType = NativeMethods.GetServiceStartupType(
+                                (ServiceStartMode)serviceInfo.dwStartType,
+                                isDelayedAutoStart.Value);
+                        }
                     }
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -740,23 +740,23 @@ namespace Microsoft.PowerShell.Commands
             }
 
             PSObject serviceAsPSObj = PSObject.AsPSObject(service);
-            PSProperty noteProperty = new("UserName", startName);
+            PSNoteProperty noteProperty = new("UserName", startName);
             serviceAsPSObj.Properties.Add(noteProperty, true);
             serviceAsPSObj.TypeNames.Insert(0, "System.Service.ServiceController#UserName");
 
-            noteProperty = new PSProperty("Description", description);
+            noteProperty = new PSNoteProperty("Description", description);
             serviceAsPSObj.Properties.Add(noteProperty, true);
             serviceAsPSObj.TypeNames.Insert(0, "System.Service.ServiceController#Description");
 
-            noteProperty = new PSProperty("DelayedAutoStart", isDelayedAutoStart);
+            noteProperty = new PSNoteProperty("DelayedAutoStart", isDelayedAutoStart);
             serviceAsPSObj.Properties.Add(noteProperty, true);
             serviceAsPSObj.TypeNames.Insert(0, "System.Service.ServiceController#DelayedAutoStart");
 
-            noteProperty = new PSProperty("BinaryPathName", binPath);
+            noteProperty = new PSNoteProperty("BinaryPathName", binPath);
             serviceAsPSObj.Properties.Add(noteProperty, true);
             serviceAsPSObj.TypeNames.Insert(0, "System.Service.ServiceController#BinaryPathName");
 
-            noteProperty = new PSProperty("StartupType", startupType);
+            noteProperty = new PSNoteProperty("StartupType", startupType);
             serviceAsPSObj.Properties.Add(noteProperty, true);
             serviceAsPSObj.TypeNames.Insert(0, "System.Service.ServiceController#StartupType");
 

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
@@ -159,9 +159,6 @@
   <data name="CouldNotSetService" xml:space="preserve">
     <value>Service '{1} ({0})' cannot be configured due to the following error: {2}</value>
   </data>
-  <data name="CouldNotGetServiceInfo" xml:space="preserve">
-    <value>Service '{1} ({0})' cannot be queried due to the following error: {2}</value>
-  </data>
   <data name="CouldNotSetServiceDescription" xml:space="preserve">
     <value>Service '{1} ({0})' description cannot be configured due to the following error: {2}</value>
   </data>
@@ -211,7 +208,7 @@
     <value>Service '{1} ({0})' resume failed.</value>
   </data>
   <data name="FailToOpenServiceControlManager" xml:space="preserve">
-    <value>Failed to configure the service '{1} ({0})' due to the following error: {2}. Run PowerShell as admin and run your command again.</value>
+    <value>Failed to open SCManager due to the following error: {0}. Run PowerShell as admin and run your command again.</value>
   </data>
   <data name="UnsupportedStartupType" xml:space="preserve">
     <value>The startup type '{0}' is not supported by {1}.</value>


### PR DESCRIPTION
# PR Summary
Ignore common errors when attempting to retrieve some properties for a service like the Description, UserName, StartupType. These properties are not critical for using a service object or to retrieve other information like the name and whether a service exists or not and by emitting an error record it could fail a script if it did not expect an error.

Instead if the service failed to retrieve the property due to permissions or other environmental problems, it will set the affected properties to $null.

## PR Context
The more common cause was doing `Get-Service` to enumerate all services or to get a particular service where the description points to a dll to extract the MUI entry. If that dll didn't exist or was set to an invalid index it would fail to get the description and then fail with a generic permission error message from PowerShell. Another less common problem was if the caller didn't have the `SERVICE_QUERY_CONFIG` access to retrieve the extra info requested.

As per the conversation in https://github.com/PowerShell/PowerShell/issues/10371#issuecomment-532897970 the WG choice was to not emit an error and set the properties to `$null`.

Fixes: https://github.com/PowerShell/PowerShell/issues/10371

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
