### PR TITLE
Revert "Update outdated package references"

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageReference Include="System.Threading.AccessControl" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.0-rc.2.24474.1" />
+    <PackageReference Include="System.Threading.AccessControl" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0-rc.1.24451.1" />
     <PackageReference Include="JsonSchema.Net" Version="7.0.4" />
   </ItemGroup>
 

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,13 +17,13 @@
   <ItemGroup>
     <!-- This section is to force the version of non-direct dependencies -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
     <!-- the following package(s) are from https://github.com/dotnet/fxdac -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.IO.Packaging" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0-rc.1.24431.7" />
     <!--
         the following package(s) are from https://github.com/dotnet/wcf
         they are pinned to the version 4.10.x due to a breaking change in newer versions.
@@ -36,7 +36,7 @@
     <PackageReference Include="System.ServiceModel.Security" Version="4.10.3" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.10.3" />
     <!-- the source could not be found for the following package(s) -->
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0-rc.2.24510.7" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0-rc.1.24452.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
+++ b/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
     <ProjectReference Include="..\Microsoft.WSMan.Runtime\Microsoft.WSMan.Runtime.csproj" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.0-rc.1.24431.7" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/System.Management.Automation/SourceGenerators/PSVersionInfoGenerator/PSVersionInfoGenerator.csproj
+++ b/src/System.Management.Automation/SourceGenerators/PSVersionInfoGenerator/PSVersionInfoGenerator.csproj
@@ -15,6 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.24165.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -19,7 +19,9 @@
     <CompilerVisibleProperty Include="PowerShellVersion" />
     <CompilerVisibleProperty Include="ReleaseTag" />
 
-    <ProjectReference Include="SourceGenerators\PSVersionInfoGenerator\PSVersionInfoGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="SourceGenerators\PSVersionInfoGenerator\PSVersionInfoGenerator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(IsWindows)' == 'true' ">
@@ -32,16 +34,16 @@
     <!-- the Application Insights package -->
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.DirectoryServices" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.DirectoryServices" Version="9.0.0-rc.1.24431.7" />
     <!--PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" /-->
-    <PackageReference Include="System.Management" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.Management" Version="9.0.0-rc.1.24431.7" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Security.Permissions" Version="9.0.0-rc.1.24431.7" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0-rc.1.24431.7" />
     <!-- the following package(s) are from the powershell org -->
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.PowerShell.Native" Version="7.4.0" />

--- a/test/tools/TestService/TestService.csproj
+++ b/test/tools/TestService/TestService.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0-rc.2.24474.4" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0-rc.1.24452.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.0-rc.1.24431.7" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts PowerShell/PowerShell#24414

Some versions that were picked up are not available on NuGet.org.