### PR TITLE
[release/v7.5]Add `BaseUrl` to buildinfo JSON file

### DIFF
--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -41,6 +41,7 @@ function New-BuildInfoJson {
         ReleaseTag = $ReleaseTag
         ReleaseDate = $dateTime
         BlobName = $blobName
+        BaseUrl = 'https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/install'
     } | ConvertTo-Json | Out-File -Encoding ascii -Force -FilePath $filename
 
     $resolvedPath = (Resolve-Path -Path $filename).ProviderPath


### PR DESCRIPTION
Backport #24376

This pull request includes a small but important change to the `tools/releaseBuild/setReleaseTag.ps1` file. The change adds a new `BaseUrl` property to the JSON output generated by the `New-BuildInfoJson` function.

* [`tools/releaseBuild/setReleaseTag.ps1`](diffhunk://#diff-3d964fe212384b9da5e682b4b2899fb588db9a6bdc19268622a095de10b72603R44): Added `BaseUrl` property with a specific URL to the JSON output in the `New-BuildInfoJson` function.