### PR TITLE
[release/v7.4] Fix seed max value for Container Linux CI

### DIFF
--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -889,9 +889,15 @@ function Invoke-InitializeContainerStage {
 
     # For PRs set the seed to the PR number so that the image is always the same
     $seed = $env:SYSTEM_PULLREQUEST_PULLREQUESTID
+
     if(!$seed) {
       # for non-PRs use the integer identifier of the build as the seed.
       $seed = $fallbackSeed
+    }
+
+    # cut down to 32 bits and keep the most varying parts, which are lower bits
+    if ($seed -ge [Int32]::MaxValue) {
+        $seed = [int]($seed -band [int]::MaxValue)
     }
 
     Write-Verbose "Seed: $seed" -Verbose


### PR DESCRIPTION
Backport #24510

This pull request includes a change to the `Invoke-InitializeContainerStage` function in the `tools/ci.psm1` file to improve the consistency of the seed value for PR builds and ensure it fits within 32 bits.

Changes to seed value handling:

* Added logic to ensure the seed value does not exceed 32 bits by using a bitwise AND operation with `Int32::MaxValue`.