### PR TITLE
[release/v7.2] Improve the handling of runtime values of `noExeRuntimes`

### DIFF
--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -30,6 +30,8 @@ jobs:
     - name: Runtime
       value: ${{ parameters.runtime }}
     - group: msixTools
+    - name: noExeRuntimes
+      value: "['fxdependent', 'fxdependentWinDesktop', 'minsize', 'arm64']"
 
   steps:
   - checkout: self
@@ -195,7 +197,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      $noExeRuntimes = @('fxdependent', 'fxdependentWinDesktop', 'minsize', 'arm64')
+      $noExeRuntimes = "$(noExeRuntimes)" | ConvertFrom-Json
 
       if ($runtime -in $noExeRuntimes) {
         Write-Verbose -Verbose "No EXE generated for $runtime"
@@ -233,7 +235,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      $noExeRuntimes = @('fxdependent', 'fxdependentWinDesktop', 'minsize')
+      $noExeRuntimes = "$(noExeRuntimes)" | ConvertFrom-Json
 
       if ($runtime -in $noExeRuntimes) {
         Write-Verbose -Verbose "No EXE generated for $runtime"


### PR DESCRIPTION
Backport 58afb7474f65471e9399fab678641b0329b8cb04

This pull request includes changes to the `.pipelines/templates/windows-package-build.yml` file to improve the handling of runtime values. The key changes involve centralizing the definition of `noExeRuntimes` and converting it from a JSON string.

Improvements to runtime handling:

* Added a new parameter `noExeRuntimes` with a list of runtime values to the `jobs:` section. (`.pipelines/templates/windows-package-build.yml`, [.pipelines/templates/windows-package-build.ymlR33-R34](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daR33-R34))
* Updated the script to convert the `noExeRuntimes` parameter from a JSON string before checking if the runtime is in the list. (`.pipelines/templates/windows-package-build.yml`, [[1]](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daL198-R200) [[2]](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daL236-R238)