### PR TITLE
Rework PSModulePath path building

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -8,7 +8,8 @@ using System.Linq;
 using System.Management.Automation.Configuration;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
-using System.Text;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 using Microsoft.PowerShell.Commands;
@@ -28,6 +29,35 @@ namespace System.Management.Automation
     /// </summary>
     public class ModuleIntrinsics
     {
+#if !UNIX
+        /// <summary>
+        /// Compares a PATH entry on Windows. Treats / and \ as the same and
+        /// compares using OrdinalIgnoreCase.
+        /// </summary>
+        private class WindowsPathEnvComparer : IEqualityComparer<char>
+        {
+            public bool Equals(char x, char y)
+            {
+                if (x == y)
+                {
+                    return true;
+                }
+                // x is always canonicalised so we only need to compare if y is /.
+                else if (x == Path.DirectorySeparatorChar && y == Path.AltDirectorySeparatorChar)
+                {
+                    return true;
+                }
+
+                return MemoryMarshal.CreateReadOnlySpan(ref x, 1).CompareTo(
+                    MemoryMarshal.CreateReadOnlySpan(ref y, 1),
+                    StringComparison.OrdinalIgnoreCase) == 0;
+            }
+
+            public int GetHashCode(char c)
+                => c.GetHashCode();
+        }
+#endif
+
         /// <summary>
         /// Tracer for module analysis.
         /// </summary>
@@ -1045,32 +1075,6 @@ namespace System.Management.Automation
         }
 #endif
 
-        /// <summary>
-        /// Combine the PS system-wide module path and the DSC module path
-        /// to get the system module paths.
-        /// </summary>
-        /// <returns></returns>
-        private static string CombineSystemModulePaths()
-        {
-            string psHomeModulePath = GetPSHomeModulePath();
-            string sharedModulePath = GetSharedModulePath();
-
-            bool isPSHomePathNullOrEmpty = string.IsNullOrEmpty(psHomeModulePath);
-            bool isSharedPathNullOrEmpty = string.IsNullOrEmpty(sharedModulePath);
-
-            if (!isPSHomePathNullOrEmpty && !isSharedPathNullOrEmpty)
-            {
-                return (sharedModulePath + Path.PathSeparator + psHomeModulePath);
-            }
-
-            if (!isPSHomePathNullOrEmpty || !isSharedPathNullOrEmpty)
-            {
-                return isPSHomePathNullOrEmpty ? sharedModulePath : psHomeModulePath;
-            }
-
-            return null;
-        }
-
         internal static string GetExpandedEnvironmentVariable(string name, EnvironmentVariableTarget target)
         {
             string result = Environment.GetEnvironmentVariable(name, target);
@@ -1080,96 +1084,6 @@ namespace System.Management.Automation
             }
 
             return result;
