### PR TITLE
Use absolute path in `FileSystemProvider.CreateDirectory`

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2666,12 +2666,6 @@ namespace Microsoft.PowerShell.Commands
                 !string.IsNullOrEmpty(path),
                 "The caller should verify path");
 
-            // Get the parent path
-            string parentPath = GetParentPath(path, null);
-
-            // The directory name
-            string childName = GetChildName(path);
-
             ErrorRecord error = null;
             if (!Force && ItemExists(path, out error))
             {
@@ -2701,7 +2695,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (ShouldProcess(resource, action))
                 {
-                    var result = Directory.CreateDirectory(Path.Combine(parentPath, childName));
+                    var result = Directory.CreateDirectory(path);
 
                     if (streamOutput)
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1207,8 +1207,9 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
 
         It "Verify Directory creation when path relative to current PSDrive is empty" {
             try {
-                New-Item "NewDirectory" -ItemType Directory -Force
-                $newPSDrive = New-PSDrive -Name "NewPSDrive" -PSProvider FileSystem -Root "NewDirectory"
+                $rootDir = New-Item "NewDirectory" -ItemType Directory -Force
+                $rootPath = $rootDir.FullName
+                $newPSDrive = New-PSDrive -Name "NewPSDrive" -PSProvider FileSystem -Root $rootPath
 
                 $result = New-Item -Path "NewPSDrive:\" -ItemType Directory -Force
                 $result.FullName.TrimEnd("/\") | Should -BeExactly $newPSDrive.Root

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1205,6 +1205,11 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $result.Name | Should -BeExactly $testDir
         }
 
+        It "Verify Provider Root Directory + Force" {
+            $result = New-Item -Path . -ItemType Directory -Force
+            $result.FullName.TrimEnd('/\') | Should -BeExactly "$TestDrive"
+        }
+
         It "Verify File + Value" {
             $result = New-Item -Path . -ItemType File -Name $testFile -Value "Some String"
             $content = Get-Content -Path $testFile

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1206,8 +1206,16 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
         }
 
         It "Verify Provider Root Directory + Force" {
-            $result = New-Item -Path . -ItemType Directory -Force
-            $result.FullName.TrimEnd('/\') | Should -BeExactly "$TestDrive"
+            try {
+                New-Item "NewDirectory" -ItemType Directory -Force
+                $newPSDrive = New-PSDrive -Name "NewPSDrive" -PSProvider FileSystem -Root "NewDirectory"
+
+                $result = New-Item -Path "NewPSDrive:\" -ItemType Directory -Force
+                $result.FullName.TrimEnd("/\") | Should -BeExactly $newPSDrive.Root
+            }
+            finally {
+                Remove-PSDrive -Name "NewPSDrive" -Force -ErrorAction SilentlyContinue
+            }
         }
 
         It "Verify File + Value" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1205,7 +1205,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $result.Name | Should -BeExactly $testDir
         }
 
-        It "Verify Provider Root Directory + Force" {
+        It "Verify Directory creation when path relative to current PSDrive is empty" {
             try {
                 New-Item "NewDirectory" -ItemType Directory -Force
                 $newPSDrive = New-PSDrive -Name "NewPSDrive" -PSProvider FileSystem -Root "NewDirectory"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Remove unnecessary path split in `FileSystemProvider.CreateDirectory` because those parts are not used anywhere and ultimately end up being combined again for the `Directory.CreateDirectory` call.

## PR Context

Fixes https://github.com/pester/Pester/issues/2258 :

> When invoking the New-Item cmdlet with a path of TestDrive:\ -Force during a test, a new folder in the current working directory with the name of the guid of the TestDrive: provider is created.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  -  Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
