### PR TITLE
Issue#24586 Fixed Conversion of forward slashes to back slashes for converting registry path.

### DIFF
--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -901,9 +901,7 @@ namespace System.Management.Automation.Provider
                 }
             }
 
-            normalizedPath = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
-
-            return normalizedPath;
+            return path;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #24586 

Context: When trying to convert a registry path, if there are forward slashes in the path, such as 
HKLM:SYSTEM\CurrentControlSet\Control\Session Manager\I/O System, they are converted into back slashes. The new path would become HKLM:SYSTEM\CurrentControlSet\Control\Session Manager\I\O System. This path would be incorrect.

Fix: In NavigationProviderBase.cs, the function NormalizePath checks if the normalization of the path needs to be skipped. Despite checking if normalization needs to be skipped because the path has a mix of slashes and exists, the call normalizedPath = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator) is called at the end of the function anyway. The fix comments out this line and the next line return normalized path. Those lines are replaced with the line return path; This allows forward slashes to be in the path if needed instead of being converted.