### PR TITLE
[release/v7.5] Added Deploy Box Product Pathway to GitHub Release and NuGet Release Pipelines

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -50,7 +50,7 @@ variables:
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: WindowsContainerImage
-    value: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+    value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/cbl-mariner/build:2.0
   - name: ReleaseTagVar
@@ -79,12 +79,12 @@ resources:
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates
   parameters:
-    # using Monitor as copy blob is being blocked by the network
+    release: 
+      category: NonAzure
     featureFlags:
-      LinuxHostVersion:
-          Network: Monitor
       WindowsHostVersion:
-          Network: Monitor
+        Version: 2022
+        Network: Netlock
     cloudvault:
       enabled: false
     globalSdl:
@@ -110,13 +110,23 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
+    - stage: DownloadPackages
+      displayName: 'Download Packages'
+      dependsOn: []
+      jobs:
+      - template: /.pipelines/templates/release-download-packages.yml@self
+
     - stage: msixbundle
       displayName: 'Create MSIX Bundle'
+      dependsOn: []
+      variables:
+        ob_release_environment: Test
       jobs:
       - template: /.pipelines/templates/release-create-msix.yml@self
 
     - stage: validateSdk
       displayName: 'Validate SDK'
+      dependsOn: []
       jobs:
       - template: /.pipelines/templates/release-validate-sdk.yml@self
         parameters:
@@ -141,6 +151,7 @@ extends:
 
     - stage: gbltool
       displayName: 'Validate Global tools'
+      dependsOn: []
       jobs:
       - template: /.pipelines/templates/release-validate-globaltools.yml@self
         parameters:
@@ -158,6 +169,7 @@ extends:
 
     - stage: fxdpackages
       displayName: 'Validate FXD Packages'
+      dependsOn: []
       jobs:
       - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
         parameters:
@@ -194,6 +206,7 @@ extends:
 
     - stage: validatePackages
       displayName: 'Validate Packages'
+      dependsOn: []
       jobs:
       - template: /.pipelines/templates/release-validate-packagenames.yml@self
 
@@ -262,23 +275,50 @@ extends:
             Update and merge the changelog for the release.
             This step is required for creating GitHub draft release.
 
+    - stage: PublishGitHubRelease
+      displayName: Publish GitHub Release
+      dependsOn: 
+        - DownloadPackages
+        - UpdateChangeLog
+      variables:
+        ob_release_environment: Production
+      jobs:
+      - template: /.pipelines/templates/release-githubtasks.yml@self
+    
+    - stage: PushGitTagAndMakeDraftPublic
+      displayName: Push Git Tag and Make Draft Public
+      dependsOn: PublishGitHubRelease
+      jobs:
+      - template: /.pipelines/templates/approvalJob.yml@self
+        parameters:
+          displayName: Push Git Tag
+          jobName: PushGitTag
+          instructions: |
+            Push the git tag to upstream  
+    
+      - template: /.pipelines/templates/approvalJob.yml@self
+        parameters:
+          displayName: Make Draft Public
+          dependsOnJob: PushGitTag
+          jobName: DraftPublic
+          instructions: |
+            Make the GitHub Release Draft Public
+  
     - stage: BlobPublic
       displayName: Make Blob Public
-      dependsOn: UpdateChangeLog
+      dependsOn: 
+        - UpdateChangeLog
+        - PushGitTagAndMakeDraftPublic
       jobs:
       - template: /.pipelines/templates/release-MakeBlobPublic.yml@self
         parameters:
-          SkipPSInfraInstallers: ${{ parameters.SkipPSInfraInstallers }}
-
-    - stage: PublishGitHubRelease
-      displayName: Publish GitHub Release
-      dependsOn: BlobPublic
-      jobs:
-      - template: /.pipelines/templates/release-githubtasks.yml@self
-
+          SkipPSInfraInstallers: ${{ parameters.SkipPSInfraInstallers }}         
+  
     - stage: PublishNuGet
       displayName: Publish NuGet
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
+      variables:
+        ob_release_environment: Production
       jobs:
       - template: /.pipelines/templates/release-publish-nuget.yml@self
         parameters:
