### PR TITLE
Fix `New-Item -Force` to error on invalid directory name

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -62,9 +62,6 @@ namespace Microsoft.PowerShell.Commands
 
         private const int COPY_FILE_ACTIVITY_ID = 0;
         private const int REMOVE_FILE_ACTIVITY_ID = 0;
-        
-        // Windows error code for invalid characters
-        private const int ERROR_INVALID_NAME = unchecked((int)0x8007007B);
 
         // The name of the key in an exception's Data dictionary when attempting
         // to copy an item onto itself.
@@ -2719,9 +2716,15 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (IOException ioException)
             {
-                // Do not suppress IOException on Windows if it has the specific HResult for invalid characters
-                // even when -Force is specified
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && ioException.HResult == ERROR_INVALID_NAME || !Force)
+#if UNIX
+                if (!Force)
+#else
+                // Windows error code for invalid characters in file or directory name
+                const int ERROR_INVALID_NAME = unchecked((int)0x8007007B);
+
+                // Do not suppress IOException on Windows if it has the specific HResult for invalid characters in directory name
+                if (ioException.HResult == ERROR_INVALID_NAME || !Force)
+#endif
                 {
                     // IOException contains specific message about the error occurred and so no need for errordetails.
                     WriteError(new ErrorRecord(ioException, "CreateDirectoryIOError", ErrorCategory.WriteError, path));

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -62,6 +62,9 @@ namespace Microsoft.PowerShell.Commands
 
         private const int COPY_FILE_ACTIVITY_ID = 0;
         private const int REMOVE_FILE_ACTIVITY_ID = 0;
+        
+        // Windows error code for invalid characters
+        private const int ERROR_INVALID_NAME = unchecked((int)0x8007007B);
 
         // The name of the key in an exception's Data dictionary when attempting
         // to copy an item onto itself.
@@ -2716,8 +2719,8 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (IOException ioException)
             {
-                // Ignore the error if force was specified
-                if (!Force)
+                // Do not suppress IOException if it has the specific HResult for invalid characters
+                if (ioException.HResult == ERROR_INVALID_NAME || !Force)
                 {
                     // IOException contains specific message about the error occurred and so no need for errordetails.
                     WriteError(new ErrorRecord(ioException, "CreateDirectoryIOError", ErrorCategory.WriteError, path));

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2719,8 +2719,9 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (IOException ioException)
             {
-                // Do not suppress IOException if it has the specific HResult for invalid characters
-                if (ioException.HResult == ERROR_INVALID_NAME || !Force)
+                // Do not suppress IOException on Windows if it has the specific HResult for invalid characters
+                // even when -Force is specified
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && ioException.HResult == ERROR_INVALID_NAME || !Force)
                 {
                     // IOException contains specific message about the error occurred and so no need for errordetails.
                     WriteError(new ErrorRecord(ioException, "CreateDirectoryIOError", ErrorCategory.WriteError, path));

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -386,3 +386,13 @@ Describe "New-Item -Force allows to create an item even if the directories in th
         $FullyQualifiedFile | Should -Exist
     }
 }
+
+Describe "New-Item -Force should throw an error for invalid characters in directory path" -Tags "CI" {
+    BeforeAll {
+        $invalidPath = Join-Path -Path $TestDrive -ChildPath 'Invalid?'
+    }
+
+    It "Should throw an error when -Force is used with an invalid directory path" {
+        { New-Item -Path $invalidPath -ItemType Directory -Force -ErrorAction Stop } | Should -Throw -ErrorId 'CreateDirectoryIOError,Microsoft.PowerShell.Commands.NewItemCommand'
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -387,7 +387,7 @@ Describe "New-Item -Force allows to create an item even if the directories in th
     }
 }
 
-Describe "New-Item -Force should throw an error for invalid characters in directory path" -Tags "CI" {
+Describe "New-Item -Force should throw an error for invalid characters in directory path" -Skip:(!$IsWindows) -Tags "CI" {
     BeforeAll {
         $invalidPath = Join-Path -Path $TestDrive -ChildPath 'Invalid?'
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -387,12 +387,12 @@ Describe "New-Item -Force allows to create an item even if the directories in th
     }
 }
 
-Describe "New-Item -Force should throw an error for invalid characters in directory path" -Skip:(!$IsWindows) -Tags "CI" {
+Describe "New-Item -Force should throw an error for invalid characters in directory path" -Tags "CI" {
     BeforeAll {
         $invalidPath = Join-Path -Path $TestDrive -ChildPath 'Invalid?'
     }
 
-    It "Should throw an error when -Force is used with an invalid directory path" {
+    It "Should throw an error when -Force is used with an invalid directory path" -Skip:(!$IsWindows) {
         { New-Item -Path $invalidPath -ItemType Directory -Force -ErrorAction Stop } | Should -Throw -ErrorId 'CreateDirectoryIOError,Microsoft.PowerShell.Commands.NewItemCommand'
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #21111

@SteveL-MSFT @iSazonov 

This PR ensures that `New-Item -Path 'Invalid?' -Force` correctly throws an error instead of being suppressed. The change specifically checks for `IOException` with the `HResult` code related to invalid characters and allows the exception to propagate, aligning behavior with PowerShell 5.1.

## PR Context

The `PowerShell Working Group` discussed this issue and agreed that, in the case of invalid characters, the cmdlet should return an error just like in PowerShell 5.1, even when `-Force` is used. The primary use case of `-Force` is to ensure success whether the target directory exists, but suppressing invalid character errors introduces inconsistencies. This PR implements a targeted fix by checking for the specific `HResult` associated with invalid characters, ensuring that such exceptions are not suppressed while maintaining existing behavior for other cases.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
