### PR TITLE
[release/v7.4]Update path filters for Windows CI

### DIFF
--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -24,21 +24,17 @@ pr:
     - feature*
   paths:
     include:
-    - '*'
+    - src/*
+    - .vsts-ci/windows.yml
+    - .vsts-ci/templates/*
+    - test/*
+    - build.psm1
+    - tools/buildCommon/*
+    - tools/ci.psm1
+    - tools/WindowsCI.psm1
     exclude:
-    - .dependabot/config.yml
-    - .github/ISSUE_TEMPLATE/*
-    - .vsts-ci/misc-analysis.yml
-    - tools/cgmanifest.json
-    - LICENSE.txt
     - test/common/markdown/*
     - test/perf/*
-    - tools/packaging/*
-    - tools/releaseBuild/*
-    - tools/releaseBuild/azureDevOps/templates/*
-    - README.md
-    - .spelling
-    - .pipelines/*
 
 variables:
   GIT_CONFIG_PARAMETERS: "'core.autocrlf=false'"


### PR DESCRIPTION
Backport #24809

This pull request includes changes to the `.vsts-ci/windows.yml` file to refine the paths included and excluded in the CI process. The most important changes include updating the paths to better target specific directories and files while excluding irrelevant ones.

Changes to CI path inclusions and exclusions:

* Included paths: `src/*`, `.vsts-ci/windows.yml`, `.vsts-ci/templates/*`, `test/*`, `build.psm1`, `tools/buildCommon/*`, `tools/ci.psm1`, `tools/WindowsCI.psm1`
* Excluded paths: `.dependabot/config.yml`, `.github/ISSUE_TEMPLATE/*`, `.vsts-ci/misc-analysis.yml`, `tools/cgmanifest.json`, `LICENSE.txt`, `test/common/markdown/*`, `test/perf/*`, `tools/packaging/*`, `tools/releaseBuild/*`, `tools/releaseBuild/azureDevOps/templates/*`, `README.md`, `.spelling`, `.pipelines/*`