### PR TITLE
Binder: Fix IntPtr optional default arguments (#19429)

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7174,6 +7174,12 @@ namespace System.Management.Automation.Language
                         // exception to this rule is when the parameter type is object.
                         argExprs[i] = Expression.Default(parameterType);
                     }
+                    else if (parameterType == typeof(nint) || parameterType == typeof(nuint))
+                    {
+                        // IntPtr and UIntPtr aren't of the correct type now that they're considered numeric
+                        // types. Cast these types explicitly to the correct parameter type.
+                        argExprs[i] = Expression.Constant(argValue).Cast(parameterType);
+                    }
                     else
                     {
                         // We don't specify the parameter type in the constant expression. Normally the default

--- a/test/powershell/engine/Basic/CLRBinding.Tests.ps1
+++ b/test/powershell/engine/Basic/CLRBinding.Tests.ps1
@@ -26,6 +26,9 @@ public class TestClass
 
     public static string StaticWithOptionalExpected() => StaticWithOptional();
     public static string StaticWithOptional([Optional] string value) => value;
+    
+    public static nint StaticWithOptionalIntPtrExpected() => StaticWithOptionalIntPtr();
+    public static nint StaticWithOptionalIntPtr(nint value = default(nint)) => value;
 
     public object InstanceWithDefaultExpected() => InstanceWithDefault();
     public object InstanceWithDefault(object value = null) => value;
@@ -98,6 +101,12 @@ public class TestClassCstorWithOptional
     It "Binds to static method with Optional argument" {
         $expected = [CLRBindingTests.TestClass]::StaticWithOptionalExpected()
         $actual = [CLRBindingTests.TestClass]::StaticWithOptional()
+        $actual | Should -Be $expected
+    }
+    
+    It "Binds to static method with default IntPtr argument" {
+        $expected = [CLRBindingTests.TestClass]::StaticWithOptionalIntPtrExpected()
+        $actual = [CLRBindingTests.TestClass]::StaticWithOptionalIntPtr()
         $actual | Should -Be $expected
     }
 


### PR DESCRIPTION
# PR Summary

Fixes the inability to use default IntPtr arguments

## PR Context

To fix the issue described in #19429

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
- **User-facing changes**
  - [X] Not Applicable
- **Testing - New and feature**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
