### PR TITLE
Update `IndexOfAny` calls with invalid path/filename to `SearchValues<char>` for more efficient char searching

### DIFF
--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1448,7 +1448,7 @@ namespace System.Management.Automation
                 // If the command contains any invalid path characters, we can't
                 // do the path lookup
 
-                if (possiblePath.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+                if (PathUtils.ContainsInvalidPathChars(possiblePath))
                 {
                     result = CanDoPathLookupResult.IllegalCharacters;
                     break;

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -2860,7 +2860,7 @@ namespace System.Management.Automation.Runspaces
             // Ensure that user name contains no invalid path characters.
             // MSDN indicates that logon names cannot contain any of these invalid characters,
             // but this check will ensure safety.
-            if (userName.IndexOfAny(System.IO.Path.GetInvalidPathChars()) > -1)
+            if (PathUtils.ContainsInvalidPathChars(userName))
             {
                 throw new PSInvalidOperationException(RemotingErrorIdStrings.InvalidUserDriveName);
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -6405,7 +6405,7 @@ namespace Microsoft.PowerShell.Commands
 
                 // If this has an extension, and it's a relative path,
                 // then we need to ensure it's a fully-qualified path
-                if ((moduleToProcess.IndexOfAny(Path.GetInvalidPathChars()) == -1) &&
+                if ((!PathUtils.ContainsInvalidPathChars(moduleToProcess)) &&
                     Path.HasExtension(moduleToProcess) &&
                     (!Path.IsPathRooted(moduleToProcess)))
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1086,11 +1086,10 @@ namespace Microsoft.PowerShell.Commands
 
             // Remove drive root first
             string pathWithoutDriveRoot = path.Substring(Path.GetPathRoot(path).Length);
-            char[] invalidFileChars = Path.GetInvalidFileNameChars();
 
             foreach (string segment in pathWithoutDriveRoot.Split(Path.DirectorySeparatorChar))
             {
-                if (segment.IndexOfAny(invalidFileChars) != -1)
+                if (PathUtils.ContainsInvalidFileNameChars(segment))
                 {
                     return false;
                 }

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -877,22 +877,22 @@ namespace System.Management.Automation
         /// <summary>
         /// Contains characters that are invalid in file names.
         /// </summary>
-        private static readonly SearchValues<char> InvalidFileNameChars
+        private static readonly SearchValues<char> s_invalidFileNameChars
             = SearchValues.Create(Path.GetInvalidFileNameChars());
 
         /// <summary>
         /// Contains characters that are invalid in path names.
         /// </summary>
-        private static readonly SearchValues<char> InvalidPathChars
+        private static readonly SearchValues<char> s_invalidPathChars
             = SearchValues.Create(Path.GetInvalidPathChars());
 
         /// <summary>
-        /// Checks if the specified path contains any characters that are invalid in file names.
+        /// Checks if the specified filename contains any characters that are invalid in file names.
         /// </summary>
-        /// <param name="path">The path to check.</param>
-        /// <returns>True if the path contains invalid file name characters, otherwise false.</returns>
-        internal static bool ContainsInvalidFileNameChars(ReadOnlySpan<char> path)
-            => path.ContainsAny(InvalidFileNameChars);
+        /// <param name="filename">The path to check.</param>
+        /// <returns>True if the filename contains invalid file name characters, otherwise false.</returns>
+        internal static bool ContainsInvalidFileNameChars(ReadOnlySpan<char> filename)
+            => filename.ContainsAny(s_invalidFileNameChars);
 
         /// <summary>
         /// Checks if the specified path contains any characters that are invalid in path names.
@@ -900,7 +900,7 @@ namespace System.Management.Automation
         /// <param name="path">The path to check.</param>
         /// <returns>True if the path contains invalid path characters, otherwise false.</returns>
         internal static bool ContainsInvalidPathChars(ReadOnlySpan<char> path)
-            => path.ContainsAny(InvalidPathChars);
+            => path.ContainsAny(s_invalidPathChars);
 
         #endregion
     }

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -868,6 +869,38 @@ namespace System.Management.Automation
         {
             return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
         }
+
+        #endregion
+
+        #region Helpers for checking invalid paths using SearchValues
+
+        /// <summary>
+        /// Contains characters that are invalid in file names.
+        /// </summary>
+        private static readonly SearchValues<char> InvalidFileNameChars
+            = SearchValues.Create(Path.GetInvalidFileNameChars());
+
+        /// <summary>
+        /// Contains characters that are invalid in path names.
+        /// </summary>
+        private static readonly SearchValues<char> InvalidPathChars
+            = SearchValues.Create(Path.GetInvalidPathChars());
+
+        /// <summary>
+        /// Checks if the specified path contains any characters that are invalid in file names.
+        /// </summary>
+        /// <param name="path">The path to check.</param>
+        /// <returns>True if the path contains invalid file name characters, otherwise false.</returns>
+        internal static bool ContainsInvalidFileNameChars(ReadOnlySpan<char> path)
+            => path.ContainsAny(InvalidFileNameChars);
+
+        /// <summary>
+        /// Checks if the specified path contains any characters that are invalid in path names.
+        /// </summary>
+        /// <param name="path">The path to check.</param>
+        /// <returns>True if the path contains invalid path characters, otherwise false.</returns>
+        internal static bool ContainsInvalidPathChars(ReadOnlySpan<char> path)
+            => path.ContainsAny(InvalidPathChars);
 
         #endregion
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Similar to the below PRs:

#24880
#24879

I've replaced the calls using `IndexOfAny` with `Path.GetInvalidFileNameChars()` & `Path.GetInvalidPathChars()` to `SearchValues<char>`. I put the methods in `PathUtils` which caches the search values and reuses them across `CommandSearcher`, `InitialSessionSate`, `ModuleCmdletBase` and `FileSystemProvider` classes.

This is because these char arrays have quite a bit of characters to scan and from benchmarks it seems search values is performing a lot better as shown below in BenchmarkDotnet.

## Benchmark

<details><summary>Details</summary>
<p>

### Test Code

```csharp
using System.Buffers;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Order;
using BenchmarkDotNet.Running;

namespace BenchMark;

[MemoryDiagnoser]
[RankColumn]
[Orderer(SummaryOrderPolicy.FastestToSlowest)]
[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory, BenchmarkLogicalGroupRule.ByParams)]
public class SearchValuesBenchmark
{
    public static readonly List<string> Paths = [];

    private static readonly SearchValues<char> invalidPathChars = SearchValues.Create(Path.GetInvalidPathChars());
    private static readonly char[] invalidPathCharsArray = Path.GetInvalidPathChars();
    private static readonly SearchValues<char> invalidFileNameChars = SearchValues.Create(Path.GetInvalidFileNameChars());
    private static readonly char[] invalidFileNameCharsArray = Path.GetInvalidFileNameChars();

    [Params(10, 100, 1000)]
    public int PathCount;

    [GlobalSetup]
    public void Setup()
    {
        string[] directories = ["Documents", "Downloads", "Music", "Pictures", "Videos"];
        string[] fileExtensions = [".txt", ".jpg", ".mp3", ".mp4", ".pdf"];

        for (int i = 1; i <= PathCount; i++)
        {
            foreach (string dir in directories)
            {
                foreach (string ext in fileExtensions)
                {
                    string path = $@"C:\Users\TestUser\{dir}\file{i}{ext}";
                    Paths.Add(path);
                }
            }
        }
    }

    [Benchmark]
    [BenchmarkCategory("InvalidPathChars")]
    public int WithSearchValuesInvalidPathChars()
    {
        int invalidCount = 0;
        foreach (var path in Paths)
        {
            if (path.AsSpan().ContainsAny(invalidPathChars))
            {
                invalidCount++;
            }
        }
        return invalidCount;
    }

    [Benchmark(Baseline = true)]
    [BenchmarkCategory("InvalidPathChars")]
    public int WithIndexOfAnyInvalidPathChars()
    {
        int invalidCount = 0;
        foreach (var path in Paths)
        {
            if (path.AsSpan().IndexOfAny(invalidPathCharsArray) >= 0)
            {
                invalidCount++;
            }
        }
        return invalidCount;
    }

    [Benchmark]
    [BenchmarkCategory("InvalidFileNameChars")]
    public int WithSearchValuesInvalidFileNameChars()
    {
        int invalidCount = 0;
        foreach (var path in Paths)
        {
            var root = Path.GetPathRoot(path);
            var pathWithoutDriveRoot = string.IsNullOrEmpty(root) ? path : path[root.Length..];

            foreach (var segment in pathWithoutDriveRoot.Split(Path.DirectorySeparatorChar))
            {
                if (segment.AsSpan().ContainsAny(invalidFileNameChars))
                {
                    invalidCount++;
                }
            }
        }
        return invalidCount;
    }

    [Benchmark(Baseline = true)]
    [BenchmarkCategory("InvalidFileNameChars")]
    public int WithIndexOfAnyInvalidFileNameChars()
    {
        int invalidCount = 0;
        foreach (var path in Paths)
        {
            var root = Path.GetPathRoot(path);
            var pathWithoutDriveRoot = string.IsNullOrEmpty(root) ? path : path[root.Length..];

            foreach (var segment in pathWithoutDriveRoot.Split(Path.DirectorySeparatorChar))
            {
                if (segment.AsSpan().IndexOfAny(invalidFileNameCharsArray) >= 0)
                {
                    invalidCount++;
                }
            }
        }
        return invalidCount;
    }

}

public class Program
{
    public static void Main(string[] args)
    {
        BenchmarkRunner.Run<SearchValuesBenchmark>();
    }
}
```

### Results

```
// * Detailed results *
SearchValuesBenchmark.WithSearchValuesInvalidFileNameChars: DefaultJob [PathCount=10]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 33.130 us, StdErr = 0.157 us (0.47%), N = 15, StdDev = 0.608 us
Min = 32.332 us, Q1 = 32.742 us, Median = 33.019 us, Q3 = 33.516 us, Max = 34.403 us
IQR = 0.773 us, LowerFence = 31.582 us, UpperFence = 34.675 us
ConfidenceInterval = [32.480 us; 33.780 us] (CI 99.9%), Margin = 0.650 us (1.96% of Mean)
Skewness = 0.55, Kurtosis = 2.1, MValue = 2
-------------------- Histogram --------------------
[32.008 us ; 33.252 us) | @@@@@@@@@@
[33.252 us ; 33.974 us) | @@@@
[33.974 us ; 34.726 us) | @
---------------------------------------------------

SearchValuesBenchmark.WithIndexOfAnyInvalidFileNameChars: DefaultJob [PathCount=10]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 49.970 us, StdErr = 0.236 us (0.47%), N = 15, StdDev = 0.915 us
Min = 48.193 us, Q1 = 49.362 us, Median = 49.957 us, Q3 = 50.514 us, Max = 51.652 us
IQR = 1.152 us, LowerFence = 47.634 us, UpperFence = 52.242 us
ConfidenceInterval = [48.992 us; 50.949 us] (CI 99.9%), Margin = 0.978 us (1.96% of Mean)
Skewness = 0.08, Kurtosis = 2.27, MValue = 2
-------------------- Histogram --------------------
[48.177 us ; 49.297 us) | @@@
[49.297 us ; 51.077 us) | @@@@@@@@@@
[51.077 us ; 52.139 us) | @@
---------------------------------------------------

SearchValuesBenchmark.WithSearchValuesInvalidFileNameChars: DefaultJob [PathCount=100]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 300.889 us, StdErr = 1.504 us (0.50%), N = 19, StdDev = 6.554 us
Min = 291.971 us, Q1 = 296.737 us, Median = 299.052 us, Q3 = 304.806 us, Max = 316.375 us
IQR = 8.069 us, LowerFence = 284.634 us, UpperFence = 316.909 us
ConfidenceInterval = [294.992 us; 306.785 us] (CI 99.9%), Margin = 5.896 us (1.96% of Mean)
Skewness = 0.73, Kurtosis = 2.53, MValue = 2
-------------------- Histogram --------------------
[288.748 us ; 294.847 us) | @@
[294.847 us ; 303.910 us) | @@@@@@@@@@@
[303.910 us ; 313.151 us) | @@@@@
[313.151 us ; 319.598 us) | @
---------------------------------------------------

SearchValuesBenchmark.WithIndexOfAnyInvalidFileNameChars: DefaultJob [PathCount=100]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 470.042 us, StdErr = 1.704 us (0.36%), N = 15, StdDev = 6.601 us
Min = 461.306 us, Q1 = 464.105 us, Median = 469.228 us, Q3 = 474.797 us, Max = 481.591 us
IQR = 10.692 us, LowerFence = 448.067 us, UpperFence = 490.836 us
ConfidenceInterval = [462.985 us; 477.099 us] (CI 99.9%), Margin = 7.057 us (1.50% of Mean)
Skewness = 0.22, Kurtosis = 1.67, MValue = 2
-------------------- Histogram --------------------
[458.736 us ; 485.104 us) | @@@@@@@@@@@@@@@
---------------------------------------------------

SearchValuesBenchmark.WithSearchValuesInvalidFileNameChars: DefaultJob [PathCount=1000]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 3.245 ms, StdErr = 0.017 ms (0.51%), N = 21, StdDev = 0.076 ms
Min = 3.110 ms, Q1 = 3.207 ms, Median = 3.234 ms, Q3 = 3.298 ms, Max = 3.372 ms
IQR = 0.090 ms, LowerFence = 3.072 ms, UpperFence = 3.433 ms
ConfidenceInterval = [3.182 ms; 3.309 ms] (CI 99.9%), Margin = 0.064 ms (1.96% of Mean)
Skewness = 0.07, Kurtosis = 2, MValue = 2
-------------------- Histogram --------------------
[3.089 ms ; 3.161 ms) | @@@
[3.161 ms ; 3.249 ms) | @@@@@@@@@@
[3.249 ms ; 3.385 ms) | @@@@@@@@
---------------------------------------------------

SearchValuesBenchmark.WithIndexOfAnyInvalidFileNameChars: DefaultJob [PathCount=1000]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 5.183 ms, StdErr = 0.021 ms (0.40%), N = 15, StdDev = 0.080 ms
Min = 4.977 ms, Q1 = 5.157 ms, Median = 5.189 ms, Q3 = 5.224 ms, Max = 5.308 ms
IQR = 0.067 ms, LowerFence = 5.056 ms, UpperFence = 5.325 ms
ConfidenceInterval = [5.097 ms; 5.268 ms] (CI 99.9%), Margin = 0.085 ms (1.64% of Mean)
Skewness = -0.86, Kurtosis = 3.68, MValue = 2
-------------------- Histogram --------------------
[4.935 ms ; 5.063 ms) | @
[5.063 ms ; 5.351 ms) | @@@@@@@@@@@@@@
---------------------------------------------------

SearchValuesBenchmark.WithSearchValuesInvalidPathChars: DefaultJob [PathCount=10]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 1.122 us, StdErr = 0.002 us (0.21%), N = 15, StdDev = 0.009 us
Min = 1.110 us, Q1 = 1.115 us, Median = 1.121 us, Q3 = 1.128 us, Max = 1.137 us
IQR = 0.013 us, LowerFence = 1.095 us, UpperFence = 1.149 us
ConfidenceInterval = [1.112 us; 1.132 us] (CI 99.9%), Margin = 0.010 us (0.87% of Mean)
Skewness = 0.36, Kurtosis = 1.7, MValue = 2
-------------------- Histogram --------------------
[1.105 us ; 1.142 us) | @@@@@@@@@@@@@@@
---------------------------------------------------

SearchValuesBenchmark.WithIndexOfAnyInvalidPathChars: DefaultJob [PathCount=10]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 8.156 us, StdErr = 0.022 us (0.27%), N = 15, StdDev = 0.084 us
Min = 8.028 us, Q1 = 8.098 us, Median = 8.139 us, Q3 = 8.203 us, Max = 8.343 us
IQR = 0.105 us, LowerFence = 7.940 us, UpperFence = 8.361 us
ConfidenceInterval = [8.066 us; 8.246 us] (CI 99.9%), Margin = 0.090 us (1.10% of Mean)
Skewness = 0.6, Kurtosis = 2.5, MValue = 2
-------------------- Histogram --------------------
[7.983 us ; 8.190 us) | @@@@@@@@@@@
[8.190 us ; 8.388 us) | @@@@
---------------------------------------------------

SearchValuesBenchmark.WithSearchValuesInvalidPathChars: DefaultJob [PathCount=100]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 10.059 us, StdErr = 0.030 us (0.29%), N = 15, StdDev = 0.115 us
Min = 9.901 us, Q1 = 9.964 us, Median = 10.055 us, Q3 = 10.136 us, Max = 10.254 us
IQR = 0.172 us, LowerFence = 9.707 us, UpperFence = 10.394 us
ConfidenceInterval = [9.936 us; 10.182 us] (CI 99.9%), Margin = 0.123 us (1.22% of Mean)
Skewness = 0.17, Kurtosis = 1.64, MValue = 2
-------------------- Histogram --------------------
[9.840 us ; 10.315 us) | @@@@@@@@@@@@@@@
---------------------------------------------------

SearchValuesBenchmark.WithIndexOfAnyInvalidPathChars: DefaultJob [PathCount=100]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 80.813 us, StdErr = 0.218 us (0.27%), N = 15, StdDev = 0.845 us
Min = 79.503 us, Q1 = 80.224 us, Median = 80.867 us, Q3 = 81.378 us, Max = 82.684 us
IQR = 1.155 us, LowerFence = 78.492 us, UpperFence = 83.110 us
ConfidenceInterval = [79.909 us; 81.716 us] (CI 99.9%), Margin = 0.903 us (1.12% of Mean)
Skewness = 0.31, Kurtosis = 2.42, MValue = 2
-------------------- Histogram --------------------
[79.053 us ; 83.134 us) | @@@@@@@@@@@@@@@
---------------------------------------------------

SearchValuesBenchmark.WithSearchValuesInvalidPathChars: DefaultJob [PathCount=1000]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 113.120 us, StdErr = 0.163 us (0.14%), N = 14, StdDev = 0.610 us
Min = 111.693 us, Q1 = 112.896 us, Median = 113.052 us, Q3 = 113.307 us, Max = 114.154 us
IQR = 0.411 us, LowerFence = 112.280 us, UpperFence = 113.923 us
ConfidenceInterval = [112.432 us; 113.808 us] (CI 99.9%), Margin = 0.688 us (0.61% of Mean)
Skewness = -0.26, Kurtosis = 3.32, MValue = 2
-------------------- Histogram --------------------
[111.360 us ; 114.186 us) | @@@@@@@@@@@@@@
---------------------------------------------------

SearchValuesBenchmark.WithIndexOfAnyInvalidPathChars: DefaultJob [PathCount=1000]
Runtime = .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2; GC = Concurrent Workstation
Mean = 836.442 us, StdErr = 2.263 us (0.27%), N = 15, StdDev = 8.764 us
Min = 824.009 us, Q1 = 830.904 us, Median = 836.347 us, Q3 = 841.614 us, Max = 853.035 us
IQR = 10.710 us, LowerFence = 814.839 us, UpperFence = 857.678 us
ConfidenceInterval = [827.073 us; 845.812 us] (CI 99.9%), Margin = 9.369 us (1.12% of Mean)
Skewness = 0.24, Kurtosis = 1.94, MValue = 2
-------------------- Histogram --------------------
[819.345 us ; 857.699 us) | @@@@@@@@@@@@@@@
---------------------------------------------------

// * Summary *

BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
AMD Ryzen Threadripper 3960X, 1 CPU, 48 logical and 24 physical cores
.NET SDK 9.0.102
  [Host]     : .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.1 (9.0.124.61010), X64 RyuJIT AVX2


| Method                               | PathCount | Mean         | Error      | StdDev     | Ratio | RatioSD | Rank | Gen0      | Allocated | Alloc Ratio |
|------------------------------------- |---------- |-------------:|-----------:|-----------:|------:|--------:|-----:|----------:|----------:|------------:|
| WithSearchValuesInvalidFileNameChars | 10        |    33.130 us |  0.6500 us |  0.6080 us |  0.66 |    0.02 |    1 |    9.8267 |   82640 B |        1.00 |
| WithIndexOfAnyInvalidFileNameChars   | 10        |    49.970 us |  0.9785 us |  0.9153 us |  1.00 |    0.03 |    2 |    9.8267 |   82640 B |        1.00 |
|                                      |           |              |            |            |       |         |      |           |           |             |
| WithSearchValuesInvalidFileNameChars | 100       |   300.889 us |  5.8964 us |  6.5538 us |  0.64 |    0.02 |    1 |  101.0742 |  845840 B |        1.00 |
| WithIndexOfAnyInvalidFileNameChars   | 100       |   470.042 us |  7.0572 us |  6.6013 us |  1.00 |    0.02 |    2 |  101.0742 |  845840 B |        1.00 |
|                                      |           |              |            |            |       |         |      |           |           |             |
| WithSearchValuesInvalidFileNameChars | 1000      | 3,245.339 us | 63.5488 us | 75.6503 us |  0.63 |    0.02 |    1 | 1011.7188 | 8477882 B |        1.00 |
| WithIndexOfAnyInvalidFileNameChars   | 1000      | 5,182.520 us | 85.1087 us | 79.6108 us |  1.00 |    0.02 |    2 | 1007.8125 | 8477883 B |        1.00 |
|                                      |           |              |            |            |       |         |      |           |           |             |
| WithSearchValuesInvalidPathChars     | 10        |     1.122 us |  0.0098 us |  0.0092 us |  0.14 |    0.00 |    1 |         - |         - |          NA |
| WithIndexOfAnyInvalidPathChars       | 10        |     8.156 us |  0.0900 us |  0.0842 us |  1.00 |    0.01 |    2 |         - |         - |          NA |
|                                      |           |              |            |            |       |         |      |           |           |             |
| WithSearchValuesInvalidPathChars     | 100       |    10.059 us |  0.1229 us |  0.1149 us |  0.12 |    0.00 |    1 |         - |         - |          NA |
| WithIndexOfAnyInvalidPathChars       | 100       |    80.813 us |  0.9032 us |  0.8449 us |  1.00 |    0.01 |    2 |         - |         - |          NA |
|                                      |           |              |            |            |       |         |      |           |           |             |
| WithSearchValuesInvalidPathChars     | 1000      |   113.120 us |  0.6879 us |  0.6098 us |  0.14 |    0.00 |    1 |         - |         - |          NA |
| WithIndexOfAnyInvalidPathChars       | 1000      |   836.442 us |  9.3694 us |  8.7641 us |  1.00 |    0.01 |    2 |         - |         - |          NA |
```
</p>
</details> 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