-        }
-
-        /// <summary>
-        /// Checks if a particular string (path) is a member of 'combined path' string (like %Path% or %PSModulePath%)
-        /// </summary>
-        /// <param name="pathToScan">'Combined path' string to analyze; can not be null.</param>
-        /// <param name="pathToLookFor">Path to search for; can not be another 'combined path' (semicolon-separated); can not be null.</param>
-        /// <returns>Index of pathToLookFor in pathToScan; -1 if not found.</returns>
-        private static int PathContainsSubstring(string pathToScan, string pathToLookFor)
-        {
-            // we don't support if any of the args are null - parent function should ensure this; empty values are ok
-            Diagnostics.Assert(pathToScan != null, "pathToScan should not be null according to contract of the function");
-            Diagnostics.Assert(pathToLookFor != null, "pathToLookFor should not be null according to contract of the function");
-
-            int pos = 0; // position of the current substring in pathToScan
-            string[] substrings = pathToScan.Split(Path.PathSeparator, StringSplitOptions.None); // we want to process empty entries
-            string goodPathToLookFor = pathToLookFor.Trim().TrimEnd(Path.DirectorySeparatorChar); // trailing backslashes and white-spaces will mess up equality comparison
-            foreach (string substring in substrings)
-            {
-                string goodSubstring = substring.Trim().TrimEnd(Path.DirectorySeparatorChar);  // trailing backslashes and white-spaces will mess up equality comparison
-
-                // We have to use equality comparison on individual substrings (as opposed to simple 'string.IndexOf' or 'string.Contains')
-                // because of cases like { pathToScan="C:\Temp\MyDir\MyModuleDir", pathToLookFor="C:\Temp" }
-
-                if (string.Equals(goodSubstring, goodPathToLookFor, StringComparison.OrdinalIgnoreCase))
-                {
-                    return pos; // match found - return index of it in the 'pathToScan' string
-                }
-                else
-                {
-                    pos += substring.Length + 1; // '1' is for trailing semicolon
-                }
-            }
-            // if we are here, that means a match was not found
-            return -1;
-        }
-
-        /// <summary>
-        /// Adds paths to a 'combined path' string (like %Path% or %PSModulePath%) if they are not already there.
-        /// </summary>
-        /// <param name="basePath">Path string (like %Path% or %PSModulePath%).</param>
-        /// <param name="pathToAdd">Collection of individual paths to add.</param>
-        /// <param name="insertPosition">-1 to append to the end; 0 to insert in the beginning of the string; etc...</param>
-        /// <returns>Result string.</returns>
-        private static string AddToPath(string basePath, string pathToAdd, int insertPosition)
-        {
-            // we don't support if any of the args are null - parent function should ensure this; empty values are ok
-            Diagnostics.Assert(basePath != null, "basePath should not be null according to contract of the function");
-            Diagnostics.Assert(pathToAdd != null, "pathToAdd should not be null according to contract of the function");
-
-            StringBuilder result = new StringBuilder(basePath);
-
-            if (!string.IsNullOrEmpty(pathToAdd)) // we don't want to append empty paths
-            {
-                foreach (string subPathToAdd in pathToAdd.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)) // in case pathToAdd is a 'combined path' (semicolon-separated)
-                {
-                    int position = PathContainsSubstring(result.ToString(), subPathToAdd); // searching in effective 'result' value ensures that possible duplicates in pathsToAdd are handled correctly
-                    if (position == -1) // subPathToAdd not found - add it
-                    {
-                        if (insertPosition == -1 || insertPosition > basePath.Length) // append subPathToAdd to the end
-                        {
-                            bool endsWithPathSeparator = false;
-                            if (result.Length > 0)
-                            {
-                                endsWithPathSeparator = (result[result.Length - 1] == Path.PathSeparator);
-                            }
-
-                            if (endsWithPathSeparator)
-                            {
-                                result.Append(subPathToAdd);
-                            }
-                            else
-                            {
-                                result.Append(Path.PathSeparator + subPathToAdd);
-                            }
-                        }
-                        else if (insertPosition > result.Length)
-                        {
-                            // handle case where path is a singleton with no path separator already
-                            result.Append(Path.PathSeparator).Append(subPathToAdd);
-                        }
-                        else // insert at the requested location (this is used by DSC (<Program Files> location) and by 'user-specific location' (SpecialFolder.MyDocuments or EVT.User))
-                        {
-                            result.Insert(insertPosition, subPathToAdd + Path.PathSeparator);
-                        }
-                    }
-                }
-            }
-
-            return result.ToString();
         }
 
         /// <summary>
@@ -1208,82 +1122,126 @@ namespace System.Management.Automation
             }
         }
 
+#nullable enable
         /// <summary>
         /// Checks the various PSModulePath environment string and returns PSModulePath string as appropriate.
+        /// The PSModulePath is built in the following order:
+        /// 1. PersonalModulePath - Can be overriden by the profile config file.
+        /// 2. SharedModulePath
+        /// 3. SystemModulePath - Can be overriden by the pwsh config file.
         /// </summary>
