### PR TITLE
Fix formatting of docs in ///-comments for Clean()

### DIFF
--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -1276,14 +1276,16 @@ namespace System.Management.Automation
         /// Clean resources for script commands of this steppable pipeline.
         /// </summary>
         /// <remarks>
-        /// The way we handle 'Clean' blocks in a steppable pipeline makes sure that:
-        ///  1. The 'Clean' blocks get to run if any exception is thrown from 'Begin/Process/End'.
-        ///  2. The 'Clean' blocks get to run if 'End' finished successfully.
+        /// <para>
+        /// The way we handle 'Clean' blocks in a steppable pipeline makes sure that:</para>
+        /// <para>1. The 'Clean' blocks get to run if any exception is thrown from 'Begin/Process/End'.</para>
+        /// <para>2. The 'Clean' blocks get to run if 'End' finished successfully.</para>
+        /// <para>
         /// However, this is not enough for a steppable pipeline, because the function, where the steppable
         /// pipeline gets used, may fail (think about a proxy function). And that may lead to the situation
         /// where "no exception was thrown from the steppable pipeline" but "the steppable pipeline didn't
         /// run to the end". In that case, 'Clean' won't run unless it's triggered explicitly on the steppable
-        /// pipeline. This method allows a user to do that from the 'Clean' block of the proxy function.
+        /// pipeline. This method allows a user to do that from the 'Clean' block of the proxy function.</para>
         /// </remarks>
         public void Clean()
         {
@@ -1386,7 +1388,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="info">Serialization information.</param>
         /// <param name="context">Streaming context.</param>
-        [Obsolete("Legacy serialization support is deprecated since .NET 8", DiagnosticId = "SYSLIB0051")] 
+        [Obsolete("Legacy serialization support is deprecated since .NET 8", DiagnosticId = "SYSLIB0051")]
         protected ScriptBlockToPowerShellNotSupportedException(SerializationInfo info, StreamingContext context)
         {
             throw new NotSupportedException();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix formatting of docs in ///-comments for Clean().

Currently the text in the ///-comments for the Clean() method is rendered as one continuous paragraph. This makes it hard to read and leads to confusion. This PR fixes the formatting of the comments so that they are rendered as separate paragraphs.

- Fixes MicrosoftDocs/PowerShell-Docs#11643

@daxian-dbw This is the fix we talked about.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
