### PR TITLE
[release/v7.4]Deploy Box Update

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -64,6 +64,10 @@ resources:
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
+    - repository: PSInternalTools
+      type: git
+      name: PowerShellCore/Internal-PowerShellTeam-Tools
+      ref: refs/heads/master
 
   pipelines:
     - pipeline: CoOrdinatedBuildPipeline
@@ -110,8 +114,14 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
+    - stage: setReleaseTagAndUploadTools
+      displayName: 'Set Release Tag and Upload Tools'
+      jobs:
+      - template: /.pipelines/templates/release-SetTagAndTools.yml@self
+
     - stage: msixbundle
       displayName: 'Create MSIX Bundle'
+      dependsOn: []
       jobs:
       - template: /.pipelines/templates/release-create-msix.yml@self
 
@@ -262,6 +272,35 @@ extends:
             Update and merge the changelog for the release.
             This step is required for creating GitHub draft release.
 
+    - stage: PublishGitHubRelease
+      displayName: Publish GitHub Release
+      dependsOn:
+        - setReleaseTagAndUploadTools
+        - UpdateChangeLog
+      variables:
+        ob_release_environment: Production
+      jobs:
+      - template: /.pipelines/templates/release-githubtasks.yml@self
+
+    - stage: PushGitTagAndMakeDraftPublic
+      displayName: Push Git Tag and Make Draft Public
+      dependsOn: PublishGitHubRelease
+      jobs:
+      - template: /.pipelines/templates/approvalJob.yml@self
+        parameters:
+          displayName: Push Git Tag
+          jobName: PushGitTag
+          instructions: |
+            Push the git tag to upstream
+
+      - template: /.pipelines/templates/approvalJob.yml@self
+        parameters:
+          displayName: Make Draft Public
+          dependsOnJob: PushGitTag
+          jobName: DraftPublic
+          instructions: |
+            Make the GitHub Release Draft Public
+
     - stage: BlobPublic
       displayName: Make Blob Public
       dependsOn: UpdateChangeLog
@@ -278,7 +317,11 @@ extends:
 
     - stage: PublishNuGet
       displayName: Publish NuGet
-      dependsOn: PublishGitHubRelease
+      dependsOn:
+        - setReleaseTagAndUploadTools
+        - PushGitTagAndMakeDraftPublic
+      variables:
+        ob_release_environment: Production
       jobs:
       - template: /.pipelines/templates/release-publish-nuget.yml@self
         parameters:

--- a/.pipelines/templates/release-SetReleaseTagandContainerName.yml
+++ b/.pipelines/templates/release-SetReleaseTagandContainerName.yml
@@ -8,9 +8,10 @@ steps:
     }
 
     $releaseTag = $Branch -replace '^.*((release|rebuild)/)'
-    $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
+    $vstsCommandString = "vso[task.setvariable variable=$Variable;isOutput=true]$releaseTag"
     Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
     Write-Host -Object "##$vstsCommandString"
+  name: OutputReleaseTag
   displayName: Set Release Tag
 
 - pwsh: |
@@ -20,7 +21,8 @@ steps:
     Write-Host "##$vstsCommandString"
 
     $version = '$(ReleaseTag)'.ToLowerInvariant().Substring(1)
-    $vstsCommandString = "vso[task.setvariable variable=Version]$version"
+    $vstsCommandString = "vso[task.setvariable variable=Version;isOutput=true]$version"
     Write-Host ("sending " + $vstsCommandString)
     Write-Host "##$vstsCommandString"
+  name: OutputVersion
   displayName: Set container name

