### PR TITLE
[release/v7.4]Add a parameter that skips verify packages step

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -3,6 +3,15 @@
 
 trigger: none
 
+parameters:
+  - name: FORCE_CODEQL
+    displayName: Debugging - Enable CodeQL and set cadence to 1 hour
+    type: boolean
+    default: false
+  - name: SkipVerifyPackages
+    type: boolean
+    default: false
+
 variables:
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
@@ -77,3 +86,4 @@ extends:
           - template: /.pipelines/templates/compliance/generateNotice.yml@self
             parameters:
               parentJobs: []
+              SkipVerifyPackages: ${{ parameters.SkipVerifyPackages }}

--- a/.pipelines/templates/compliance/generateNotice.yml
+++ b/.pipelines/templates/compliance/generateNotice.yml
@@ -4,6 +4,8 @@
 parameters:
   - name: parentJobs
     type: jobList
+  - name: SkipVerifyPackages
+    type: boolean
 
 jobs:
 - job: generateNotice
@@ -60,7 +62,7 @@ jobs:
   - pwsh: |
       $(repoRoot)/tools/clearlyDefined/ClearlyDefined.ps1 -TestAndHarvest
     displayName: Verify that packages have license data
-
+    condition: eq(${{ parameters.SkipVerifyPackages }}, false)
 
   - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
     displayName: 'NOTICE File Generator'
@@ -70,7 +72,6 @@ jobs:
       outputformat: text
       # this isn't working
       # additionaldata: $(Build.SourcesDirectory)\assets\additionalAttributions.txt
-
 
   - pwsh: |
       Get-Content -Raw -Path $(repoRoot)\assets\additionalAttributions.txt | Out-File '$(ob_outputDirectory)\ThirdPartyNotices.txt' -Encoding utf8NoBOM -Force -Append


### PR DESCRIPTION
Backport #24763

This pull request includes changes to the `.pipelines/apiscan-gen-notice.yml` and `.pipelines/templates/compliance/generateNotice.yml` files to introduce new parameters and improve the flexibility of the pipeline configuration. The most important changes include adding new parameters for debugging and skipping package verification, and modifying job conditions based on these parameters.

Pipeline configuration improvements:

* Added `FORCE_CODEQL` and `SkipVerifyPackages` parameters to `.pipelines/apiscan-gen-notice.yml` for debugging and skipping package verification.
* Modified the `extends:` section in `.pipelines/apiscan-gen-notice.yml` to pass the `SkipVerifyPackages` parameter to the compliance template.

Compliance template updates:

* Added `SkipVerifyPackages` parameter to `.pipelines/templates/compliance/generateNotice.yml`.
* Updated job conditions in `.pipelines/templates/compliance/generateNotice.yml` to skip package verification if `SkipVerifyPackages` is set to true.
* Cleaned up comments and formatting in `.pipelines/templates/compliance/generateNotice.yml`.