### PR TITLE
Seal internal type `ClientRemoteSessionDSHandlerImpl`

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
@@ -13,7 +13,7 @@ namespace System.Management.Automation.Remoting
     /// <summary>
     /// Implements ServerRemoteSessionDataStructureHandler.
     /// </summary>
-    internal class ClientRemoteSessionDSHandlerImpl : ClientRemoteSessionDataStructureHandler, IDisposable
+    internal sealed class ClientRemoteSessionDSHandlerImpl : ClientRemoteSessionDataStructureHandler, IDisposable
     {
         [TraceSourceAttribute("CRSDSHdlerImpl", "ClientRemoteSessionDSHandlerImpl")]
         private static readonly PSTraceSource s_trace = PSTraceSource.GetTracer("CRSDSHdlerImpl", "ClientRemoteSessionDSHandlerImpl");

--- a/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
@@ -736,26 +736,14 @@ namespace System.Management.Automation.Remoting
         #region IDisposable
 
         /// <summary>
-        /// Public method for dispose.
+        /// Release all resources.
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
+            _transportManager.Dispose();
 
             GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Release all resources.
-        /// </summary>
-        /// <param name="disposing">If true, release all managed resources.</param>
-        protected void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _transportManager.Dispose();
-            }
-        }
+        }   
 
         #endregion IDisposable
 


### PR DESCRIPTION
Contributes to https://github.com/PowerShell/PowerShell/issues/24094.

Seal internal type `System.Management.Automation.Remoting.ClientRemoteSessionDSHandlerImpl` in `src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs`

The motivation of this PR is this comment by @PaulHigin https://github.com/PowerShell/PowerShell/pull/11820#discussion_r452405592.
