### PR TITLE
Add CodeQL scanning to APIScan build

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -3,6 +3,12 @@
 
 trigger: none
 
+parameters:
+  - name: FORCE_CODEQL
+    displayName: Debugging - Enable CodeQL and set cadence to 1 hour
+    type: boolean
+    default: false
+
 variables:
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
@@ -17,6 +23,15 @@ variables:
     value: onebranch.azurecr.io/linux/ubuntu-2004:latest
   - name: WindowsContainerImage
     value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
+  - ${{ if eq(parameters['FORCE_CODEQL'],'true') }}:
+    # Cadence is hours before CodeQL will allow a re-upload of the database
+    - name: CodeQL.Cadence
+      value: 1
+  - name: CODEQL_ENABLED
+    ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters['FORCE_CODEQL'],'true')) }}:
+      value: true
+    ${{ else }}:
+      value: false
 
 resources:
   repositories:
@@ -32,8 +47,10 @@ extends:
       WindowsHostVersion:
         Version: 2022
     globalSdl:
-      compiled:
-        enabled: true
+      codeql:
+        compiled:
+          enabled: $(CODEQL_ENABLED)
+        tsaEnabled: $(CODEQL_ENABLED) # This enables TSA bug filing only for CodeQL 3000
       armory:
         enabled: false
       sbom:

--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -32,6 +32,8 @@ variables:
       value: true
     ${{ else }}:
       value: false
+  - name: Codeql.TSAEnabled
+    value: $(CODEQL_ENABLED)
 
 resources:
   repositories:

--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -34,6 +34,13 @@ variables:
       value: false
   - name: Codeql.TSAEnabled
     value: $(CODEQL_ENABLED)
+  # AnalyzeInPipeline: false = upload results
+  # AnalyzeInPipeline: true = do not upload results
+  - name: Codeql.AnalyzeInPipeline
+    ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters['FORCE_CODEQL'],'true')) }}:
+      value: false
+    ${{ else }}:
+      value: true
 
 resources:
   repositories:

--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-
+name: apiscan-genNotice-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 trigger: none
 
 parameters:

--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -26,7 +26,7 @@ variables:
   - ${{ if eq(parameters['FORCE_CODEQL'],'true') }}:
     # Cadence is hours before CodeQL will allow a re-upload of the database
     - name: CodeQL.Cadence
-      value: 1
+      value: 0
   - name: CODEQL_ENABLED
     ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters['FORCE_CODEQL'],'true')) }}:
       value: true

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -119,7 +119,7 @@ jobs:
       workingDirectory: '$(repoRoot)'
       condition: succeededOrFailed()
 
-    - task: CodeQL3000Init@1 # Add CodeQL Init task right before your 'Build' step.
+    - task: CodeQL3000Init@0 # Add CodeQL Init task right before your 'Build' step.
       displayName: 🔏 CodeQL 3000 Init
       condition: eq(variables['CODEQL_ENABLED'], 'true')
       inputs:
@@ -143,7 +143,7 @@ jobs:
       workingDirectory: '$(repoRoot)'
       displayName: 'Build PowerShell Source'
 
-    - task: CodeQL3000Finalize@1 # Add CodeQL Finalize task right after your 'Build' step.
+    - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.
       displayName: 🔏 CodeQL 3000 Finalize
       condition: eq(variables['CODEQL_ENABLED'], 'true')
 

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -119,15 +119,12 @@ jobs:
       workingDirectory: '$(repoRoot)'
       condition: succeededOrFailed()
 
-    - task: CodeQL3000Init@0 # Add CodeQL Init task right before your 'Build' step.
+    - task: CodeQL3000Init@1 # Add CodeQL Init task right before your 'Build' step.
       displayName: 🔏 CodeQL 3000 Init
       condition: eq(variables['CODEQL_ENABLED'], 'true')
       inputs:
-        Enabled: true
-        # AnalyzeInPipeline: false = upload results
-        # AnalyzeInPipeline: true = do not upload results
-        AnalyzeInPipeline: false
         Language: csharp
+        sourceCodeDirectory: '$(repoRoot)'
 
     - pwsh: |
         Import-Module .\build.psm1 -force
@@ -146,7 +143,7 @@ jobs:
       workingDirectory: '$(repoRoot)'
       displayName: 'Build PowerShell Source'
 
-    - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.
+    - task: CodeQL3000Finalize@1 # Add CodeQL Finalize task right after your 'Build' step.
       displayName: 🔏 CodeQL 3000 Finalize
       condition: eq(variables['CODEQL_ENABLED'], 'true')
 

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -32,6 +32,8 @@ jobs:
         value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
       - name: ob_sdl_credscan_suppressionsFile
         value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      - name: Codeql.SourceRoot
+        value: $(repoRoot)
 
     pool:
         type: windows
@@ -124,7 +126,6 @@ jobs:
       condition: eq(variables['CODEQL_ENABLED'], 'true')
       inputs:
         Language: csharp
-        sourceCodeDirectory: '$(repoRoot)'
 
     - pwsh: |
         Import-Module .\build.psm1 -force

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -120,6 +120,7 @@ jobs:
       condition: succeededOrFailed()
 
     - task: CodeQL3000Init@0 # Add CodeQL Init task right before your 'Build' step.
+      displayName: 🔏 CodeQL 3000 Init
       condition: eq(variables['CODEQL_ENABLED'], 'true')
       inputs:
         Enabled: true
