### PR TITLE
Support PSObject wrapped values in ArgumentToEncodingTransformationAttribute

### DIFF
--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -115,10 +115,7 @@ namespace System.Management.Automation
     {
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
-            if (inputData is PSObject inputPSObject)
-            {
-                inputData = inputPSObject.BaseObject;
-            }
+            inputData = PSObject.Base(inputData);
 
             switch (inputData)
             {

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -115,6 +115,11 @@ namespace System.Management.Automation
     {
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
+            if (inputData is PSObject inputPSObject)
+            {
+                inputData = inputPSObject.BaseObject;
+            }
+
             switch (inputData)
             {
                 case string stringName:

--- a/test/powershell/engine/Basic/Encoding.Tests.ps1
+++ b/test/powershell/engine/Basic/Encoding.Tests.ps1
@@ -89,6 +89,8 @@ Describe "File encoding tests" -Tag CI {
         It "Parameter 'Encoding' should accept '<encoding>'" -TestCases @(
             @{ encoding = 1251 }
             @{ encoding = "windows-1251" }
+            # Piping the string creates a PSObject boxed value that we are testing.
+            @{ encoding = ("windows-1251" | Write-Output) }
         ) {
             param ( $encoding )
             $testFile = "${TESTDRIVE}/fileEncoding-$($encoding).txt"


### PR DESCRIPTION
# PR Summary
Add support for using a PSObject wrapped value when specifying the -Encoding parameter in cmdlets like Get-Content.

## PR Context
Currently trying to use a PSObject wrapped value like a piped string will fail for the `-Encoding` parameter with

```powershell
$enc = 'utf8' | Write-Output
Get-Content test.txt -Encoding $enc
```

```
Get-Content: Cannot bind parameter 'Encoding'. Cannot convert the "utf8" value of type "System.String" to type "System.Text.Encoding".
```

By unwrapping the `PSObject` `BaseObject` the transformer can handle these cases.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
