### PR TITLE
Bring More Release Branch Changes to release/v7.5

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -21,6 +21,10 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip PMC Publish
     type: boolean
     default: false
+  - name: SkipPSInfraInstallers
+    displayName: Skip Copying Archives and Installers to PSInfrastructure Public Location
+    type: boolean
+    default: false
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -263,6 +267,8 @@ extends:
       dependsOn: UpdateChangeLog
       jobs:
       - template: /.pipelines/templates/release-MakeBlobPublic.yml@self
+        parameters:
+          SkipPSInfraInstallers: ${{ parameters.SkipPSInfraInstallers }}
 
     - stage: PublishGitHubRelease
       displayName: Publish GitHub Release

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -75,6 +75,12 @@ resources:
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates
   parameters:
+    # still using KS2 because we are not yet using a Box Product Deployment
+    featureFlags:
+      LinuxHostVersion:
+          Network: KS2
+      WindowsHostVersion:
+          Network: KS2
     cloudvault:
       enabled: false
     globalSdl:

--- a/.pipelines/templates/release-MakeBlobPublic.yml
+++ b/.pipelines/templates/release-MakeBlobPublic.yml
@@ -159,7 +159,7 @@ jobs:
           $prefix = 'globaltool'
 
           $destinationStorageAccountName = '$(PSInfraStorageAccount)'
-          $destinationContainerName = "$web"
+          $destinationContainerName = '$web'
           $destinationPrefix = 'tool/$(Version)'
 
           $sourceContext = New-AzStorageContext -StorageAccountName $sourceStorageAccountName

--- a/.pipelines/templates/release-MakeBlobPublic.yml
+++ b/.pipelines/templates/release-MakeBlobPublic.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: SkipPSInfraInstallers
+    displayName: Skip Copying Archives and Installers to PSInfrastructure Public Location
+    type: boolean
+    default: false
+
 jobs:
 - template: /.pipelines/templates/approvalJob.yml@self
   parameters:
@@ -106,6 +112,7 @@ jobs:
 - job: PSInfraBlobPublic
   displayName: Copy global tools to PSInfra storage
   dependsOn: CopyBlobApproval
+  condition: and(succeeded(), ne(variables['SkipPSInfraInstallers'], true))
   pool:
     type: windows
 

--- a/.pipelines/templates/release-MakeBlobPublic.yml
+++ b/.pipelines/templates/release-MakeBlobPublic.yml
@@ -156,9 +156,11 @@ jobs:
         inline: |
           $sourceStorageAccountName = '$(StorageAccount)'
           $sourceContainerName = '$(AzureVersion)-nuget'
+          $prefix = 'globaltool'
 
           $destinationStorageAccountName = '$(PSInfraStorageAccount)'
-          $destinationContainerName = "tool"
+          $destinationContainerName = "$web"
+          $destinationPrefix = 'tool/$(Version)'
 
           $sourceContext = New-AzStorageContext -StorageAccountName $sourceStorageAccountName
           Write-Verbose -Verbose "Source context: $($sourceContext.BlobEndPoint)"
@@ -166,19 +168,18 @@ jobs:
           $destinationContext = New-AzStorageContext -StorageAccountName $destinationStorageAccountName
           Write-Verbose -Verbose "Destination context: $($destinationContext.BlobEndPoint)"
 
-          $prefix = 'globaltool'
           $blobs = Get-AzStorageBlob -Context $sourceContext -Container $sourceContainerName -Prefix $prefix
 
           Write-Verbose -Verbose "Blobs found in $sourceContainerName"
           $blobs.Name | Write-Verbose -Verbose
 
