### PR TITLE
[release/v7.4] Fix backport mistake in #24429

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageReference Include="System.Threading.AccessControl" Version="9.0.0-preview.6.24327.7" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.0-preview.6.24327.6" />
+    <PackageReference Include="System.Threading.AccessControl" Version="8.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.10" />
     <PackageReference Include="JsonSchema.Net" Version="7.0.4" />
   </ItemGroup>
 

--- a/test/tools/TestService/TestService.csproj
+++ b/test/tools/TestService/TestService.csproj
@@ -15,8 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0-preview.6.24327.6" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.0-preview.6.24327.7" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix backport mistake in #24429

This pull request includes updates to the package references in two project files to use stable versions instead of preview versions.

Package reference updates:

* [`src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj`](diffhunk://#diff-1d477db337d41a086f43d0d9351448c5781d5818a906fb88b55d5e08cf755509L36-R37): Updated `System.Threading.AccessControl` to version `8.0.0` and `System.Drawing.Common` to version `8.0.10`.
* [`test/tools/TestService/TestService.csproj`](diffhunk://#diff-d224acd6e2ea8267a83c21e62e5bafeb690619aef341154b76ca4ab1210371daL18-R18): Updated `Microsoft.Windows.Compatibility` to version `8.0.1` and removed the reference to `System.Formats.Asn1`.