### PR TITLE
[release/v7.4]Fix changelog content grab during GitHub release

### DIFF
--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -74,14 +74,12 @@ jobs:
 
         $changelog = Get-Content -Path $filePath
 
-        $startPattern = "^## \[" + ([regex]::Escape($releaseVersion)) + "\]"
-        $endPattern = "^## \[{0}\.{1}\.{2}*" -f $semanticVersion.Major, $semanticVersion.Minor, $semanticVersion.Patch
+        $headingPattern = "^## \[\d+\.\d+\.\d+"
+        $headingStartLines = $changelog | Select-String -Pattern $headingPattern | Select-Object -ExpandProperty LineNumber
+        $startLine = $headingStartLines[0]
+        $endLine = $headingStartLines[1] - 1
 
-        $clContent = $changelog | ForEach-Object {
-            if ($_ -match $startPattern) { $outputLine = $true }
-            elseif ($_ -match $endPattern) { $outputLine = $false }
-            if ($outputLine) { $_}
-          } | Out-String
+        $clContent = $changelog | Select-Object -Skip ($startLine-1) -First ($endLine - $startLine) | Out-String
 
         Write-Verbose -Verbose "Selected content: `n$clContent"
 


### PR DESCRIPTION
Backport #24788

This pull request includes a change to the `jobs:` section in the `.pipelines/templates/release-githubtasks.yml` file to improve the extraction of changelog content between version headings.

Improvements to changelog extraction:

* [`.pipelines/templates/release-githubtasks.yml`](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2L77-R82): Modified the logic to identify the start and end lines of the changelog content by using a regular expression pattern to match version headings and selecting the appropriate lines. This simplifies the extraction process and ensures accurate content selection.