### PR TITLE
[release/v7.5]Fix GitHub Action filter overmatching

### DIFF
--- a/.github/action-filters.yml
+++ b/.github/action-filters.yml
@@ -1,0 +1,23 @@
+github: &github
+  - .github/actions/**
+  - .github/workflows/**-ci.yml
+tools: &tools
+  - tools/buildCommon/**
+  - tools/ci.psm1
+props: &props
+  - '**.props'
+tests: &tests
+  - test/powershell/**
+  - test/tools/**
+  - test/xUnit/**
+mainSource: &mainSource
+  - src/**
+buildModule: &buildModule
+  - build.psm1
+source:
+  - *github
+  - *tools
+  - *props
+  - *buildModule
+  - *mainSource
+  - *tests

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -48,22 +48,27 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
     steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          source:
-            - ".github/actions/**"
-            - ".github/workflows/linux-ci.yml"
-            - "**.props"
-            - build.psm1
-            - src/**
-            - test/**
-            - tools/buildCommon/**
-            - tools/ci.psm1
-            - "!test/common/markdown/**"
-            - "!test/perf/**"
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+
+        # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          list-files: json
+          filters: .github/action-filters.yml
+
+      - name: Capture outputs
+        run: |
+          "source: ${{ steps.filter.outputs.source }}"
+          "github: ${{ steps.filter.outputs.github }}"
+          "tools: ${{ steps.filter.outputs.tools }}"
+          "props: ${{ steps.filter.outputs.props }}"
+          "tests: ${{ steps.filter.outputs.tests }}"
+          "mainSource: ${{ steps.filter.outputs.mainSource }}"
+          "buildModule: ${{ steps.filter.outputs.buildModule }}"
+        shell: pwsh
+
   ci_build:
     name: Build PowerShell
     runs-on: ubuntu-20.04

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -47,22 +47,27 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
     steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          source:
-            - ".github/actions/**"
-            - ".github/workflows/macos-ci.yml"
-            - "**.props"
-            - build.psm1
-            - src/**
-            - test/**
-            - tools/buildCommon/**
-            - tools/ci.psm1
-            - "!test/common/markdown/**"
-            - "!test/perf/**"
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+
+        # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          list-files: json
+          filters: .github/action-filters.yml
+
+      - name: Capture outputs
+        run: |
+          "source: ${{ steps.filter.outputs.source }}"
+          "github: ${{ steps.filter.outputs.github }}"
+          "tools: ${{ steps.filter.outputs.tools }}"
+          "props: ${{ steps.filter.outputs.props }}"
+          "tests: ${{ steps.filter.outputs.tests }}"
+          "mainSource: ${{ steps.filter.outputs.mainSource }}"
+          "buildModule: ${{ steps.filter.outputs.buildModule }}"
+        shell: pwsh
+
   ci_build:
     name: Build PowerShell
     runs-on: macos-latest

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -48,23 +48,27 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
     steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          source:
-            - ".github/actions/**"
-            - ".github/workflows/windows-ci.yml"
-            - "**.props"
-            - build.psm1
-            - src/**
-            - test/**
-            - tools/buildCommon/**
-            - tools/ci.psm1
-            - tools/WindowsCI.psm1
-            - "!test/common/markdown/**"
-            - "!test/perf/**"
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+
+        # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          list-files: json
+          filters: .github/action-filters.yml
+
+      - name: Capture outputs
+        run: |
+          "source: ${{ steps.filter.outputs.source }}"
+          "github: ${{ steps.filter.outputs.github }}"
+          "tools: ${{ steps.filter.outputs.tools }}"
+          "props: ${{ steps.filter.outputs.props }}"
+          "tests: ${{ steps.filter.outputs.tests }}"
+          "mainSource: ${{ steps.filter.outputs.mainSource }}"
+          "buildModule: ${{ steps.filter.outputs.buildModule }}"
+        shell: pwsh
+
   ci_build:
     name: Build PowerShell
     needs: changes


### PR DESCRIPTION
Backport #24929

This pull request includes changes to streamline the GitHub Actions workflows by centralizing the filter definitions and updating the workflow files to use these centralized filters. The most important changes include the addition of a new filter file and updates to the Linux, macOS, and Windows CI workflow files to use this new filter file.

Centralization of filter definitions:

* [`.github/action-filters.yml`](diffhunk://#diff-bb695f926de5ec805885c07b1f47a32c7cd1c30cf6442db1e74ea8744f3ec281R1-R23): Added a new file to define filter paths for various components like GitHub actions, tools, properties, tests, main source, and build module.

Updates to CI workflows:

* [`.github/workflows/linux-ci.yml`](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fR51-R71): Updated the workflow to use the centralized filter definitions from `.github/action-filters.yml` and added a step to capture outputs.
* [`.github/workflows/macos-ci.yml`](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aR50-R70): Updated the workflow to use the centralized filter definitions from `.github/action-filters.yml` and added a step to capture outputs.
* [`.github/workflows/windows-ci.yml`](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37R51-R71): Updated the workflow to use the centralized filter definitions from `.github/action-filters.yml` and added a step to capture outputs.