### PR TITLE
[release/v7.4] Make the `AssemblyVersion` not change for servicing releases 7.4.7 and onward

### DIFF
--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -120,7 +120,7 @@ jobs:
       $refAssemblyFolder = Join-Path '$(System.ArtifactsDirectory)' 'RefAssembly'
       $null = New-Item -Path $refAssemblyFolder -Force -Verbose -Type Directory
 
-      Start-PSBuild -Clean -Runtime linux-x64 -Configuration Release
+      Start-PSBuild -Clean -Runtime linux-x64 -Configuration Release -ReleaseTag $(ReleaseTagVar)
 
       $sharedModules | Foreach-Object {
         $refFile = Get-ChildItem -Path "$(PowerShellRoot)\src\$_\obj\Release\net8.0\refint\$_.dll"
@@ -136,7 +136,7 @@ jobs:
         }
       }
 
-      Start-PSBuild -Clean -Runtime win7-x64 -Configuration Release
+      Start-PSBuild -Clean -Runtime win7-x64 -Configuration Release -ReleaseTag $(ReleaseTagVar)
 
       $winOnlyModules | Foreach-Object {
         $refFile = Get-ChildItem -Path "$(PowerShellRoot)\src\$_\obj\Release\net8.0\refint\*.dll"

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -60,9 +60,9 @@
       <PSCoreFileVersion Condition = "'$(PSCoreFileVersion)' == ''">$(ReleaseTagVersionPart).$(GAIncrementValue)</PSCoreFileVersion>
       <!-- Set 'FileVersion' and 'AssemblyVersion' explicitly:
            - make 'FileVersion' the same as 'PSCoreFileVersion'
-           - make 'AssemblyVersion' be the 'PSCoreFileVersion' with the 'Build' field set to 0, so the assembly version doesn't change for servicing releases -->
+           - make 'AssemblyVersion' be the 'PSCoreFileVersion' with the 'Build' field set to 6, so the assembly version doesn't change for servicing releases 7.4.7 and plus -->
       <FileVersion>$(PSCoreFileVersion)</FileVersion>
-      <AssemblyVersion>$([System.Version]::Parse($(PSCoreFileVersion)).Major).$([System.Version]::Parse($(PSCoreFileVersion)).Minor).0.$([System.Version]::Parse($(PSCoreFileVersion)).Revision)</AssemblyVersion>
+      <AssemblyVersion>$([System.Version]::Parse($(PSCoreFileVersion)).Major).$([System.Version]::Parse($(PSCoreFileVersion)).Minor).6.$([System.Version]::Parse($(PSCoreFileVersion)).Revision)</AssemblyVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -58,6 +58,11 @@
       <PSCoreFileVersion Condition = "'$(ReleaseTagSemVersionPart)' != ''">$(ReleaseTagVersionPart).$(ReleaseTagSemVersionPart)</PSCoreFileVersion>
       <!-- Create the version if we have a release build -->
       <PSCoreFileVersion Condition = "'$(PSCoreFileVersion)' == ''">$(ReleaseTagVersionPart).$(GAIncrementValue)</PSCoreFileVersion>
+      <!-- Set 'FileVersion' and 'AssemblyVersion' explicitly:
+           - make 'FileVersion' the same as 'PSCoreFileVersion'
+           - make 'AssemblyVersion' be the 'PSCoreFileVersion' with the 'Build' field set to 0, so the assembly version doesn't change for servicing releases -->
+      <FileVersion>$(PSCoreFileVersion)</FileVersion>
+      <AssemblyVersion>$([System.Version]::Parse($(PSCoreFileVersion)).Major).$([System.Version]::Parse($(PSCoreFileVersion)).Minor).0.$([System.Version]::Parse($(PSCoreFileVersion)).Revision)</AssemblyVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -84,7 +89,7 @@
       -->
 
       <!--
-            Here we define explicitly 'Version' to set 'FileVersion' and 'AssemblyVersion' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
+            Here we define explicitly 'Version' to set 'FileVersion' and 'AssemblyVersion' when they are not explicitly set.
             Here we define explicitly 'InformationalVersion' because by default it is defined as 'Version' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
       -->
       <Version>$(PSCoreFileVersion)</Version>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This is for backporting #24667 to v7.4, so that `AssemblyVersion` stay unchanged for servicing releases 7.4.7 and onward.
Comparing to the original PR, the `Build` field of the `AssemblyVersion` is fixed to `6`, so that the `AssemblyVersion` will always be `7.4.6.500` for all subsequent 7.4 servicing releases.