### PR TITLE
[release/v7.5]Update Microsoft.PowerShell.PSResourceGet to 1.1.0

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
-    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.1.0-rc2" />
+    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.1.0" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.3.6" />
     <PackageReference Include="ThreadJob" Version="2.0.3" />


### PR DESCRIPTION
Backport #24767

This pull request includes an update to the `PSGalleryModules.csproj` file to upgrade the version of the `Microsoft.PowerShell.PSResourceGet` package.

Dependency update:

* [`src/Modules/PSGalleryModules.csproj`](diffhunk://#diff-c5607631ae8e51c58ed12c063bb5d26ed89bc04b8bafc882c83f11ee0ee68273L16-R16): Updated `Microsoft.PowerShell.PSResourceGet` package version from `1.1.0-rc2` to `1.1.0`.