### PR TITLE
[release/v7.4] Use workload identity service connection to download makeappx tool from storage account

### DIFF
--- a/.pipelines/templates/release-create-msix.yml
+++ b/.pipelines/templates/release-create-msix.yml
@@ -28,27 +28,24 @@ jobs:
       displayName: Download x86 msix
       patterns: '**/*.msix'
 
-    - pwsh: |
-        $cmd = Get-Command makeappx.exe -ErrorAction Ignore
-        if ($cmd) {
-            Write-Verbose -Verbose 'makeappx available in PATH'
-            $exePath = $cmd.Source
-        } else {
-            $toolsDir = '$(Pipeline.Workspace)\releasePipeline\tools'
-            New-Item $toolsDir -Type Directory -Force > $null
-            Invoke-RestMethod -Uri '$(makeappUrl)' -OutFile "$toolsDir\makeappx.zip"
-            Expand-Archive "$toolsDir\makeappx.zip" -DestinationPath "$toolsDir\makeappx" -Force
-            $exePath = "$toolsDir\makeappx\makeappx.exe"
-
-            Write-Verbose -Verbose 'makeappx was installed:'
-            Get-ChildItem -Path $toolsDir -Recurse
-        }
-
-        $vstsCommandString = "vso[task.setvariable variable=MakeAppxPath]$exePath"
-        Write-Host "sending " + $vstsCommandString
-        Write-Host "##$vstsCommandString"
+    - task: AzurePowerShell@5
       displayName: Install makeappx tool
       retryCountOnTaskFailure: 1
+      inputs:
+        azureSubscription: az-blob-cicd-infra
+        scriptType: inlineScript
+        azurePowerShellVersion: LatestVersion
+        pwsh: true
+        inline: |
+          $toolsDir = '$(Pipeline.Workspace)\releasePipeline\tools'
+          New-Item $toolsDir -Type Directory -Force > $null
+          Invoke-RestMethod -Uri '$(makeappUrlDirect)' -OutFile "$toolsDir\makeappx.zip"
+          Expand-Archive "$toolsDir\makeappx.zip" -DestinationPath "$toolsDir\makeappx" -Force
+          $exePath = "$toolsDir\makeappx\makeappx.exe"
+
+          $vstsCommandString = "vso[task.setvariable variable=MakeAppxPath]$exePath"
+          Write-Host "sending " + $vstsCommandString
+          Write-Host "##$vstsCommandString"
 
     - pwsh: |
         $sourceDir = '$(Pipeline.Workspace)\releasePipeline\msix'


### PR DESCRIPTION
Backport #24817

This pull request includes changes to the `.pipelines/templates/release-create-msix.yml` file to improve the installation process for the `makeappx` tool. The changes involve replacing a PowerShell script with an Azure PowerShell task.

Improvements to the installation process:

* Replaced the inline PowerShell script with an `AzurePowerShell@5` task to install the `makeappx` tool, ensuring better integration and reliability in the pipeline.