### PR TITLE
[release/v7.4]Convert powershell/PowerShell-CI-linux to GitHub Actions

### DIFF
--- a/.github/actions/test/linux-packaging/action.yml
+++ b/.github/actions/test/linux-packaging/action.yml
@@ -1,0 +1,95 @@
+name: linux_packaging
+description: 'Test very basic Linux packaging'
+
+# This isn't working yet
+# It fails with
+
+# ERROR:  While executing gem ... (Gem::FilePermissionError)
+# You don't have write permissions for the /var/lib/gems/2.7.0 directory.
+#   WARNING: Installation of gem dotenv 2.8.1 failed! Must resolve manually.
+
+runs:
+  using: composite
+  steps:
+  - name: Capture Environment
+    if: success() || failure()
+    run: 'Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose'
+    shell: pwsh
+  - name: Download Build Artifacts
+    uses: actions/download-artifact@v4
+    with:
+      path: "${{ github.workspace }}"
+  - name: Capture Artifacts Directory
+    continue-on-error: true
+    run: Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
+    shell: pwsh
+
+  - name: Bootstrap
+    run: |-
+      Import-Module ./build.psm1
+      Start-PSBootstrap -Package
+    shell: pwsh
+  - name: Capture Artifacts Directory
+    continue-on-error: true
+    run: Import-Module ./build.psm1
+    shell: pwsh
+  - name: Extract Files
+    uses: actions/github-script@v7.0.0
+    env:
+      DESTINATION_FOLDER: "${{ github.workspace }}/bins"
+      ARCHIVE_FILE_PATTERNS: "${{ github.workspace }}/build/build.zip"
+    with:
+      script: |-
+        const fs = require('fs').promises
+        const path = require('path')
+        const target = path.resolve(process.env.DESTINATION_FOLDER)
+        const patterns = process.env.ARCHIVE_FILE_PATTERNS
+        const globber = await glob.create(patterns)
+        await io.mkdirP(path.dirname(target))
+        for await (const file of globber.globGenerator()) {
+          if ((await fs.lstat(file)).isDirectory()) continue
+          await exec.exec(`7z x ${file} -o${target} -aoa`)
+        }
+  - name: Fix permissions
+    continue-on-error: true
+    run: |-
+      find "${{ github.workspace }}/bins" -type d -exec chmod +rwx {} \;
+      find "${{ github.workspace }}/bins" -type f -exec chmod +rw {} \;
+    shell: bash
+  - name: Capture Extracted Build ZIP
+    continue-on-error: true
+    run: Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
+    shell: pwsh
+  - name: Packaging Tests
+    if: success()
+    run: |-
+      Import-Module ./tools/ci.psm1
+      Restore-PSOptions -PSOptionsPath '${{ github.workspace }}/build/psoptions.json'
+      $options = (Get-PSOptions)
+      $rootPath = '${{ github.workspace }}/bins'
+      $originalRootPath = Split-Path -path $options.Output
+      $path = Join-Path -path $rootPath -ChildPath (split-path -leaf -path $originalRootPath)
+      $pwshPath = Join-Path -path $path -ChildPath 'pwsh'
+      chmod a+x $pwshPath
+      $options.Output = $pwshPath
+      Set-PSOptions $options
+      Invoke-CIFinish
+    shell: pwsh
+  - name: Upload packages
+    run: |-
+      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.deb" -Recurse | ForEach-Object {
+        $packagePath = $_.FullName
+        Write-Host "Uploading $packagePath"
+        Write-Host "##vso[artifact.upload containerfolder=deb;artifactname=deb]$packagePath"
+      }
+      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.rpm" -Recurse | ForEach-Object {
+        $packagePath = $_.FullName
+        Write-Host "Uploading $packagePath"
+        Write-Host "##vso[artifact.upload containerfolder=rpm;artifactname=rpm]$packagePath"
+      }
+      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.tar.gz" -Recurse | ForEach-Object {
+        $packagePath = $_.FullName
+        Write-Host "Uploading $packagePath"
+        Write-Host "##vso[artifact.upload containerfolder=rpm;artifactname=rpm]$packagePath"
+      }
+    shell: pwsh

