### PR TITLE
[release/v7.5]Fix release branch filters

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -8,8 +8,7 @@ on:
   push:
     branches:
       - master
-      - release*
-      - feature*
+      - release/**
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -20,7 +19,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
 # Path filters for PRs need to go into the changes job
 
 concurrency:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -18,7 +17,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
 # Path filters for PRs need to go into the changes job
 
 concurrency:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
     paths:
       - "**"
       - "!.vsts-ci/misc-analysis.yml"
@@ -17,7 +16,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
 # Path filters for PRs need to go into the changes job
 
 concurrency:


### PR DESCRIPTION
Backport #24933

This pull request includes changes to the CI workflow configuration files for Linux, macOS, and Windows. The most important changes involve modifying the branch filters to streamline the CI process.

Changes to branch filters:

* [`.github/workflows/linux-ci.yml`](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL11-R11): Updated branch filters to include `release/**` and removed `feature*` branches. [[1]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL11-R11) [[2]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL23)
* [`.github/workflows/macos-ci.yml`](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aL10): Updated branch filters to include `release/**` and removed `feature*` branches. [[1]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aL10) [[2]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aL21)
* [`.github/workflows/windows-ci.yml`](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37L8): Updated branch filters to include `release/**` and removed `feature*` branches. [[1]](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37L8) [[2]](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37L20)