@@ -286,14 +326,14 @@ extends:
 
     - stage: PublishPMC
       displayName: Publish PMC
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       jobs:
       - template: /.pipelines/templates/release-publish-pmc.yml@self
         parameters:
           skipPublish: ${{ parameters.SkipPMCPublish }}
 
     - stage: ReleaseDocker
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       displayName: 'Docker Release'
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
@@ -312,7 +352,7 @@ extends:
             Kickoff docker release
 
     - stage: UpdateDotnetDocker
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       displayName: Update DotNet SDK Docker images
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
@@ -327,7 +367,7 @@ extends:
             4. create PR targeting nightly branch
 
     - stage: UpdateWinGet
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       displayName: Add manifest entry to winget
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
@@ -338,7 +378,7 @@ extends:
             This is typically done by the community 1-2 days after the release.
 
     - stage: PublishMsix
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       displayName: Publish MSIX to store
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
@@ -349,7 +389,7 @@ extends:
             Ask Steve to release MSIX bundle package to Store
 
     - stage: PublishVPack
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       displayName: Release vPack
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
@@ -367,20 +407,22 @@ extends:
     #   - template: templates/release-UpdateDepsJson.yml
 
     - stage: UploadBuildInfoJson
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       displayName: Upload BuildInfo.json
       jobs:
       - template: /.pipelines/templates/release-upload-buildinfo.yml@self
 
     - stage: ReleaseSymbols
-      dependsOn: PublishGitHubRelease
+      dependsOn: PushGitTagAndMakeDraftPublic
       displayName: Release Symbols
       jobs:
       - template: /.pipelines/templates/release-symbols.yml@self
 
     - stage: ChangesToMaster
       displayName: Ensure changes are in GH master
-      dependsOn: ['PublishNuGet', 'PublishPMC']
+      dependsOn: 
+        - PublishNuGet 
+        - PublishPMC
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
         parameters:
@@ -391,7 +433,7 @@ extends:
 
     - stage: ReleaseSnap
       displayName: Release Snap
-      dependsOn: 'ChangesToMaster'
+      dependsOn: ChangesToMaster
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
         parameters:
@@ -402,7 +444,7 @@ extends:
 
     - stage: ReleaseToMU
       displayName: Release to MU
-      dependsOn: ['PublishNuGet', 'PublishPMC', 'ChangesToMaster']
+      dependsOn: PushGitTagAndMakeDraftPublic # This only needs the blob to be available
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
         parameters:
@@ -412,7 +454,10 @@ extends:
 
     - stage: ReleaseClose
       displayName: Finish Release
-      dependsOn: ['ReleaseToMU', 'ReleaseSymbols', 'ReleaseSnap']
+      dependsOn: 
+        - ReleaseToMU
+        - ReleaseSymbols
+        - ReleaseSnap
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
         parameters:

