### PR TITLE
[release/v7.4] Add ability to capture MSBuild Binary logs when restore fails

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -26,6 +26,10 @@ parameters:
     displayName: Enable MSBuild Binary Logs
     type: boolean
     default: false
+  - name: ENABLE_MSBUILD_BINLOGS
+    displayName: Enable MSBuild Binary Logs
+    type: boolean
+    default: false
 
 resources:
   repositories:

--- a/build.psm1
+++ b/build.psm1
@@ -763,7 +763,7 @@ function Switch-PSNugetConfig {
     } elseif ( $Source -eq 'NuGetOnly') {
         New-NugetConfigFile -NugetPackageSource $nugetorg   -Destination "$PSScriptRoot/" @extraParams
         New-NugetConfigFile -NugetPackageSource $gallery                -Destination "$PSScriptRoot/src/Modules/" @extraParams
-        New-NugetConfigFile -NugetPackageSource $gallery                -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams        
+        New-NugetConfigFile -NugetPackageSource $gallery                -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
     } elseif ( $Source -eq 'Private') {
         $powerShellPackages = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json'; Name = 'powershell' }
 
@@ -882,7 +882,7 @@ function Restore-PSPackage
             $RestoreArguments += "--interactive"
         }
 
-        if ($env:ENABLE_MSBUILD_BINLOGS -eq 'true') {
+        if ($env:ENABLE_MSBUILD_BINLOGS) {
             $RestoreArguments += '-bl'
         }
 
@@ -903,7 +903,7 @@ function Restore-PSPackage
                     $retryCount++
                     if($retryCount -ge $maxTries)
                     {
-                        if ($env:ENABLE_MSBUILD_BINLOGS -eq 'true') {
+                        if ($env:ENABLE_MSBUILD_BINLOGS) {
                             if ( Test-Path ./msbuild.binlog ) {
                                 if (!(Test-Path $env:OB_OUTPUTDIRECTORY -PathType Container)) {
                                     $null = New-Item -path $env:OB_OUTPUTDIRECTORY -ItemType Directory -Force -Verbose


### PR DESCRIPTION
Backport #24128

This pull request includes changes to the `ENABLE_MSBUILD_BINLOGS` parameter in the PowerShell build scripts and pipeline configuration. The most important changes include adding the `ENABLE_MSBUILD_BINLOGS` parameter to the pipeline configuration and simplifying the conditional checks for this parameter in the `Restore-PSPackage` function.

Pipeline configuration:

* [`.pipelines/PowerShell-Coordinated_Packages-Official.yml`](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR29-R32): Added the `ENABLE_MSBUILD_BINLOGS` parameter to enable MSBuild binary logs.

Build script simplification:

* [`build.psm1`](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL885-R885): Simplified the conditional checks for `ENABLE_MSBUILD_BINLOGS` in the `Restore-PSPackage` function by removing the comparison to the string 'true'. [[1]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL885-R885) [[2]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL906-R906)