### PR TITLE
[release/v7.4]Add *.props and sort path filters for windows CI

### DIFF
--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -24,11 +24,12 @@ pr:
     - feature*
   paths:
     include:
-    - src/*
-    - .vsts-ci/windows.yml
     - .vsts-ci/templates/*
-    - test/*
+    - .vsts-ci/windows.yml
+    - '*.props'
     - build.psm1
+    - src/*
+    - test/*
     - tools/buildCommon/*
     - tools/ci.psm1
     - tools/WindowsCI.psm1


### PR DESCRIPTION
Backport #24822

This pull request includes updates to the `.vsts-ci/windows.yml` file to refine the paths included in the CI pipeline. The most important changes involve reordering and modifying the paths for better organization and functionality.

Changes to CI paths:

* [`.vsts-ci/windows.yml`](diffhunk://#diff-0c75d2c6f3ceda412aedd44f1141924e95597eb522d36c1018cba218c1e7a166L27-R32): Reordered and updated the paths to include `*.props` and ensure the correct files are included for the CI process.