-        public static string GetModulePath(string currentProcessModulePath, string hklmMachineModulePath, string hkcuUserModulePath)
+        /// <param name="currentProcessModulePath">The current process module path to append to the end of the env var list.</param>
+        /// <param name="hklmMachineModulePath">The system module path from the system pwsh config.</param>
+        /// <param name="hkcuUserModulePath">The personal module path from the user pwsh config.</param>
+        /// <returns>The final PSModulePath string.</returns>
+        public static string GetModulePath(string? currentProcessModulePath, string? hklmMachineModulePath, string? hkcuUserModulePath)
         {
-            string personalModulePath = GetPersonalModulePath();
-            string sharedModulePath = GetSharedModulePath(); // aka <Program Files> location
-            string psHomeModulePath = GetPSHomeModulePath(); // $PSHome\Modules location
+            string? personalModulePathToUse = string.IsNullOrEmpty(hkcuUserModulePath) ? GetPersonalModulePath() : hkcuUserModulePath;
+            string? sharedModulePath = GetSharedModulePath(); // aka <Program Files> location
+            string? systemModulePathToUse = string.IsNullOrEmpty(hklmMachineModulePath) ? GetPSHomeModulePath() : hklmMachineModulePath;
 
-            // If the variable isn't set, then set it to the default value
-            if (currentProcessModulePath == null)  // EVT.Process does Not exist - really corner case
+            List<string> finalModulePath = new List<string>();
+            AddPath(finalModulePath, personalModulePathToUse);
+            AddPath(finalModulePath, sharedModulePath);
+            AddPath(finalModulePath, systemModulePathToUse);
+
+            // If the existing module path if provided, we add it to the end of the list.
+            if (currentProcessModulePath != null)
             {
-                // Handle the default case...
-                if (string.IsNullOrEmpty(hkcuUserModulePath)) // EVT.User does Not exist -> set to <SpecialFolder.MyDocuments> location
-                {
-                    currentProcessModulePath = personalModulePath; // = SpecialFolder.MyDocuments + Utils.ProductNameForDirectory + Utils.ModuleDirectory
-                }
-                else // EVT.User exists -> set to EVT.User
-                {
-                    currentProcessModulePath = hkcuUserModulePath; // = EVT.User
-                }
-
-                if (string.IsNullOrEmpty(currentProcessModulePath))
-                {
-                    currentProcessModulePath ??= string.Empty;
-                }
-                else
-                {
-                    currentProcessModulePath += Path.PathSeparator;
-                }
-
-                if (string.IsNullOrEmpty(hklmMachineModulePath)) // EVT.Machine does Not exist
-                {
-                    currentProcessModulePath += CombineSystemModulePaths(); // += (SharedModulePath + $PSHome\Modules)
-                }
-                else
-                {
-                    currentProcessModulePath += hklmMachineModulePath; // += EVT.Machine
-                }
-            }
-            // EVT.Process exists
-            // Now handle the case where the environment variable is already set.
-            else
-            {
-                string personalModulePathToUse = string.IsNullOrEmpty(hkcuUserModulePath) ? personalModulePath : hkcuUserModulePath;
-                string systemModulePathToUse = string.IsNullOrEmpty(hklmMachineModulePath) ? psHomeModulePath : hklmMachineModulePath;
-
-                // Maintain order of the paths, but ahead of any existing paths:
-                // personalModulePath
-                // sharedModulePath
-                // systemModulePath
-
-                int insertIndex = 0;
-
-                currentProcessModulePath = UpdatePath(currentProcessModulePath, personalModulePathToUse, ref insertIndex);
-                currentProcessModulePath = UpdatePath(currentProcessModulePath, sharedModulePath, ref insertIndex);
-                currentProcessModulePath = UpdatePath(currentProcessModulePath, systemModulePathToUse, ref insertIndex);
+                AddPath(finalModulePath, currentProcessModulePath);
             }
 
-            return currentProcessModulePath;
+            return string.Join(Path.PathSeparator, finalModulePath);
         }
 
