### PR TITLE
[release/v7.2] Update and add new NuGet package sources for different environments.

### DIFF
--- a/test/tools/Modules/nuget.config
+++ b/test/tools/Modules/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="PSGallery" value="https://www.powershellgallery.com/api/v2/" />
+    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell-7-5-preview-test-2/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
Backport #24264

This pull request introduces new functions to streamline NuGet configuration management and adds a feature to conditionally generate experimental features. It also updates the NuGet package source in a configuration file.

New functions in `build.psm1`:

* Added `Switch-PSNugetConfig` function to manage NuGet configurations based on the source type (`Public` or `Private`). This function includes parameters for user authentication and handles different NuGet package sources accordingly. (`[build.psm1R693-R778](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR693-R778)`)
* Added `Test-ShouldGenerateExperimentalFeatures` function to determine if experimental features should be generated based on the runtime environment and build conditions. (`[build.psm1R693-R778](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR693-R778)`)

Configuration updates:

* Updated the NuGet package source in `test/tools/Modules/nuget.config` to point to a new private feed for PowerShell packages. (`[test/tools/Modules/nuget.configL5-R5](diffhunk://#diff-686074974c03a838500f2ff2eb5e61d23b8b58e3c49b07d69aed33ea7cfae45cL5-R5)`)