### PR TITLE
[release/v7.4] Add a way to use only NuGet feed sources

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -733,7 +733,7 @@ function Switch-PSNugetConfig {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'user')]
         [Parameter(Mandatory = $true, ParameterSetName = 'nouser')]
-        [ValidateSet('Public', 'Private')]
+        [ValidateSet('Public', 'Private', 'NuGetOnly')]
         [string] $Source,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'user')]
@@ -753,16 +753,19 @@ function Switch-PSNugetConfig {
         }
     }
 
+    $dotnetSdk = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v2'; Name = 'dotnet' }
+    $gallery = [NugetPackageSource] @{Url = 'https://www.powershellgallery.com/api/v2/'; Name = 'psgallery' }
+    $nugetorg = [NugetPackageSource] @{Url = 'https://api.nuget.org/v3/index.json'; Name = 'nuget.org' }
     if ( $Source -eq 'Public') {
-        $dotnetSdk = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v2'; Name = 'dotnet' }
-        $gallery = [NugetPackageSource] @{Url = 'https://www.powershellgallery.com/api/v2/'; Name = 'psgallery' }
-        $nugetorg = [NugetPackageSource] @{Url = 'https://api.nuget.org/v3/index.json'; Name = 'nuget.org' }
-
         New-NugetConfigFile -NugetPackageSource $nugetorg, $dotnetSdk   -Destination "$PSScriptRoot/" @extraParams
         New-NugetConfigFile -NugetPackageSource $gallery                -Destination "$PSScriptRoot/src/Modules/" @extraParams
         New-NugetConfigFile -NugetPackageSource $gallery                -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
+    } elseif ( $Source -eq 'NuGetOnly') {
+        New-NugetConfigFile -NugetPackageSource $nugetorg   -Destination "$PSScriptRoot/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $gallery                -Destination "$PSScriptRoot/src/Modules/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $gallery                -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams        
     } elseif ( $Source -eq 'Private') {
-        $powerShellPackages = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell-7-5-preview-test-2/nuget/v3/index.json'; Name = 'powershell' }
+        $powerShellPackages = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json'; Name = 'powershell' }
 
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/" @extraParams
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/src/Modules/" @extraParams

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-dotnet-9/nuget/v3/index.json" />
+    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/src/Modules/nuget.config
+++ b/src/Modules/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-dotnet-9/nuget/v3/index.json" />
+    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/test/tools/Modules/nuget.config
+++ b/test/tools/Modules/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell-7-5-preview-test-2/nuget/v3/index.json" />
+    <add key="powershell" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/tools/findMissingNotices.ps1
+++ b/tools/findMissingNotices.ps1
@@ -26,7 +26,9 @@ $existingRegistrationsJson.Registrations | ForEach-Object {
     $registration = [Registration]$_
     if ($registration.Component) {
         $name = $registration.Component.Name()
-        $existingRegistrationTable.Add($name, $registration)
+        if (!$existingRegistrationTable.ContainsKey($name)) {
+            $existingRegistrationTable.Add($name, $registration)
+        }
     }
 }
 
@@ -86,6 +88,28 @@ $winDesktopSdk = 'Microsoft.NET.Sdk.WindowsDesktop'
 if (!$IsWindows) {
     $winDesktopSdk = 'Microsoft.NET.Sdk'
     Write-Warning "Always using $winDesktopSdk since this is not windows!!!"
+}
+
+function ConvertTo-SemVer {
+    param(
+        [String] $Version
+    )
+
+    [System.Management.Automation.SemanticVersion]$desiredVersion = [System.Management.Automation.SemanticVersion]::Empty
+
+    try {
+        $desiredVersion = $Version
+    } catch {
+        <#
+            Json.More.Net broke the rules and published 2.0.1.2 as 2.0.1.
+            So, I'm making the logic work for that scenario by
+            thorwing away any part that doesn't match non-pre-release semver portion
+        #>
+        $null = $Version -match '^(\d+\.\d+\.\d+).*'
+        $desiredVersion = $matches[1]
+    }
+
+    return $desiredVersion
 }
 
 function New-NugetComponent {


### PR DESCRIPTION
Backport #24528

This pull request includes updates to the `build.psm1` file to add a new source option and various configuration files to update package source URLs. Additionally, there are improvements to the `tools/findMissingNotices.ps1` script to handle missing registrations and version conversion.

Updates to `build.psm1`:

* Added `NuGetOnly` to the `ValidateSet` for the `$Source` parameter in the `Switch-PSNugetConfig` function.
* Updated the `Switch-PSNugetConfig` function to handle the new `NuGetOnly` source option.

Configuration updates:

* Updated the package source URL in `nuget.config` to use the new `PowerShell` URL.
* Updated the package source URL in `src/Modules/nuget.config` to use the new `PowerShell` URL.
* Updated the package source URL in `test/tools/Modules/nuget.config` to use the new `PowerShell` URL.

Improvements to `tools/findMissingNotices.ps1`:

* Added a check to ensure that the registration table does not already contain the component name before adding it.
* Added a new `ConvertTo-SemVer` function to handle version conversion and edge cases.