--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -1,0 +1,91 @@
+name: nix_test
+description: 'Test PowerShell on non-Windows platforms'
+
+inputs:
+  purpose:
+    required: false
+    default: ''
+    type: string
+  tagSet:
+    required: false
+    default: CI
+    type: string
+  ctrfFolder:
+    required: false
+    default: ctrf
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Capture Environment
+    if: success() || failure()
+    run: 'Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose'
+    shell: pwsh
+  - name: Download Build Artifacts
+    uses: actions/download-artifact@v4
+    with:
+      path: "${{ github.workspace }}"
+  - name: Capture Artifacts Directory
+    continue-on-error: true
+    run: Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
+    shell: pwsh
+
+  - name: Bootstrap
+    shell: pwsh
+    run: |-
+      Import-Module ./tools/ci.psm1
+      Invoke-CIInstall -SkipUser
+
+  - name: Extract Files
+    uses: actions/github-script@v7.0.0
+    env:
+      DESTINATION_FOLDER: "${{ github.workspace }}/bins"
+      ARCHIVE_FILE_PATTERNS: "${{ github.workspace }}/build/build.zip"
+    with:
+      script: |-
+        const fs = require('fs').promises
+        const path = require('path')
+        const target = path.resolve(process.env.DESTINATION_FOLDER)
+        const patterns = process.env.ARCHIVE_FILE_PATTERNS
+        const globber = await glob.create(patterns)
+        await io.mkdirP(path.dirname(target))
+        for await (const file of globber.globGenerator()) {
+          if ((await fs.lstat(file)).isDirectory()) continue
+          await exec.exec(`7z x ${file} -o${target} -aoa`)
+        }
+
+  - name: Fix permissions
+    continue-on-error: true
+    run: |-
+      find "${{ github.workspace }}/bins" -type d -exec chmod +rwx {} \;
+      find "${{ github.workspace }}/bins" -type f -exec chmod +rw {} \;
+    shell: bash
+
+  - name: Capture Extracted Build ZIP
+    continue-on-error: true
+    run: Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
+    shell: pwsh
+
+  - name: Test
+    if: success()
+    run: |-
+      Import-Module ./tools/ci.psm1
+      Restore-PSOptions -PSOptionsPath '${{ github.workspace }}/build/psoptions.json'
+      $options = (Get-PSOptions)
+      $rootPath = '${{ github.workspace }}/bins'
+      $originalRootPath = Split-Path -path $options.Output
+      $path = Join-Path -path $rootPath -ChildPath (split-path -leaf -path $originalRootPath)
+      $pwshPath = Join-Path -path $path -ChildPath 'pwsh'
+      chmod a+x $pwshPath
+      $options.Output = $pwshPath
+      Set-PSOptions $options
+      Invoke-CITest -Purpose '${{ inputs.purpose }}' -TagSet '${{ inputs.tagSet }}' -TitlePrefix '${{ inputs.buildName }}' -OutputFormat JUnitXml
+    shell: pwsh
+
+  - name: Convert, Publish, and Upload Pester Test Results
+    uses: "./.github/actions/test/process-pester-results"
+    with:
+      name: "${{ inputs.purpose }}-${{ inputs.tagSet }}"
+      testResultsFolder: "${{ runner.workspace }}/testResults"
+      ctrfFolder: "${{ inputs.ctrfFolder }}"

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -1,0 +1,64 @@
+name: process-pester-test-results
+description: 'Process Pester test results'
+
+inputs:
+  name:
+    required: true
+    default: ''
+    type: string
+  testResultsFolder:
+    required: false
+    default: "${{ runner.workspace }}/testResults"
+    type: string
+  ctrfFolder:
+    required: false
+    default: ctrf
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Convert JUnit to CTRF
+    run: |-
+      Get-ChildItem -Path "${{ inputs.testResultsFolder }}/*.xml" -Recurse | ForEach-Object {
+        npx --yes junit-to-ctrf $_.FullName --output ./${{ inputs.ctrfFolder }}/$($_.BaseName).json --tool Pester
+      }
+    shell: pwsh
+
+  # this task only takes / as directory separators
+  - name: Publish Test Report
+    uses: ctrf-io/github-test-reporter@v1
+    with:
+      report-path: './${{ inputs.ctrfFolder }}/*.json'
+      exit-on-fail: true
+      summary-report: true
+      test-report: false
+      test-list-report: false
+      failed-report: false
+      fail-rate-report: false
+      flaky-report: false
+      flaky-rate-report: false
+      failed-folded-report: true
+      previous-results-report: false
+      ai-report: true
+      skipped-report: false
+      suite-folded-report: false
+      suite-list-report: false
+      pull-request-report: false
+      commit-report: false
+      custom-report: false
+    if: always()
+
+  - name: Upload testResults artifact
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: junit-pester-${{ inputs.name }}
+      path: ${{ runner.workspace }}/testResults
+
+  - name: Upload ctrf artifact
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: ctrf-pester-${{ inputs.name }}
+      path: ${{ inputs.ctrfFolder }}

