### PR TITLE
[release/v7.4]Fixed release pipeline errors and switched to KS3

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -88,7 +88,8 @@ extends:
       LinuxHostVersion:
           Network: Monitor
       WindowsHostVersion:
-          Network: Monitor
+        Version: 2022
+        Network: KS3
     cloudvault:
       enabled: false
     globalSdl:

--- a/.pipelines/templates/release-SetReleaseTagandContainerName.yml
+++ b/.pipelines/templates/release-SetReleaseTagandContainerName.yml
@@ -15,12 +15,12 @@ steps:
   displayName: Set Release Tag
 
 - pwsh: |
-    $azureVersion = '$(ReleaseTag)'.ToLowerInvariant() -replace '\.', '-'
-    $vstsCommandString = "vso[task.setvariable variable=AzureVersion]$azureVersion"
+    $azureVersion = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant() -replace '\.', '-'
+    $vstsCommandString = "vso[task.setvariable variable=AzureVersion;isOutput=true]$azureVersion"
     Write-Host "sending " + $vstsCommandString
     Write-Host "##$vstsCommandString"
 
-    $version = '$(ReleaseTag)'.ToLowerInvariant().Substring(1)
+    $version = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant().Substring(1)
     $vstsCommandString = "vso[task.setvariable variable=Version;isOutput=true]$version"
     Write-Host ("sending " + $vstsCommandString)
     Write-Host "##$vstsCommandString"

--- a/.pipelines/templates/release-create-msix.yml
+++ b/.pipelines/templates/release-create-msix.yml
@@ -96,7 +96,7 @@ jobs:
         azurePowerShellVersion: LatestVersion
         pwsh: true
         inline: |
-          $containerName = '$(AzureVersion)-private'
+          $containerName = '$(OutputVersion.AzureVersion)-private'
           $storageAccount = '$(StorageAccount)'
 
           $storageContext = New-AzStorageContext -StorageAccountName $storageAccount -UseConnectedAccount

--- a/.pipelines/templates/release-githubtasks.yml
+++ b/.pipelines/templates/release-githubtasks.yml
@@ -63,6 +63,7 @@ jobs:
       pwsh: true
       script: |
         Import-module '$(Pipeline.Workspace)/ToolArtifact/GitHubRelease.psm1'
+        $releaseVersion = '$(ReleaseTag)' -replace '^v',''
         Write-Verbose -Verbose "Available modules: "
         Get-Module | Write-Verbose -Verbose
 

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -85,7 +85,7 @@ jobs:
         $packageName = '${{ parameters.globalToolPackageName }}'
         Write-Verbose -Verbose "Installing $packageName"
 
-        dotnet tool install --add-source "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg" --tool-path $toolPath --version '$(Version)' $packageName
+        dotnet tool install --add-source "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/drop_nupkg_build_nupkg" --tool-path $toolPath --version '$(OutputVersion.Version)' $packageName
 
         Get-ChildItem -Path $toolPath
 
@@ -133,7 +133,7 @@ jobs:
 
         $versionFound = & $toolPath -c '$PSVersionTable.PSVersion.ToString()'
 
-        if ( '$(Version)' -ne $versionFound)
+        if ( '$(OutputVersion.Version)' -ne $versionFound)
         {
             throw "Expected version of global tool not found. Installed version is $versionFound"
         }

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -50,7 +50,7 @@ jobs:
       inline: |
         $storageAccount = Get-AzStorageAccount -ResourceGroupName '$(StorageResourceGroup)' -Name '$(StorageAccount)'
         $ctx = $storageAccount.Context
-        $container = '$(AzureVersion)'
+        $container = '$(OutputVersion.AzureVersion)'
 
         $destinationPath = '$(System.ArtifactsDirectory)'
         $blobList = Get-AzStorageBlob -Container $container -Context $ctx

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -95,7 +95,7 @@ jobs:
         </packageSources>
         "@
 
-        $releaseVersion = '$(Version)'
+        $releaseVersion = '$(OutputVersion.Version)'
 
         Write-Verbose -Message "Release Version: $releaseVersion" -Verbose
 


### PR DESCRIPTION
Backport #24751

This pull request includes several updates to various pipeline template files to ensure consistent use of output variables and improve the clarity and accuracy of the release process.

### Updates to pipeline templates:

* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL91-R92): Updated the `WindowsHostVersion` section to specify `Version: 2022` and changed the network to `KS3`.

* [`.pipelines/templates/release-SetReleaseTagandContainerName.yml`](diffhunk://#diff-a2cb4e499ab43d4196f31e243bfe523b3f543591768fb7a388ddb6dc52101730L18-R23): Modified the script to use `$(OutputReleaseTag.ReleaseTag)` instead of `$(ReleaseTag)` for setting the `AzureVersion` and `Version` variables.

* [`.pipelines/templates/release-create-msix.yml`](diffhunk://#diff-9cc831b9876377ff38572eacdb3d885fc0d526800cb17abaeac45e95a9a8d4e7L99-R99): Changed the container name to use `$(OutputVersion.AzureVersion)` instead of `$(AzureVersion)`.

* [`.pipelines/templates/release-githubtasks.yml`](diffhunk://#diff-399a6bedf8e2e8bd47ca1f1f0687a77870f8556867401ef327d44783595092e2R66): Added a new line to extract the release version from `$(ReleaseTag)` by removing the leading 'v'.

* [`.pipelines/templates/release-validate-globaltools.yml`](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL88-R88): Updated the commands to use `$(OutputVersion.Version)` instead of `$(Version)` for tool installation and version validation. [[1]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL88-R88) [[2]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL136-R136)

* [`.pipelines/templates/release-validate-packagenames.yml`](diffhunk://#diff-4a25f413e1bcba380ef7b8c81f15b8091a3041417bbb1cf9d84d329e104e8d42L53-R53): Changed the container variable to use `$(OutputVersion.AzureVersion)` instead of `$(AzureVersion)`.

* [`.pipelines/templates/release-validate-sdk.yml`](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L98-R98): Updated the release version variable to use `$(OutputVersion.Version)` instead of `$(Version)`.