### PR TITLE
Deploy Box Update

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -110,17 +110,14 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
-    - stage: DownloadPackages
-      displayName: 'Download Packages'
-      dependsOn: []
+    - stage: setReleaseTagAndUploadTools
+      displayName: 'Set Release Tag and Upload Tools'
       jobs:
-      - template: /.pipelines/templates/release-download-packages.yml@self
+      - template: /.pipelines/templates/release-SetTagAndTools.yml@self
 
     - stage: msixbundle
       displayName: 'Create MSIX Bundle'
       dependsOn: []
-      variables:
-        ob_release_environment: Test
       jobs:
       - template: /.pipelines/templates/release-create-msix.yml@self
 
@@ -278,7 +275,7 @@ extends:
     - stage: PublishGitHubRelease
       displayName: Publish GitHub Release
       dependsOn: 
-        - DownloadPackages
+        - setReleaseTagAndUploadTools
         - UpdateChangeLog
       variables:
         ob_release_environment: Production
@@ -316,7 +313,9 @@ extends:
   
     - stage: PublishNuGet
       displayName: Publish NuGet
-      dependsOn: PushGitTagAndMakeDraftPublic
+      dependsOn:
+        - setReleaseTagAndUploadTools
+        - PushGitTagAndMakeDraftPublic
       variables:
         ob_release_environment: Production
       jobs:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -77,7 +77,7 @@ resources:
             - releases/*
 
 extends:
-  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
   parameters:
     release: 
       category: NonAzure
@@ -110,17 +110,14 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
-    - stage: DownloadPackages
-      displayName: 'Download Packages'
-      dependsOn: []
+    - stage: setReleaseTagAndUploadTools
+      displayName: 'Set Release Tag and Upload Tools'
       jobs:
-      - template: /.pipelines/templates/release-download-packages.yml@self
+      - template: /.pipelines/templates/release-SetTagAndTools.yml@self
 
     - stage: msixbundle
       displayName: 'Create MSIX Bundle'
       dependsOn: []
-      variables:
-        ob_release_environment: Test
       jobs:
       - template: /.pipelines/templates/release-create-msix.yml@self
 
@@ -278,10 +275,10 @@ extends:
     - stage: PublishGitHubRelease
       displayName: Publish GitHub Release
       dependsOn: 
-        - DownloadPackages
+        - setReleaseTagAndUploadTools
         - UpdateChangeLog
       variables:
-        ob_release_environment: Production
+        ob_release_environment: Test
       jobs:
       - template: /.pipelines/templates/release-githubtasks.yml@self
     
@@ -316,9 +313,11 @@ extends:
   
     - stage: PublishNuGet
       displayName: Publish NuGet
-      dependsOn: PushGitTagAndMakeDraftPublic
+      dependsOn:
+        - setReleaseTagAndUploadTools
+        - PushGitTagAndMakeDraftPublic
       variables:
-        ob_release_environment: Production
+        ob_release_environment: Test
       jobs:
       - template: /.pipelines/templates/release-publish-nuget.yml@self
         parameters:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -81,7 +81,7 @@ resources:
             - releases/*
 
 extends:
-  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
+  template: v2/OneBranch.Official.CrossPlat.yml@templates
   parameters:
     release: 
       category: NonAzure
@@ -282,7 +282,7 @@ extends:
         - setReleaseTagAndUploadTools
         - UpdateChangeLog
       variables:
-        ob_release_environment: Test
+        ob_release_environment: Production
       jobs:
       - template: /.pipelines/templates/release-githubtasks.yml@self
     
@@ -321,7 +321,7 @@ extends:
         - setReleaseTagAndUploadTools
         - PushGitTagAndMakeDraftPublic
       variables:
-        ob_release_environment: Test
+        ob_release_environment: Production
       jobs:
       - template: /.pipelines/templates/release-publish-nuget.yml@self
         parameters:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -63,6 +63,10 @@ resources:
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
+    - repository: PSInternalTools
+      type: git
+      name: PowerShellCore/Internal-PowerShellTeam-Tools
+      ref: refs/heads/master
 
   pipelines:
     - pipeline: CoOrdinatedBuildPipeline

--- a/.pipelines/templates/release-SetReleaseTagandContainerName.yml
+++ b/.pipelines/templates/release-SetReleaseTagandContainerName.yml
@@ -8,9 +8,10 @@ steps:
     }
 
     $releaseTag = $Branch -replace '^.*((release|rebuild)/)'
-    $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
+    $vstsCommandString = "vso[task.setvariable variable=$Variable;isOutput=true]$releaseTag"
     Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
     Write-Host -Object "##$vstsCommandString"
+  name: OutputReleaseTag
   displayName: Set Release Tag
 
 - pwsh: |
@@ -20,7 +21,8 @@ steps:
     Write-Host "##$vstsCommandString"
 
     $version = '$(ReleaseTag)'.ToLowerInvariant().Substring(1)
-    $vstsCommandString = "vso[task.setvariable variable=Version]$version"
+    $vstsCommandString = "vso[task.setvariable variable=Version;isOutput=true]$version"
     Write-Host ("sending " + $vstsCommandString)
     Write-Host "##$vstsCommandString"
+  name: OutputVersion
   displayName: Set container name

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -18,7 +18,7 @@ jobs:
   - pwsh: |
       New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
       Get-ChildItem -Path '$(Pipeline.Workspace)/tools/Scripts' -Recurse -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
-        Copy-Item -Destination '$(Pipeline.Workspace)'
+        Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact'
       
       Write-Verbose -Verbose "The tools will be signed and uploaded to artifacts: "
       Get-ChildItem -Path '$(Pipeline.Workspace)/ToolArtifact' -Recurse |

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -60,6 +60,7 @@ jobs:
 
       $filePath = "$(REPOROOT)/PowerShell/CHANGELOG/$fileName"
       Write-Verbose -Verbose "Selected Log file: $filePath"
+      Get-ChildItem -Path $(REPOROOT) -Recurse | Out-String -Stream | Write-Verbose -Verbose
       
       Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
       New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -44,7 +44,9 @@ jobs:
     displayName: Upload Tools
   
   - pwsh: |
+      Write-Verbose -Verbose "Release Tag: $(ReleaseTag)"
       $releaseVersion = '$(ReleaseTag)' -replace '^v',''
+      Write-Verbose -Verbose "Release Version: $releaseVersion"
       $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
 
       $isPreview = $semanticVersion.PreReleaseLabel -ne $null

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -44,8 +44,8 @@ jobs:
     displayName: Upload Tools
   
   - pwsh: |
-      Write-Verbose -Verbose "Release Tag: $(ReleaseTag)"
-      $releaseVersion = '$(ReleaseTag)' -replace '^v',''
+      Write-Verbose -Verbose "Release Tag: $(OutputReleaseTag.releaseTag)"
+      $releaseVersion = '$(OutputReleaseTag.releaseTag)' -replace '^v',''
       Write-Verbose -Verbose "Release Version: $releaseVersion"
       $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
 

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -42,3 +42,24 @@ jobs:
         ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
         Copy-Item -Destination $(ob_outputDirectory)/ToolArtifact -Recurse
     displayName: Upload Tools
+  
+  - pwsh: |
+      $releaseVersion = '$(ReleaseTag)' -replace '^v',''
+      $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
+
+      $isPreview = $semanticVersion.PreReleaseLabel -ne $null
+
+      $fileName = if ($isPreview) {
+        "preview.md"
+      }
+      else {
+        $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
+      }
+
+      $filePath = "$(REPOROOT)/PowerShell/CHANGELOG/$fileName"
+      Write-Verbose -Verbose "Selected Log file: $filePath"
+      
+      Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
+      New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force
+      Copy-Item -Path $filePath -Destination $(ob_outputDirectory)/CHANGELOG
+    displayName: Upload Changelog

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -58,9 +58,8 @@ jobs:
         $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
       }
 
-      $filePath = "$(REPOROOT)/PowerShell/CHANGELOG/$fileName"
+      $filePath = "$(REPOROOT)/CHANGELOG/$fileName"
       Write-Verbose -Verbose "Selected Log file: $filePath"
-      Get-ChildItem -Path $(REPOROOT) -Recurse | Out-String -Stream | Write-Verbose -Verbose
       
       Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
       New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -5,6 +5,7 @@ jobs:
   pool:
     type: windows
   variables:
+  - group: 'mscodehub-code-read-akv'
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   steps:

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -13,13 +13,13 @@ jobs:
 
   - checkout: self
     clean: true
-    path: $(Build.SourcesDirectory)/PowerShell
+    path: PowerShell
     env:
       ob_restore_phase: true
 
   - checkout: PSInternalTools
     clean: true
-    path: $(Build.SourcesDirectory)/tools
+    path: tools
     env:
       ob_restore_phase: true
 

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -13,19 +13,19 @@ jobs:
 
   - checkout: self
     clean: true
-    path: $(Pipeline.Workspace)/PowerShell
+    path: $(Build.SourcesDirectory)/PowerShell
     env:
       ob_restore_phase: true
 
   - checkout: PSInternalTools
     clean: true
-    path: $(Pipeline.Workspace)/tools
+    path: $(Build.SourcesDirectory)/tools
     env:
       ob_restore_phase: true
 
   - pwsh: |
       New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
-      Get-ChildItem -Path '$(Pipeline.Workspace)/tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
+      Get-ChildItem -Path '$(Build.SourcesDirectory)/tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
         Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact' -Verbose
     displayName: Move GitHub Tool
 
@@ -59,7 +59,7 @@ jobs:
         $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
       }
 
-      $filePath = "$(Pipeline.Workspace)/PowerShell/CHANGELOG/$fileName"
+      $filePath = "$(Build.SourcesDirectory)/PowerShell/CHANGELOG/$fileName"
       Write-Verbose -Verbose "Selected Log file: $filePath"
 
       if (-not (Test-Path -Path $filePath)) {

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -17,7 +17,7 @@ jobs:
 
   - pwsh: |
       New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
-      Get-ChildItem -Path '$(Pipeline.Workspace)/tools/Scripts' -Recurse -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
+      Get-ChildItem -Path '$(Pipeline.Workspace)/tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
         Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact'
       
       Write-Verbose -Verbose "The tools will be signed and uploaded to artifacts: "
@@ -36,6 +36,9 @@ jobs:
       search_root: '$(Pipeline.Workspace)/ToolArtifact'
 
   - pwsh: | 
-      Write-Verbose -Verbose "Uploading signed tools to $(ob_outputDirectory)"
-      Copy-Item -Path '$(Pipeline.Workspace)/ToolArtifact' -Destination '$(ob_outputDirectory)' -Force -Verbose
+      Write-Verbose -Verbose "Creating output directory for release tools: $(ob_outputDirectory)/ToolArtifact"
+      New-Item -Path $(ob_outputDirectory)/ToolArtifact -ItemType Directory -Force
+      Get-ChildItem -Path "$(Pipeline.Workspace)/ToolArtifact/*" -Recurse | 
+        ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
+        Copy-Item -Destination $(ob_outputDirectory)/ToolArtifact -Recurse
     displayName: Upload Tools

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -1,0 +1,37 @@
+jobs:
+- job: SetTagAndTools
+  displayName: Set Tag and Tools
+  condition: succeeded()
+  pool:
+    type: windows
+  steps:
+  - template: release-SetReleaseTagandContainerName.yml@self
+
+  - pwsh: |
+      git clone --depth 1 https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
+    displayName: Clone Internal-Tools repository
+
+  - pwsh: |
+      New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
+      Get-ChildItem -Path '$(Pipeline.Workspace)/tools/Scripts' -Recurse -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
+        Copy-Item -Destination '$(Pipeline.Workspace)'
+      
+      Write-Verbose -Verbose "The tools will be signed and uploaded to artifacts: "
+      Get-ChildItem -Path '$(Pipeline.Workspace)/ToolArtifact' -Recurse |
+        ForEach-Object {
+          Write-Verbose -Verbose $_.FullName
+        }
+    displayName: Move GitHub Tool
+
+  - task: onebranch.pipeline.signing@1
+    displayName: Sign Tools
+    inputs:
+      command: 'sign'
+      signing_profile: internal_azure_service
+      files_to_sign: '*.ps1;*.psm1'
+      search_root: '$(Pipeline.Workspace)/ToolArtifact'
+
+  - pwsh: | 
+      Write-Verbose -Verbose "Uploading signed tools to $(ob_outputDirectory)"
+      Copy-Item -Path '$(Pipeline.Workspace)/ToolArtifact' -Destination '$(ob_outputDirectory)' -Force -Verbose
+    displayName: Upload Tools

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -4,6 +4,9 @@ jobs:
   condition: succeeded()
   pool:
     type: windows
+  variables:
+  - name: ob_outputDirectory
+    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   steps:
   - template: release-SetReleaseTagandContainerName.yml@self
 

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -13,13 +13,11 @@ jobs:
 
   - checkout: self
     clean: true
-    path: PowerShell
     env:
       ob_restore_phase: true
 
   - checkout: PSInternalTools
     clean: true
-    path: tools
     env:
       ob_restore_phase: true
 

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -11,9 +11,17 @@ jobs:
   steps:
   - template: release-SetReleaseTagandContainerName.yml@self
 
-  - pwsh: |
-      git clone --depth 1 https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
-    displayName: Clone Internal-Tools repository
+  - checkout: self
+    clean: true
+    path: $(Pipeline.Workspace)/PowerShell
+    env:
+      ob_restore_phase: true
+
+  - checkout: PSInternalTools
+    clean: true
+    path: $(Pipeline.Workspace)/tools
+    env:
+      ob_restore_phase: true
 
   - pwsh: |
       New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
@@ -51,8 +59,13 @@ jobs:
         $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
       }
 
-      $filePath = "$(REPOROOT)/CHANGELOG/$fileName"
+      $filePath = "$(Pipeline.Workspace)/PowerShell/CHANGELOG/$fileName"
       Write-Verbose -Verbose "Selected Log file: $filePath"
+
+      if (-not (Test-Path -Path $filePath)) {
+        Write-Error "Changelog file not found: $filePath"
+        exit 1
+      }
       
       Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
       New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -27,7 +27,7 @@ jobs:
 
   - pwsh: |
       New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
-      Get-ChildItem -Path '$(Build.SourcesDirectory)/tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
+      Get-ChildItem -Path '$(Build.SourcesDirectory)/Internal-PowerShellTeam-Tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
         Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact' -Verbose
     displayName: Move GitHub Tool
 

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -8,6 +8,10 @@ jobs:
   - group: 'mscodehub-code-read-akv'
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+  - name: ob_sdl_credscan_suppressionsFile
+    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+  - name: ob_sdl_tsa_configFile
+    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
   steps:
   - template: release-SetReleaseTagandContainerName.yml@self
 

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -1,0 +1,67 @@
+jobs:
+- job: SetTagAndTools
+  displayName: Set Tag and Tools
+  condition: succeeded()
+  pool:
+    type: windows
+  variables:
+  - group: 'mscodehub-code-read-akv'
+  - name: ob_outputDirectory
+    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+  steps:
+  - template: release-SetReleaseTagandContainerName.yml@self
+
+  - pwsh: |
+      git clone --depth 1 https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
+    displayName: Clone Internal-Tools repository
+
+  - pwsh: |
+      New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
+      Get-ChildItem -Path '$(Pipeline.Workspace)/tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
+        Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact'
+      
+      Write-Verbose -Verbose "The tools will be signed and uploaded to artifacts: "
+      Get-ChildItem -Path '$(Pipeline.Workspace)/ToolArtifact' -Recurse |
+        ForEach-Object {
+          Write-Verbose -Verbose $_.FullName
+        }
+    displayName: Move GitHub Tool
+
+  - task: onebranch.pipeline.signing@1
+    displayName: Sign Tools
+    inputs:
+      command: 'sign'
+      signing_profile: internal_azure_service
+      files_to_sign: '*.ps1;*.psm1'
+      search_root: '$(Pipeline.Workspace)/ToolArtifact'
+
+  - pwsh: | 
+      Write-Verbose -Verbose "Creating output directory for release tools: $(ob_outputDirectory)/ToolArtifact"
+      New-Item -Path $(ob_outputDirectory)/ToolArtifact -ItemType Directory -Force
+      Get-ChildItem -Path "$(Pipeline.Workspace)/ToolArtifact/*" -Recurse | 
+        ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
+        Copy-Item -Destination $(ob_outputDirectory)/ToolArtifact -Recurse
+    displayName: Upload Tools
+  
+  - pwsh: |
+      Write-Verbose -Verbose "Release Tag: $(OutputReleaseTag.releaseTag)"
+      $releaseVersion = '$(OutputReleaseTag.releaseTag)' -replace '^v',''
+      Write-Verbose -Verbose "Release Version: $releaseVersion"
+      $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
+
+      $isPreview = $semanticVersion.PreReleaseLabel -ne $null
+
+      $fileName = if ($isPreview) {
+        "preview.md"
+      }
+      else {
+        $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
+      }
+
+      $filePath = "$(REPOROOT)/CHANGELOG/$fileName"
+      Write-Verbose -Verbose "Selected Log file: $filePath"
+      
+      Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
+      New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force
+      Copy-Item -Path $filePath -Destination $(ob_outputDirectory)/CHANGELOG
+    displayName: Upload Changelog

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -18,13 +18,7 @@ jobs:
   - pwsh: |
       New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
       Get-ChildItem -Path '$(Pipeline.Workspace)/tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
-        Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact'
-      
-      Write-Verbose -Verbose "The tools will be signed and uploaded to artifacts: "
-      Get-ChildItem -Path '$(Pipeline.Workspace)/ToolArtifact' -Recurse |
-        ForEach-Object {
-          Write-Verbose -Verbose $_.FullName
-        }
+        Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact' -Verbose
     displayName: Move GitHub Tool
 
   - task: onebranch.pipeline.signing@1
@@ -39,8 +33,7 @@ jobs:
       Write-Verbose -Verbose "Creating output directory for release tools: $(ob_outputDirectory)/ToolArtifact"
       New-Item -Path $(ob_outputDirectory)/ToolArtifact -ItemType Directory -Force
       Get-ChildItem -Path "$(Pipeline.Workspace)/ToolArtifact/*" -Recurse | 
-        ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
-        Copy-Item -Destination $(ob_outputDirectory)/ToolArtifact -Recurse
+        Copy-Item -Destination $(ob_outputDirectory)/ToolArtifact -Recurse -Verbose
     displayName: Upload Tools
   
   - pwsh: |

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -63,20 +63,10 @@ jobs:
       pwsh: true
       script: |
         Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
-        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-        $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
-  
-        $isPreview = $semanticVersion.PreReleaseLabel -ne $null
-  
-        $fileName = if ($isPreview) {
-          "preview.md"
-        }
-        else {
-          $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
-        }
-  
-        $filePath = "$(Pipeline.Workspace)/PowerShell/CHANGELOG/$fileName"
-        Write-Verbose -Verbose "Selected Log file: $filePath"
+        Write-Verbose -Verbose "Available modules: "
+        Get-Module | Write-Verbose -Verbose
+
+        $filePath = Get-ChildItem -Path "$(Pipeline.Workspace)/CHANGELOG" -Filter '*.md' | Select-Object -First 1 -ExpandProperty FullName
   
         if (-not (Test-Path $filePath)) {
           throw "$filePath not found"

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -8,23 +8,22 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        artifactName: drop_DownloadPackages_upload_packages
+        artifactName: drop_upload_upload_packages
   variables:
-  - template: ./variable/release-shared.yml@self
+    - template: ./variable/release-shared.yml@self
+      parameters:
+        RELEASETAG: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputReleaseTag.releaseTag'] ]
 
   steps:
   - task: PowerShell@2
     inputs:
       targetType: inline
       script: |
+        Write-Verbose -Verbose "Release Tag: $(ReleaseTag)"
         Get-ChildItem Env: | Out-String -Stream | write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
   - template: release-install-pwsh.yml
-
-  - template: release-checkout-pwsh-repo.yml
-
-  - template: release-SetReleaseTagAndContainerName.yml
 
   - task: PowerShell@2
     inputs:
@@ -54,17 +53,6 @@ jobs:
         $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
         Write-Verbose -Verbose -Message $fileContent
     displayName: Add sha256 hashes
-
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      pwsh: true
-      script: |
-        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-        $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
-        Write-Host "sending " + $vstsCommandString
-        Write-Host "##$vstsCommandString"
-    displayName: 'Set release version'
   
   - task: PowerShell@2
     inputs:

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -8,6 +8,9 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
+        artifactName: drop_setReleaseTagAndUploadTools_SetTagAndTools
+      - input: pipelineArtifact
+        pipeline: 'PowerShell-Packages-Official'
         artifactName: drop_upload_upload_packages
   variables:
     - template: ./variable/release-shared.yml@self
@@ -67,7 +70,7 @@ jobs:
       targetType: inline
       pwsh: true
       script: |
-        Import-module '$(Pipeline.Workspace)/tools/Scripts/GitHubRelease.psm1'
+        Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
         $releaseVersion = '$(ReleaseTag)' -replace '^v',''
         $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
   

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -33,14 +33,6 @@ jobs:
       targetType: inline
       pwsh: true
       script: |
-        git clone --depth 1 https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
-    displayName: Clone Internal-Tools repository
-
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      pwsh: true
-      script: |
         $Path = "$(Pipeline.Workspace)/GitHubPackages"
         $OutputPath = Join-Path $Path 'hashes.sha256'
         $packages  = Get-ChildItem -Path $Path -Include * -Recurse -File

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -23,7 +23,7 @@ jobs:
       targetType: inline
       script: |
         Write-Verbose -Verbose "Release Tag: $(ReleaseTag)"
-        Get-ChildItem Env: | Out-String -Stream | write-Verbose -Verbose
+        Get-ChildItem Env: | Out-String -Stream | Write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
   - template: release-install-pwsh.yml

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -8,31 +8,25 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        artifactName: drop_DownloadPackages_upload_packages
+        artifactName: drop_setReleaseTagAndUploadTools_SetTagAndTools
+      - input: pipelineArtifact
+        pipeline: PSPackagesOfficial
+        artifactName: drop_upload_upload_packages
   variables:
-  - template: ./variable/release-shared.yml@self
+    - template: ./variable/release-shared.yml@self
+      parameters:
+        RELEASETAG: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputReleaseTag.releaseTag'] ]
 
   steps:
   - task: PowerShell@2
     inputs:
       targetType: inline
       script: |
-        Get-ChildItem Env: | Out-String -Stream | write-Verbose -Verbose
+        Write-Verbose -Verbose "Release Tag: $(ReleaseTag)"
+        Get-ChildItem Env: | Out-String -Stream | Write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
   - template: release-install-pwsh.yml
-
-  - template: release-checkout-pwsh-repo.yml
-
-  - template: release-SetReleaseTagAndContainerName.yml
-
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      pwsh: true
-      script: |
-        git clone --depth 1 https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
-    displayName: Clone Internal-Tools repository
 
   - task: PowerShell@2
     inputs:
@@ -54,17 +48,6 @@ jobs:
         $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
         Write-Verbose -Verbose -Message $fileContent
     displayName: Add sha256 hashes
-
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      pwsh: true
-      script: |
-        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-        $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
-        Write-Host "sending " + $vstsCommandString
-        Write-Host "##$vstsCommandString"
-    displayName: 'Set release version'
   
   - task: PowerShell@2
     inputs:
@@ -79,21 +62,11 @@ jobs:
       targetType: inline
       pwsh: true
       script: |
-        Import-module '$(Pipeline.Workspace)/tools/Scripts/GitHubRelease.psm1'
-        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-        $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
-  
-        $isPreview = $semanticVersion.PreReleaseLabel -ne $null
-  
-        $fileName = if ($isPreview) {
-          "preview.md"
-        }
-        else {
-          $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
-        }
-  
-        $filePath = "$(Pipeline.Workspace)/PowerShell/CHANGELOG/$fileName"
-        Write-Verbose -Verbose "Selected Log file: $filePath"
+        Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
+        Write-Verbose -Verbose "Available modules: "
+        Get-Module | Write-Verbose -Verbose
+
+        $filePath = Get-ChildItem -Path "$(Pipeline.Workspace)/CHANGELOG" -Filter '*.md' | Select-Object -First 1 -ExpandProperty FullName
   
         if (-not (Test-Path $filePath)) {
           throw "$filePath not found"

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -10,7 +10,7 @@ jobs:
       - input: pipelineArtifact
         artifactName: drop_setReleaseTagAndUploadTools_SetTagAndTools
       - input: pipelineArtifact
-        pipeline: 'PowerShell-Packages-Official'
+        pipeline: PSPackagesOfficial
         artifactName: drop_upload_upload_packages
   variables:
     - template: ./variable/release-shared.yml@self

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -13,7 +13,7 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        pipeline: 'PowerShell-Packages-Official'
+        pipeline: PSPackagesOfficial
         artifactName: drop_upload_upload_packages
   variables:
   - template: ./variable/release-shared.yml@self

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -13,19 +13,17 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        artifactName: drop_DownloadPackages_upload_packages
-
+        artifactName: drop_upload_upload_packages
   variables:
   - template: ./variable/release-shared.yml@self
+    parameters:
+      VERSION: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputVersion.Version'] ]
 
   steps:
   - template: release-install-pwsh.yml
 
-  - template: release-checkout-pwsh-repo.yml
-
-  - template: release-SetReleaseTagAndContainerName.yml
-
   - pwsh: |
+      Write-Verbose -Verbose "Version: $(Version)"
       Get-ChildItem Env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
@@ -34,7 +32,7 @@ jobs:
       $null = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/release"
       Copy-Item "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -Destination "$(Pipeline.Workspace)/release" -Exclude "PowerShell.*.nupkg" -Force -Verbose
 
-      $releaseVersion = '$(VERSION)'
+      $releaseVersion = '$(Version)'
       $globalToolPath = "$(Pipeline.Workspace)/NuGetPackages/PowerShell.$releaseVersion.nupkg"
 
       if ($releaseVersion -notlike '*-*') {

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -13,6 +13,7 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
+        pipeline: 'PowerShell-Packages-Official'
         artifactName: drop_upload_upload_packages
   variables:
   - template: ./variable/release-shared.yml@self

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -13,19 +13,18 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        artifactName: drop_DownloadPackages_upload_packages
-
+        pipeline: 'PowerShell-Packages-Official'
+        artifactName: drop_upload_upload_packages
   variables:
   - template: ./variable/release-shared.yml@self
+    parameters:
+      VERSION: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputVersion.Version'] ]
 
   steps:
   - template: release-install-pwsh.yml
 
-  - template: release-checkout-pwsh-repo.yml
-
-  - template: release-SetReleaseTagAndContainerName.yml
-
   - pwsh: |
+      Write-Verbose -Verbose "Version: $(Version)"
       Get-ChildItem Env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
@@ -34,7 +33,7 @@ jobs:
       $null = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/release"
       Copy-Item "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -Destination "$(Pipeline.Workspace)/release" -Exclude "PowerShell.*.nupkg" -Force -Verbose
 
-      $releaseVersion = '$(VERSION)'
+      $releaseVersion = '$(Version)'
       $globalToolPath = "$(Pipeline.Workspace)/NuGetPackages/PowerShell.$releaseVersion.nupkg"
 
       if ($releaseVersion -notlike '*-*') {

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -23,7 +23,7 @@ jobs:
     displayName: Capture environment
 
   - pwsh: |
-      $name = "{0}_{1:x}" -f '$(releaseTag)', (Get-Date).Ticks
+      $name = "{0}_{1:x}" -f '$(OutputReleaseTag.releaseTag)', (Get-Date).Ticks
       Write-Host $name
       Write-Host "##vso[build.updatebuildnumber]$name"
     displayName: Set Release Name

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -235,23 +235,23 @@ jobs:
       Get-ChildItem '$(Build.ArtifactStagingDirectory)/downloads' | Select-Object -ExpandProperty FullName
     displayName: 'Capture downloads'
 
-  # - pwsh: |
-  #     Write-Verbose -Verbose "Copying Github Release files in $(Build.ArtifactStagingDirectory)/downloads to use in Release Pipeline"
-  #     
-  #     Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
-  #     New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
-  #     Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
-  #       Where-Object { $_.Extension -notin '.msix', '.nupkg' } | 
-  #       ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
-  #       Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse
-  #     
-  #     Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
-  #     New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
-  #     Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
-  #       Where-Object { $_.Extension -eq '.nupkg' } | 
-  #       ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
-  #       Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse
-  #   displayName: Copy downloads to Artifacts
+  - pwsh: |
+      Write-Verbose -Verbose "Copying Github Release files in $(Build.ArtifactStagingDirectory)/downloads to use in Release Pipeline"
+      
+      Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
+      New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
+        Where-Object { $_.Extension -notin '.msix', '.nupkg' } | 
+        ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
+        Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse
+      
+      Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
+      New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
+        Where-Object { $_.Extension -eq '.nupkg' } | 
+        ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
+        Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse
+    displayName: Copy downloads to Artifacts
 
   - pwsh: |
       # Create output directory for packages which have been uploaded to blob storage

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -242,15 +242,13 @@ jobs:
       New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
       Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
         Where-Object { $_.Extension -notin '.msix', '.nupkg' } | 
-        ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
-        Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse
+        Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse -Verbose
       
       Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
       New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
       Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
         Where-Object { $_.Extension -eq '.nupkg' } | 
-        ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
-        Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse
+        Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse -Verbose
     displayName: Copy downloads to Artifacts
 
   - pwsh: |

--- a/.pipelines/templates/variable/release-shared.yml
+++ b/.pipelines/templates/variable/release-shared.yml
@@ -5,6 +5,12 @@ parameters:
   - name: SBOM
     type: boolean
     default: false
+  - name: RELEASETAG
+    type: string
+    default: 'Not Initialized'
+  - name: VERSION
+    type: string
+    default: 'Not Initialized'
 
 variables:
   - name: ob_signing_setup_enabled            
@@ -30,3 +36,7 @@ variables:
     value: ${{ parameters.REPOROOT }}\.config\suppress.json
   - name: ob_sdl_codeql_compiled_enabled
     value: false
+  - name: ReleaseTag
+    value: ${{ parameters.RELEASETAG }}
+  - name: Version
+    value: ${{ parameters.VERSION }}


### PR DESCRIPTION
# PR Summary

This pull request includes significant updates to the PowerShell release pipeline configuration. The changes primarily focus on renaming stages, updating dependencies, and improving the handling of release tags and versions.

### Pipeline Configuration Updates:

* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL113-L123): Removed the temporary `DownloadPackages` stage and added the `setReleaseTagAndUploadTools` stage and updated the corresponding dependencies and templates. `setReleaseTagAndUploadTools` stage uploads the github release tool to artifacts and sets up the ReleaseTag and VErsoin variables to be used in the github stage and the nuget stage. [[1]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL113-L123) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL281-R278) [[3]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL319-R318)

### Template Modifications:

* [`.pipelines/templates/release-SetReleaseTagandContainerName.yml`](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L11-R14): Updated the PowerShell commands to set variables as output and added names for the outputs. [[1]](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L11-R14) [[2]](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L23-R27)
* [`.pipelines/templates/release-SetTagAndTools.yml`](diffhunk://#diff-b9e5aa1224d680253d023e9d9442a953d336c7484f3a7773398e7a230c5ded67R1-R67): Added a new template for setting the release tag and uploading tools, including steps for cloning repositories, signing tools, and uploading changelogs.

### Job Adjustments:

* [`.pipelines/templates/release-githubtasks.yml`](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L11-L36): Updated job definitions to use the new `setReleaseTagAndUploadTools` stage and removed redundant steps for setting release tags and versions. [[1]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L11-L36) [[2]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L58-L68) [[3]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L82-R69)
* [`.pipelines/templates/release-publish-nuget.yml`](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafL16-R27): Adjusted to use output variables from the `setReleaseTagAndUploadTools` stage and updated artifact names. [[1]](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafL16-R27) [[2]](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafL37-R36)

### Variable Enhancements:

* [`.pipelines/templates/variable/release-shared.yml`](diffhunk://#diff-2d644da01d1ced46893b1472b24bf6b86ae30db3517ecbe062d8b59ae976878cR8-R13): Added parameters and variables for `RELEASETAG` and `VERSION`. [[1]](diffhunk://#diff-2d644da01d1ced46893b1472b24bf6b86ae30db3517ecbe062d8b59ae976878cR8-R13) [[2]](diffhunk://#diff-2d644da01d1ced46893b1472b24bf6b86ae30db3517ecbe062d8b59ae976878cR39-R42)
## PR Context

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
