### PR TITLE
Fix completion of provider paths when a path returns itself instead of its children

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4814,8 +4814,6 @@ namespace System.Management.Automation
                     (pathInfo.Provider.FullName + "::" + pathInfo.ProviderPath).EqualsOrdinalIgnoreCase(childItemOutput[0].Properties["PSPath"].Value as string))
                 {
                     // Get-ChildItem returned the item itself instead of the children so there must be no child items to complete.
-                    // The filesystem provider does this when pointing to files: Get-ChildItem C:\pagefile.sys -Force and other providers may follow this pattern.
-                    // (The filesystem provider has its own completion method: GetFileSystemProviderResults)
                     continue;
                 }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4815,6 +4815,7 @@ namespace System.Management.Automation
                 {
                     // Get-ChildItem returned the item itself instead of the children so there must be no child items to complete.
                     // The filesystem provider does this when pointing to files: Get-ChildItem C:\pagefile.sys -Force and other providers may follow this pattern.
+                    // (The filesystem provider has its own completion method: GetFileSystemProviderResults)
                     continue;
                 }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4853,7 +4853,7 @@ namespace System.Management.Automation
 
                 if (childNameList.Count == 0)
                 {
-                    continue;
+                    return results;
                 }
 
                 string basePath = providerPrefix.Length > 0

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -107,6 +107,122 @@ Describe "TabCompletion" -Tags CI {
         }
     }
 
+    context CustomProviderTests {
+        BeforeAll {
+            $testModulePath = Join-Path $TestDrive "ReproModule"
+            New-Item -Path $testModulePath -ItemType Directory > $null
+
+            New-ModuleManifest -Path "$testModulePath/ReproModule.psd1" -RootModule 'testmodule.dll'
+
+            $testBinaryModulePath = Join-Path $testModulePath "testmodule.dll"
+            $binaryModule = @'
+using System;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Provider;
+
+namespace BugRepro
+{
+    public class IntItemInfo
+    {
+        public string Name;
+        public IntItemInfo(string name) => Name = name;
+    }
+
+    [CmdletProvider("Int", ProviderCapabilities.None)]
+    public class IntProvider : NavigationCmdletProvider
+    {
+        public static string[] ToChunks(string path) => path.Split("/", StringSplitOptions.RemoveEmptyEntries);
+
+        protected string _ChildName(string path)
+        {
+            var name = ToChunks(path).LastOrDefault();
+            return name ?? string.Empty;
+        }
+
+        protected string Normalize(string path) => string.Join("/", ToChunks(path));
+
+        protected override string GetChildName(string path)
+        {
+            var name = _ChildName(path);
+            // if (!IsItemContainer(path)) { return string.Empty; }
+            return name;
+        }
+
+        protected override bool IsValidPath(string path) => int.TryParse(GetChildName(path), out int _);
+
+        protected override bool IsItemContainer(string path)
+        {
+            var name = _ChildName(path);
+            if (!int.TryParse(name, out int value))
+            {
+                return false;
+            }
+            if (ToChunks(path).Count() > 3)
+            {
+                return false;
+            }
+            return value % 2 == 0;
+        }
+
+        protected override bool ItemExists(string path)
+        {
+            foreach (var chunk in ToChunks(path))
+            {
+                if (!int.TryParse(chunk, out int value))
+                {
+                    return false;
+                }
+                if (value < 0 || value > 9)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        protected override void GetItem(string path)
+        {
+            var name = GetChildName(path);
+            if (!int.TryParse(name, out int _))
+            {
+                return;
+            }
+            WriteItemObject(new IntItemInfo(name), path, IsItemContainer(path));
+        }
+        protected override bool HasChildItems(string path) => IsItemContainer(path);
+
+        protected override void GetChildItems(string path, bool recurse)
+        {
+            if (!IsItemContainer(path)) { GetItem(path); return; }
+
+            for (var i = 0; i <= 9; i++)
+            {
+                var _path = $"{Normalize(path)}/{i}";
+                if (recurse)
+                {
+                    GetChildItems(_path, recurse);
+                }
+                else
+                {
+                    GetItem(_path);
+                }
+            }
+        }
+    }
+}
+'@
+            Add-Type -OutputAssembly $testBinaryModulePath -TypeDefinition $binaryModule
+
+            $pwsh = "$PSHOME\pwsh"
+        }
+
+        It "Should not complete invalid items when a provider path returns itself instead of its children" {
+            $result = & $pwsh -NoProfile -Command "Import-Module -Name $testModulePath; (TabExpansion2 'Get-ChildItem Int::/2/3/').CompletionMatches.Count"
+            $result | Should -BeExactly "0"
+        }
+    }
+
     It 'should complete index expression for <Intent>' -TestCases @(
         @{
             Intent = 'Hashtable with no user input'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes an issue when trying to complete an item in a path as if it was a container in providers that returns the item itself when calling `Get-ChildItem` on an item. This would make it complete the same item name again like this: `Provider::Container1\Item1\<Tab>` -> `Provider::Container1\Item1\Item1`

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/24744
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [X] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