--- a/.pipelines/templates/release-SetTagAndTools.yml
+++ b/.pipelines/templates/release-SetTagAndTools.yml
@@ -1,0 +1,75 @@
+jobs:
+- job: SetTagAndTools
+  displayName: Set Tag and Tools
+  condition: succeeded()
+  pool:
+    type: windows
+  variables:
+  - group: 'mscodehub-code-read-akv'
+  - name: ob_outputDirectory
+    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+  - name: ob_sdl_credscan_suppressionsFile
+    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+  - name: ob_sdl_tsa_configFile
+    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
+  steps:
+  - template: release-SetReleaseTagandContainerName.yml@self
+
+  - checkout: self
+    clean: true
+    env:
+      ob_restore_phase: true
+
+  - checkout: PSInternalTools
+    clean: true
+    env:
+      ob_restore_phase: true
+
+  - pwsh: |
+      New-Item -ItemType Directory -Path '$(Pipeline.Workspace)/ToolArtifact'
+      Get-ChildItem -Path '$(Build.SourcesDirectory)/Internal-PowerShellTeam-Tools/Scripts' -Filter 'GitHubRelease.psm1' -ErrorAction SilentlyContinue |
+        Copy-Item -Destination '$(Pipeline.Workspace)/ToolArtifact' -Verbose
+    displayName: Move GitHub Tool
+
+  - task: onebranch.pipeline.signing@1
+    displayName: Sign Tools
+    inputs:
+      command: 'sign'
+      signing_profile: internal_azure_service
+      files_to_sign: '*.ps1;*.psm1'
+      search_root: '$(Pipeline.Workspace)/ToolArtifact'
+
+  - pwsh: | 
+      Write-Verbose -Verbose "Creating output directory for release tools: $(ob_outputDirectory)/ToolArtifact"
+      New-Item -Path $(ob_outputDirectory)/ToolArtifact -ItemType Directory -Force
+      Get-ChildItem -Path "$(Pipeline.Workspace)/ToolArtifact/*" -Recurse | 
+        Copy-Item -Destination $(ob_outputDirectory)/ToolArtifact -Recurse -Verbose
+    displayName: Upload Tools
+  
+  - pwsh: |
+      Write-Verbose -Verbose "Release Tag: $(OutputReleaseTag.releaseTag)"
+      $releaseVersion = '$(OutputReleaseTag.releaseTag)' -replace '^v',''
+      Write-Verbose -Verbose "Release Version: $releaseVersion"
+      $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
+
+      $isPreview = $semanticVersion.PreReleaseLabel -ne $null
+
+      $fileName = if ($isPreview) {
+        "preview.md"
+      }
+      else {
+        $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
+      }
+
+      $filePath = "$(Build.SourcesDirectory)/PowerShell/CHANGELOG/$fileName"
+      Write-Verbose -Verbose "Selected Log file: $filePath"
+
+      if (-not (Test-Path -Path $filePath)) {
+        Write-Error "Changelog file not found: $filePath"
+        exit 1
+      }
+      
+      Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
+      New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force
+      Copy-Item -Path $filePath -Destination $(ob_outputDirectory)/CHANGELOG
+    displayName: Upload Changelog

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -3,148 +3,89 @@ jobs:
   displayName: Create GitHub Release Draft
   condition: succeeded()
   pool:
-    type: windows
+    type: release
+    os: windows
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        artifactName: drop_setReleaseTagAndUploadTools_SetTagAndTools
+      - input: pipelineArtifact
+        pipeline: PSPackagesOfficial
+        artifactName: drop_upload_upload_packages
   variables:
-  - name: runCodesignValidationInjection
-    value: false
-  - name: NugetSecurityAnalysisWarningLevel
-    value: none
-  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
-    value: 1
-  - group: 'mscodehub-code-read-akv'
-  - group: 'Azure Blob variable group'
-  - group: 'GitHubTokens'
-  - name: ob_outputDirectory
-    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-  - name: ob_sdl_codeSignValidation_enabled
-    value: false
-  - name: ob_sdl_binskim_enabled
-    value: false
-  - name: ob_sdl_tsa_configFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
-  - name: ob_sdl_credscan_suppressionsFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+    - template: ./variable/release-shared.yml@self
+      parameters:
+        RELEASETAG: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputReleaseTag.releaseTag'] ]
 
   steps:
-  - checkout: self
-    clean: true
-    env:
-      ob_restore_phase: true # This ensures checkout is done at the beginning of the restore phase
-
-  - template: release-SetReleaseTagAndContainerName.yml
-
-  - pwsh: |
-      Get-ChildItem Env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      script: |
+        Write-Verbose -Verbose "Release Tag: $(ReleaseTag)"
+        Get-ChildItem Env: | Out-String -Stream | Write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
-  - pwsh: |
-      # Uninstall Azure RM modules
-      $azRmModules = Get-Module -Name AzureRM* -ListAvailable
-      if ($azRmModules) {
-        $azRmModules | Remove-Module -Force
-      }
+  - template: release-install-pwsh.yml
 
-      # Install Az.Storage module if not already installed
-      if (-not (Get-Module -Name Az.Storage -ListAvailable)) {
-        Install-Module -Name Az.Storage -Force -AllowClobber -Scope CurrentUser -Verbose
-      }
-    displayName: Install Az.Storage module
-
-  - task: AzurePowerShell@5
-    displayName: Download packages from Azure Storage
+  - task: PowerShell@2
     inputs:
-      azureSubscription: az-blob-cicd-infra
-      scriptType: inlineScript
-      azurePowerShellVersion: LatestVersion
+      targetType: inline
       pwsh: true
-      inline: |
-        $storageAccount = "$(StorageAccount)"
-        $containerName = "$(AzureVersion)"
-        $destinationPath = "$(System.ArtifactsDirectory)"
-
-        # Get storage account context
-        $storageContext = New-AzStorageContext -StorageAccountName $storageAccount
-
-        $blobList = Get-AzStorageBlob -Container $containerName -Context $storageContext
-        foreach ($blob in $blobList) {
-          $blobName = $blob.Name
-          $destinationFile = Join-Path -Path $destinationPath -ChildPath $blobName
-          Get-AzStorageBlobContent -Container $containerName -Blob $blobName -Destination $destinationFile -Context $storageContext -Force
-          Write-Output "Downloaded $blobName to $destinationFile"
-        }
-
-        $packagesPath = Get-ChildItem -Path $destinationPath\*.deb -Recurse -File | Select-Object -First 1 -ExpandProperty DirectoryName
-        Write-Host "sending -- vso[task.setvariable variable=PackagesRoot]$packagesPath"
-        Write-Host "##vso[task.setvariable variable=PackagesRoot]$packagesPath"
-
-  - pwsh: |
-      Get-ChildItem $(System.ArtifactsDirectory)\* -recurse | Select-Object -ExpandProperty FullName
-    displayName: Capture downloaded artifacts
-
-  - pwsh: |
-      git clone https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools '$(Pipeline.Workspace)/tools'
-    displayName: Clone Internal-Tools repository
-
-  - pwsh: |
-      $Path = "$(System.ArtifactsDirectory)"
-      $OutputPath = Join-Path $Path 'hashes.sha256'
-      $srcPaths = @($Path)
-      $packages  = Get-ChildItem -Path $srcPaths -Include * -Recurse -File
-      $checksums = $packages |
-          ForEach-Object {
-              Write-Verbose -Verbose "Generating checksum file for $($_.FullName)"
-              $packageName = $_.Name
-              $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower()
-              # the '*' before the packagename signifies it is a binary
-              "$hash *$packageName"
-          }
-      $checksums | Out-File -FilePath $OutputPath -Force
-      $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
-      Write-Verbose -Verbose -Message $fileContent
+      script: |
+        $Path = "$(Pipeline.Workspace)/GitHubPackages"
+        $OutputPath = Join-Path $Path 'hashes.sha256'
+        $packages  = Get-ChildItem -Path $Path -Include * -Recurse -File
+        $checksums = $packages |
+            ForEach-Object {
+                Write-Verbose -Verbose "Generating checksum file for $($_.FullName)"
+                $packageName = $_.Name
+                $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower()
+                # the '*' before the packagename signifies it is a binary
+                "$hash *$packageName"
+            }
+        $checksums | Out-File -FilePath $OutputPath -Force
+        $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
+        Write-Verbose -Verbose -Message $fileContent
     displayName: Add sha256 hashes
 
-  - pwsh: |
-      $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-      $vstsCommandString = "vso[task.setvariable variable=ReleaseVersion]$releaseVersion"
-      Write-Host "sending " + $vstsCommandString
-      Write-Host "##$vstsCommandString"
-    displayName: 'Set release version'
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        Get-ChildItem $(Pipeline.Workspace) -recurse | Select-Object -ExpandProperty FullName
+    displayName: List all files in the workspace
 
-  - pwsh: |
-      Import-module '$(Pipeline.Workspace)/tools/Scripts/GitHubRelease.psm1'
-      $releaseVersion = '$(ReleaseTag)' -replace '^v',''
-      $semanticVersion = [System.Management.Automation.SemanticVersion]$releaseVersion
+  - task: PowerShell@2
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
+        Write-Verbose -Verbose "Available modules: "
+        Get-Module | Write-Verbose -Verbose
 
-      $isPreview = $semanticVersion.PreReleaseLabel -ne $null
+        $filePath = Get-ChildItem -Path "$(Pipeline.Workspace)/CHANGELOG" -Filter '*.md' | Select-Object -First 1 -ExpandProperty FullName
 
-      $fileName = if ($isPreview) {
-        "preview.md"
-      }
-      else {
-        $semanticVersion.Major.ToString() + "." + $semanticVersion.Minor.ToString() + ".md"
-      }
+        if (-not (Test-Path $filePath)) {
+          throw "$filePath not found"
+        }
 