-        private static string UpdatePath(string path, string pathToAdd, ref int insertIndex)
+        /// <summary>
+        /// Adds the path if not present to the final module path list. Each
+        /// path is split by the path separator and added to the final list.
+        /// </summary>
+        /// <param name="finalModulePath">The final module path list.</param>
+        /// <param name="path">The path to add.</param>
+        private static void AddPath(List<string> finalModulePath, ReadOnlySpan<char> path)
         {
-            if (!string.IsNullOrEmpty(pathToAdd))
+            ReadOnlySpan<char> dirSeparatorChars = stackalloc char[] {
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar
+            };
+
+#if UNIX
+            IEqualityComparer<char>? valueComparer = null;
+#else
+            IEqualityComparer<char> valueComparer = new WindowsPathEnvComparer();
+#endif
+
+            foreach (Range segment in path.Split(Path.PathSeparator))
             {
-                path = AddToPath(path, pathToAdd, insertIndex);
-                insertIndex = path.IndexOf(Path.PathSeparator, PathContainsSubstring(path, pathToAdd));
-                if (insertIndex != -1)
+                // We trim any surrounding whitespace and trailing directory separators
+                // to canonicalize the path. The comparer on Windows will also treat
+                // '/' and '\' as the same and in a case insensitive operation.
+                scoped ReadOnlySpan<char> entry = path[segment].Trim();
+                if (entry.Length == 0)
                 {
-                    // advance past the path separator
-                    insertIndex++;
+                    continue;
+                }
+#if UNIX
+                // Don't trim if it's just '/' as that's a valid entry on *nix.
+                else if (!(entry.Length == 1 && entry[0] == Path.DirectorySeparatorChar))
+#else
+                else
+#endif
+                {
+                    entry = entry.TrimEnd(dirSeparatorChars);
+                }
+
+                // If after trimming we don't have a path value we ignore it.
+                if (entry.Length == 0)
+                {
+                    continue;
+                }
+
+                bool add = true;
+                foreach (ReadOnlySpan<char> listEntry in finalModulePath)
+                {
+                    if (listEntry.SequenceEqual(entry, valueComparer))
+                    {
+                        add = false;
+                        break;
+                    }
+                }
+
+                if (add)
+                {
+#if UNIX
+                    string pathEntry = entry.ToString();
+#else
+                    string pathEntry;
+                    unsafe
+                    {
+                        // Weird code avoids multiple allocations to replace / with \.
+                        pathEntry = string.Create(
+                            entry.Length,
+                            ((nint)Unsafe.AsPointer(ref MemoryMarshal.GetReference(entry)), entry.Length),
+                            static (span, state) =>
+                            {
+                                (nint ptr, int length) = state;
+                                ReadOnlySpan<char> value = new((void*)ptr, length);
+                                for (int i = 0; i < value.Length; i++)
+                                {
+                                    char c = value[i];
+                                    if (c == Path.AltDirectorySeparatorChar)
+                                    {
+                                        c = Path.DirectorySeparatorChar;
+                                    }
+                                    span[i] = c;
+                                }
+                            });
+                    }
+#endif
+                    finalModulePath.Add(pathEntry);
                 }
             }
-            return path;
         }
+#nullable disable
 
         /// <summary>
         /// Checks if $env:PSModulePath is not set and sets it as appropriate. Note - because these

--- a/test/xUnit/csharp/test_ModuleIntrinsics.cs
+++ b/test/xUnit/csharp/test_ModuleIntrinsics.cs
@@ -206,16 +206,17 @@ namespace PSTests.Parallel
         [InlineData("C:/")]
         [InlineData("C:\\\\")]
         [InlineData("C://")]
