### PR TITLE
[release/v7.4] Download package from package build for generating vPack

### DIFF
--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -138,7 +138,7 @@ extends:
               installationPath: $(Agent.ToolsDirectory)/dotnet
 
           - pwsh: |
-              $packageArtifactName = 'drop_windows_package_package_win_${{ parameters.architecture }}'
+              $packageArtifactName = 'drop_windows_package_package_${{ parameters.architecture }}'
               $vstsCommandString = "vso[task.setvariable variable=PackageArtifactName]$packageArtifactName"
               Write-Host "sending " + $vstsCommandString
               Write-Host "##$vstsCommandString"


### PR DESCRIPTION
Backport #24481

This pull request includes a minor update to the `.pipelines/PowerShell-vPack-Official.yml` file. The change involves modifying the `pwsh` script to adjust the `packageArtifactName` variable to remove redundant text and simplify the naming convention.

* [`.pipelines/PowerShell-vPack-Official.yml`](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L141-R141): Updated the `packageArtifactName` variable in the `pwsh` script to remove redundant text and simplify the naming convention.