### PR TITLE
[release/v7.4] Add CodeQL scanning to APIScan build

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -1,7 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-
+name: apiscan-genNotice-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 trigger: none
+
+parameters:
+  - name: FORCE_CODEQL
+    displayName: Debugging - Enable CodeQL and set cadence to 1 hour
+    type: boolean
+    default: false
 
 variables:
   - name: ob_outputDirectory
@@ -17,6 +23,24 @@ variables:
     value: onebranch.azurecr.io/linux/ubuntu-2004:latest
   - name: WindowsContainerImage
     value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
+  - ${{ if eq(parameters['FORCE_CODEQL'],'true') }}:
+    # Cadence is hours before CodeQL will allow a re-upload of the database
+    - name: CodeQL.Cadence
+      value: 0
+  - name: CODEQL_ENABLED
+    ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters['FORCE_CODEQL'],'true')) }}:
+      value: true
+    ${{ else }}:
+      value: false
+  - name: Codeql.TSAEnabled
+    value: $(CODEQL_ENABLED)
+  # AnalyzeInPipeline: false = upload results
+  # AnalyzeInPipeline: true = do not upload results
+  - name: Codeql.AnalyzeInPipeline
+    ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(parameters['FORCE_CODEQL'],'true')) }}:
+      value: false
+    ${{ else }}:
+      value: true
 
 resources:
   repositories:
@@ -32,8 +56,10 @@ extends:
       WindowsHostVersion:
         Version: 2022
     globalSdl:
-      compiled:
-        enabled: true
+      codeql:
+        compiled:
+          enabled: $(CODEQL_ENABLED)
+        tsaEnabled: $(CODEQL_ENABLED) # This enables TSA bug filing only for CodeQL 3000
       armory:
         enabled: false
       sbom:

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -4,34 +4,36 @@
 jobs:
   - job: APIScan
     variables:
-        - name: runCodesignValidationInjection
-          value : false
-        - name: NugetSecurityAnalysisWarningLevel
-          value: none
-        - name: ReleaseTagVar
-          value: fromBranch
-        # Defines the variables APIScanClient, APIScanTenant and APIScanSecret
-        - group: PS-PS-APIScan
-        # PAT permissions NOTE: Declare a SymbolServerPAT variable in this group with a 'microsoft' organizanization scoped PAT with 'Symbols' Read permission.
-        # A PAT in the wrong org will give a single Error 203. No PAT will give a single Error 401, and individual pdbs may be missing even if permissions are correct.
-        - group: symbols
-        - name: branchCounterKey
-          value: $[format('{0:yyyyMMdd}-{1}', pipeline.startTime,variables['Build.SourceBranch'])]
-        - name: branchCounter
-          value: $[counter(variables['branchCounterKey'], 1)]
-        - group: DotNetPrivateBuildAccess
-        - group: Azure Blob variable group
-        - group: ReleasePipelineSecrets
-        - group: mscodehub-feed-read-general
-        - group: mscodehub-feed-read-akv
-        - name: ob_outputDirectory
-          value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-        - name: repoRoot
-          value: '$(Build.SourcesDirectory)\PowerShell'
-        - name: ob_sdl_tsa_configFile
-          value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
-        - name: ob_sdl_credscan_suppressionsFile
-          value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      - name: runCodesignValidationInjection
+        value : false
+      - name: NugetSecurityAnalysisWarningLevel
+        value: none
+      - name: ReleaseTagVar
+        value: fromBranch
+      # Defines the variables APIScanClient, APIScanTenant and APIScanSecret
+      - group: PS-PS-APIScan
+      # PAT permissions NOTE: Declare a SymbolServerPAT variable in this group with a 'microsoft' organizanization scoped PAT with 'Symbols' Read permission.
+      # A PAT in the wrong org will give a single Error 203. No PAT will give a single Error 401, and individual pdbs may be missing even if permissions are correct.
+      - group: symbols
+      - name: branchCounterKey
+        value: $[format('{0:yyyyMMdd}-{1}', pipeline.startTime,variables['Build.SourceBranch'])]
+      - name: branchCounter
+        value: $[counter(variables['branchCounterKey'], 1)]
+      - group: DotNetPrivateBuildAccess
+      - group: Azure Blob variable group
+      - group: ReleasePipelineSecrets
+      - group: mscodehub-feed-read-general
+      - group: mscodehub-feed-read-akv
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+      - name: repoRoot
+        value: '$(Build.SourcesDirectory)\PowerShell'
+      - name: ob_sdl_tsa_configFile
+        value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
+      - name: ob_sdl_credscan_suppressionsFile
+        value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      - name: Codeql.SourceRoot
+        value: $(repoRoot)
 
     pool:
         type: windows
@@ -119,6 +121,12 @@ jobs:
       workingDirectory: '$(repoRoot)'
       condition: succeededOrFailed()
 
+    - task: CodeQL3000Init@0 # Add CodeQL Init task right before your 'Build' step.
+      displayName: 🔏 CodeQL 3000 Init
+      condition: eq(variables['CODEQL_ENABLED'], 'true')
+      inputs:
+        Language: csharp
+
     - pwsh: |
         Import-Module .\build.psm1 -force
         Find-DotNet
@@ -135,6 +143,10 @@ jobs:
 
       workingDirectory: '$(repoRoot)'
       displayName: 'Build PowerShell Source'
+
+    - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.
+      displayName: 🔏 CodeQL 3000 Finalize
+      condition: eq(variables['CODEQL_ENABLED'], 'true')
 
     - pwsh: |
         Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose


### PR DESCRIPTION
Backport #24303

This pull request introduces several changes to the pipeline configuration files to enable and configure CodeQL scanning based on certain conditions. The main updates include adding parameters and variables to control CodeQL settings and integrating CodeQL tasks into the pipeline jobs.

Key changes include:

### Enhancements to pipeline configuration:

* [`.pipelines/apiscan-gen-notice.yml`](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2L3-R11): Added a `FORCE_CODEQL` parameter and associated variables to control CodeQL scanning and its cadence. Updated the `extends:` section to conditionally enable CodeQL based on the new variables. [[1]](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2L3-R11) [[2]](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2R26-R43) [[3]](diffhunk://#diff-b15446077e1469eba6a0cd3a92b59266ad66ba8e52f620039f461e3a831160d2R59-R62)

### Integration of CodeQL tasks:

* [`.pipelines/templates/compliance/apiscan.yml`](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R35-R36): Added `Codeql.SourceRoot` variable and integrated `CodeQL3000Init` and `CodeQL3000Finalize` tasks to the job steps, conditioned on the `CODEQL_ENABLED` variable. [[1]](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R35-R36) [[2]](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R124-R129) [[3]](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11R147-R150)