### PR TITLE
[release/v7.5]Deploy Box Update

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -63,6 +63,10 @@ resources:
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
+    - repository: PSInternalTools
+      type: git
+      name: PowerShellCore/Internal-PowerShellTeam-Tools
+      ref: refs/heads/master
 
   pipelines:
     - pipeline: CoOrdinatedBuildPipeline
@@ -110,17 +114,14 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
-    - stage: DownloadPackages
-      displayName: 'Download Packages'
-      dependsOn: []
+    - stage: setReleaseTagAndUploadTools
+      displayName: 'Set Release Tag and Upload Tools'
       jobs:
-      - template: /.pipelines/templates/release-download-packages.yml@self
+      - template: /.pipelines/templates/release-SetTagAndTools.yml@self
 
     - stage: msixbundle
       displayName: 'Create MSIX Bundle'
       dependsOn: []
-      variables:
-        ob_release_environment: Test
       jobs:
       - template: /.pipelines/templates/release-create-msix.yml@self
 
@@ -278,7 +279,7 @@ extends:
     - stage: PublishGitHubRelease
       displayName: Publish GitHub Release
       dependsOn: 
-        - DownloadPackages
+        - setReleaseTagAndUploadTools
         - UpdateChangeLog
       variables:
         ob_release_environment: Production
@@ -316,7 +317,9 @@ extends:
   
     - stage: PublishNuGet
       displayName: Publish NuGet
-      dependsOn: PushGitTagAndMakeDraftPublic
+      dependsOn:
+        - setReleaseTagAndUploadTools
+        - PushGitTagAndMakeDraftPublic
       variables:
         ob_release_environment: Production
       jobs:

--- a/.pipelines/templates/release-SetReleaseTagandContainerName.yml
+++ b/.pipelines/templates/release-SetReleaseTagandContainerName.yml
@@ -8,9 +8,10 @@ steps:
     }
 
     $releaseTag = $Branch -replace '^.*((release|rebuild)/)'
-    $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
+    $vstsCommandString = "vso[task.setvariable variable=$Variable;isOutput=true]$releaseTag"
     Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
     Write-Host -Object "##$vstsCommandString"
+  name: OutputReleaseTag
   displayName: Set Release Tag
 
 - pwsh: |
@@ -20,7 +21,8 @@ steps:
     Write-Host "##$vstsCommandString"
 
     $version = '$(ReleaseTag)'.ToLowerInvariant().Substring(1)
-    $vstsCommandString = "vso[task.setvariable variable=Version]$version"
+    $vstsCommandString = "vso[task.setvariable variable=Version;isOutput=true]$version"
     Write-Host ("sending " + $vstsCommandString)
     Write-Host "##$vstsCommandString"
+  name: OutputVersion
   displayName: Set container name

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -1,0 +1,75 @@
+jobs:
+- job: SetTagAndTools
+  displayName: Set Tag and Tools
+  condition: succeeded()
+  pool:
+    type: windows
+  variables:
+  - group: 'mscodehub-code-read-akv'
+  - name: ob_outputDirectory
+    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+  - name: ob_sdl_credscan_suppressionsFile
+    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+  - name: ob_sdl_tsa_configFile
+    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
+  steps:
+  - template: release-SetReleaseTagandContainerName.yml@self
+
+  - checkout: self
+    clean: true
+    env:
+      ob_restore_phase: true
+
+  - checkout: PSInternalTools
+    clean: true
+    env:
+      ob_restore_phase: true
+
+  - pwsh: |
+      New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
+      Get-ChildItem -Path '$(Build.SourcesDirectory)/Internal-PowerShellTeam-Tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
+        Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact' -Verbose
+    displayName: Move GitHub Tool
+
+  - task: onebranch.pipeline.signing@1
+    displayName: Sign Tools
+    inputs:
+      command: 'sign'
+      signing_profile: internal_azure_service
+      files_to_sign: '*.ps1;*.psm1'
+      search_root: '$(Pipeline.Workspace)/ToolArtifact'
+
+  - pwsh: | 
+      Write-Verbose -Verbose "Creating output directory for release tools: $(ob_outputDirectory)/ToolArtifact"
+      New-Item -Path $(ob_outputDirectory)/ToolArtifact -ItemType Directory -Force
+      Get-ChildItem -Path "$(Pipeline.Workspace)/ToolArtifact/*" -Recurse | 
+        Copy-Item -Destination $(ob_outputDirectory)/ToolArtifact -Recurse -Verbose
+    displayName: Upload Tools
+  
+  - pwsh: |
+      Write-Verbose -Verbose "Release Tag: $(OutputReleaseTag.releaseTag)"
+      $releaseVersion = '$(OutputReleaseTag.releaseTag)' -replace '^v',''
+      Write-Verbose -Verbose "Release Version: $releaseVersion"
+      $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
+
+      $isPreview = $semanticVersion.PreReleaseLabel -ne $null
+
+      $fileName = if ($isPreview) {
+        "preview.md"
+      }
+      else {
+        $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
+      }
+
+      $filePath = "$(Build.SourcesDirectory)/PowerShell/CHANGELOG/$fileName"
+      Write-Verbose -Verbose "Selected Log file: $filePath"
+
+      if (-not (Test-Path -Path $filePath)) {
+        Write-Error "Changelog file not found: $filePath"
+        exit 1
+      }
+      
+      Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
+      New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force
+      Copy-Item -Path $filePath -Destination $(ob_outputDirectory)/CHANGELOG
+    displayName: Upload Changelog

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -8,31 +8,25 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        artifactName: drop_DownloadPackages_upload_packages
+        artifactName: drop_setReleaseTagAndUploadTools_SetTagAndTools
+      - input: pipelineArtifact
+        pipeline: PSPackagesOfficial
+        artifactName: drop_upload_upload_packages
   variables:
-  - template: ./variable/release-shared.yml@self
+    - template: ./variable/release-shared.yml@self
+      parameters:
+        RELEASETAG: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputReleaseTag.releaseTag'] ]
 
   steps:
   - task: PowerShell@2
     inputs:
       targetType: inline
       script: |
-        Get-ChildItem Env: | Out-String -Stream | write-Verbose -Verbose
+        Write-Verbose -Verbose "Release Tag: $(ReleaseTag)"
+        Get-ChildItem Env: | Out-String -Stream | Write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
   - template: release-install-pwsh.yml
-
-  - template: release-checkout-pwsh-repo.yml
-
-  - template: release-SetReleaseTagAndContainerName.yml
-
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      pwsh: true
-      script: |
-        git clone --depth 1 https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
-    displayName: Clone Internal-Tools repository
 
   - task: PowerShell@2
     inputs:
@@ -54,18 +48,7 @@ jobs:
         $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
         Write-Verbose -Verbose -Message $fileContent
     displayName: Add sha256 hashes
-
-  - task: PowerShell@2
-    inputs:
-      targetType: inline
-      pwsh: true
-      script: |
-        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-        $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
-        Write-Host "sending " + $vstsCommandString
-        Write-Host "##$vstsCommandString"
-    displayName: 'Set release version'
-
+  
   - task: PowerShell@2
     inputs:
       targetType: inline
@@ -79,22 +62,12 @@ jobs:
       targetType: inline
       pwsh: true
       script: |
-        Import-module '$(Pipeline.Workspace)/tools/Scripts/GitHubRelease.psm1'
-        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-        $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
+        Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
+        Write-Verbose -Verbose "Available modules: "
+        Get-Module | Write-Verbose -Verbose
 
-        $isPreview = $semanticVersion.PreReleaseLabel -ne $null
-
-        $fileName = if ($isPreview) {
-          "preview.md"
-        }
-        else {
-          $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
-        }
-
-        $filePath = "$(Pipeline.Workspace)/PowerShell/CHANGELOG/$fileName"
-        Write-Verbose -Verbose "Selected Log file: $filePath"
-
+        $filePath = Get-ChildItem -Path "$(Pipeline.Workspace)/CHANGELOG" -Filter '*.md' | Select-Object -First 1 -ExpandProperty FullName
+  
         if (-not (Test-Path $filePath)) {
           throw "$filePath not found"
         }

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -13,20 +13,19 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
-        artifactName: drop_DownloadPackages_upload_packages
-
+        pipeline: PSPackagesOfficial
+        artifactName: drop_upload_upload_packages
   variables:
   - template: ./variable/release-shared.yml@self
+    parameters:
+      VERSION: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputVersion.Version'] ]
 
   steps:
   - template: release-install-pwsh.yml
 
-  - template: release-checkout-pwsh-repo.yml
-
-  - template: release-SetReleaseTagAndContainerName.yml
-
   - pwsh: |
-      Get-ChildItem Env:
+      Write-Verbose -Verbose "Version: $(Version)"
+      Get-ChildItem Env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
   - pwsh: |
@@ -34,7 +33,7 @@ jobs:
       $null = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/release"
       Copy-Item "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -Destination "$(Pipeline.Workspace)/release" -Exclude "PowerShell.*.nupkg" -Force -Verbose
 
