### PR TITLE
Fix `SA1411`: Attribute constructor should not use unnecessary parenthesis

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -572,7 +572,7 @@ namespace Microsoft.PowerShell.Commands
         /// since it is optional for GetService and mandatory otherwise.
         /// </remarks>
         [Parameter(Position = 0, ParameterSetName = "Default", ValueFromPipelineByPropertyName = true, ValueFromPipeline = true)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         [Alias("ServiceName")]
         public string[] Name
         {
@@ -1547,7 +1547,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter]
-        [Credential()]
+        [Credential]
         public PSCredential Credential { get; set; }
 
         /// <summary>
@@ -2085,7 +2085,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter]
-        [Credential()]
+        [Credential]
         public PSCredential Credential
         {
             get { return credential; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSBreakpoint.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSBreakpoint.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = CommandParameterSetName)]
         [Parameter(ParameterSetName = VariableParameterSetName)]
         [Parameter(ParameterSetName = TypeParameterSetName)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         public string[] Script { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands
         /// The Name parameter for the command.
         /// </summary>
         [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         public string[] Name
         {
             get { return _names; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRunspaceCommand.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0,
                    ParameterSetName = GetRunspaceCommand.NameParameterSet)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Name
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -243,7 +243,7 @@ namespace Microsoft.PowerShell.Commands
         /// Name of the PSVariable.
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         public string[] Name
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/GetTracerCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/GetTracerCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         public string[] Name
         {
             get

--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/ComInterfaces.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/ComInterfaces.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell
         internal interface IShellLinkW
         {
             void GetPath(
-                [Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile,
+                [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile,
                 int cchMaxPath,
                 IntPtr pfd,
                 uint fFlags);
@@ -61,14 +61,14 @@ namespace Microsoft.PowerShell
             void SetIDList(IntPtr pidl);
 
             void GetDescription(
-                [Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile,
+                [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile,
                 int cchMaxName);
 
             void SetDescription(
                 [MarshalAs(UnmanagedType.LPWStr)] string pszName);
 
             void GetWorkingDirectory(
-                [Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir,
+                [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir,
                 int cchMaxPath
                 );
 
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell
                 [MarshalAs(UnmanagedType.LPWStr)] string pszDir);
 
             void GetArguments(
-                [Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs,
+                [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs,
                 int cchMaxPath);
 
             void SetArguments(
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell
             void SetShowCmd(uint iShowCmd);
 
             void GetIconLocation(
-                [Out(), MarshalAs(UnmanagedType.LPWStr)] out StringBuilder pszIconPath,
+                [Out, MarshalAs(UnmanagedType.LPWStr)] out StringBuilder pszIconPath,
                 int cchIconPath,
                 out int iIcon);
 
@@ -172,7 +172,7 @@ namespace Microsoft.PowerShell
             HResult BeginList(
                 out uint cMaxSlots,
                 ref Guid riid,
-                [Out(), MarshalAs(UnmanagedType.Interface)] out object ppvObject);
+                [Out, MarshalAs(UnmanagedType.Interface)] out object ppvObject);
 
             [PreserveSig]
             HResult AppendCategory(
@@ -190,7 +190,7 @@ namespace Microsoft.PowerShell
 
             void GetRemovedDestinations(
                 ref Guid riid,
-                [Out(), MarshalAs(UnmanagedType.Interface)] out object ppvObject);
+                [Out, MarshalAs(UnmanagedType.Interface)] out object ppvObject);
 
             void DeleteList(
                 [MarshalAs(UnmanagedType.LPWStr)] string pszAppID);
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell
             void GetAt(
                 uint iIndex,
                 ref Guid riid,
-                [Out(), MarshalAs(UnmanagedType.Interface)] out object ppvObject);
+                [Out, MarshalAs(UnmanagedType.Interface)] out object ppvObject);
         }
 
         [ComImport]
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell
             void GetAt(
                 uint iIndex,
                 ref Guid riid,
-                [Out(), MarshalAs(UnmanagedType.Interface)] out object ppvObject);
+                [Out, MarshalAs(UnmanagedType.Interface)] out object ppvObject);
 
             // IObjectCollection
             void AddObject(

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -13,7 +13,7 @@ namespace System.Management.Automation
     /// This attribute is used to specify an argument completer for a parameter to a cmdlet or function.
     /// <example>
     /// <code>
-    ///     [Parameter()]
+    ///     [Parameter]
     ///     [ArgumentCompleter(typeof(NounArgumentCompleter))]
     ///     public string Noun { get; set; }
     /// </code>
@@ -197,7 +197,7 @@ namespace System.Management.Automation
         /// Gets or sets the script block that will be executed to provide argument completions.
         /// </summary>
         [Parameter(Mandatory = true)]
-        [AllowNull()]
+        [AllowNull]
         public ScriptBlock ScriptBlock { get; set; }
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace System.Management.Automation
     /// This attribute is used to specify an argument completions for a parameter of a cmdlet or function
     /// based on string array.
     /// <example>
-    ///     [Parameter()]
+    ///     [Parameter]
     ///     [ArgumentCompletions("Option1","Option2","Option3")]
     ///     public string Noun { get; set; }
     /// </example>

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the ExcludeModule parameter to the cmdlet.
         /// </summary>
-        [Parameter()]
+        [Parameter]
         public string[] ExcludeModule
         {
             get
@@ -241,7 +241,7 @@ namespace Microsoft.PowerShell.Commands
         /// This parameter causes the output to be packaged into ShowCommandInfo PSObject types
         /// needed to display GUI command information.
         /// </summary>
-        [Parameter()]
+        [Parameter]
         public SwitchParameter ShowCommandInfo { get; set; }
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7631,7 +7631,7 @@ namespace Microsoft.PowerShell.Commands
         /// A parameter to return the streams of an item.
         /// </summary>
         [Parameter]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Stream { get; set; }
 #endif
@@ -7647,7 +7647,7 @@ namespace Microsoft.PowerShell.Commands
         /// A parameter to return the streams of an item.
         /// </summary>
         [Parameter]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Stream { get; set; }
 #endif


### PR DESCRIPTION
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md

Contributes to https://github.com/PowerShell/PowerShell/issues/26922
