### PR TITLE
Add completion single/double quote support for `-PSEdition` parameter

### DIFF
--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -605,6 +605,6 @@ namespace Microsoft.PowerShell.Commands
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters) 
-                => CompletionCompleters.GetMatchingResults(wordToComplete, Utils.AllowedEditionValues);
+                => CompletionCompleters.GetMatchingResults(wordToComplete, possibleCompletionValues: Utils.AllowedEditionValues);
     }
 }

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -598,7 +598,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="wordToComplete">The word to complete.</param>
         /// <param name="commandAst">The command AST.</param>
         /// <param name="fakeBoundParameters">The fake bound parameters.</param>
-        /// <returns>List of Completion Results.</returns>
+        /// <returns>List of completion results.</returns>
         public IEnumerable<CompletionResult> CompleteArgument(
             string commandName,
             string parameterName,

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -586,24 +586,25 @@ namespace Microsoft.PowerShell.Commands
     }
 
     /// <summary>
-    /// PSEditionArgumentCompleter for PowerShell Edition names.
+    /// Provides argument completion for PSEdition parameter.
     /// </summary>
     public class PSEditionArgumentCompleter : IArgumentCompleter
     {
         /// <summary>
-        /// CompleteArgument.
+        /// Returns completion results for PSEdition parameter.
         /// </summary>
-        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
-        {
-            var wordToCompletePattern = WildcardPattern.Get(string.IsNullOrWhiteSpace(wordToComplete) ? "*" : wordToComplete + "*", WildcardOptions.IgnoreCase);
-
-            foreach (var edition in Utils.AllowedEditionValues)
-            {
-                if (wordToCompletePattern.IsMatch(edition))
-                {
-                    yield return new CompletionResult(edition, edition, CompletionResultType.Text, edition);
-                }
-            }
-        }
+        /// <param name="commandName">The command name.</param>
+        /// <param name="parameterName">The parameter name.</param>
+        /// <param name="wordToComplete">The word to complete.</param>
+        /// <param name="commandAst">The command AST.</param>
+        /// <param name="fakeBoundParameters">The fake bound parameters.</param>
+        /// <returns>List of Completion Results.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters) 
+                => CompletionCompleters.GetMatchingResults(wordToComplete, Utils.AllowedEditionValues);
     }
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -2653,15 +2653,18 @@ dir -Recurse `
     Context "Module cmdlet completion tests" {
         It "ArugmentCompleter for PSEdition should work for '<cmd>'" -TestCases @(
             @{cmd = "Get-Module -PSEdition "; expected = "Desktop", "Core"}
+            @{cmd = "Get-Module -PSEdition '"; expected = "'Desktop'", "'Core'"}
+            @{cmd = "Get-Module -PSEdition """; expected = """Desktop""", """Core"""}
+            @{cmd = "Get-Module -PSEdition 'Desk"; expected = "'Desktop'"}
+            @{cmd = "Get-Module -PSEdition ""Desk"; expected = """Desktop"""}
+            @{cmd = "Get-Module -PSEdition Co"; expected = "Core"}
+            @{cmd = "Get-Module -PSEdition 'Co"; expected = "'Core'"}
+            @{cmd = "Get-Module -PSEdition ""Co"; expected = """Core"""}
         ) {
             param($cmd, $expected)
             $res = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-            $res.CompletionMatches | Should -HaveCount $expected.Count
-            $completionOptions = ""
-            foreach ($completion in $res.CompletionMatches) {
-                $completionOptions += $completion.ListItemText
-            }
-            $completionOptions | Should -BeExactly ([string]::Join("", $expected))
+            $completionText = $res.CompletionMatches.CompletionText
+            $completionText -join ' ' | Should -BeExactly ($expected -join ' ')
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Use `CompletionCompleters.GetMatchingResults` in `PSEditionArgumentCompleter` so `-PSEdition` parameter for `Get-Module` has support for single/double quotes.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Related to #24873

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