+        [InlineData("C:")]
+        [InlineData("C: ")]
         public static void AddsDriveRootToModulePath(string pathEntry)
         {
             string expected = $"{personalModulePath}{Path.PathSeparator}" +
                 $"{sharedModulePath}{Path.PathSeparator}" +
-                $"{allUsersModulePath}{Path.PathSeparator}" +
                 "C:\\";
 
             string actual = ModuleIntrinsics.GetModulePath(
                 pathEntry,
-                null,
+                pathEntry,
                 null);
 
             Assert.Equal(expected, actual);

--- a/test/xUnit/csharp/test_ModuleIntrinsics.cs
+++ b/test/xUnit/csharp/test_ModuleIntrinsics.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Management.Automation;
+using Xunit;
+
+namespace PSTests.Parallel
+{
+    public static class ModuleIntrinsicsTests
+    {
+        private static string personalModulePath = ModuleIntrinsics.GetPersonalModulePath();
+        private static string allUsersModulePath = ModuleIntrinsics.GetPSHomeModulePath();
+        private static string sharedModulePath = ModuleIntrinsics.GetSharedModulePath();
+
+        [Fact]
+        public static void GetsDefaultModulePathNoExistingEnv()
+        {
+            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"{allUsersModulePath}";
+
+            string actual = ModuleIntrinsics.GetModulePath(null, null, null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void GetsDefaultModulePathWithExistingEnv()
+        {
+            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"{allUsersModulePath}{Path.PathSeparator}" +
+                $"Foo{Path.PathSeparator}bAr";
+
+            string actual = ModuleIntrinsics.GetModulePath($"Foo{Path.PathSeparator}bAr", null, null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void GetsModulePathWithCustomUserPath()
+        {
+            string expected = $"foo{Path.PathSeparator}Bar{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"{allUsersModulePath}";
+
+            string actual = ModuleIntrinsics.GetModulePath(null, null, $"foo{Path.PathSeparator}Bar");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void GetsModulePathWithCustomAllUsersPath()
+        {
+            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"foo{Path.PathSeparator}Bar";
+
+            string actual = ModuleIntrinsics.GetModulePath(null, $"foo{Path.PathSeparator}Bar", null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void IgnoresEmptyModulePathValues()
+        {
+            string expected = $"{sharedModulePath}";
+
+            string actual = ModuleIntrinsics.GetModulePath(null, $" {Path.PathSeparator} {Path.PathSeparator}", $"{Path.PathSeparator}");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void IgnoresDuplicatePathValues()
+        {
+            string expected = $"foo1{Path.PathSeparator}bar1{Path.PathSeparator}bar2{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                "foo2";
+
+            string actual = ModuleIntrinsics.GetModulePath("bar1", $"foo1{Path.PathSeparator}bar2{Path.PathSeparator}foo2", $"foo1{Path.PathSeparator}bar1{Path.PathSeparator}bar2");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void IgnoresPathEntryEndingWithSeparator()
+        {
+            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                "foo";
+
+            string actual = ModuleIntrinsics.GetModulePath(null, $"foo{Path.PathSeparator}", null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void IgnoresWhitespaceAroundPathEntry()
+        {
+            string expected = $"foobar{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"bar{Path.PathSeparator}" +
+                "foo";
+
+            string actual = ModuleIntrinsics.GetModulePath($"foo  {Path.PathSeparator}bar ", "  bar", "  foobar  ");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void IgnoresTrailingDirectorySeparatorAroundPathEntry()
+        {
+            string expected = $"dir3{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"dir2{Path.PathSeparator}" +
+                "dir1";
+
+            string actual = ModuleIntrinsics.GetModulePath(
+                $"dir1{Path.DirectorySeparatorChar}",
+                $"dir2{Path.DirectorySeparatorChar} ",
+                $"dir3{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void PreservedWhitespaceInsideDirectorySeparatorInPathEntry()
+        {
+            string expected = $"{Path.DirectorySeparatorChar} dir3 {Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"{Path.DirectorySeparatorChar}dir2 {Path.PathSeparator}" +
+                $"{Path.DirectorySeparatorChar} dir1";
+
+            string actual = ModuleIntrinsics.GetModulePath(
+                $"{Path.DirectorySeparatorChar} dir1{Path.DirectorySeparatorChar}",
+                $"{Path.DirectorySeparatorChar}dir2 {Path.DirectorySeparatorChar}",
+                $"{Path.DirectorySeparatorChar} dir3 {Path.DirectorySeparatorChar}");
+
+            Assert.Equal(expected, actual);
+        }
+
+#if UNIX
+        [Fact]
+        public static void AddsRootPathToModulePath()
+        {
+            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"/{Path.PathSeparator}" +
+                "/foo/bar";
+
+            string actual = ModuleIntrinsics.GetModulePath("/foo/bar", "/", null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void TreatsModulePathsAsCaseSensitiveOnUnix()
+        {
+            string expected = $"foo{Path.PathSeparator}bar{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"Foo{Path.PathSeparator}" +
+                "Bar";
+
+            string actual = ModuleIntrinsics.GetModulePath(
+                $"foo{Path.PathSeparator}Bar",
+                $"foo{Path.PathSeparator}Foo{Path.PathSeparator}Bar",
+                $"foo{Path.PathSeparator}bar");
+
+            Assert.Equal(expected, actual);
+        }
+#else
+        [Fact]
+        public static void TreatsModulePathAsCaseInSensitiveOnWindows()
+        {
+            string expected = $"foo{Path.PathSeparator}bar{Path.PathSeparator}" +
+                $"{sharedModulePath}";
+
+            string actual = ModuleIntrinsics.GetModulePath(
+                $"foo{Path.PathSeparator}Bar",
+                $"foo{Path.PathSeparator}Foo{Path.PathSeparator}Bar",
+                $"foo{Path.PathSeparator}bar");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void TreatsAltDirSepTheSameAsDirSepOnWindows()
+        {
+            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"{allUsersModulePath}{Path.PathSeparator}" +
+                "C:\\folder;C:\\other1;C:\\other2;c:\\dir1\\dir2";
+
+            string actual = ModuleIntrinsics.GetModulePath(
+                $"C:/folder;C:\\folder;C:/folder/;C:\\folder\\;C:/other1/\\;C:/other2\\/;c:/dir1\\dir2",
+                null,
+                null);
+
+            Assert.Equal(expected, actual);
+        }
+#endif
+    }
+}

--- a/test/xUnit/csharp/test_ModuleIntrinsics.cs
+++ b/test/xUnit/csharp/test_ModuleIntrinsics.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Management.Automation;
+using System.Runtime;
 using Xunit;
 
 namespace PSTests.Parallel
@@ -145,12 +146,11 @@ namespace PSTests.Parallel
         [Fact]
         public static void AddsRootPathToModulePath()
         {
-            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+            string expected = $"/{Path.PathSeparator}" +
                 $"{sharedModulePath}{Path.PathSeparator}" +
-                $"/{Path.PathSeparator}" +
                 "/foo/bar";
 
-            string actual = ModuleIntrinsics.GetModulePath("/foo/bar", "/", null);
+            string actual = ModuleIntrinsics.GetModulePath("/foo/bar", "/", "//");
 
             Assert.Equal(expected, actual);
         }
@@ -195,6 +195,26 @@ namespace PSTests.Parallel
 
             string actual = ModuleIntrinsics.GetModulePath(
                 $"C:/folder;C:\\folder;C:/folder/;C:\\folder\\;C:/other1/\\;C:/other2\\/;c:/dir1\\dir2",
+                null,
+                null);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("C:\\")]
+        [InlineData("C:/")]
+        [InlineData("C:\\\\")]
+        [InlineData("C://")]
+        public static void AddsDriveRootToModulePath(string pathEntry)
+        {
+            string expected = $"{personalModulePath}{Path.PathSeparator}" +
+                $"{sharedModulePath}{Path.PathSeparator}" +
+                $"{allUsersModulePath}{Path.PathSeparator}" +
+                "C:\\";
+
+            string actual = ModuleIntrinsics.GetModulePath(
+                pathEntry,
                 null,
                 null);
 


### PR DESCRIPTION
# PR Summary
Fixes the parsing of the powershell.config.json PSModulePath entry when it contains the path separator char. Instead of crashing this is able to handle entries with those characters and treat them as multiple entries.

This also rewrites the logic when building the process PSModulePath to
simplify the way entries were added and deal with canonicalisation of
the path entries.

Fixes: https://github.com/PowerShell/PowerShell/issues/20706

## PR Context
Using `powershell.config.json` with a `PSModulePath` entry that contains the `Path.Separator` char (`;` for Windows and `:` for *nix) crashes the process on startup. This is because the current logic adds the value provided as is to the path but then attempts to find the index for where it is located. This lookup splits the new path value by the `Path.Separator` so the entry being added is never found (the raw value is never a split component of the new path).

This new PR consolidates the various path addition logic and tries to make it more consistent in how it handles new values. It also attempts to remove as much string allocations by working on spans where possible to hopefully improve the memory allocation at startup.

Ultimately the behaviour of this logic when building the `PSModulePath` is

+ Add the current user path
  + Uses the current user `.config.json` and falls back to the default user's modules dir
+ Add the shared machine wide path
  + On Windows this is `C:\Program Files\PowerShell\Modules`
  + This not controlled by any config
+ Add the machine/system path
  + Uses the `$PSHome/powershell.config.json` entry and falls back to `$PSHome/Modules`
+ Adds the existing process `PSModulePath` if present
  + On Windows this is typically the machine wide `PSModulePath` (System32/Program Files\WindowsPowerShell)
  + Will inherit from the parent process that spawned PowerShell
  + On Linux this is not set by default but can be using whatever shell that is spawning PowerShell

There are a few behavioural changes introduced by this PR which I think aren't breaking changes but are behaviour differences for the better.

+ Paths are canonicalised and only added if not already present
  + Whitespace is trimmed
  + Trailing `/` or `\` (on Windows) is removed
  + On Windows `/` is converted to `\`
  + All duplicates and empty entries are removed
  + In the past some paths were checked before adding while others are just appended as is leading to mixed behaviour
  + This new logic is consistent with all stages of building the `PSModulePath`
+ On non-Windows paths are compared in a case sensitive way
  + This is because these OS’ are typically run on a filesystem where the case does matter
+ When `PSModulePath` is not set as a process env var (Linux mostly) and there is an explicit `PSModulePath` in the `$PSHome/powershell.config.json` the shared module path is now included
  + This was omitted before but I cannot understand why
  + Making this change keeps things consistent
  + Should be a rare scenario in any case which is probably why it was never picked up

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
