### PR TITLE
Take the newest windows signature nuget package

### DIFF
--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.PowerShell.Native" Version="7.4.0" />
     <!-- Signing APIs -->
-    <PackageReference Include="Microsoft.Security.Extensions" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Security.Extensions" Version="1.3.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# Backport https://github.com/PowerShell/PowerShell/pull/20556

# PR Summary

This pull request includes an update to the `src/System.Management.Automation/System.Management.Automation.csproj` file to upgrade the version of the `Microsoft.Security.Extensions` package.

* [`src/System.Management.Automation/System.Management.Automation.csproj`](diffhunk://#diff-7f76b862df0ba75765a372c47d13cd6efc2d81f5abe6a6580531d104ef1d6279L51-R51): Upgraded `Microsoft.Security.Extensions` package from version 1.2.0 to 1.3.0.

## PR Context

Symbols don't exist for 1.2 so some static analysis tools fail for that package and despite the numbering, we know this is not a breaking change.
