### PR TITLE
Filter out the nested modules of `PSReadLine` from module name tab completion

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -471,11 +471,14 @@ namespace System.Management.Automation
                 // which should be filtered out below.
                 // When the completion is triggered from global session state, such as when running 'TabExpansion2' from command line,
                 // the module associated with engine session state will be null.
+                //
+                // Note that, it's intentional to not hard code the name 'PSReadLine' in the change, so that in case the tab completion
+                // is triggered from within a different module, its nested modules can also be filtered out.
                 HashSet<PSModuleInfo> nestedModulesToFilterOut = null;
-                PSModuleInfo curModule = context.ExecutionContext.EngineSessionState.Module;
-                if (loadedModulesOnly && curModule?.NestedModules.Count > 0)
+                PSModuleInfo currentModule = context.ExecutionContext.EngineSessionState.Module;
+                if (loadedModulesOnly && currentModule?.NestedModules.Count > 0)
                 {
-                    nestedModulesToFilterOut = new(curModule.NestedModules);
+                    nestedModulesToFilterOut = new(currentModule.NestedModules);
                 }
 
                 foreach (PSObject item in psObjects)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -15,7 +15,6 @@ using System.Management.Automation.Language;
 using System.Management.Automation.Provider;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

When doing module name completion such as `Get-Module mic<tab>` or `Get-Module psr<tab>`, you will see `Microsoft.PowerShell.PSReadLine2` as the result of completion. `Microsoft.PowerShell.PSReadLine2` is a nested module of `PSReadLine`, which shouldn't be returned by completion. It's returned because the completion happens in PSReadLine's context (using PSReadLine's `SessionState` as the `EngineSessionState`) and hence its nested modules are visible to the tab completion.

![completion](https://github.com/user-attachments/assets/92f4c264-3c76-4d6d-a74e-a00839ca8a00)

This PR filters out the nested modules of `PSReadLine` from the tab completion results. It's intentional to not hard code the name 'PSReadLine' in the change, so that in case the tab completion is triggered from within a different module, its nested modules can also be filtered out.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively 
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
