### PR TITLE
[release/v7.2] Add ability to capture MSBuild Binary logs when restore fails

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -14,6 +14,10 @@ parameters:
     displayName: Skip Signing
     type: string
     default: 'NO'
+  - name: ENABLE_MSBUILD_BINLOGS
+    displayName: Enable MSBuild Binary Logs
+    type: boolean
+    default: false
 
 resources:
   repositories:


### PR DESCRIPTION
Backport #24128

This pull request includes a small change to the `.pipelines/PowerShell-Coordinated_Packages-Official.yml` file. The change introduces a new parameter to enable MSBuild binary logs.

* [`.pipelines/PowerShell-Coordinated_Packages-Official.yml`](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR17-R20): Added a new boolean parameter `ENABLE_MSBUILD_BINLOGS` with a default value of `false`.