### PR TITLE
[release/v7.2] Enable create and submit in vPack build by default

### DIFF
--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -6,7 +6,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'createVPack'
   displayName: 'Create and Submit VPack'
   type: boolean
-  default: false
+  default: true
 - name: 'debug'
   displayName: 'Enable debug output'
   type: boolean


### PR DESCRIPTION
Backport #24181

This pull request includes a small but significant change to the `.pipelines/PowerShell-vPack-Official.yml` file. The default value for the `createVPack` parameter has been updated to `true`.

* [`.pipelines/PowerShell-vPack-Official.yml`](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L9-R9): Changed the default value of the `createVPack` parameter from `false` to `true`.