-      $filePath = "$env:BUILD_SOURCESDIRECTORY/PowerShell/CHANGELOG/$fileName"
-      Write-Verbose -Verbose "Selected Log file: $filePath"
+        $changelog = Get-Content -Path $filePath
 
-      if (-not (Test-Path $filePath)) {
-        throw "$filePath not found"
-      }
+        $startPattern = "^## \[" + ([regex]::Escape($releaseVersion)) + "\]"
+        $endPattern = "^## \[{0}\.{1}\.{2}*" -f $semanticVersion.Major, $semanticVersion.Minor, $semanticVersion.Patch
 
-      $changelog = Get-Content -Path $filePath
+        $clContent = $changelog | ForEach-Object {
+            if ($_ -match $startPattern) { $outputLine = $true }
+            elseif ($_ -match $endPattern) { $outputLine = $false }
+            if ($outputLine) { $_}
+          } | Out-String
 
-      $startPattern = "^## \[" + ([regex]::Escape($releaseVersion)) + "\]"
-      $endPattern = "^## \[{0}\.{1}\.{2}*" -f $semanticVersion.Major, $semanticVersion.Minor, $semanticVersion.Patch
+        Write-Verbose -Verbose "Selected content: `n$clContent"
 
-      $clContent = $changelog | ForEach-Object {
-          if ($_ -match $startPattern) { $outputLine = $true }
-          elseif ($_ -match $endPattern) { $outputLine = $false }
-          if ($outputLine) { $_}
-        } | Out-String
-
-      Write-Verbose -Verbose "Selected content: `n$clContent"
-
-      Publish-ReleaseDraft -Tag '$(ReleaseTag)' -Name '$(ReleaseTag) Release of PowerShell' -Description $clContent -User PowerShell -Repository PowerShell  -PackageFolder $(PackagesRoot) -Token $(GitHubReleasePat)
+        Publish-ReleaseDraft -Tag '$(ReleaseTag)' -Name '$(ReleaseTag) Release of PowerShell' -Description $clContent -User PowerShell -Repository PowerShell  -PackageFolder "$(Pipeline.Workspace)/GitHubPackages" -Token $(GitHubReleasePat)
     displayName: Publish Release Draft
 
 - template: /.pipelines/templates/approvalJob.yml@self

--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -8,35 +8,23 @@ jobs:
   displayName: Publish to NuGet
   condition: succeeded()
   pool:
-    type: windows
+    type: release
+    os: windows
+  templateContext:
+    inputs:
+      - input: pipelineArtifact
+        pipeline: PSPackagesOfficial
+        artifactName: drop_upload_upload_packages
   variables:
-  - name: runCodesignValidationInjection
-    value: false
-  - name: NugetSecurityAnalysisWarningLevel
-    value: none
-  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
-    value: 1
-  - group: 'mscodehub-code-read-akv'
-  - name: ob_outputDirectory
-    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
-  - name: ob_sdl_codeSignValidation_enabled
-    value: false
-  - name: ob_sdl_binskim_enabled
-    value: false
-  - name: ob_sdl_tsa_configFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
-  - name: ob_sdl_credscan_suppressionsFile
-    value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+  - template: ./variable/release-shared.yml@self
+    parameters:
+      VERSION: $[ stageDependencies.setReleaseTagAndUploadTools.SetTagAndTools.outputs['OutputVersion.Version'] ]
 
   steps:
-  - checkout: self
-    clean: true
-    env:
-      ob_restore_phase: true # This ensures checkout is done at the beginning of the restore phase
-
-  - template: release-SetReleaseTagAndContainerName.yml
+  - template: release-install-pwsh.yml
 
   - pwsh: |
+      Write-Verbose -Verbose "Version: $(Version)"
       Get-ChildItem Env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
@@ -49,8 +37,8 @@ jobs:
       $null = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/release"
       Copy-Item "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg/*.nupkg" -Destination "$(Pipeline.Workspace)/release" -Exclude "PowerShell.*.nupkg" -Force -Verbose
 
