### PR TITLE
[release/v7.2] chore: Refactor Nuget package source creation to use New-NugetPackageSource function

### DIFF
--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -5,7 +5,10 @@ steps:
 - pwsh: |
     $configPath = "${env:NugetConfigDir}/nuget.config"
     Import-Module ${{ parameters.repoRoot }}/build.psm1 -Force
-    New-NugetConfigFile -NugetFeedUrl $(PowerShellCore_PublicPackages) -UserName $(AzDevopsFeedUserNameKVPAT) -ClearTextPAT $(mscodehubPackageReadPat) -FeedName AzDevOpsFeed -Destination "${env:NugetConfigDir}"
+
+    $powerShellPublicPackages = New-NugetPackageSource -Url '$(PowerShellCore_PublicPackages)' -Name 'AzDevOpsFeed'
+
+    New-NugetConfigFile -NugetPackageSource $powerShellPublicPackages -UserName $(AzDevopsFeedUserNameKVPAT) -ClearTextPAT $(mscodehubPackageReadPat) -Destination "${env:NugetConfigDir}"
     if(-not (Test-Path $configPath))
     {
         throw "nuget.config is not created"
@@ -20,8 +23,11 @@ steps:
 - pwsh: |
     $configPath = "${env:NugetConfigDir}/nuget.config"
     Import-Module ${{ parameters.repoRoot }}/build.psm1 -Force
-    New-NugetConfigFile -NugetFeedUrl $(PowerShellCore_PublicPackages) -UserName $(AzDevopsFeedUserNameKVPAT) -ClearTextPAT $(mscodehubPackageReadPat) -FeedName AzDevOpsFeed -Destination "${env:NugetConfigDir}"
-    if(-not (Test-Path $configPath))
+
+    $powerShellPublicPackages = New-NugetPackageSource -Url '$(PowerShellCore_PublicPackages)' -Name 'AzDevOpsFeed'
+
+    New-NugetConfigFile -NugetPackageSource $powerShellPublicPackages -UserName $(AzDevopsFeedUserNameKVPAT) -ClearTextPAT $(mscodehubPackageReadPat) -Destination "${env:NugetConfigDir}"
+    if (-not (Test-Path $configPath))
     {
         throw "nuget.config is not created"
     }

--- a/build.psm1
+++ b/build.psm1
@@ -3259,8 +3259,21 @@ function New-TestPackage
     [System.IO.Compression.ZipFile]::CreateFromDirectory($packageRoot, $packagePath)
 }
 
-function New-NugetConfigFile
-{
+class NugetPackageSource {
+    [string] $Url
+    [string] $Name
+}
+
+function New-NugetPackageSource {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Url,
+        [Parameter(Mandatory = $true)] [string] $Name
+    )
+
+    return [NugetPackageSource] @{Url = $Url; Name = $Name }
+}
+
+function New-NugetConfigFile {
     param(
         [Parameter(Mandatory=$true)] [string] $NugetFeedUrl,
         [Parameter(Mandatory=$true)] [string] $FeedName,


### PR DESCRIPTION
Backport #24104

This pull request includes changes to improve the handling of NuGet package sources in the pipeline configuration and build scripts. The modifications introduce a new `NugetPackageSource` class and simplify the creation of NuGet configuration files.

### Improvements to NuGet package handling:

* [`.pipelines/templates/insert-nuget-config-azfeed.yml`](diffhunk://#diff-69953bf967d1671c7627e0bd3fffcd1bc77812827be14a74c3fcc8b15d16213eL8-R11): Replaced direct usage of `New-NugetConfigFile` with a new `New-NugetPackageSource` function to create a `NugetPackageSource` object before passing it to `New-NugetConfigFile`. [[1]](diffhunk://#diff-69953bf967d1671c7627e0bd3fffcd1bc77812827be14a74c3fcc8b15d16213eL8-R11) [[2]](diffhunk://#diff-69953bf967d1671c7627e0bd3fffcd1bc77812827be14a74c3fcc8b15d16213eL23-R29)
* [`build.psm1`](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL3262-R3276): Introduced a new `NugetPackageSource` class and the `New-NugetPackageSource` function to encapsulate NuGet package source details, and updated the `New-NugetConfigFile` function to accept a `NugetPackageSource` object.