### PR TITLE
Turn off AMSI member invocation on *nix release builds

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -6947,15 +6947,7 @@ namespace System.Management.Automation.Language
                 //  - Log method invocation to AMSI Notifications (can throw PSSecurityException)
                 //  - Invoke method
                 string targetName = methodInfo.ReflectedType?.FullName ?? string.Empty;
-                expr = Expression.Block(
-                    Expression.Call(
-                        CachedReflectionInfo.MemberInvocationLoggingOps_LogMemberInvocation,
-                        Expression.Constant(targetName),
-                        Expression.Constant(name),
-                        Expression.NewArrayInit(
-                            typeof(object),
-                            args.Select(static e => e.Expression.Cast(typeof(object))))),
-                    expr);
+                MaybeAddMemberInvocationLogging(expr, targetName, name, args);
 
                 // If we're calling SteppablePipeline.{Begin|Process|End}, we don't want
                 // to wrap exceptions - this is very much a special case to help error
@@ -7565,6 +7557,33 @@ namespace System.Management.Automation.Language
                 }
             }
         }
+
+#nullable enable
+        private static Expression MaybeAddMemberInvocationLogging(
+            Expression expr,
+            string targetName,
+            string name,
+            DynamicMetaObject[] args)
+        {
+#if UNIX && !DEBUG
+            // For efficiency this is a no-op on non-Windows platforms in release builds.
+            return expr;
+#else
+            Expression[] invocationArgs = new Expression[args.Length];
+            for (int i = 0; i < args.Length; i++)
+            {
+                invocationArgs[i] = args[i].Expression.Cast(typeof(object));
+            }
+            return Expression.Block(
+                Expression.Call(
+                    CachedReflectionInfo.MemberInvocationLoggingOps_LogMemberInvocation,
+                    Expression.Constant(targetName),
+                    Expression.Constant(name),
+                    Expression.NewArrayInit(typeof(object), invocationArgs)),
+                expr);
+#endif
+        }
+#nullable disable
 
         #endregion
     }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3694,6 +3694,10 @@ namespace System.Management.Automation
 
         internal static void LogMemberInvocation(string targetName, string name, object[] args)
         {
+#if UNIX && !DEBUG
+            // For efficiency this is a no-op on non-Windows platforms in release builds.
+            return;
+#else
             try
             {
                 var contentName = "PowerShellMemberInvocation";
@@ -3741,6 +3745,7 @@ namespace System.Management.Automation
                     Console.WriteLine($"!!! Amsi notification report exception: {ex} !!!");
                 }
             }
+#endif
         }
     }
 }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3694,10 +3694,6 @@ namespace System.Management.Automation
 
         internal static void LogMemberInvocation(string targetName, string name, object[] args)
         {
-#if UNIX && !DEBUG
-            // For efficiency this is a no-op on non-Windows platforms in release builds.
-            return;
-#else
             try
             {
                 var contentName = "PowerShellMemberInvocation";
@@ -3745,7 +3741,6 @@ namespace System.Management.Automation
                     Console.WriteLine($"!!! Amsi notification report exception: {ex} !!!");
                 }
             }
-#endif
         }
     }
 }


### PR DESCRIPTION
# PR Summary
Turn off the AMSI member invocation logging for non-Windows release builds. This is slightly more efficient as there's no extra work to create the AMSI string.

Fixes: https://github.com/PowerShell/PowerShell/issues/21492

## PR Context
https://github.com/PowerShell/PowerShell/issues/21492#issuecomment-2070926281

> WG reviewed this and agreed that the .NET method invocation logging for AMSI should only apply to Windows. The change should be separate and not dependent on the env var.

It doesn't make sense for this feature to be on for a proper release build as writing to stdout will affect anything calling PowerShell. The env var name also indicates this is an internal optional and not a publicly supported feature so shouldn't be under any API contract.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