--- a/.github/actions/test/windows/action.yml
+++ b/.github/actions/test/windows/action.yml
@@ -60,48 +60,9 @@ runs:
       Invoke-CITest -Purpose '${{ inputs.purpose }}' -TagSet '${{ inputs.tagSet }}' -OutputFormat JUnitXml
     shell: pwsh
 
-  - name: Convert JUnit to CTRF
-    run: |-
-      Get-ChildItem -Path "${{ runner.workspace }}/testResults/*.xml" -Recurse | ForEach-Object {
-        npx --yes junit-to-ctrf $_.FullName --output .\${{ inputs.ctrfFolder }}\$($_.BaseName).json --tool Pester --env 'Windows ${{ inputs.purpose }} ${{ inputs.tagSet }}'
-      }
-    shell: powershell
-
-  # this task only takes / as directory separators
-  - name: Publish Test Report
-    uses: ctrf-io/github-test-reporter@v1
+  - name: Convert, Publish, and Upload Pester Test Results
+    uses: "./.github/actions/test/process-pester-results"
     with:
-      report-path: './${{ inputs.ctrfFolder }}/*.json'
-      exit-on-fail: true
-      summary-report: true
-      test-report: false
-      test-list-report: false
-      failed-report: false
-      fail-rate-report: false
-      flaky-report: false
-      flaky-rate-report: false
-      failed-folded-report: true
-      previous-results-report: false
-      ai-report: true
-      skipped-report: false
-      suite-folded-report: false
-      suite-list-report: false
-      pull-request-report: false
-      commit-report: false
-      custom-report: false
-
-    if: always()
-
-  - name: Upload testResults artifact
-    if: always()
-    uses: actions/upload-artifact@v4
-    with:
-      name: junit-pester-${{ inputs.purpose }}-${{ inputs.tagSet }}
-      path: ${{ runner.workspace }}\testResults
-
-  - name: Upload ctrf artifact
-    if: always()
-    uses: actions/upload-artifact@v4
-    with:
-      name: ctrf-pester-${{ inputs.purpose }}-${{ inputs.tagSet }}
-      path: ${{ inputs.ctrfFolder }}
+      name: "${{ inputs.purpose }}-${{ inputs.tagSet }}"
+      testResultsFolder: ${{ runner.workspace }}\testResults
+      ctrfFolder: "${{ inputs.ctrfFolder }}"

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -1,24 +1,29 @@
-name: Windows-CI
+name: Linux-CI
+
+run-name: "${{ github.ref_name }} - ${{ github.run_number }}"
+
 on:
   workflow_dispatch:
+
   push:
     branches:
       - master
