### PR TITLE
Update PSReadLine to 2.3.6

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.1.0-preview1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-    <PackageReference Include="PSReadLine" Version="2.3.5" />
+    <PackageReference Include="PSReadLine" Version="2.3.6" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update PSReadLine to 2.3.6
This is a servicing release to exclude SBOM files from the module to avoid false positive security vulnerability report.