### PR TITLE
Fix `IDisposable` implementation in sealed classes

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/PowerShellStreams.cs
+++ b/src/System.Management.Automation/engine/remoting/client/PowerShellStreams.cs
@@ -97,19 +97,9 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Dispose implementation.
+        /// Release all resources.
         /// </summary>
         public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Protected virtual implementation of Dispose.
-        /// </summary>
-        /// <param name="disposing"></param>
-        private void Dispose(bool disposing)
         {
             if (_disposed)
                 return;
@@ -118,26 +108,23 @@ namespace System.Management.Automation
             {
                 if (!_disposed)
                 {
-                    if (disposing)
-                    {
-                        _inputStream.Dispose();
-                        _outputStream.Dispose();
-                        _errorStream.Dispose();
-                        _warningStream.Dispose();
-                        _progressStream.Dispose();
-                        _verboseStream.Dispose();
-                        _debugStream.Dispose();
-                        _informationStream.Dispose();
+                    _inputStream.Dispose();
+                    _outputStream.Dispose();
+                    _errorStream.Dispose();
+                    _warningStream.Dispose();
+                    _progressStream.Dispose();
+                    _verboseStream.Dispose();
+                    _debugStream.Dispose();
+                    _informationStream.Dispose();
 
-                        _inputStream = null;
-                        _outputStream = null;
-                        _errorStream = null;
-                        _warningStream = null;
-                        _progressStream = null;
-                        _verboseStream = null;
-                        _debugStream = null;
-                        _informationStream = null;
-                    }
+                    _inputStream = null;
+                    _outputStream = null;
+                    _errorStream = null;
+                    _warningStream = null;
+                    _progressStream = null;
+                    _verboseStream = null;
+                    _debugStream = null;
+                    _informationStream = null;
 
                     _disposed = true;
                 }

--- a/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
@@ -1904,7 +1904,7 @@ namespace System.Management.Automation.Runspaces.Internal
             if (!_isDisposed)
             {
                 _isDisposed = true;
-                DataStructureHandler.Dispose(disposing);
+                DataStructureHandler.Dispose();
                 _applicationPrivateDataReceived.Dispose();
             }
         }

--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -949,28 +949,14 @@ namespace System.Management.Automation.Internal
         #region IDisposable
 
         /// <summary>
-        /// Public interface for dispose.
+        /// Release all resources.
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
-
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Release all resources.
-        /// </summary>
-        /// <param name="disposing">If true, release all managed resources.</param>
-        public void Dispose(bool disposing)
-        {
-            if (disposing)
+            if (RemoteSession != null)
             {
-                if (RemoteSession != null)
-                {
-                    ((ClientRemoteSessionImpl)RemoteSession).Dispose();
-                    RemoteSession = null;
-                }
+                ((ClientRemoteSessionImpl)RemoteSession).Dispose();
+                RemoteSession = null;
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ThrottlingJob.cs
@@ -1176,9 +1176,11 @@ namespace System.Management.Automation
                 }
             }
 
+            /// <summary>
+            /// Release all resources.
+            /// </summary>
             public void Dispose()
             {
-                GC.SuppressFinalize(this);
                 _cancellationTokenSource.Cancel();
                 lock (_myLock)
                 {

--- a/src/System.Management.Automation/engine/remoting/server/ServerSteppablePipelineDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerSteppablePipelineDriver.cs
@@ -43,14 +43,13 @@ namespace System.Management.Automation
             return result;
         }
 
-        // Summary:
-        //     Performs application-defined tasks associated with freeing, releasing, or
-        //     resetting unmanaged resources.
-        void IDisposable.Dispose()
+        /// <summary>
+        /// Release all resources.
+        /// </summary>
+        public void Dispose()
         {
             _executionContext.InternalHost.InternalUI.SetInformationalMessageBuffers(_originalInformationalBuffers);
             _executionContext.InternalHost.SetHostRef(_originalHost);
-            GC.SuppressFinalize(this);
         }
     }
 


### PR DESCRIPTION
* Do not invoke `GC.SuppressFinalize` for types without a finalizer.
* Remove redundant `void Dispose(bool disposing)` method for sealed types.

_Best reviewed with [whitespace hidden](https://github.com/PowerShell/PowerShell/pull/24719/files?w=1)._
