### PR TITLE
Fixed release pipeline errors and switched to KS3

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -88,7 +88,7 @@ extends:
     featureFlags:
       WindowsHostVersion:
         Version: 2022
-        Network: Netlock
+        Network: KS3
     cloudvault:
       enabled: false
     globalSdl:

--- a/.pipelines/templates/release-SetReleaseTagandContainerName.yml
+++ b/.pipelines/templates/release-SetReleaseTagandContainerName.yml
@@ -15,12 +15,12 @@ steps:
   displayName: Set Release Tag
 
 - pwsh: |
-    $azureVersion = '$(ReleaseTag)'.ToLowerInvariant() -replace '\.', '-'
-    $vstsCommandString = "vso[task.setvariable variable=AzureVersion]$azureVersion"
+    $azureVersion = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant() -replace '\.', '-'
+    $vstsCommandString = "vso[task.setvariable variable=AzureVersion;isOutput=true]$azureVersion"
     Write-Host "sending " + $vstsCommandString
     Write-Host "##$vstsCommandString"
 
-    $version = '$(ReleaseTag)'.ToLowerInvariant().Substring(1)
+    $version = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant().Substring(1)
     $vstsCommandString = "vso[task.setvariable variable=Version;isOutput=true]$version"
     Write-Host ("sending " + $vstsCommandString)
     Write-Host "##$vstsCommandString"

--- a/.pipelines/templates/release-create-msix.yml
+++ b/.pipelines/templates/release-create-msix.yml
@@ -96,7 +96,7 @@ jobs:
         azurePowerShellVersion: LatestVersion
         pwsh: true
         inline: |
-          $containerName = '$(AzureVersion)-private'
+          $containerName = '$(OutputVersion.AzureVersion)-private'
           $storageAccount = '$(StorageAccount)'
 
           $storageContext = New-AzStorageContext -StorageAccountName $storageAccount -UseConnectedAccount

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -63,6 +63,7 @@ jobs:
       pwsh: true
       script: |
         Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
+        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
         Write-Verbose -Verbose "Available modules: "
         Get-Module | Write-Verbose -Verbose
 

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -85,7 +85,7 @@ jobs:
         $packageName = '${{ parameters.globalToolPackageName }}'
         Write-Verbose -Verbose "Installing $packageName"
 
-        dotnet tool install --add-source "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg" --tool-path $toolPath --version '$(Version)' $packageName
+        dotnet tool install --add-source "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg" --tool-path $toolPath --version '$(OutputVersion.Version)' $packageName
 
         Get-ChildItem -Path $toolPath
 
@@ -133,7 +133,7 @@ jobs:
 
         $versionFound = & $toolPath -c '$PSVersionTable.PSVersion.ToString()'
 
-        if ( '$(Version)' -ne $versionFound)
+        if ( '$(OutputVersion.Version)' -ne $versionFound)
         {
             throw "Expected version of global tool not found. Installed version is $versionFound"
         }

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -50,7 +50,7 @@ jobs:
       inline: |
         $storageAccount = Get-AzStorageAccount -ResourceGroupName '$(StorageResourceGroup)' -Name '$(StorageAccount)'
         $ctx = $storageAccount.Context
-        $container = '$(AzureVersion)'
+        $container = '$(OutputVersion.AzureVersion)'
 
         $destinationPath = '$(System.ArtifactsDirectory)'
         $blobList = Get-AzStorageBlob -Container $container -Context $ctx

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -95,7 +95,7 @@ jobs:
         </packageSources>
         "@
 
-        $releaseVersion = '$(Version)'
+        $releaseVersion = '$(OutputVersion.Version)'
 
         Write-Verbose -Message "Release Version: $releaseVersion" -Verbose
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes several changes to the Azure Pipelines YAML files, focusing on updating variables and references to improve consistency and functionality.

Key changes include:

### Variable Updates:
* Updated the `Network` value from `Netlock` to `KS3` in the `extends:` section of the `.pipelines/PowerShell-Release-Official.yml` file.

### Output Variables:
* Modified the `steps:` in `.pipelines/templates/release-SetReleaseTagandContainerName.yml` to use `OutputReleaseTag.ReleaseTag` instead of `ReleaseTag` and added `isOutput=true` to the `vso[task.setvariable]` command.
* Updated the `jobs:` in `.pipelines/templates/release-create-msix.yml` to use `OutputVersion.AzureVersion` instead of `AzureVersion`.
* Added a new variable `$releaseVersion` in the `jobs:` section of `.pipelines/templates/release-githubtasks.yml` to strip the leading 'v' from `ReleaseTag`.
* Changed the `jobs:` in `.pipelines/templates/release-validate-globaltools.yml` to use `OutputVersion.Version` for both the `dotnet tool install` command and the version check. [[1]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL88-R88) [[2]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL136-R136)
* Updated the `jobs:` in `.pipelines/templates/release-validate-packagenames.yml` to use `OutputVersion.AzureVersion` instead of `AzureVersion`.
* Modified the `jobs:` in `.pipelines/templates/release-validate-sdk.yml` to use `OutputVersion.Version` instead of `Version`.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