--- a/.pipelines/templates/release-checkout-pwsh-repo.yml
+++ b/.pipelines/templates/release-checkout-pwsh-repo.yml
@@ -1,0 +1,13 @@
+steps:
+  - pwsh: |
+      Write-Verbose -Verbose "Deploy Box Product Pathway Does Not Support the `"checkout`" task"
+      if ($ENV:BUILD_REASON -eq 'PullRequest') {
+        throw 'We dont support PRs'
+      }
+      
+      Write-Verbose -Verbose $ENV:BUILD_SOURCEBRANCH
+      $branchName = $ENV:BUILD_SOURCEBRANCH -replace '^refs/heads/'
+      Write-Verbose -Verbose "Branch Name: $branchName"
+      git clone --depth 1 --branch $branchName https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/PowerShell '$(Pipeline.Workspace)/PowerShell'
+      cd $(Pipeline.Workspace)/PowerShell
+    displayName: Checkout Powershell Repository

--- a/.pipelines/templates/release-download-packages.yml
+++ b/.pipelines/templates/release-download-packages.yml
@@ -1,0 +1,122 @@
+jobs:
+- job: upload_packages
+  displayName: Upload packages
+  condition: succeeded()
+  pool:
+    type: windows
+  variables:
+  - template: ./variable/release-shared.yml@self
+    parameters:
+      REPOROOT: $(Build.SourcesDirectory)
+      SBOM: true
+
+  steps:
+  - pwsh: |
+      Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
+    displayName: Capture environment variables
+  
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_deb
+    displayName: Download linux deb packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_fxdependent
+    displayName: Download linux fx packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_mariner_arm64
+    displayName: Download linux mariner packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_mariner_x64
+    displayName: Download linux mariner x64 packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_minSize
+    displayName: Download linux min packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_rpm
+    displayName: Download linux rpm packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_tar
+    displayName: Download linux tar packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_tar_alpine
+    displayName: Download linux tar alpine packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_tar_alpine_fxd
+    displayName: Download linux tar alpine fxd packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_tar_arm
+    displayName: Download linux tar arm packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_linux_package_tar_arm64
+    displayName: Download linux tar arm 64 packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_nupkg_build_nupkg
+    displayName: Download nupkg packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_windows_package_package_win_arm64
+    displayName: Download windows arm64 packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_windows_package_package_win_fxdependent
+    displayName: Download windows fxdependent packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_windows_package_package_win_fxdependentWinDesktop
+    displayName: Download windows fxdependentWinDesktop packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_windows_package_package_win_minsize
+    displayName: Download windows minsize packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_windows_package_package_win_x64
+    displayName: Download windows x64 packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_windows_package_package_win_x86
+    displayName: Download windows x86 packages
+
+  - download: PSPackagesOfficial
+    artifact: macos-pkgs
+    displayName: Download macos tar packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_mac_package_sign_package_macos_arm64
+    displayName: Download macos arm packages
+
+  - download: PSPackagesOfficial
+    artifact: drop_mac_package_sign_package_macos_x64
+    displayName: Download macos x64 packages
+
+  - pwsh: |
+      Get-ChildItem '$(Pipeline.Workspace)/PSPackagesOfficial' -Recurse | Select-Object -ExpandProperty FullName
+    displayName: 'Capture downloads'
+  
+  - pwsh: |
+      $PackagesPath = '$(Pipeline.Workspace)/PSPackagesOfficial'
+      Write-Verbose -Verbose "Copying Github Release files in $PackagesPath to use in Release Pipeline"
+      
+      Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
+      New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$PackagesPath/*" -Recurse | 
+        Where-Object { $_.Extension -notin '.msix', '.nupkg' } |
+        Where-Object { $_.Extension -in '.gz', '.pkg', '.msi', '.zip', '.deb', '.rpm', '.zip' } |
+        Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse -Verbose
+      
+      Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
+      New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$PackagesPath/*" -Recurse | 
+        Where-Object { $_.Extension -eq '.nupkg' } | 
+        Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse -Verbose
+    displayName: Copy downloads to Artifacts

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -3,162 +3,114 @@ jobs:
   displayName: Create GitHub Release Draft
   condition: succeeded()
   pool:
-    type: windows
+    type: release
+    os: windows
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        artifactName: drop_DownloadPackages_upload_packages
   variables:
-  - name: runCodesignValidationInjection
-    value: false
-  - name: NugetSecurityAnalysisWarningLevel
-    value: none
-  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
-    value: 1
-  - group: 'mscodehub-code-read-akv'
-  - group: 'Azure Blob variable group'
-  - group: 'GitHubTokens'
-  - name: ob_outputDirectory
-    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-  - name: ob_sdl_codeSignValidation_enabled
-    value: false
-  - name: ob_sdl_binskim_enabled
-    value: false
-  - name: ob_sdl_tsa_configFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
-  - name: ob_sdl_credscan_suppressionsFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+  - template: ./variable/release-shared.yml@self
 
   steps:
-  - checkout: self
-    clean: true
-    env:
-      ob_restore_phase: true # This ensures checkout is done at the beginning of the restore phase
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        Get-ChildItem Env: | Out-String -Stream | write-Verbose -Verbose
+    displayName: 'Capture Environment Variables'
+
+  - template: release-install-pwsh.yml
+
+  - template: release-checkout-pwsh-repo.yml
 
   - template: release-SetReleaseTagAndContainerName.yml
 
-  - pwsh: |
-      Get-ChildItem Env:
-    displayName: 'Capture Environment Variables'
-
-  - pwsh: |
-      # Uninstall Azure RM modules
-      $azRmModules = Get-Module -Name AzureRM* -ListAvailable
-      if ($azRmModules) {
-        $azRmModules | Remove-Module -Force
-      }
-
-      # Install Az.Storage module if not already installed
-      if (-not (Get-Module -Name Az.Storage -ListAvailable)) {
-        Install-Module -Name Az.Storage -Force -AllowClobber -Scope CurrentUser -Verbose
-      }
-    displayName: Install Az.Storage module
-
-  - task: AzurePowerShell@5
-    displayName: Download packages from Azure Storage
+  - task: PowerShell@2
     inputs:
-      azureSubscription: az-blob-cicd-infra
-      scriptType: inlineScript
-      azurePowerShellVersion: LatestVersion
+      targetType: inline
       pwsh: true
-      inline: |
-        $storageAccount = "$(StorageAccount)"
-        $containerName = "$(AzureVersion)"
-        $destinationPath = "$(System.ArtifactsDirectory)"
-
-        # Get storage account context
-        $storageContext = New-AzStorageContext -StorageAccountName $storageAccount
-
-        $blobList = Get-AzStorageBlob -Container $containerName -Context $storageContext
-        foreach ($blob in $blobList) {
-          $blobName = $blob.Name
-          $destinationFile = Join-Path -Path $destinationPath -ChildPath $blobName
-          Get-AzStorageBlobContent -Container $containerName -Blob $blobName -Destination $destinationFile -Context $storageContext -Force
-          Write-Output "Downloaded $blobName to $destinationFile"
-        }
-
-        $packagesPath = Get-ChildItem -Path $destinationPath\*.deb -Recurse -File | Select-Object -First 1 -ExpandProperty DirectoryName
-        Write-Host "sending -- vso[task.setvariable variable=PackagesRoot]$packagesPath"
-        Write-Host "##vso[task.setvariable variable=PackagesRoot]$packagesPath"
-
-  - pwsh: |
-      Get-ChildItem $(System.ArtifactsDirectory)\* -recurse | Select-Object -ExpandProperty FullName
-    displayName: Capture downloaded artifacts
-
-  - pwsh: |
-      git clone https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
+      script: |
+        git clone --depth 1 https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
     displayName: Clone Internal-Tools repository
 
-  - pwsh: |
-      $Path = "$(System.ArtifactsDirectory)"
-      $OutputPath = Join-Path $Path 'hashes.sha256'
-      $srcPaths = @($Path)
-      $packages  = Get-ChildItem -Path $srcPaths -Include * -Recurse -File
-      $checksums = $packages |
-          ForEach-Object {
-              Write-Verbose -Verbose "Generating checksum file for $($_.FullName)"
-              $packageName = $_.Name
-              $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower()
-              # the '*' before the packagename signifies it is a binary
-              "$hash *$packageName"
-          }
-      $checksums | Out-File -FilePath $OutputPath -Force
-      $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
-      Write-Verbose -Verbose -Message $fileContent
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        $Path = "$(Pipeline.Workspace)/GitHubPackages"
+        $OutputPath = Join-Path $Path 'hashes.sha256'
+        $packages  = Get-ChildItem -Path $Path -Include * -Recurse -File
+        $checksums = $packages |
+            ForEach-Object {
+                Write-Verbose -Verbose "Generating checksum file for $($_.FullName)"
+                $packageName = $_.Name
+                $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower()
+                # the '*' before the packagename signifies it is a binary
+                "$hash *$packageName"
+            }
+        $checksums | Out-File -FilePath $OutputPath -Force
+        $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
+        Write-Verbose -Verbose -Message $fileContent
     displayName: Add sha256 hashes
 
-  - pwsh: |
-      $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-      $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
-      Write-Host "sending " + $vstsCommandString
-      Write-Host "##$vstsCommandString"
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
+        $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
     displayName: 'Set release version'
 
-  - pwsh: |
-      Import-module '$(Pipeline.Workspace)/tools/Scripts/GitHubRelease.psm1'
-      $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-      $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        Get-ChildItem $(Pipeline.Workspace) -recurse | Select-Object -ExpandProperty FullName
+    displayName: List all files in the workspace
 
-      $isPreview = $semanticVersion.PreReleaseLabel -ne $null
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        Import-module '$(Pipeline.Workspace)/tools/Scripts/GitHubRelease.psm1'
+        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
+        $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
 
-      $fileName = if ($isPreview) {
-        "preview.md"
-      }
-      else {
-        $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
-      }
+        $isPreview = $semanticVersion.PreReleaseLabel -ne $null
 
-      $filePath = "$env:BUILD_SOURCESDIRECTORY/PowerShell/CHANGELOG/$fileName"
-      Write-Verbose -Verbose "Selected Log file: $filePath"
+        $fileName = if ($isPreview) {
+          "preview.md"
+        }
+        else {
+          $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
+        }
 
-      if (-not (Test-Path $filePath)) {
-        throw "$filePath not found"
-      }
+        $filePath = "$(Pipeline.Workspace)/PowerShell/CHANGELOG/$fileName"
+        Write-Verbose -Verbose "Selected Log file: $filePath"
 
-      $changelog = Get-Content -Path $filePath
+        if (-not (Test-Path $filePath)) {
+          throw "$filePath not found"
+        }
 
-      $startPattern = "^## \[" + ([regex]::Escape($releaseVersion)) + "\]"
-      $endPattern = "^## \[{0}\.{1}\.{2}*" -f $semanticVersion.Major, $semanticVersion.Minor, $semanticVersion.Patch
+        $changelog = Get-Content -Path $filePath
 
-      $clContent = $changelog | ForEach-Object {
-          if ($_ -match $startPattern) { $outputLine = $true }
-          elseif ($_ -match $endPattern) { $outputLine = $false }
-          if ($outputLine) { $_}
-        } | Out-String
+        $startPattern = "^## \[" + ([regex]::Escape($releaseVersion)) + "\]"
+        $endPattern = "^## \[{0}\.{1}\.{2}*" -f $semanticVersion.Major, $semanticVersion.Minor, $semanticVersion.Patch
 
-      Write-Verbose -Verbose "Selected content: `n$clContent"
+        $clContent = $changelog | ForEach-Object {
+            if ($_ -match $startPattern) { $outputLine = $true }
+            elseif ($_ -match $endPattern) { $outputLine = $false }
+            if ($outputLine) { $_}
+          } | Out-String
 
