### PR TITLE
[release/v7.5] Fix Changelog content grab during GitHub Release (#24788)

### DIFF
--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -74,14 +74,12 @@ jobs:
 
         $changelog = Get-Content -Path $filePath
 
-        $startPattern = "^## \[" + ([regex]::Escape($releaseVersion)) + "\]"
-        $endPattern = "^## \[{0}\.{1}\.{2}*" -f $semanticVersion.Major, $semanticVersion.Minor, $semanticVersion.Patch
+        $headingPattern = "^## \[\d+\.\d+\.\d+"
+        $headingStartLines = $changelog | Select-String -Pattern $headingPattern | Select-Object -ExpandProperty LineNumber
+        $startLine = $headingStartLines[0]
+        $endLine = $headingStartLines[1] - 1
 
-        $clContent = $changelog | ForEach-Object {
-            if ($_ -match $startPattern) { $outputLine = $true }
-            elseif ($_ -match $endPattern) { $outputLine = $false }
-            if ($outputLine) { $_}
-          } | Out-String
+        $clContent = $changelog | Select-Object -Skip ($startLine-1) -First ($endLine - $startLine) | Out-String
 
         Write-Verbose -Verbose "Selected content: `n$clContent"
 


### PR DESCRIPTION
backport #24788 

This pull request includes a change to the `jobs:` section in the `.pipelines/templates/release-githubtasks.yml` file to improve the process of extracting changelog content based on version headings.

Improvements to extracting changelog content:

* [`.pipelines/templates/release-githubtasks.yml`](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L77-R82): Modified the method to identify the start and end lines of the changelog content by using a regex pattern to match version headings. This change simplifies the extraction logic by directly selecting lines between the identified start and end lines.