### PR TITLE
[release/v7.4]Fix release branch filters

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -20,7 +19,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
 # Path filters for PRs need to go into the changes job
 
 concurrency:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -18,7 +17,6 @@ on:
     branches:
       - master
       - release/**
-      - feature*
 # Path filters for PRs need to go into the changes job
 
 concurrency:


### PR DESCRIPTION
Backport #24933

This pull request includes changes to the CI workflow configurations for both Linux and macOS. The most important changes involve removing the `feature*` branch filter from the `on:` section in the workflow files.

Changes to CI workflow configurations:

* [`.github/workflows/linux-ci.yml`](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL12): Removed the `feature*` branch filter from the `on:` section. [[1]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL12) [[2]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL23)
* [`.github/workflows/macos-ci.yml`](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aL10): Removed the `feature*` branch filter from the `on:` section. [[1]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aL10) [[2]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aL21)