### PR TITLE
Never load a module targeting the PSReadLine module's `SessionState`

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -136,22 +136,12 @@ namespace Microsoft.PowerShell.Commands
 
         internal SessionState TargetSessionState
         {
-            get
-            {
-                if (BaseGlobal)
-                {
-                    return Context.TopLevelSessionState.PublicSessionState;
-                }
-                else
-                {
-                    // Module loading could happen during tab completion triggered by PSReadLine,
-                    // but that doesn't mean the module should be loaded targeting the PSReadLine
-                    // module's session state. In that case, use Global session state instead.
-                    return Context.EngineSessionState.Module?.Name is "PSReadLine"
-                        ? Context.TopLevelSessionState.PublicSessionState
-                        : Context.SessionState;
-                }
-            }
+            // Module loading could happen during tab completion triggered by PSReadLine,
+            // but that doesn't mean the module should be loaded targeting the PSReadLine
+            // module's session state. In that case, use Global session state instead.
+            get => BaseGlobal || Context.EngineSessionState.Module?.Name is "PSReadLine"
+                ? Context.TopLevelSessionState.PublicSessionState
+                : Context.SessionState;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -140,11 +140,16 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (BaseGlobal)
                 {
-                    return this.Context.TopLevelSessionState.PublicSessionState;
+                    return Context.TopLevelSessionState.PublicSessionState;
                 }
                 else
                 {
-                    return this.Context.SessionState;
+                    // Module loading could happen during tab completion triggered by PSReadLine,
+                    // but that doesn't mean the module should be loaded targeting the PSReadLine
+                    // module's session state. In that case, use Global session state instead.
+                    return Context.EngineSessionState.Module?.Name is "PSReadLine"
+                        ? Context.TopLevelSessionState.PublicSessionState
+                        : Context.SessionState;
                 }
             }
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #24904

Module loading could happen in PSReadLine module's context because
1. it may be due to tab completion triggered by PSReadLine,
2. it may be due to a command run triggered by key-binding press

But that doesn't mean the module should be loaded targeting the PSReadLine module's session state. In this case, we should use the `Global` session state instead. PSReadLine doesn't depend on any other modules and should not have any module loaded into its session state.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively **because the module loading needs to be triggered from within PSReadLine**
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
