### PR TITLE
[release/v7.5]Fixed release pipeline errors and switched to KS3

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -88,7 +88,7 @@ extends:
     featureFlags:
       WindowsHostVersion:
         Version: 2022
-        Network: Netlock
+        Network: KS3
     cloudvault:
       enabled: false
     globalSdl:

--- a/.pipelines/templates/release-SetReleaseTagandContainerName.yml
+++ b/.pipelines/templates/release-SetReleaseTagandContainerName.yml
@@ -15,12 +15,12 @@ steps:
   displayName: Set Release Tag
 
 - pwsh: |
-    $azureVersion = '$(ReleaseTag)'.ToLowerInvariant() -replace '\.', '-'
-    $vstsCommandString = "vso[task.setvariable variable=AzureVersion]$azureVersion"
+    $azureVersion = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant() -replace '\.', '-'
+    $vstsCommandString = "vso[task.setvariable variable=AzureVersion;isOutput=true]$azureVersion"
     Write-Host "sending " + $vstsCommandString
     Write-Host "##$vstsCommandString"
 
-    $version = '$(ReleaseTag)'.ToLowerInvariant().Substring(1)
+    $version = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant().Substring(1)
     $vstsCommandString = "vso[task.setvariable variable=Version;isOutput=true]$version"
     Write-Host ("sending " + $vstsCommandString)
     Write-Host "##$vstsCommandString"

--- a/.pipelines/templates/release-create-msix.yml
+++ b/.pipelines/templates/release-create-msix.yml
@@ -96,7 +96,7 @@ jobs:
         azurePowerShellVersion: LatestVersion
         pwsh: true
         inline: |
-          $containerName = '$(AzureVersion)-private'
+          $containerName = '$(OutputVersion.AzureVersion)-private'
           $storageAccount = '$(StorageAccount)'
 
           $storageContext = New-AzStorageContext -StorageAccountName $storageAccount -UseConnectedAccount

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -63,6 +63,7 @@ jobs:
       pwsh: true
       script: |
         Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
+        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
         Write-Verbose -Verbose "Available modules: "
         Get-Module | Write-Verbose -Verbose
 

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -85,7 +85,7 @@ jobs:
         $packageName = '${{ parameters.globalToolPackageName }}'
         Write-Verbose -Verbose "Installing $packageName"
 
-        dotnet tool install --add-source "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg" --tool-path $toolPath --version '$(Version)' $packageName
+        dotnet tool install --add-source "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg" --tool-path $toolPath --version '$(OutputVersion.Version)' $packageName
 
         Get-ChildItem -Path $toolPath
 
@@ -133,7 +133,7 @@ jobs:
 
         $versionFound = & $toolPath -c '$PSVersionTable.PSVersion.ToString()'
 
-        if ( '$(Version)' -ne $versionFound)
+        if ( '$(OutputVersion.Version)' -ne $versionFound)
         {
             throw "Expected version of global tool not found. Installed version is $versionFound"
         }

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -50,7 +50,7 @@ jobs:
       inline: |
         $storageAccount = Get-AzStorageAccount -ResourceGroupName '$(StorageResourceGroup)' -Name '$(StorageAccount)'
         $ctx = $storageAccount.Context
-        $container = '$(AzureVersion)'
+        $container = '$(OutputVersion.AzureVersion)'
 
         $destinationPath = '$(System.ArtifactsDirectory)'
         $blobList = Get-AzStorageBlob -Container $container -Context $ctx

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -95,7 +95,7 @@ jobs:
         </packageSources>
         "@
 
-        $releaseVersion = '$(Version)'
+        $releaseVersion = '$(OutputVersion.Version)'
 
         Write-Verbose -Message "Release Version: $releaseVersion" -Verbose
 


### PR DESCRIPTION
Backport #24751
This pull request focuses on updating various Azure pipeline templates to use output variables for versioning and container names. The changes aim to make the pipeline scripts more consistent and reliable by using the `OutputVersion` and `OutputReleaseTag` variables.

Key changes include:

* Updated network configuration in `.pipelines/PowerShell-Release-Official.yml`:
  * Changed `Network` from `Netlock` to `KS3`.

* Updates in `.pipelines/templates/release-SetReleaseTagandContainerName.yml`:
  * Modified the script to use `OutputReleaseTag.ReleaseTag` for setting `AzureVersion` and `Version` variables.

* Changes in `.pipelines/templates/release-create-msix.yml`:
  * Updated the container name to use `OutputVersion.AzureVersion`.

* Modifications in `.pipelines/templates/release-githubtasks.yml`:
  * Added a line to set `releaseVersion` by stripping the 'v' prefix from `ReleaseTag`.

* Updates in `.pipelines/templates/release-validate-globaltools.yml`:
  * Changed the version used in `dotnet tool install` and version validation to `OutputVersion.Version`. [[1]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL88-R88) [[2]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL136-R136)

* Changes in `.pipelines/templates/release-validate-packagenames.yml`:
  * Updated the container variable to `OutputVersion.AzureVersion`.

* Updates in `.pipelines/templates/release-validate-sdk.yml`:
  * Modified the script to use `OutputVersion.Version` for `releaseVersion`.