### PR TITLE
[release/v7.2] Make some release tests run in a hosted pools

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -51,6 +51,7 @@ variables:
     value: mcr.microsoft.com/onebranch/cbl-mariner/build:2.0
   - name: ReleaseTagVar
     value: ${{ parameters.ReleaseTagVar }}
+  - group: PoolNames
 
 resources:
   repositories:
@@ -111,19 +112,22 @@ extends:
         parameters:
           jobName: "windowsSDK"
           displayName: "Windows SDK Validation"
-          jobtype: windows
+          imageName: PSMMS2019-Secure
+          poolName: $(windowsPool)
 
       - template: /.pipelines/templates/release-validate-sdk.yml@self
         parameters:
           jobName: "MacOSSDK"
           displayName: "MacOS SDK Validation"
-          jobtype: macos
+          imageName: macOS-latest
+          poolName: Azure Pipelines
 
       - template: /.pipelines/templates/release-validate-sdk.yml@self
         parameters:
           jobName: "LinuxSDK"
           displayName: "Linux SDK Validation"
-          jobtype: linux
+          imageName: PSMMSUbuntu20.04-Secure
+          poolName: $(ubuntuPool)
 
     - stage: gbltool
       displayName: 'Validate Global tools'

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -1,33 +1,35 @@
 parameters:
   jobName: ""
   displayName: ""
-  jobtype: "windows"
+  poolName: "windows"
+  imageName: 'none'
 
 jobs:
 - job: ${{ parameters.jobName }}
   displayName: ${{ parameters.displayName }}
   pool:
-    ${{ if eq(parameters.jobtype, 'macos') }}:
-      type: linux
-      isCustom: true
-      name: Azure Pipelines
-      vmImage: 'macOS-latest'
+    type: linux
+    isCustom: true
+    ${{ if eq( parameters.poolName, 'Azure Pipelines') }}:
+      name: ${{ parameters.poolName }}
+      vmImage: ${{ parameters.imageName }}
     ${{ else }}:
-      type: ${{ parameters.jobtype }}
+      name: ${{ parameters.poolName }}
+      demands:
+        - ImageOverride -equals ${{ parameters.imageName }}
 
   variables:
   - group: AzDevOpsArtifacts
   - group: DotNetPrivateBuildAccess
-  - name: ob_outputDirectory
-    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-  - name: ob_sdl_credscan_suppressionsFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
-  - name: ob_sdl_tsa_configFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
 
   steps:
     - checkout: self
       clean: true
+      lfs: false
+
+    - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
+      parameters:
+        repoRoot: "$(Build.SourcesDirectory)"
 
     - template: release-SetReleaseTagandContainerName.yml@self
 
@@ -44,7 +46,7 @@ jobs:
       displayName: 'Capture Downloaded Artifacts'
 
     - pwsh: |
-        $repoRoot = $isMacOS ? "$(Build.SourcesDirectory)" : "$(Build.SourcesDirectory)/PowerShell"
+        $repoRoot = "$(Build.SourcesDirectory)"
 
         $dotnetMetadataPath = "$repoRoot/DotnetRuntimeMetadata.json"
         $dotnetMetadataJson = Get-Content $dotnetMetadataPath -Raw | ConvertFrom-Json
@@ -79,7 +81,7 @@ jobs:
         __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
 
     - pwsh: |
-        $repoRoot = $isMacOS ? "$(Build.SourcesDirectory)" : "$(Build.SourcesDirectory)/PowerShell"
+        $repoRoot = "$(Build.SourcesDirectory)"
 
         $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
         Import-Module "$repoRoot/build.psm1" -Force
@@ -101,12 +103,17 @@ jobs:
         Get-ChildItem
 
         ## register the packages download directory in the nuget file
-        $nugetConfigContent = Get-Content ./NuGet.Config -Raw
+        $nugetPath = './NuGet.Config'
+        if(!(test-path $nugetPath)) {
+          $nugetPath = "$repoRoot/nuget.config"
+        }
+        Write-Verbose -Verbose "nugetPath: $nugetPath"
+        $nugetConfigContent = Get-Content $nugetPath -Raw
         $updateNugetContent = $nugetConfigContent.Replace("</packageSources>", $xmlElement)
 
-        $updateNugetContent | Out-File ./NuGet.Config -Encoding ascii
+        $updateNugetContent | Out-File $nugetPath -Encoding ascii
 
-        Get-Content ./NuGet.Config
+        Get-Content $nugetPath
 
         # Add workaround to unblock xUnit testing see issue: https://github.com/dotnet/sdk/issues/26462
         $dotnetPath = if ($IsWindows) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
@@ -115,7 +122,6 @@ jobs:
         dotnet --info
         dotnet restore
         dotnet test /property:RELEASE_VERSION=$releaseVersion --test-adapter-path:. "--logger:xunit;LogFilePath=$(System.DefaultWorkingDirectory)/test-hosting.xml"
-
       displayName: Restore and execute tests
       env:
         __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)


### PR DESCRIPTION
Backport #24270

This pull request includes several changes to the `.pipelines/PowerShell-Release-Official.yml` and `.pipelines/templates/release-validate-sdk.yml` files to improve the pipeline configuration and job execution. The most important changes include adding pool names and image names for different SDK validation jobs, updating pool and image parameters, and refining the handling of repository paths and NuGet configuration.

Pipeline configuration improvements:

* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL114-R130): Added `poolName` and `imageName` parameters for Windows, MacOS, and Linux SDK validation jobs. (`[.pipelines/PowerShell-Release-Official.ymlL114-R130](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL114-R130)`)
* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR54): Added a new variable group `PoolNames`. (`[.pipelines/PowerShell-Release-Official.ymlR54](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR54)`)

Job parameter updates:

* [`.pipelines/templates/release-validate-sdk.yml`](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L4-R32): Replaced `jobtype` with `poolName` and `imageName` parameters to better specify the job environment. (`[.pipelines/templates/release-validate-sdk.ymlL4-R32](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L4-R32)`)
* [`.pipelines/templates/release-validate-sdk.yml`](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L4-R32): Updated job pool configuration to use the new `poolName` and `imageName` parameters. (`[.pipelines/templates/release-validate-sdk.ymlL4-R32](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L4-R32)`)

Repository path and NuGet configuration refinements:

* [`.pipelines/templates/release-validate-sdk.yml`](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L47-R49): Unified repository path handling by removing conditional logic for MacOS. (`[[1]](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L47-R49)`, `[[2]](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L82-R84)`)
* [`.pipelines/templates/release-validate-sdk.yml`](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L104-R116): Added logic to handle different NuGet configuration paths and ensure correct file updates. (`[.pipelines/templates/release-validate-sdk.ymlL104-R116](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L104-R116)`)
* [`.pipelines/templates/release-validate-sdk.yml`](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L4-R32): Added a step to insert NuGet config for Azure feed. (`[.pipelines/templates/release-validate-sdk.ymlL4-R32](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L4-R32)`)