### PR TITLE
Dynamically evaluate width of LastWriteTime for formatting output on Unix

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
@@ -49,20 +49,10 @@ namespace System.Management.Automation.Runspaces
                     .AddHeader(Alignment.Left, label: "UnixMode", width: 10)
                     .AddHeader(Alignment.Right, label: "User", width: 10)
                     .AddHeader(Alignment.Left, label: "Group", width: 10)
-                    // Until LastWriteTime prints as '{0:d} {0:HH}:{0:mm}', it will always be ShortDatePattern + 6 wide.
-                    // Some locale's ShortDatePattern don't trivially relate to the length of the serialized date string.
-                    // Some patterns only have a single day or month designator but will likely take 2 characters, and
-                    // some even have era designators in their ShortDatePattern, which we take the length of and 1 extra
-                    // for a space character. The Fixed 6 comes from the time suffix, eg. " 23:59".
-                    // https://github.com/PowerShell/PowerShell/issues/19723
                     .AddHeader(
                         Alignment.Right,
                         label: "LastWriteTime",
-                        width: CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.Length +
-                            (CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.AsSpan().Count('d') == 1 ? 1 : 0) +
-                            (CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.AsSpan().Count('M') == 1 ? 1 : 0) +
-                            (CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.AsSpan().Count('g') == 1 ? 1 + CultureInfo.CurrentCulture.DateTimeFormat.GetEraName(1).Length : 0) +
-                            6)
+                        width: String.Format(CultureInfo.CurrentCulture, "{0:d} {0:HH}:{0:mm}", CultureInfo.CurrentCulture.Calendar.MaxSupportedDateTime).Length)
                     .AddHeader(Alignment.Right, label: "Size", width: 12)
                     .AddHeader(Alignment.Left, label: "Name")
                     .StartRowDefinition(wrap: true)

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace System.Management.Automation.Runspaces
 {
@@ -48,7 +49,9 @@ namespace System.Management.Automation.Runspaces
                     .AddHeader(Alignment.Left, label: "UnixMode", width: 10)
                     .AddHeader(Alignment.Right, label: "User", width: 10)
                     .AddHeader(Alignment.Left, label: "Group", width: 10)
-                    .AddHeader(Alignment.Right, label: "LastWriteTime", width: 16)
+                    // Until LastWriteTime prints as '{0:d} {0:HH}:{0:mm}', it will always be local date + 6 wide.
+                    // https://github.com/PowerShell/PowerShell/issues/19723
+                    .AddHeader(Alignment.Right, label: "LastWriteTime", width: CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.Length + 6)
                     .AddHeader(Alignment.Right, label: "Size", width: 12)
                     .AddHeader(Alignment.Left, label: "Name")
                     .StartRowDefinition(wrap: true)

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/FileSystem_format_ps1xml.cs
@@ -49,9 +49,20 @@ namespace System.Management.Automation.Runspaces
                     .AddHeader(Alignment.Left, label: "UnixMode", width: 10)
                     .AddHeader(Alignment.Right, label: "User", width: 10)
                     .AddHeader(Alignment.Left, label: "Group", width: 10)
-                    // Until LastWriteTime prints as '{0:d} {0:HH}:{0:mm}', it will always be local date + 6 wide.
+                    // Until LastWriteTime prints as '{0:d} {0:HH}:{0:mm}', it will always be ShortDatePattern + 6 wide.
+                    // Some locale's ShortDatePattern don't trivially relate to the length of the serialized date string.
+                    // Some patterns only have a single day or month designator but will likely take 2 characters, and
+                    // some even have era designators in their ShortDatePattern, which we take the length of and 1 extra
+                    // for a space character. The Fixed 6 comes from the time suffix, eg. " 23:59".
                     // https://github.com/PowerShell/PowerShell/issues/19723
-                    .AddHeader(Alignment.Right, label: "LastWriteTime", width: CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.Length + 6)
+                    .AddHeader(
+                        Alignment.Right,
+                        label: "LastWriteTime",
+                        width: CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.Length +
+                            (CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.AsSpan().Count('d') == 1 ? 1 : 0) +
+                            (CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.AsSpan().Count('M') == 1 ? 1 : 0) +
+                            (CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern.AsSpan().Count('g') == 1 ? 1 + CultureInfo.CurrentCulture.DateTimeFormat.GetEraName(1).Length : 0) +
+                            6)
                     .AddHeader(Alignment.Right, label: "Size", width: 12)
                     .AddHeader(Alignment.Left, label: "Name")
                     .StartRowDefinition(wrap: true)


### PR DESCRIPTION
# PR Summary

Fixes #19723 

As per @iSazonov 's request, here is a screenshot of some output freom before and after the PR in en-US and a few trickier locales, including the motivating hu-HU locale. The table width visibly adapts to the time format length.

<img width="1459" height="948" alt="image" src="https://github.com/user-attachments/assets/05488d7b-dd57-4d02-85d9-a2b53343b885" />

## PR Context

The issue which was unresolved has since been aggravated by another PR #18183. This PR adds the required characters to the LastWriteTime column to make it render correctly on all locales.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
