### PR TITLE
Update `DnsNameList` for `X509Certificate2` to use `X509SubjectAlternativeNameExtension.EnumerateDnsNames` Method

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -3345,7 +3345,7 @@ namespace Microsoft.PowerShell.Commands
             // extract DNS name from subject distinguish name
             // if it exists and does not contain a comma
             // a comma, indicates it is not a DNS name
-            if (cert.Subject.StartsWith(distinguishedNamePrefix, System.StringComparison.OrdinalIgnoreCase) &&
+            if (cert.Subject.StartsWith(distinguishedNamePrefix, StringComparison.OrdinalIgnoreCase) &&
                 !cert.Subject.Contains(','))
             {
                 string parsedSubjectDistinguishedDnsName = cert.Subject.Substring(distinguishedNamePrefix.Length);

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -3355,6 +3355,7 @@ namespace Microsoft.PowerShell.Commands
                 _dnsList.Add(dnsName);
             }
 
+            // Extract DNS names from SAN extensions
             foreach (X509Extension extension in cert.Extensions)
             {
                 if (extension is X509SubjectAlternativeNameExtension sanExtension)

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -3309,7 +3309,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class DnsNameProperty
     {
         private readonly List<DnsNameRepresentation> _dnsList = new();
-        private readonly System.Globalization.IdnMapping idnMapping = new();
+        private readonly IdnMapping idnMapping = new();
 
         private const string distinguishedNamePrefix = "CN=";
 
@@ -3346,8 +3346,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public DnsNameProperty(X509Certificate2 cert)
         {
-            string name;
-            DnsNameRepresentation dnsName;
             _dnsList = new List<DnsNameRepresentation>();
 
             // extract DNS name from subject distinguish name
@@ -3356,8 +3354,8 @@ namespace Microsoft.PowerShell.Commands
             if (cert.Subject.StartsWith(distinguishedNamePrefix, System.StringComparison.OrdinalIgnoreCase) &&
                 !cert.Subject.Contains(','))
             {
-                name = cert.Subject.Substring(distinguishedNamePrefix.Length);
-                dnsName = GetDnsNameRepresentation(name);
+                string parsedSubjectDistinguishedDnsName = cert.Subject.Substring(distinguishedNamePrefix.Length);
+                DnsNameRepresentation dnsName = GetDnsNameRepresentation(parsedSubjectDistinguishedDnsName);
                 _dnsList.Add(dnsName);
             }
 
@@ -3368,7 +3366,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (string dnsNameEntry in sanExtension.EnumerateDnsNames())
                     {
-                        dnsName = GetDnsNameRepresentation(dnsNameEntry);
+                        DnsNameRepresentation dnsName = GetDnsNameRepresentation(dnsNameEntry);
 
                         // Only add the name if it is not the same as an existing name.
                         if (!_dnsList.Contains(dnsName))

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -3361,8 +3361,19 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (string dnsNameEntry in sanExtension.EnumerateDnsNames())
                     {
-                        dnsName = new DnsNameRepresentation(dnsNameEntry);
+                        try
+                        {
+                            unicodeName = idnMapping.GetUnicode(dnsNameEntry);
+                        }
+                        catch (ArgumentException)
+                        {
+                            // The name is not valid punyCode, assume it's valid ascii.
+                            unicodeName = dnsNameEntry;
+                        }
 
+                        dnsName = new DnsNameRepresentation(dnsNameEntry, unicodeName);
+
+                        // Only add the name if it is not the same as an existing name.
                         if (!_dnsList.Contains(dnsName))
                         {
                             _dnsList.Add(dnsName);

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -3316,13 +3316,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Get property of DnsNameList.
         /// </summary>
-        public List<DnsNameRepresentation> DnsNameList
-        {
-            get
-            {
-                return _dnsList;
-            }
-        }
+        public List<DnsNameRepresentation> DnsNameList => _dnsList;
 
         private DnsNameRepresentation GetDnsNameRepresentation(string dnsName)
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -333,9 +333,24 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         It "Should set DNSNameList from SAN extensions" {
             $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($pfxFilePath, $password)
 
+            $expectedDnsNameList = @(
+                [PSCustomObject]@{
+                    Punycode = "yourdomain.com"
+                    Unicode  = "yourdomain.com"
+                }
+                [PSCustomObject]@{
+                    Punycode = "www.yourdomain.com"
+                    Unicode  = "www.yourdomain.com"
+                }
+                [PSCustomObject]@{
+                    Punycode = "api.yourdomain.com"
+                    Unicode  = "api.yourdomain.com"
+                }
+            )
+
             $cert | Should -Not -BeNullOrEmpty
             $cert.DnsNameList | Should -HaveCount 3
-            $cert.DnsNameList | Should -BeExactly @('yourdomain.com', 'www.yourdomain.com', 'api.yourdomain.com')
+            ($cert.DnsNameList | ConvertTo-Json -Compress)  | Should -BeExactly ($expectedDnsNameList | ConvertTo-Json -Compress)
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -299,7 +299,7 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $keyFilePath = Join-Path -Path $TestDrive -ChildPath 'privateKey.key'
             $certFilePath = Join-Path -Path $TestDrive -ChildPath 'certificate.crt'
             $pfxFilePath = Join-Path -Path $TestDrive -ChildPath 'certificate.pfx'
-            $password = "test"
+            $password = New-CertificatePassword | ConvertFrom-SecureString -AsPlainText
 
             $config = @"
             [ req ]

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -292,4 +292,50 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $certs.Thumbprint | Should -BeExactly $thumbprint
         }
     }
+
+    Context "SAN DNS Name Tests" {
+        BeforeAll {
+            $configFilePath = Join-Path -Path $TestDrive -ChildPath 'openssl.cnf'
+            $keyFilePath = Join-Path -Path $TestDrive -ChildPath 'privateKey.key'
+            $certFilePath = Join-Path -Path $TestDrive -ChildPath 'certificate.crt'
+            $pfxFilePath = Join-Path -Path $TestDrive -ChildPath 'certificate.pfx'
+            $password = "test"
+
+            $config = @"
+            [ req ]
+            default_bits       = 2048
+            distinguished_name = req_distinguished_name
+            req_extensions     = v3_req
+            prompt             = no
+
+            [ req_distinguished_name ]
+            CN                 = yourdomain.com
+
+            [ v3_req ]
+            subjectAltName     = @alt_names
+
+            [ alt_names ]
+            DNS.1              = yourdomain.com
+            DNS.2              = www.yourdomain.com
+            DNS.3              = api.yourdomain.com
+"@
+
+            # Write the configuration to the specified path
+            Set-Content -Path $configFilePath -Value $config
+
+            # Generate the self-signed certificate with SANs
+            openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $keyFilePath -out $certFilePath -config $configFilePath -extensions v3_req
+
+            # Create the PFX file
+            openssl pkcs12 -export -out $pfxFilePath -inkey $keyFilePath -in $certFilePath -passout pass:$password
+        }
+
+        It "Should set DNSNameList from SAN extensions" {
+            $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($pfxFilePath, $password)
+
+            $cert | Should -Not -BeNullOrEmpty
+            $cert.DnsNameList | Should -HaveCount 3
+            $cert.DnsNameList | Should -BeExactly @('yourdomain.com', 'www.yourdomain.com', 'api.yourdomain.com')
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -318,6 +318,9 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             DNS.1              = yourdomain.com
             DNS.2              = www.yourdomain.com
             DNS.3              = api.yourdomain.com
+            DNS.4              = xn--mnchen-3ya.com
+            DNS.5              = xn--80aaxitdbjr.com
+            DNS.6              = xn--caf-dma.com
 "@
 
             # Write the configuration to the specified path
@@ -346,10 +349,22 @@ Describe "Certificate Provider tests" -Tags "Feature" {
                     Punycode = "api.yourdomain.com"
                     Unicode  = "api.yourdomain.com"
                 }
+                [PSCustomObject]@{
+                    Punycode = "xn--mnchen-3ya.com"
+                    Unicode  = "münchen.com"
+                }
+                [PSCustomObject]@{
+                    Punycode = "xn--80aaxitdbjr.com"
+                    Unicode  = "папитрока.com"
+                }
+                [PSCustomObject]@{
+                    Punycode = "xn--caf-dma.com"
+                    Unicode  = "café.com"
+                }
             )
 
             $cert | Should -Not -BeNullOrEmpty
-            $cert.DnsNameList | Should -HaveCount 3
+            $cert.DnsNameList | Should -HaveCount 6
             ($cert.DnsNameList | ConvertTo-Json -Compress)  | Should -BeExactly ($expectedDnsNameList | ConvertTo-Json -Compress)
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Updated `DnsNameList` for `X509Certificate2` to use [`X509SubjectAlternativeNameExtension.EnumerateDnsNames`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509subjectalternativenameextension.enumeratednsnames?view=net-9.0#system-security-cryptography-x509certificates-x509subjectalternativenameextension-enumeratednsnames) method. This replaces the `DNS Name=` prefix + OID 2.5.29.17 checking code which is error prone when using different language clients.

Using the [`public X509SubjectAlternativeNameExtension (byte[] rawData, bool critical = false)`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509subjectalternativenameextension.-ctor?view=net-9.0#system-security-cryptography-x509certificates-x509subjectalternativenameextension-ctor(system-byte()-system-boolean)) constructor with `cert.RawData` did not work and resulted in [`CryptographicException`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptographicexception?view=net-9.0) exceptions. Instead, what was much more robust was just casting the extension to `X509SubjectAlternativeNameExtension` and then using the `EnumerateDnsNames()` method.

Also testing previous code with different culture/locale I could not get DNS name prefix to output in a different language, so that case is a bit difficult to reproduce. Although it seems like this is supposed to just work moving to the .NET `EnumerateDnsNames()` method. I am not even sure switching cultures is good enough to expose this problem and how it can even be validated in the tests. 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Fixes #24594

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