-          Write-Verbose -Verbose "Copying blobs from $sourceContainerName to $destinationContainerName"
+          Write-Verbose -Verbose "Copying blobs from $sourceContainerName to $destinationContainerName/$destinationPrefix"
 
           foreach ($blob in $blobs) {
             $sourceBlobName = $blob.Name
             Write-Verbose -Verbose "sourceBlobName = $sourceBlobName"
 
-            $destinationBlobName = $sourceBlobName -replace "$prefix", '$(Version)'
+            $destinationBlobName = $sourceBlobName -replace "$prefix", $destinationPrefix
             Write-Verbose -Verbose "destinationBlobName = $destinationBlobName"
 
             Copy-AzStorageBlob -SourceContext $sourceContext -DestinationContext $destinationContext -SrcContainer $sourceContainerName -SrcBlob $sourceBlobName -DestContainer $destinationContainerName -DestBlob $destinationBlobName -Force -Verbose -Confirm:$false

--- a/.pipelines/templates/release-MakeBlobPublic.yml
+++ b/.pipelines/templates/release-MakeBlobPublic.yml
@@ -15,6 +15,7 @@ jobs:
 - job: PSInfraReleaseBlobPublic
   displayName: Copy release to PSInfra storage
   dependsOn: CopyReleaseBlobApproval
+  condition: and(succeeded(), ne(variables['SkipPSInfraInstallers'], true))
   pool:
     type: windows
 
@@ -112,7 +113,6 @@ jobs:
 - job: PSInfraBlobPublic
   displayName: Copy global tools to PSInfra storage
   dependsOn: CopyBlobApproval
-  condition: and(succeeded(), ne(variables['SkipPSInfraInstallers'], true))
   pool:
     type: windows
 

--- a/.pipelines/templates/release-MakeBlobPublic.yml
+++ b/.pipelines/templates/release-MakeBlobPublic.yml
@@ -106,7 +106,6 @@ jobs:
   parameters:
     displayName: Approve Copy Global tool packages to PSInfra storage
     jobName: CopyBlobApproval
-    dependsOnJob: PSInfraReleaseBlobPublic
     instructions: |
       Approval for Copy global tool packages to PSInfra storage
 
@@ -117,14 +116,14 @@ jobs:
     type: windows
 
   variables:
-  - group: 'PSInfraStorage'
-  - group: 'Azure Blob variable group'
-  - name: ob_outputDirectory
-    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-  - name: ob_sdl_tsa_configFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
-  - name: ob_sdl_credscan_suppressionsFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+    - group: 'PSInfraStorage'
+    - group: 'Azure Blob variable group'
+    - name: ob_outputDirectory
+      value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+    - name: ob_sdl_tsa_configFile
+      value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
+    - name: ob_sdl_credscan_suppressionsFile
+      value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
 
   steps:
     - checkout: self

--- a/.pipelines/templates/release-MakeBlobPublic.yml
+++ b/.pipelines/templates/release-MakeBlobPublic.yml
@@ -15,7 +15,7 @@ jobs:
 - job: PSInfraReleaseBlobPublic
   displayName: Copy release to PSInfra storage
   dependsOn: CopyReleaseBlobApproval
-  condition: and(succeeded(), ne(variables['SkipPSInfraInstallers'], true))
+  condition: and(succeeded(), ne('${{ parameters.SkipPSInfraInstallers }}', true))
   pool:
     type: windows
 

--- a/.pipelines/templates/release-publish-pmc.yml
+++ b/.pipelines/templates/release-publish-pmc.yml
@@ -77,7 +77,7 @@ jobs:
       $params = @{
           ReleaseTag = "$(ReleaseTag)"
           AadClientId = "$(PmcCliClientID)"
-          BlobFolderName = "$(AzureVersion)"
+          BlobFolderName = "$(ReleaseTag)"
           LTS = $metadata.LTSRelease.Latest
           ForProduction = $true
           SkipPublish = $${{ parameters.skipPublish }}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes several changes to the `.pipelines` directory, primarily focusing on adding new parameters and modifying existing job conditions to improve the flexibility and functionality of the release pipeline.

### New Parameters and Conditions

* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR24-R27): Added a new boolean parameter `SkipPSInfraInstallers` to allow skipping the copying of archives and installers to the PSInfrastructure public location. [[1]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR24-R27) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR270-R271)
* [`.pipelines/templates/release-MakeBlobPublic.yml`](diffhunk://#diff-a50a834a4973c5d0e102732843cad360b60b6b0037f3d38a832db4214d62704dR1-R6): Introduced the `SkipPSInfraInstallers` parameter and added a condition to the `PSInfraReleaseBlobPublic` job to skip execution if this parameter is true. [[1]](diffhunk://#diff-a50a834a4973c5d0e102732843cad360b60b6b0037f3d38a832db4214d62704dR1-R6) [[2]](diffhunk://#diff-a50a834a4973c5d0e102732843cad360b60b6b0037f3d38a832db4214d62704dR18)

### Resource Configuration

* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR82-R87): Added feature flags for `LinuxHostVersion` and `WindowsHostVersion` under the `resources` section to specify network configurations.

### Blob Storage Adjustments

* [`.pipelines/templates/release-MakeBlobPublic.yml`](diffhunk://#diff-a50a834a4973c5d0e102732843cad360b60b6b0037f3d38a832db4214d62704dR165-R188): Modified the blob storage copying logic to include a destination prefix and updated the destination container configuration.

### Miscellaneous Changes

* [`.pipelines/templates/release-publish-pmc.yml`](diffhunk://#diff-a5cf0878c545f6c666c94076ec0d25ec8d8b8b13d67e908da250806017588248L80-R80): Changed the `BlobFolderName` parameter from `$(AzureVersion)` to `$(ReleaseTag)` to better reflect the release tag in the blob folder name.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