-      Publish-ReleaseDraft -Tag '$(ReleaseTag)' -Name '$(ReleaseTag) Release of PowerShell' -Description $clContent -User PowerShell -Repository PowerShell  -PackageFolder $(PackagesRoot) -Token $(GitHubReleasePat)
+        Write-Verbose -Verbose "Selected content: `n$clContent"
+
+        Publish-ReleaseDraft -Tag '$(ReleaseTag)' -Name '$(ReleaseTag) Release of PowerShell' -Description $clContent -User PowerShell -Repository PowerShell  -PackageFolder "$(Pipeline.Workspace)/GitHubPackages" -Token $(GitHubReleasePat)
     displayName: Publish Release Draft
-
-- template: /.pipelines/templates/approvalJob.yml@self
-  parameters:
-    displayName: Push Git Tag
-    jobName: PushGitTag
-    dependsOnJob: GithubReleaseDraft
-    instructions: |
-      Push the git tag to upstream
-
-- template: /.pipelines/templates/approvalJob.yml@self
-  parameters:
-    displayName: Make Draft Public
-    jobName: DraftPublic
-    dependsOnJob: PushGitTag
-    instructions: |
-      Make the GitHub Release Draft Public

--- a/.pipelines/templates/release-install-pwsh.yml
+++ b/.pipelines/templates/release-install-pwsh.yml
@@ -1,0 +1,34 @@
+steps:
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        $localInstallerPath = Get-ChildItem -Path "$(Pipeline.Workspace)/GitHubPackages" -Filter '*win-x64.msi' | Select-Object -First 1 -ExpandProperty FullName
+        if (Test-Path -Path $localInstallerPath) {
+          Write-Verbose -Verbose "Installer found at $localInstallerPath"
+        } else {
+          throw "Installer not found"
+        }
+        Write-Verbose -Verbose "Installing PowerShell via msiexec"
+        Start-Process -FilePath msiexec -ArgumentList "/package $localInstallerPath /quiet REGISTER_MANIFEST=1" -Wait -NoNewWindow
+        $pwshPath = Get-ChildItem -Directory -Path 'C:\Program Files\PowerShell\7*' | Select-Object -First 1 -ExpandProperty FullName
+        if (Test-Path -Path $pwshPath) {
+          Write-Verbose -Verbose "PowerShell installed at $pwshPath"
+          Write-Verbose -Verbose "Adding pwsh to env:PATH"
+          Write-Host "##vso[task.prependpath]$pwshPath"
+        } else {
+          throw "PowerShell not installed"
+        }
+    displayName: Install pwsh 7
+
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        Write-Verbose -Verbose "Pwsh 7 Installed"
+        Write-Verbose -Verbose "env:Path: "
+        $env:PATH -split ';' | ForEach-Object {
+          Write-Verbose -Verbose $_
+        }
+    displayName: Check pwsh 7 installation

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -8,31 +8,20 @@ jobs:
   displayName: Publish to NuGet
   condition: succeeded()
   pool:
-    type: windows
+    type: release
+    os: windows
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        pipeline: PSPackagesOfficial
+        artifactName: drop_upload_upload_packages
   variables:
-  - name: runCodesignValidationInjection
-    value: false
-  - name: NugetSecurityAnalysisWarningLevel
-    value: none
-  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
-    value: 1
-  - group: 'mscodehub-code-read-akv'
-  - name: ob_outputDirectory
-    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-  - name: ob_sdl_codeSignValidation_enabled
-    value: false
-  - name: ob_sdl_binskim_enabled
-    value: false
-  - name: ob_sdl_tsa_configFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
-  - name: ob_sdl_credscan_suppressionsFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+  - template: ./variable/release-shared.yml@self
 
   steps:
-  - checkout: self
-    clean: true
-    env:
-      ob_restore_phase: true # This ensures checkout is done at the beginning of the restore phase
+  - template: release-install-pwsh.yml
+
+  - template: release-checkout-pwsh-repo.yml
 
   - template: release-SetReleaseTagAndContainerName.yml
 
@@ -40,23 +29,20 @@ jobs:
       Get-ChildItem Env:
     displayName: 'Capture Environment Variables'
 
-  - download: PSPackagesOfficial
-    artifact: drop_nupkg_build_nupkg
-    displayName: Download nuget packages
-
   - pwsh: |
       #Exclude all global tool packages. Their names start with 'PowerShell.'
       $null = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/release"