-      $releaseVersion = '$(VERSION)'
-      $globalToolPath = "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg/PowerShell.$releaseVersion.nupkg"
+      $releaseVersion = '$(Version)'
+      $globalToolPath = "$(Pipeline.Workspace)/NuGetPackages/PowerShell.$releaseVersion.nupkg"
 
       if ($releaseVersion -notlike '*-*') {
           # Copy the global tool package for stable releases

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -23,7 +23,7 @@ jobs:
     displayName: Capture environment
 
   - pwsh: |
-      $name = "{0}_{1:x}" -f '$(releaseTag)', (Get-Date).Ticks
+      $name = "{0}_{1:x}" -f '$(OutputReleaseTag.releaseTag)', (Get-Date).Ticks
       Write-Host $name
       Write-Host "##vso[build.updatebuildnumber]$name"
     displayName: Set Release Name

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -234,6 +234,22 @@ jobs:
     displayName: 'Capture downloads'
 
   - pwsh: |
+      Write-Verbose -Verbose "Copying Github Release files in $(Build.ArtifactStagingDirectory)/downloads to use in Release Pipeline"
+
+      Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
+      New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse |
+        Where-Object { $_.Extension -notin '.msix', '.nupkg' } |
+        Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse -Verbose
+
+      Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
+      New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse |
+        Where-Object { $_.Extension -eq '.nupkg' } |
+        Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse -Verbose
+    displayName: Copy downloads to Artifacts
+
+  - pwsh: |
       # Create output directory for packages which have been uploaded to blob storage
       New-Item -Path $(Build.ArtifactStagingDirectory)/uploaded -ItemType Directory -Force
     displayName: Create output directory for packages

--- a/.pipelines/templates/variable/release-shared.yml
+++ b/.pipelines/templates/variable/release-shared.yml
@@ -1,0 +1,42 @@
+parameters:
+  - name: REPOROOT
+    type: string
+    default: $(Build.SourcesDirectory)\PowerShell
+  - name: SBOM
+    type: boolean
+    default: false
+  - name: RELEASETAG
+    type: string
+    default: 'Not Initialized'
+  - name: VERSION
+    type: string
+    default: 'Not Initialized'
+
+variables:
+  - name: ob_signing_setup_enabled            
+    value: false
+  - name: ob_sdl_sbom_enabled
+    value: ${{ parameters.SBOM }}
+  - name: runCodesignValidationInjection
+    value: false
+  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+    value: 1
+  - group: 'mscodehub-code-read-akv'
+  - group: 'Azure Blob variable group'
+  - group: 'GitHubTokens'
+  - name: ob_outputDirectory
+    value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+  - name: ob_sdl_codeSignValidation_enabled
+    value: false
+  - name: ob_sdl_binskim_enabled
+    value: false
+  - name: ob_sdl_tsa_configFile
+    value: ${{ parameters.REPOROOT }}\.config\tsaoptions.json
+  - name: ob_sdl_credscan_suppressionsFile
+    value: ${{ parameters.REPOROOT }}\.config\suppress.json
+  - name: ob_sdl_codeql_compiled_enabled
+    value: false
+  - name: ReleaseTag
+    value: ${{ parameters.RELEASETAG }}
+  - name: Version
+    value: ${{ parameters.VERSION }}


### PR DESCRIPTION
Backport #24632

This pull request includes several changes to the PowerShell release pipeline configuration to improve the release process and ensure proper handling of artifacts and versioning. The most important changes include adding new stages and jobs, modifying existing jobs to use outputs as inputs, and updating variable management.

Enhancements to the release pipeline:

* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR67-R70): Added a new repository `PSInternalTools` and introduced multiple new stages including `setReleaseTagAndUploadTools`, `PublishGitHubRelease`, and `PushGitTagAndMakeDraftPublic`. These changes improve the release tagging and artifact upload processes. [[1]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR67-R70) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR117-R124) [[3]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR275-R303) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL281-R324)

* [`.pipelines/templates/release-SetReleaseTagandContainerName.yml`](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L11-R14): Updated the script to set release tag and container name as output variables, and added names to the steps for better traceability. [[1]](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L11-R14) [[2]](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L23-R27)

* [`.pipelines/templates/release-SetTagAndTools.yml`](diffhunk://#diff-b9e5aa1224d680253d023e9d9442a953d336c7484f3a7773398e7a230c5ded67R1-R75): Added a new job `SetTagAndTools` to handle setting the release tag, signing tools, and uploading the changelog. This job ensures that the necessary tools and changelog are correctly prepared and uploaded.

* [`.pipelines/templates/release-githubtasks.yml`](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L6-R38): Modified the job to use the new output variables and improved the handling of GitHub release tasks by using a more structured approach to manage artifacts and environment variables. [[1]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L6-R38) [[2]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L106-R69) [[3]](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L147-R88)

* [`.pipelines/templates/release-publish-nuget.yml`](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafL11-R27): Updated the job to use the new output version variable and improved the process for capturing environment variables and handling NuGet packages. [[1]](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafL11-R27) [[2]](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafL52-R41)

These changes collectively enhance the robustness and traceability of the release pipeline, ensuring a smoother and more reliable release process.