@@ -146,6 +147,7 @@ jobs:
       displayName: 'Build PowerShell Source'
 
     - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.
+      displayName: 🔏 CodeQL 3000 Finalize
       condition: eq(variables['CODEQL_ENABLED'], 'true')
 
     - pwsh: |

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -119,6 +119,15 @@ jobs:
       workingDirectory: '$(repoRoot)'
       condition: succeededOrFailed()
 
+    - task: CodeQL3000Init@0 # Add CodeQL Init task right before your 'Build' step.
+      condition: eq(variables['CODEQL_ENABLED'], 'true')
+      inputs:
+        Enabled: true
+        # AnalyzeInPipeline: false = upload results
+        # AnalyzeInPipeline: true = do not upload results
+        AnalyzeInPipeline: false
+        Language: csharp
+
     - pwsh: |
         Import-Module .\build.psm1 -force
         Find-DotNet
@@ -135,6 +144,9 @@ jobs:
 
       workingDirectory: '$(repoRoot)'
       displayName: 'Build PowerShell Source'
+
+    - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.
+      condition: eq(variables['CODEQL_ENABLED'], 'true')
 
     - pwsh: |
         Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -4,34 +4,34 @@
 jobs:
   - job: APIScan
     variables:
-        - name: runCodesignValidationInjection
-          value : false
-        - name: NugetSecurityAnalysisWarningLevel
-          value: none
-        - name: ReleaseTagVar
-          value: fromBranch
-        # Defines the variables APIScanClient, APIScanTenant and APIScanSecret
-        - group: PS-PS-APIScan
-        # PAT permissions NOTE: Declare a SymbolServerPAT variable in this group with a 'microsoft' organizanization scoped PAT with 'Symbols' Read permission.
-        # A PAT in the wrong org will give a single Error 203. No PAT will give a single Error 401, and individual pdbs may be missing even if permissions are correct.
-        - group: symbols
-        - name: branchCounterKey
-          value: $[format('{0:yyyyMMdd}-{1}', pipeline.startTime,variables['Build.SourceBranch'])]
-        - name: branchCounter
-          value: $[counter(variables['branchCounterKey'], 1)]
-        - group: DotNetPrivateBuildAccess
-        - group: Azure Blob variable group
-        - group: ReleasePipelineSecrets
-        - group: mscodehub-feed-read-general
-        - group: mscodehub-feed-read-akv
-        - name: ob_outputDirectory
-          value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-        - name: repoRoot
-          value: '$(Build.SourcesDirectory)\PowerShell'
-        - name: ob_sdl_tsa_configFile
-          value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
-        - name: ob_sdl_credscan_suppressionsFile
-          value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      - name: runCodesignValidationInjection
+        value : false
+      - name: NugetSecurityAnalysisWarningLevel
+        value: none
+      - name: ReleaseTagVar
+        value: fromBranch
+      # Defines the variables APIScanClient, APIScanTenant and APIScanSecret
+      - group: PS-PS-APIScan
+      # PAT permissions NOTE: Declare a SymbolServerPAT variable in this group with a 'microsoft' organizanization scoped PAT with 'Symbols' Read permission.
+      # A PAT in the wrong org will give a single Error 203. No PAT will give a single Error 401, and individual pdbs may be missing even if permissions are correct.
+      - group: symbols
+      - name: branchCounterKey
+        value: $[format('{0:yyyyMMdd}-{1}', pipeline.startTime,variables['Build.SourceBranch'])]
+      - name: branchCounter
+        value: $[counter(variables['branchCounterKey'], 1)]
+      - group: DotNetPrivateBuildAccess
+      - group: Azure Blob variable group
+      - group: ReleasePipelineSecrets
+      - group: mscodehub-feed-read-general
+      - group: mscodehub-feed-read-akv
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+      - name: repoRoot
+        value: '$(Build.SourcesDirectory)\PowerShell'
+      - name: ob_sdl_tsa_configFile
+        value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
+      - name: ob_sdl_credscan_suppressionsFile
+        value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
 
     pool:
         type: windows


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request introduces several changes to the `.pipelines/apiscan-gen-notice.yml` and `.pipelines/templates/compliance/apiscan.yml` files to incorporate CodeQL scanning capabilities. The most important changes include adding parameters for enabling CodeQL, configuring CodeQL-related variables, and integrating CodeQL tasks into the pipeline.

### CodeQL Integration:

* [`.pipelines/apiscan-gen-notice.yml`](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2L3-R11): Added a `FORCE_CODEQL` parameter to enable CodeQL scanning and set its cadence to 1 hour.
* [`.pipelines/apiscan-gen-notice.yml`](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2R26-R43): Configured variables to enable or disable CodeQL based on the branch or `FORCE_CODEQL` parameter.
* [`.pipelines/apiscan-gen-notice.yml`](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2R59-R62): Updated the `codeql` section under `globalSdl` to use the new `CODEQL_ENABLED` variable.

### Pipeline Task Updates:

* [`.pipelines/templates/compliance/apiscan.yml`](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R35-R36): Added `Codeql.SourceRoot` variable to the job configuration.
* [`.pipelines/templates/compliance/apiscan.yml`](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R124-R129): Introduced `CodeQL3000Init` and `CodeQL3000Finalize` tasks to initialize and finalize CodeQL scanning around the build step. [[1]](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R124-R129) [[2]](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R147-R150)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
