### PR TITLE
Stringify ErrorRecord with empty exception message to empty string

### DIFF
--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -1689,12 +1689,7 @@ namespace System.Management.Automation
 
             if (Exception != null)
             {
-                if (!string.IsNullOrEmpty(Exception.Message))
-                {
-                    return Exception.Message;
-                }
-
-                return Exception.ToString();
+                return Exception.Message ?? Exception.ToString();
             }
 
             return base.ToString();

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -1633,7 +1633,7 @@ try
             try {
                 Invoke-Command $session { function attack(${foo="$(calc)"}){Write-Output "It is done."}}
                 $module = Import-PSSession -Session $session -CommandName attack -ErrorAction SilentlyContinue -ErrorVariable expectedError -AllowClobber
-                $expectedError | Should -Not -BeNullOrEmpty
+                $expectedError | Should -Not -Be $null
             } finally {
                 if ($null -ne $module) { Remove-Module $module -Force -ErrorAction SilentlyContinue }
             }

--- a/test/xUnit/csharp/test_Utils.cs
+++ b/test/xUnit/csharp/test_Utils.cs
@@ -167,7 +167,7 @@ namespace PSTests.Parallel
         [Fact]
         public static void TestEmptyErrorRecordToString()
         {
-            Assert.Equal("", new ErrorRecord(new Exception(""), null, ErrorCategory.NotSpecified, null).ToString());
+            Assert.Equal(string.Empty, new ErrorRecord(new Exception(string.Empty), null, ErrorCategory.NotSpecified, null).ToString());
         }
 
         [Fact]

--- a/test/xUnit/csharp/test_Utils.cs
+++ b/test/xUnit/csharp/test_Utils.cs
@@ -163,5 +163,17 @@ namespace PSTests.Parallel
             string json = JsonObject.ConvertToJson(hash, in context);
             Assert.Null(json);
         }
+
+        [Fact]
+        public static void TestEmptyErrorRecordToString()
+        {
+            Assert.Equal("", new ErrorRecord(new Exception(""), null, ErrorCategory.NotSpecified, null).ToString());
+        }
+
+        [Fact]
+        public static void TestNonEmptyErrorRecordToString()
+        {
+            Assert.Equal("test", new ErrorRecord(new Exception("test"), null, ErrorCategory.NotSpecified, null).ToString());
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #23950.

## PR Context

When a native process writes a line to stderr, PowerShell wraps it in an `ErrorRecord`. Users often want to merge the stdout and stderr streams, at which point they need to convert the `ErrorRecord` from stderr back to a string. However, before this PR, an `ErrorRecord` with an empty exception message string stringifies to the name of the exception (`System.Management.Automation.RemoteException` for this specific scenario), which requires the user to use various workarounds (e.g. grabbing `.Exception.Message` manually) to get the original string.

Reproduction:
```powershell
$(try {throw ""} catch {$_}) | % {"$_"} # System.Management.Automation.RuntimeException
```

This PR makes `.ToString()` behave consistently even for empty exception messages, so just running `.ToString()` on items from stderr should be enough to get back the original strings. While this is technically a breaking change, I'm pretty sure it falls into bucket 3 (unlikely gray area).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
