### PR TITLE
Fix up buffer management getting network roots

### DIFF
--- a/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
@@ -27,8 +27,8 @@ internal static partial class Interop
 
             ReadOnlySpan<char> driveName = stackalloc char[] { drive, ':', '\0' };
             int bufferSize = MAX_PATH;
-            Span<char> uncBuffer = stackalloc char[bufferSize];
-            if (InternalTestHooks.WNetGetConnectionBufferSize > 0)
+            Span<char> uncBuffer = stackalloc char[MAX_PATH];
+            if (InternalTestHooks.WNetGetConnectionBufferSize > 0 && InternalTestHooks.WNetGetConnectionBufferSize <= MAX_PATH)
             {
                 bufferSize = InternalTestHooks.WNetGetConnectionBufferSize;
                 uncBuffer = uncBuffer.Slice(0, bufferSize);

--- a/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
+using System.Management.Automation.Internal;
 
 internal static partial class Interop
 {
@@ -24,15 +25,14 @@ internal static partial class Interop
                 return ERROR_NOT_SUPPORTED;
             }
 
-#if DEBUG
-            int testBufferSize = System.Management.Automation.Internal.InternalTestHooks.WNetGetConnectionBufferSize;
-            int bufferSize = testBufferSize == 0 ? MAX_PATH : testBufferSize;
-#else
-            int bufferSize = MAX_PATH;
-#endif
-
             ReadOnlySpan<char> driveName = stackalloc char[] { drive, ':', '\0' };
+            int bufferSize = MAX_PATH;
             Span<char> uncBuffer = stackalloc char[bufferSize];
+            if (InternalTestHooks.WNetGetConnectionBufferSize > 0)
+            {
+                bufferSize = InternalTestHooks.WNetGetConnectionBufferSize;
+                uncBuffer = uncBuffer.Slice(0, bufferSize);
+            }
 
             char[]? rentedArray = null;
             while (true)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1610,7 +1610,7 @@ namespace System.Management.Automation.Internal
         internal static string OneDriveTestSymlinkName = "link-Beta";
 
         // Test out smaller connection buffer size when calling WNetGetConnection.
-        internal static int WNetGetConnectionBufferSize;
+        internal static int WNetGetConnectionBufferSize = -1;
 
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1609,6 +1609,9 @@ namespace System.Management.Automation.Internal
         internal static bool OneDriveTestRecurseOn;
         internal static string OneDriveTestSymlinkName = "link-Beta";
 
+        // Test out smaller connection buffer size when calling WNetGetConnection.
+        internal static int WNetGetConnectionBufferSize;
+
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
@@ -66,7 +66,7 @@ Describe "Temp: drive" -Tag Feature {
     }
 }
 
-Describe "Get-PSDrive for network path" -Tags "Feature","RequireAdminOnWindows" {
+Describe "Get-PSDrive for network path" -Tags "CI","RequireAdminOnWindows" {
 
     It 'Check P/Invoke GetDosDevice/QueryDosDevice' -Skip:(-not $IsWindows) {
         $UsedDrives  = Get-PSDrive | Select-Object -ExpandProperty Name
@@ -77,5 +77,40 @@ Describe "Get-PSDrive for network path" -Tags "Feature","RequireAdminOnWindows" 
         $drive = Get-PSDrive $PSDriveName
         $drive.DisplayRoot | Should -BeExactly '\\localhost\c$\Windows'
         subst "$($PSDriveName):" /D
+    }
+
+    It 'Check P/Invoke for WNetGetConnection with small buffer <SmallBuffer>' -Skip:(-not $IsWindows) -TestCases @(
+        @{ SmallBuffer = $false }
+        @{ SmallBuffer = $true }
+    ) {
+        param ($SmallBuffer)
+
+        $UsedDrives  = Get-PSDrive | Select-Object -ExpandProperty Name
+        $PSDriveName = 'D'..'Z' | Where-Object -FilterScript {$_ -notin $UsedDrives} | Get-Random
+
+        $drive = New-PSDrive -Name $PSDriveName -PSProvider FileSystem -Root \\localhost\c$\Windows -Persist
+        try {
+            if ($SmallBuffer) {
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('WNetGetConnectionBufferSize', 4)
+            }
+
+            # The result is cached in the current instance, use a new
+            # PowerShell instance to test out WNetGetConnection code.
+            $ps = [PowerShell]::Create()
+            $actual = $ps.AddCommand('Get-PSDrive').AddParameter('Name', $PSDriveName).Invoke()
+            if ($ps.HadErrors) {
+                throw $ps.Streams.Error[0]
+            }
+
+            $actual.Name | Should -BeExactly $PSDriveName
+            $actual.DisplayRoot | Should -BeExactly '\\localhost\c$\Windows'
+        }
+        finally {
+            $drive | Remove-PSDrive
+
+            if ($SmallBuffer) {
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('WNetGetConnectionBufferSize', 0)
+            }
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
@@ -79,7 +79,7 @@ Describe "Get-PSDrive for network path" -Tags "CI","RequireAdminOnWindows" {
         subst "$($PSDriveName):" /D
     }
 
-    It 'Check P/Invoke for WNetGetConnection with small buffer <SmallBuffer>' -Skip:(-not $IsWindows) -TestCases @(
+    It 'Check P/Invoke for WNetGetConnection with small buffer: <SmallBuffer>' -Skip:(-not $IsWindows) -TestCases @(
         @{ SmallBuffer = $false }
         @{ SmallBuffer = $true }
     ) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
@@ -109,7 +109,7 @@ Describe "Get-PSDrive for network path" -Tags "CI","RequireAdminOnWindows" {
             $drive | Remove-PSDrive
 
             if ($SmallBuffer) {
-                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('WNetGetConnectionBufferSize', 0)
+                [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('WNetGetConnectionBufferSize', -1)
             }
         }
     }


### PR DESCRIPTION
# PR Summary
Fixes the logic used when getting the PSDrive DisplayRoot for network PSDrive paths to exclude null terminators.

## PR Context
2nd attempt at fixes: https://github.com/PowerShell/PowerShell/issues/21064. Original was https://github.com/PowerShell/PowerShell/pull/21068.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
