### PR TITLE
Fix `Start-Transcript` error when `$Transcript` is a `PSObject` wrapped string

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    _outFilename = (string)value;
+                    _outFilename = (string)PSObject.Base(value);
                 }
             }
 

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -86,24 +86,10 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $outputFilePath = Join-Path $TestDrive "PowerShell_transcript*"
         ValidateTranscription -scriptToExecute $script -outputFilePath $outputFilePath
     }
-    It "Should create Transcript file with path stored in 'Transcript' preference variable" {
-        try {
-            $Global:Transcript = $transcriptFilePath
-
-            [String]$message = New-Guid
-            $script = {
-                Start-Transcript
-                Write-Host -Message $message -InformationAction Ignore
-                Stop-Transcript
-            }
-
-            & $script
-
-            $transcriptFilePath | Should -Exist
-            $transcriptFilePath | Should -Not -FileContentMatch $message
-        } finally {
-            $Global:Transcript = $null
-        }
+    It "Should create Transcript file with 'Transcript' preference variable" {
+        # Casting to PSObject is necessary because Set-Variable does not automatically wrap the value in a PSObject
+        $script = "Set-Variable -Scope Global -Name Transcript -Value ([PSObject]'$transcriptFilePath'); Start-Transcript"
+        ValidateTranscription -scriptToExecute $script -outputFilePath $transcriptFilePath
     }
     It "Should Append Transcript data in existing file if 'Append' parameter is used with Path parameter" {
         $script = "Start-Transcript -path $transcriptFilePath -Append"

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -86,6 +86,25 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $outputFilePath = Join-Path $TestDrive "PowerShell_transcript*"
         ValidateTranscription -scriptToExecute $script -outputFilePath $outputFilePath
     }
+    It "Should create Transcript file with path stored in 'Transcript' preference variable" {
+        try {
+            $Global:Transcript = $transcriptFilePath
+
+            [String]$message = New-Guid
+            $script = {
+                Start-Transcript
+                Write-Host -Message $message -InformationAction Ignore
+                Stop-Transcript
+            }
+
+            & $script
+
+            $transcriptFilePath | Should -Exist
+            $transcriptFilePath | Should -Not -FileContentMatch $message
+        } finally {
+            $Global:Transcript = $null
+        }
+    }
     It "Should Append Transcript data in existing file if 'Append' parameter is used with Path parameter" {
         $script = "Start-Transcript -path $transcriptFilePath -Append"
         ValidateTranscription -scriptToExecute $script -outputFilePath $transcriptFilePath -append


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #24740 

## PR Context

Unwrap transcript filename stored as `PSObject` in `$Transcript` preference variable.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
