### PR TITLE
Fix a bug in how Write-Host handles XML Elements

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
@@ -60,9 +60,9 @@ namespace Microsoft.PowerShell.Commands
                         return s;
                     }
                 }
-                else if (o is XmlElement)
+                else if (o is XmlNode xmlNode)
                 {
-                    return ((XmlElement)o).Name;
+                    return xmlNode.Name;
                 }
                 else if (o is IEnumerable enumerable)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Management.Automation;
 using System.Text;
+using System.Xml;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -58,6 +59,10 @@ namespace Microsoft.PowerShell.Commands
                     {
                         return s;
                     }
+                }
+                else if (o is XmlElement)
+                {
+                    return ((XmlElement)o).Name;
                 }
                 else if (o is IEnumerable enumerable)
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -60,6 +60,7 @@ Describe "Write-Host with TestHostCS" -Tags "CI" {
             @{ Name = '-Separator, colors and -NoNewLine'; Command = "Write-Host a,b,c -Separator ',' -ForegroundColor Yellow -BackgroundColor DarkBlue -NoNewline"; returnCount = 1; returnValue = @("Yellow:DarkBlue:a,b,c:NoNewLine"); returnInfo = @("a,b,c") }
             @{ Name = '-NoNewline:$true and colors';       Command = "Write-Host a,b -NoNewline:`$true -ForegroundColor Red -BackgroundColor Green;Write-Host a,b";  returnCount = 2; returnValue = @("Red:Green:a b:NoNewLine", "White:Black:a b:NewLine"); returnInfo = @("a b", "a b") }
             @{ Name = '-NoNewline:$false and colors';      Command = "Write-Host a,b -NoNewline:`$false -ForegroundColor Red -BackgroundColor Green;Write-Host a,b"; returnCount = 2; returnValue = @("Red:Green:a b:NewLine","White:Black:a b:NewLine"); returnInfo = @("a b", "a b") }
+            @{ Name = 'XMLElement';                        Command = "Write-Host ([xml] '<OhElement>Where art thou?</OhElement>').DocumentElement";                  returnCount = 1; returnValue = @("White:Black:OhElement:NewLine"); returnInfo = @("OhElement") }
         )
 
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -61,6 +61,7 @@ Describe "Write-Host with TestHostCS" -Tags "CI" {
             @{ Name = '-NoNewline:$true and colors';       Command = "Write-Host a,b -NoNewline:`$true -ForegroundColor Red -BackgroundColor Green;Write-Host a,b";  returnCount = 2; returnValue = @("Red:Green:a b:NoNewLine", "White:Black:a b:NewLine"); returnInfo = @("a b", "a b") }
             @{ Name = '-NoNewline:$false and colors';      Command = "Write-Host a,b -NoNewline:`$false -ForegroundColor Red -BackgroundColor Green;Write-Host a,b"; returnCount = 2; returnValue = @("Red:Green:a b:NewLine","White:Black:a b:NewLine"); returnInfo = @("a b", "a b") }
             @{ Name = 'XMLElement';                        Command = "Write-Host ([xml] '<OhElement>Where art thou?</OhElement>').DocumentElement";                  returnCount = 1; returnValue = @("White:Black:OhElement:NewLine"); returnInfo = @("OhElement") }
+            @{ Name = 'XMLDocument';                        Command = "Write-Host ([system.xml.xmldocument] '<OhElement>Where art thou?</OhElement>').DocumentElement";                  returnCount = 1; returnValue = @("White:Black:OhElement:NewLine"); returnInfo = @("OhElement") }
         )
 
     }


### PR DESCRIPTION
# PR Summary

Changes how the `Write-Host` cmdlet handles XMLElements, fixes https://github.com/PowerShell/PowerShell/issues/24508

## PR Context

I'm not positive this is the right fix, spiritually I could get behind using `.OuterXml` instead which would print the whole XML document from that element, which seems aligned with the iteration of an Enumerable.

Either way, it is definitely the case that the current code doesn't work as expected.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [X] Issue filed: https://github.com/PowerShell/PowerShell/issues/24508
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