-      Copy-Item "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg/*.nupkg" -Destination "$(Pipeline.Workspace)/release" -Exclude "PowerShell.*.nupkg" -Force -Verbose
+      Copy-Item "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -Destination "$(Pipeline.Workspace)/release" -Exclude "PowerShell.*.nupkg" -Force -Verbose
 
       $releaseVersion = '$(VERSION)'
-      $globalToolPath = "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg/PowerShell.$releaseVersion.nupkg"
+      $globalToolPath = "$(Pipeline.Workspace)/NuGetPackages/PowerShell.$releaseVersion.nupkg"
 
       if ($releaseVersion -notlike '*-*') {
           # Copy the global tool package for stable releases
           Copy-Item $globalToolPath -Destination "$(Pipeline.Workspace)/release"
       }
 
+      Write-Verbose -Verbose "The .nupkgs below will be pushed:"
       Get-ChildItem "$(Pipeline.Workspace)/release" -recurse
     displayName: Download and capture nupkgs
     condition: and(ne('${{ parameters.skipPublish }}', 'false'), succeeded())

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -5,6 +5,8 @@ jobs:
   pool:
     type: windows
   variables:
+  - name: ob_sdl_sbom_enabled
+    value: false
   - name: runCodesignValidationInjection
     value: false
   - name: NugetSecurityAnalysisWarningLevel