-      - release/**
+      - release*
+      - feature*
     paths:
       - "**"
-      - "!.vsts-ci/misc-analysis.yml"
       - "!.github/ISSUE_TEMPLATE/**"
       - "!.dependabot/config.yml"
-      - "!test/perf/**"
       - "!.pipelines/**"
+      - "!test/perf/**"
   pull_request:
     branches:
       - master
-      - release/**
+      - release*
+      - feature*
     paths:
       - ".github/actions/**"
-      - ".github/workflows/windows-ci.yml"
+      - ".github/workflows/linux-ci.yml"
       - "**.props"
       - build.psm1
       - src/**
@@ -28,23 +33,20 @@ on:
       - tools/WindowsCI.psm1
       - "!test/common/markdown/**"
       - "!test/perf/**"
-permissions:
-  contents: read
-
-run-name: "${{ github.ref_name }} - ${{ github.run_number }}"
-
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  GIT_CONFIG_PARAMETERS: "'core.autocrlf=false'"
-  NugetSecurityAnalysisWarningLevel: none
+  FORCE_FEATURE: 'False'
+  FORCE_PACKAGE: 'False'
+  NUGET_KEY: none
   POWERSHELL_TELEMETRY_OPTOUT: 1
   __SuppressAnsiEscapeSequences: 1
   nugetMultiFeedWarnLevel: none
+  system_debug: 'false'
 jobs:
   ci_build:
     name: Build PowerShell
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.0
@@ -52,66 +54,66 @@ jobs:
           fetch-depth: 1000
       - name: Build
         uses: "./.github/actions/build/ci"
-  windows_test:
-    name: Windows Unelevated CI
+  linux_test_unelevated_ci:
+    name: Linux Unelevated CI
     needs: ci_build
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 1000
-      - name: Windows Unelevated CI
-        uses: "./.github/actions/test/windows"
+      - name: Linux Unelevated CI
+        uses: "./.github/actions/test/nix"
         with:
           purpose: UnelevatedPesterTests
           tagSet: CI
-  windows_test_2:
-    name: Windows Elevated CI
+  linux_test_elevated_ci:
+    name: Linux Elevated CI
     needs: ci_build
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 1000
-      - name: Windows Elevated CI
-        uses: "./.github/actions/test/windows"
+      - name: Linux Elevated CI
+        uses: "./.github/actions/test/nix"
         with:
           purpose: ElevatedPesterTests
           tagSet: CI
-  windows_test_3:
-    name: Windows Unelevated Others
+  linux_test_unelevated_others:
+    name: Linux Unelevated Others
     needs: ci_build
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 1000
-      - name: Windows Unelevated Others
-        uses: "./.github/actions/test/windows"
+      - name: Linux Unelevated Others
+        uses: "./.github/actions/test/nix"
         with:
           purpose: UnelevatedPesterTests
           tagSet: Others
-  windows_test_4:
-    name: Windows Elevated Others
+  linux_test_elevated_others:
+    name: Linux Elevated Others
     needs: ci_build
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 1000
-      - name: Windows Elevated Others
-        uses: "./.github/actions/test/windows"
+      - name: Linux Elevated Others
+        uses: "./.github/actions/test/nix"
         with:
           purpose: ElevatedPesterTests
           tagSet: Others
   verify_xunit:
     name: Verify xUnit test results
     needs: ci_build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.0
@@ -119,3 +121,21 @@ jobs:
           fetch-depth: 1000
       - name: Verify xUnit test results
         uses: "./.github/actions/test/verify_xunit"
+
+  # TODO: Enable this when we have a Linux packaging workflow
+
+  # ERROR:  While executing gem ... (Gem::FilePermissionError)
+  # You don't have write permissions for the /var/lib/gems/2.7.0 directory.
+  #   WARNING: Installation of gem dotenv 2.8.1 failed! Must resolve manually.
+
+  # linux_packaging:
+  #   name: Attempt Linux Packaging
+  #   needs: ci_build
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v4.1.0
+  #       with:
+  #         fetch-depth: 1000
+  #     - name: Verify xUnit test results
+  #       uses: "./.github/actions/test/linux-packaging"

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,7 +19,7 @@ on:
   pull_request:
     branches:
       - master
-      - release*
+      - release/**
       - feature*
     paths:
       - ".github/actions/**"


### PR DESCRIPTION
Backport #24913

This pull request includes several changes to improve the CI workflows, particularly for Linux and non-Windows platforms. The changes involve adding new GitHub Actions workflows, modifying existing workflows, and enhancing the `Invoke-CITest` function to support different output formats.

New GitHub Actions workflows:

* [`.github/actions/test/linux-packaging/action.yml`](diffhunk://#diff-563b328e4298c6de2609ba9cc8bdc3106451999c98c0ac0e6c61b0e18a8f702bR1-R95): Added a new action to test basic Linux packaging.
* [`.github/actions/test/nix/action.yml`](diffhunk://#diff-ce613df0a0f3c35f27cac9c72c5ac0d1a63070013b29d51fa04b9cf9b7f18e19R1-R91): Added a new action to test PowerShell on non-Windows platforms.
* [`.github/actions/test/process-pester-results/action.yml`](diffhunk://#diff-c78ac092fabb982eaff3e37c872e1c601476b0e4ca97b6387863a684767fe412R1-R64): Added a new action to process Pester test results.

Enhancements to existing workflows:

* [`.github/workflows/linux-ci.yml`](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fR1-R141): Added a new workflow for Linux CI, including steps for building and testing PowerShell on Linux.
* [`.github/workflows/windows-ci.yml`](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37L9-R30): Updated the paths to trigger the workflow and improved the file structure.

Enhancements to `Invoke-CITest` function:

* [`tools/ci.psm1`](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400L262-R262): Modified the `Invoke-CITest` function to support an `OutputFormat` parameter and improved the Pester test invocation to skip rebuilding test tools. [[1]](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400L262-R262) [[2]](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400L387-R388) [[3]](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400L731-R733) [[4]](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400R752) [[5]](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400L787-R790) [[6]](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400R805) [[7]](diffhunk://#diff-d6a0a16023ad444077336e0a3b589b3ccff075c8831329252b65091a77471400L834-R840)