### PR TITLE
[release/v7.5]Add a parameter that skips verify packages step

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -8,6 +8,9 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
+  - name: SkipVerifyPackages
+    type: boolean
+    default: false
 
 variables:
   - name: ob_outputDirectory
@@ -103,3 +106,4 @@ extends:
           - template: /.pipelines/templates/compliance/generateNotice.yml@self
             parameters:
               parentJobs: []
+              SkipVerifyPackages: ${{ parameters.SkipVerifyPackages }}

--- a/.pipelines/templates/compliance/generateNotice.yml
+++ b/.pipelines/templates/compliance/generateNotice.yml
@@ -4,6 +4,8 @@
 parameters:
   - name: parentJobs
     type: jobList
+  - name: SkipVerifyPackages
+    type: boolean
 
 jobs:
 - job: generateNotice
@@ -60,7 +62,7 @@ jobs:
   - pwsh: |
       $(repoRoot)/tools/clearlyDefined/ClearlyDefined.ps1 -TestAndHarvest
     displayName: Verify that packages have license data
-
+    condition: eq(${{ parameters.SkipVerifyPackages }}, false)
 
   - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
     displayName: 'NOTICE File Generator'
@@ -70,7 +72,6 @@ jobs:
       outputformat: text
       # this isn't working
       # additionaldata: $(Build.SourcesDirectory)\assets\additionalAttributions.txt
-
 
   - pwsh: |
       Get-Content -Raw -Path $(repoRoot)\assets\additionalAttributions.txt | Out-File '$(ob_outputDirectory)\ThirdPartyNotices.txt' -Encoding utf8NoBOM -Force -Append


### PR DESCRIPTION
Backport #24763

This pull request introduces a new parameter to the pipeline configuration files to allow skipping the verification of packages during the notice generation process. The most important changes include adding the `SkipVerifyPackages` parameter and updating the conditions in the pipeline jobs accordingly.

Changes to pipeline configuration:

* [`.pipelines/apiscan-gen-notice.yml`](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2R11-R13): Added the `SkipVerifyPackages` parameter and passed it to the compliance template. [[1]](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2R11-R13) [[2]](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2R109)
* [`.pipelines/templates/compliance/generateNotice.yml`](diffhunk://#diff-f4db1c8be28518cd870bf3745816c18052518f267d13fa9a3c21e1554a914eefR7-R8): Added the `SkipVerifyPackages` parameter and updated the job conditions to skip the package verification step if the parameter is set to true. [[1]](diffhunk://#diff-f4db1c8be28518cd870bf3745816c18052518f267d13fa9a3c21e1554a914eefR7-R8) [[2]](diffhunk://#diff-f4db1c8be28518cd870bf3745816c18052518f267d13fa9a3c21e1554a914eefL63-R65) [[3]](diffhunk://#diff-f4db1c8be28518cd870bf3745816c18052518f267d13fa9a3c21e1554a914eefL74)