### PR TITLE
[release/v7.5] Make the `AssemblyVersion` does not change for servicing releases

### DIFF
--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -120,7 +120,7 @@ jobs:
       $refAssemblyFolder = Join-Path '$(System.ArtifactsDirectory)' 'RefAssembly'
       $null = New-Item -Path $refAssemblyFolder -Force -Verbose -Type Directory
 
-      Start-PSBuild -Clean -Runtime linux-x64 -Configuration Release
+      Start-PSBuild -Clean -Runtime linux-x64 -Configuration Release -ReleaseTag $(ReleaseTagVar)
 
       $sharedModules | Foreach-Object {
         $refFile = Get-ChildItem -Path "$(PowerShellRoot)\src\$_\obj\Release\net9.0\refint\$_.dll"
@@ -136,7 +136,7 @@ jobs:
         }
       }
 
-      Start-PSBuild -Clean -Runtime win7-x64 -Configuration Release
+      Start-PSBuild -Clean -Runtime win7-x64 -Configuration Release -ReleaseTag $(ReleaseTagVar)
 
       $winOnlyModules | Foreach-Object {
         $refFile = Get-ChildItem -Path "$(PowerShellRoot)\src\$_\obj\Release\net9.0\refint\*.dll"

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -58,6 +58,11 @@
       <PSCoreFileVersion Condition = "'$(ReleaseTagSemVersionPart)' != ''">$(ReleaseTagVersionPart).$(ReleaseTagSemVersionPart)</PSCoreFileVersion>
       <!-- Create the version if we have a release build -->
       <PSCoreFileVersion Condition = "'$(PSCoreFileVersion)' == ''">$(ReleaseTagVersionPart).$(GAIncrementValue)</PSCoreFileVersion>
+      <!-- Set 'FileVersion' and 'AssemblyVersion' explicitly:
+           - make 'FileVersion' the same as 'PSCoreFileVersion'
+           - make 'AssemblyVersion' be the 'PSCoreFileVersion' with the 'Build' field set to 0, so the assembly version doesn't change for servicing releases -->
+      <FileVersion>$(PSCoreFileVersion)</FileVersion>
+      <AssemblyVersion>$([System.Version]::Parse($(PSCoreFileVersion)).Major).$([System.Version]::Parse($(PSCoreFileVersion)).Minor).0.$([System.Version]::Parse($(PSCoreFileVersion)).Revision)</AssemblyVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -84,7 +89,7 @@
       -->
 
       <!--
-            Here we define explicitly 'Version' to set 'FileVersion' and 'AssemblyVersion' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
+            Here we define explicitly 'Version' to set 'FileVersion' and 'AssemblyVersion' when they are not explicitly set.
             Here we define explicitly 'InformationalVersion' because by default it is defined as 'Version' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
       -->
       <Version>$(PSCoreFileVersion)</Version>


### PR DESCRIPTION
Backport #24667

This pull request includes changes to the build configuration files to improve versioning and tagging for release builds. The most important changes include adding a `ReleaseTag` parameter to the `Start-PSBuild` commands and explicitly setting `FileVersion` and `AssemblyVersion` in the `PowerShell.Common.props` file.

Changes to build configuration:

* [`.pipelines/templates/nupkg.yml`](diffhunk://#diff-fef5d4fa72338febdeb6ec147c8a2dc2c59e458b0071f8ddbf15380d991eb9e0L123-R123): Added `-ReleaseTag $(ReleaseTagVar)` parameter to `Start-PSBuild` commands for both `linux-x64` and `win7-x64` runtimes. [[1]](diffhunk://#diff-fef5d4fa72338febdeb6ec147c8a2dc2c59e458b0071f8ddbf15380d991eb9e0L123-R123) [[2]](diffhunk://#diff-fef5d4fa72338febdeb6ec147c8a2dc2c59e458b0071f8ddbf15380d991eb9e0L139-R139)

Changes to versioning:

* [`PowerShell.Common.props`](diffhunk://#diff-e63303dba71f6f8537ceef1486078a2e19181bfcb15b7574c828bd7d3410eb6bR61-R65): Added explicit settings for `FileVersion` and `AssemblyVersion` to ensure consistent versioning for servicing releases.
* [`PowerShell.Common.props`](diffhunk://#diff-e63303dba71f6f8537ceef1486078a2e19181bfcb15b7574c828bd7d3410eb6bL87-R92): Updated comment to clarify when `FileVersion` and `AssemblyVersion` are set explicitly.