@@ -232,6 +234,24 @@ jobs:
   - pwsh: |
       Get-ChildItem '$(Build.ArtifactStagingDirectory)/downloads' | Select-Object -ExpandProperty FullName
     displayName: 'Capture downloads'
+
+  # - pwsh: |
+  #     Write-Verbose -Verbose "Copying Github Release files in $(Build.ArtifactStagingDirectory)/downloads to use in Release Pipeline"
+  #     
+  #     Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
+  #     New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
+  #     Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
+  #       Where-Object { $_.Extension -notin '.msix', '.nupkg' } | 
+  #       ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
+  #       Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse
+  #     
+  #     Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
+  #     New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
+  #     Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
+  #       Where-Object { $_.Extension -eq '.nupkg' } | 
+  #       ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
+  #       Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse
+  #   displayName: Copy downloads to Artifacts
 
   - pwsh: |
       # Create output directory for packages which have been uploaded to blob storage

--- a/.pipelines/templates/variable/release-shared.yml
+++ b/.pipelines/templates/variable/release-shared.yml
@@ -1,0 +1,32 @@
+parameters:
+  - name: REPOROOT
+    type: string
+    default: $(Build.SourcesDirectory)\PowerShell
+  - name: SBOM
+    type: boolean
+    default: false
+
+variables:
+  - name: ob_signing_setup_enabled            
+    value: false
+  - name: ob_sdl_sbom_enabled
+    value: ${{ parameters.SBOM }}
+  - name: runCodesignValidationInjection
+    value: false
+  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+    value: 1
+  - group: 'mscodehub-code-read-akv'
+  - group: 'Azure Blob variable group'
+  - group: 'GitHubTokens'
+  - name: ob_outputDirectory
+    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+  - name: ob_sdl_codeSignValidation_enabled
+    value: false
+  - name: ob_sdl_binskim_enabled
+    value: false
+  - name: ob_sdl_tsa_configFile
+    value: ${{ parameters.REPOROOT }}\.config\tsaoptions.json
+  - name: ob_sdl_credscan_suppressionsFile
+    value: ${{ parameters.REPOROOT }}\.config\suppress.json
+  - name: ob_sdl_codeql_compiled_enabled
+    value: false


### PR DESCRIPTION
Backport #24583

This pull request includes significant changes to the `.pipelines/PowerShell-Release-Official.yml` file to update container images, modify dependencies, and add new stages. Additionally, new templates for downloading packages and checking out repositories have been introduced.

Key changes include:

### Container Image Updates:
* Updated the `WindowsContainerImage` to use `ltsc2022` instead of `ltsc2019`.

### Dependency Modifications:
* Modified the `resources` section to include a new `release` category and updated `WindowsHostVersion` to `2022` with `Netlock` network.

### New Stages and Dependencies:
* Added new stages such as `DownloadPackages`, `PublishGitHubRelease`, and `PushGitTagAndMakeDraftPublic`. Each new stage includes its respective jobs and dependencies. [[1]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR113-R129) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR278-R336)
* Updated dependencies for existing stages to depend on the new stages where necessary, ensuring a streamlined release process. [[1]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL315-R355) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL330-R370) [[3]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL341-R381)

### Template Additions:
* Introduced a new template `release-download-packages.yml` for downloading various package types, including Linux, Windows, and macOS packages.
* Added `release-checkout-pwsh-repo.yml` for checking out the PowerShell repository, including a script to handle branch names and clone the repository.

### Refactoring GitHub Tasks:
* Updated `release-githubtasks.yml` to use the `release` pool and added new variables and steps to streamline the GitHub release process. [[1]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L6-R44) [[2]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L106-R81) [[3]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L127-R95)