-      $releaseVersion = '$(VERSION)'
+      $releaseVersion = '$(Version)'
       $globalToolPath = "$(Pipeline.Workspace)/NuGetPackages/PowerShell.$releaseVersion.nupkg"
 
       if ($releaseVersion -notlike '*-*') {

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -23,7 +23,7 @@ jobs:
     displayName: Capture environment
 
   - pwsh: |
-      $name = "{0}_{1:x}" -f '$(releaseTag)', (Get-Date).Ticks
+      $name = "{0}_{1:x}" -f '$(OutputReleaseTag.releaseTag)', (Get-Date).Ticks
       Write-Host $name
       Write-Host "##vso[build.updatebuildnumber]$name"
     displayName: Set Release Name

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -235,23 +235,21 @@ jobs:
       Get-ChildItem '$(Build.ArtifactStagingDirectory)/downloads' | Select-Object -ExpandProperty FullName
     displayName: 'Capture downloads'
 
-  # - pwsh: |
-  #     Write-Verbose -Verbose "Copying Github Release files in $(Build.ArtifactStagingDirectory)/downloads to use in Release Pipeline"
-  #     
-  #     Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
-  #     New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
-  #     Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
-  #       Where-Object { $_.Extension -notin '.msix', '.nupkg' } | 
-  #       ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
-  #       Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse
-  #     
-  #     Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
-  #     New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
-  #     Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
-  #       Where-Object { $_.Extension -eq '.nupkg' } | 
-  #       ForEach-Object { Write-Verbose -Verbose $_.FullName ; $_  } |
-  #       Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse
-  #   displayName: Copy downloads to Artifacts
+  - pwsh: |
+      Write-Verbose -Verbose "Copying Github Release files in $(Build.ArtifactStagingDirectory)/downloads to use in Release Pipeline"
+      
+      Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
+      New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
+        Where-Object { $_.Extension -notin '.msix', '.nupkg' } | 
+        Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse -Verbose
+      
+      Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
+      New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
+        Where-Object { $_.Extension -eq '.nupkg' } | 
+        Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse -Verbose
+    displayName: Copy downloads to Artifacts
 
   - pwsh: |
       # Create output directory for packages which have been uploaded to blob storage

--- a/.pipelines/templates/variable/release-shared.yml
+++ b/.pipelines/templates/variable/release-shared.yml
@@ -5,6 +5,12 @@ parameters:
   - name: SBOM
     type: boolean
     default: false
+  - name: RELEASETAG
+    type: string
+    default: 'Not Initialized'
+  - name: VERSION
+    type: string
+    default: 'Not Initialized'
 
 variables:
   - name: ob_signing_setup_enabled            
@@ -30,3 +36,7 @@ variables:
     value: ${{ parameters.REPOROOT }}\.config\suppress.json
   - name: ob_sdl_codeql_compiled_enabled
     value: false
+  - name: ReleaseTag
+    value: ${{ parameters.RELEASETAG }}
+  - name: Version
+    value: ${{ parameters.VERSION }}


### PR DESCRIPTION
Backport #24632

This pull request includes significant updates to the PowerShell release pipeline, focusing on restructuring stages and jobs, improving variable handling, and enhancing artifact management.

Pipeline restructuring and job updates:

* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL113-L123): Added a new `setReleaseTagAndUploadTools` stage to replace the `DownloadPackages` stage, and updated dependencies and templates accordingly. [[1]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL113-L123) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL281-R282) [[3]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL319-R322)
* [`.pipelines/templates/release-SetTagAndTools.yml`](diffhunk://#diff-b9e5aa1224d680253d023e9d9442a953d336c7484f3a7773398e7a230c5ded67R1-R75): Introduced a new job for setting release tags and uploading tools, including steps for signing tools and uploading changelogs.

Variable handling improvements:

* [`.pipelines/templates/release-SetReleaseTagandContainerName.yml`](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L11-R14): Updated the `vstsCommandString` to include `isOutput=true` for better output management. [[1]](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L11-R14) [[2]](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L23-R27)
* [`.pipelines/templates/variable/release-shared.yml`](diffhunk://#diff-2d644da01d1ced46893b1472b24bf6b86ae30db3517ecbe062d8b59ae976878cR8-R13): Added new parameters `RELEASETAG` and `VERSION` and corresponding variables to manage release tags and versions. [[1]](diffhunk://#diff-2d644da01d1ced46893b1472b24bf6b86ae30db3517ecbe062d8b59ae976878cR8-R13) [[2]](diffhunk://#diff-2d644da01d1ced46893b1472b24bf6b86ae30db3517ecbe062d8b59ae976878cR39-R42)

Artifact management enhancements:

* [`.pipelines/templates/release-githubtasks.yml`](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L11-L36): Updated artifact names and added steps to capture environment variables and manage GitHub release files. [[1]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L11-L36) [[2]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L58-L68) [[3]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L82-R69)
* [`.pipelines/templates/release-publish-nuget.yml`](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafL16-R36): Updated artifact names and parameters for version management.
* [`.pipelines/templates/uploadToAzure.yml`](diffhunk://#diff-198718b336446a8a528c995da4f1bc5edf20c0ba40ea06852fece3512c67e0c9L238-R252): Re-enabled and updated the script for copying GitHub release files and NuGet packages to the artifacts directory.