### PR TITLE
Stop Using Sample Standard Deviation in Measure-Object

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -775,10 +775,10 @@ namespace Microsoft.PowerShell.Commands
             if (_measureStandardDeviation && stat.count > 1)
             {
                 // Based off of iterative method of calculating variance on
-                // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                // "https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm"
                 double avgPrevious = stat.sumPrevious / (stat.count - 1);
-                stat.variance *= (stat.count - 2.0) / (stat.count - 1);
-                stat.variance += (numValue - avgPrevious) * (numValue - avgPrevious) / stat.count;
+                double avg = stat.sum / stat.count;
+                stat.variance += (((numValue - avgPrevious) * (numValue - avg)) - stat.variance) / stat.count;
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -178,7 +178,7 @@ Describe "Measure-Object" -Tags "CI" {
             $result.Sum      | Should -Be 55
             $result.Minimum  | Should -Be 1
             $result.Maximum  | Should -Be 10
-            ($result.StandardDeviation - 2.8722813232690143) | Should -BeLessThan .000000000000001
+            $result.StandardDeviation | Should -Be 2.8722813232690143
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -20,47 +20,40 @@ Describe "Measure-Object" -Tags "CI" {
 
     It "Should calculate Standard Deviation" {
         $actual = ($testObject | Measure-Object -StandardDeviation)
-        # We check this way since .StandardDeviation returns a double value
-        # 1.52752523165195 was calculated outside powershell using formula from
-        # http://mathworld.wolfram.com/StandardDeviation.html
-        [Math]::abs($actual.StandardDeviation - 1.52752523165195) | Should -BeLessThan .00000000000001
+        # 1.247219128924647 was calculated using python numpy.std([1,3,4])
+        # Just assert it's within 15dp as the answer is irrational
+        ($actual.StandardDeviation - 1.247219128924647) | Should -BeLessThan .000000000000001
     }
 
 
     It "Should calculate Standard Deviation" {
         $actual = ($testObject2 | Measure-Object -StandardDeviation)
-        # We check this way since .StandardDeviation returns a double value
-        # 29.011491975882 was calculated outside powershell using formula from
-        # http://mathworld.wolfram.com/StandardDeviation.html
-        [Math]::abs($actual.StandardDeviation - 29.011491975882) | Should -BeLessThan .0000000000001
+        # 28.86607004772212 was calculated using python numpy.std(list(range(1,101)))
+        $actual.StandardDeviation | Should -Be 28.86607004772212
     }
 
     It "Should calculate Standard Deviation with -Sum" {
         $actual = ($testObject | Measure-Object -Sum -StandardDeviation)
         # We check this way since .StandardDeviation returns a double value
         $actual.Sum | Should -Be 8
-        # 1.52752523165195 was calculated outside powershell using formula from
-        # http://mathworld.wolfram.com/StandardDeviation.html
-        [Math]::abs($actual.StandardDeviation - 1.52752523165195) | Should -BeLessThan .00000000000001
+        # 1.247219128924647 was calculated using python numpy.std([1,3,4])
+        # Just assert it's within 15dp as the answer is irrational
+        ($actual.StandardDeviation - 1.247219128924647) | Should -BeLessThan .000000000000001
     }
 
     It "Should calculate Standard Deviation with -Average" {
         $actual = ($testObject | Measure-Object -Average -StandardDeviation)
-        # We check this way since .StandardDeviation returns a double value
-        [Math]::abs($actual.Average - 2.66666666666667) | Should -BeLessThan .00000000000001
-        # 1.52752523165195 was calculated outside powershell using formula from
-        # http://mathworld.wolfram.com/StandardDeviation.html
-        [Math]::abs($actual.StandardDeviation - 1.52752523165195) | Should -BeLessThan .00000000000001
+        # 1.247219128924647 was calculated using python numpy.std([1,3,4])
+        # Just assert it's within 15dp as the answer is irrational
+        ($actual.StandardDeviation - 1.247219128924647) | Should -BeLessThan .000000000000001
     }
 
     It "Should calculate Standard Deviation with -Sum -Average" {
         $actual = ($testObject2 | Measure-Object -Sum -Average -StandardDeviation)
-        # We check this way since .StandardDeviation returns a double value
         $actual.Sum | Should -Be 5050
         $actual.Average | Should -Be 50.5
-        # 29.011491975882 was calculated outside powershell using formula from
-        # http://mathworld.wolfram.com/StandardDeviation.html
-        [Math]::abs($actual.StandardDeviation - 29.011491975882) | Should -BeLessThan .0000000000001
+        # 28.86607004772212 was calculated using python numpy.std(list(range(1,101)))
+        $actual.StandardDeviation | Should -Be 28.86607004772212
     }
 
     It "Should be able to count using the Property switch" {
@@ -185,7 +178,7 @@ Describe "Measure-Object" -Tags "CI" {
             $result.Sum      | Should -Be 55
             $result.Minimum  | Should -Be 1
             $result.Maximum  | Should -Be 10
-            ($result.StandardDeviation).ToString()  | Should -Be '3.0276503540974917'
+            ($result.StandardDeviation - 2.8722813232690143) | Should -BeLessThan .000000000000001
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Measure-Object -StandardDeviation is currently doing the sample standard deviation meaning division by n-1 instead of n so update it to do the standard deviation.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
I was using the StandardDeviation measure as a calculator to confirm some calculations online and found inconsistencies which were due to the sample standard deviation being used. When calculating the standard deviation I don't think people are expecting the sample standard deviation.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
