### PR TITLE
[release/v7.4] Add tool package download in NuGet release stage 

### DIFF
--- a/.pipelines/templates/release-publish-nuget.yml
+++ b/.pipelines/templates/release-publish-nuget.yml
@@ -13,6 +13,8 @@ jobs:
   templateContext:
     inputs:
       - input: pipelineArtifact
+        artifactName: drop_setReleaseTagAndUploadTools_SetTagAndTools
+      - input: pipelineArtifact
         pipeline: PSPackagesOfficial
         artifactName: drop_upload_upload_packages
   variables:


### PR DESCRIPTION
Backport #24790

This pull request includes a small change to the `.pipelines/templates/release-publish-nuget.yml` file. The change adds a new `pipelineArtifact` input under the `inputs` section for the `jobs:` configuration.

* [`.pipelines/templates/release-publish-nuget.yml`](diffhunk://#diff-fe4ea9895cd5ee1821c6ea572b2b9eec7f5fa24cd86c7e7133120ef5b193eeafR15-R16): Added a new `pipelineArtifact` input with the artifact name `drop_setReleaseTagAndUploadTools_SetTagAndTools`.