### PR TITLE
Add completion single/double quote support for `-Noun` parameter

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8421,6 +8421,33 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// Calls Get-Command to get command info objects.
+        /// </summary>
+        /// <param name="fakeBoundParameters">The fake bound parameters.</param>
+        /// <param name="parametersToAdd">The parameters to add.</param>
+        /// <returns>Collection of command info objects.</returns>
+        internal static Collection<CommandInfo> GetCommandInfo(
+            IDictionary fakeBoundParameters, 
+            params string[] parametersToAdd)
+        {
+            using var ps = PowerShell.Create(RunspaceMode.CurrentRunspace);
+
+            ps.AddCommand("Get-Command");
+
+            foreach (string parameter in parametersToAdd)
+            {
+                if (fakeBoundParameters.Contains(parameter))
+                {
+                    ps.AddParameter(parameter, fakeBoundParameters[parameter]);
+                }
+            }
+
+            Collection<CommandInfo> commands = ps.Invoke<CommandInfo>();
+
+            return commands;
+        }
+
         internal static bool IsSplattedVariable(Ast targetExpr)
         {
             if (targetExpr is VariableExpressionAst && ((VariableExpressionAst)targetExpr).Splatted)

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1714,17 +1714,17 @@ namespace Microsoft.PowerShell.Commands
             CommandAst commandAst,
             IDictionary fakeBoundParameters) => CompletionCompleters.GetMatchingResults(
                 wordToComplete,
-                possibleCompletionValues: GetCommandNouns(fakeBoundParameters).Order());
+                possibleCompletionValues: GetCommandNouns(fakeBoundParameters));
 
         /// <summary>
-        /// Get command nouns using Get-Command.
+        /// Get sorted set of command nouns using Get-Command.
         /// </summary>
         /// <param name="fakeBoundParameters">The fake bound parameters.</param>
-        /// <returns>List of command nouns.</returns>
-        private static HashSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
+        /// <returns>Sorted set of command nouns.</returns>
+        private static SortedSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
         {
             Collection<CommandInfo> commands = CompletionCompleters.GetCommandInfo(fakeBoundParameters, "Module", "Verb");
-            HashSet<string> nouns = new(commands.Count, StringComparer.OrdinalIgnoreCase);
+            SortedSet<string> nouns = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (CommandInfo command in commands)
             {

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1724,7 +1724,7 @@ namespace Microsoft.PowerShell.Commands
         private static SortedSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
         {
             Collection<CommandInfo> commands = CompletionCompleters.GetCommandInfo(fakeBoundParameters, "Module", "Verb");
-            SortedSet<string> nouns = new();
+            SortedSet<string> nouns = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (CommandInfo command in commands)
             {

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1723,23 +1723,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>List of command nouns.</returns>
         private static HashSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
         {
-            using var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-
-            ps.AddCommand("Get-Command");
-
-            // Completion: Get-Command -Module <module> -Noun <wordToComplete>
-            if (fakeBoundParameters.Contains("Module"))
-            {
-                ps.AddParameter("Module", fakeBoundParameters["Module"]);
-            }
-
-            // Completion: Get-Command -Verb <verb> -Noun <wordToComplete>
-            if (fakeBoundParameters.Contains("Verb"))
-            {
-                ps.AddParameter("Verb", fakeBoundParameters["Verb"]);
-            }
-
-            Collection<CommandInfo> commands = ps.Invoke<CommandInfo>();
+            Collection<CommandInfo> commands = CompletionCompleters.GetCommandInfo(fakeBoundParameters, "Module", "Verb");
             HashSet<string> nouns = new(commands.Count, StringComparer.OrdinalIgnoreCase);
 
             foreach (CommandInfo command in commands)

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1724,7 +1724,7 @@ namespace Microsoft.PowerShell.Commands
         private static SortedSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
         {
             Collection<CommandInfo> commands = CompletionCompleters.GetCommandInfo(fakeBoundParameters, "Module", "Verb");
-            SortedSet<string> nouns = new(StringComparer.OrdinalIgnoreCase);
+            SortedSet<string> nouns = new();
 
             foreach (CommandInfo command in commands)
             {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1143,11 +1143,10 @@ ConstructorTestClass(int i, bool b)
             @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun 'C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote }
             @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun ""C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote }
         ) {
-            param($TextInput, $ExpectedNouns)
+            param($TextInput, [System.Collections.Generic.SortedSet[string]]$ExpectedNouns)
             $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
-            $sortedCompletionText = $res.CompletionMatches.CompletionText | Sort-Object -Unique -CaseSensitive
-            $sortedExpectedNouns = $ExpectedNouns | Sort-Object -Unique -CaseSensitive
-            $sortedCompletionText -join ' ' | Should -BeExactly ($sortedExpectedNouns -join ' ')
+            $completionText = $res.CompletionMatches.CompletionText
+            $completionText -join ' ' | Should -BeExactly ($ExpectedNouns -join ' ')
         }
     }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1078,6 +1078,43 @@ ConstructorTestClass(int i, bool b)
         }
     }
 
+    Context 'Get-Command -Noun parameter completion' {
+        BeforeAll {
+            $allUtilityCommandNouns = "Alias CliXml Command Csv Culture Custom Date Debug Debugger EngineEvent Error Event EventSubscriber Expression File FileHash FormatData GridView Guid Hex Host Html Information Json List LocalizedData MailMessage Markdown MarkdownOption Member Object ObjectEvent Output PowerShellDataFile Printer Progress PSBreakpoint PSCallStack PSSession Random RestMethod Runspace RunspaceDebug SddlString SecureRandom Sleep String StringData Table TemporaryFile TimeSpan TraceSource Type TypeData UICulture Unique Uptime Variable Verb Verbose Warning WebRequest Wide Xml"
+            $allUtilityCommandNounsSingleQuote = "'Alias' 'CliXml' 'Command' 'Csv' 'Culture' 'Custom' 'Date' 'Debug' 'Debugger' 'EngineEvent' 'Error' 'Event' 'EventSubscriber' 'Expression' 'File' 'FileHash' 'FormatData' 'GridView' 'Guid' 'Hex' 'Host' 'Html' 'Information' 'Json' 'List' 'LocalizedData' 'MailMessage' 'Markdown' 'MarkdownOption' 'Member' 'Object' 'ObjectEvent' 'Output' 'PowerShellDataFile' 'Printer' 'Progress' 'PSBreakpoint' 'PSCallStack' 'PSSession' 'Random' 'RestMethod' 'Runspace' 'RunspaceDebug' 'SddlString' 'SecureRandom' 'Sleep' 'String' 'StringData' 'Table' 'TemporaryFile' 'TimeSpan' 'TraceSource' 'Type' 'TypeData' 'UICulture' 'Unique' 'Uptime' 'Variable' 'Verb' 'Verbose' 'Warning' 'WebRequest' 'Wide' 'Xml'"
+            $allUtilityCommandNounsDoubleQuote = """Alias"" ""CliXml"" ""Command"" ""Csv"" ""Culture"" ""Custom"" ""Date"" ""Debug"" ""Debugger"" ""EngineEvent"" ""Error"" ""Event"" ""EventSubscriber"" ""Expression"" ""File"" ""FileHash"" ""FormatData"" ""GridView"" ""Guid"" ""Hex"" ""Host"" ""Html"" ""Information"" ""Json"" ""List"" ""LocalizedData"" ""MailMessage"" ""Markdown"" ""MarkdownOption"" ""Member"" ""Object"" ""ObjectEvent"" ""Output"" ""PowerShellDataFile"" ""Printer"" ""Progress"" ""PSBreakpoint"" ""PSCallStack"" ""PSSession"" ""Random"" ""RestMethod"" ""Runspace"" ""RunspaceDebug"" ""SddlString"" ""SecureRandom"" ""Sleep"" ""String"" ""StringData"" ""Table"" ""TemporaryFile"" ""TimeSpan"" ""TraceSource"" ""Type"" ""TypeData"" ""UICulture"" ""Unique"" ""Uptime"" ""Variable"" ""Verb"" ""Verbose"" ""Warning"" ""WebRequest"" ""Wide"" ""Xml"""
+            $utilityCommandNounsStartingWithF = "File FileHash FormatData"
+            $utilityCommandNounsStartingWithFSingleQuote = "'File' 'FileHash' 'FormatData'"
+            $utilityCommandNounsStartingWithFDoubleQuote = """File"" ""FileHash"" ""FormatData"""
+            $utilityCommandNounsWithConvertToVerb = "CliXml Csv Html Json Xml"
+            $utilityCommandNounsWithConvertToVerbSingleQuote = "'CliXml' 'Csv' 'Html' 'Json' 'Xml'"
+            $utilityCommandNounsWithConvertToVerbDoubleQuote = """CliXml"" ""Csv"" ""Html"" ""Json"" ""Xml"""
+            $utilityCommandNounsWithConvertToVerbStartingWithC = "CliXml Csv"
+            $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote = "'CliXml' 'Csv'"
+            $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote = """CliXml"" ""Csv"""
+        }
+
+        It "Should complete Noun for '<TextInput>'" -TestCases @(
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun "; ExpectedNouns = $allUtilityCommandNouns }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun '"; ExpectedNouns = $allUtilityCommandNounsSingleQuote }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun """; ExpectedNouns = $allUtilityCommandNounsDoubleQuote }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun F"; ExpectedNouns = $utilityCommandNounsStartingWithF  }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun 'F"; ExpectedNouns = $utilityCommandNounsStartingWithFSingleQuote }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun ""F"; ExpectedNouns = $utilityCommandNounsStartingWithFDoubleQuote }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun "; ExpectedNouns = $utilityCommandNounsWithConvertToVerb  }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun '"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbSingleQuote }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun """; ExpectedNouns = $utilityCommandNounsWithConvertToVerbDoubleQuote }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithC  }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun 'C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote }
+            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun ""C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote }
+        ) {
+            param($TextInput, $ExpectedNouns)
+            $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
+            $completionText = $res.CompletionMatches.CompletionText
+            $completionText -join ' ' | Should -BeExactly $ExpectedNouns
+        }
+    }
+
     Context "Format cmdlet's View paramter completion" {
         BeforeAll {
             $viewDefinition = @'

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1143,10 +1143,18 @@ ConstructorTestClass(int i, bool b)
             @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun 'C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote }
             @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun ""C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote }
         ) {
-            param($TextInput, [System.Collections.Generic.SortedSet[string]]$ExpectedNouns)
+            param($TextInput, $ExpectedNouns)
             $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
             $completionText = $res.CompletionMatches.CompletionText
-            $completionText -join ' ' | Should -BeExactly ($ExpectedNouns -join ' ')
+
+            # Avoid using Sort-Object -Unique because it generates different order than SortedSet on MacOS/Linux
+            $sortedSetExpectedNouns = [System.Collections.Generic.SortedSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($noun in $ExpectedNouns)
+            {
+                $sortedSetExpectedNouns.Add($noun) | Out-Null
+            }
+
+            $completionText -join ' ' | Should -BeExactly ($sortedSetExpectedNouns -join ' ')
         }
     }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1080,38 +1080,52 @@ ConstructorTestClass(int i, bool b)
 
     Context 'Get-Command -Noun parameter completion' {
         BeforeAll {
-            $allUtilityCommandNouns = "Alias CliXml Command Csv Culture Custom Date Debug Debugger EngineEvent Error Event EventSubscriber Expression File FileHash FormatData GridView Guid Hex Host Html Information Json List LocalizedData MailMessage Markdown MarkdownOption Member Object ObjectEvent Output PowerShellDataFile Printer Progress PSBreakpoint PSCallStack PSSession Random RestMethod Runspace RunspaceDebug SddlString SecureRandom Sleep String StringData Table TemporaryFile TimeSpan TraceSource Type TypeData UICulture Unique Uptime Variable Verb Verbose Warning WebRequest Wide Xml"
-            $allUtilityCommandNounsSingleQuote = "'Alias' 'CliXml' 'Command' 'Csv' 'Culture' 'Custom' 'Date' 'Debug' 'Debugger' 'EngineEvent' 'Error' 'Event' 'EventSubscriber' 'Expression' 'File' 'FileHash' 'FormatData' 'GridView' 'Guid' 'Hex' 'Host' 'Html' 'Information' 'Json' 'List' 'LocalizedData' 'MailMessage' 'Markdown' 'MarkdownOption' 'Member' 'Object' 'ObjectEvent' 'Output' 'PowerShellDataFile' 'Printer' 'Progress' 'PSBreakpoint' 'PSCallStack' 'PSSession' 'Random' 'RestMethod' 'Runspace' 'RunspaceDebug' 'SddlString' 'SecureRandom' 'Sleep' 'String' 'StringData' 'Table' 'TemporaryFile' 'TimeSpan' 'TraceSource' 'Type' 'TypeData' 'UICulture' 'Unique' 'Uptime' 'Variable' 'Verb' 'Verbose' 'Warning' 'WebRequest' 'Wide' 'Xml'"
-            $allUtilityCommandNounsDoubleQuote = """Alias"" ""CliXml"" ""Command"" ""Csv"" ""Culture"" ""Custom"" ""Date"" ""Debug"" ""Debugger"" ""EngineEvent"" ""Error"" ""Event"" ""EventSubscriber"" ""Expression"" ""File"" ""FileHash"" ""FormatData"" ""GridView"" ""Guid"" ""Hex"" ""Host"" ""Html"" ""Information"" ""Json"" ""List"" ""LocalizedData"" ""MailMessage"" ""Markdown"" ""MarkdownOption"" ""Member"" ""Object"" ""ObjectEvent"" ""Output"" ""PowerShellDataFile"" ""Printer"" ""Progress"" ""PSBreakpoint"" ""PSCallStack"" ""PSSession"" ""Random"" ""RestMethod"" ""Runspace"" ""RunspaceDebug"" ""SddlString"" ""SecureRandom"" ""Sleep"" ""String"" ""StringData"" ""Table"" ""TemporaryFile"" ""TimeSpan"" ""TraceSource"" ""Type"" ""TypeData"" ""UICulture"" ""Unique"" ""Uptime"" ""Variable"" ""Verb"" ""Verbose"" ""Warning"" ""WebRequest"" ""Wide"" ""Xml"""
-            $utilityCommandNounsStartingWithF = "File FileHash FormatData"
-            $utilityCommandNounsStartingWithFSingleQuote = "'File' 'FileHash' 'FormatData'"
-            $utilityCommandNounsStartingWithFDoubleQuote = """File"" ""FileHash"" ""FormatData"""
-            $utilityCommandNounsWithConvertToVerb = "CliXml Csv Html Json Xml"
-            $utilityCommandNounsWithConvertToVerbSingleQuote = "'CliXml' 'Csv' 'Html' 'Json' 'Xml'"
-            $utilityCommandNounsWithConvertToVerbDoubleQuote = """CliXml"" ""Csv"" ""Html"" ""Json"" ""Xml"""
-            $utilityCommandNounsWithConvertToVerbStartingWithC = "CliXml Csv"
-            $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote = "'CliXml' 'Csv'"
-            $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote = """CliXml"" ""Csv"""
+            function GetModuleCommandNouns([string]$module, [switch]$singleQuote, [switch]$doubleQuote) {
+                $nouns = (Get-Command -Module $module).Noun | Sort-Object -Unique
+
+                if ($singleQuote) {
+                    return ($nouns | ForEach-Object { "'$_'" })
+                }
+                elseif ($doubleQuote) {
+                    return ($nouns | ForEach-Object { """$_""" })
+                }
+
+                return $nouns
+            }
+
+            $utilityModuleName = 'Microsoft.PowerShell.Utility'
+            $allUtilityCommandNouns = GetModuleCommandNouns -Module $utilityModuleName
+            $allUtilityCommandNounsSingleQuote = GetModuleCommandNouns -Module $utilityModuleName -SingleQuote
+            $allUtilityCommandNounsDoubleQuote = GetModuleCommandNouns -Module $utilityModuleName -DoubleQuote
+            $utilityCommandNounsStartingWithF = $allUtilityCommandNouns | Where-Object { $_ -like 'F*'}
+            $utilityCommandNounsStartingWithFSingleQuote = $allUtilityCommandNounsSingleQuote | Where-Object { $_ -like "'F*"}
+            $utilityCommandNounsStartingWithFDoubleQuote = $allUtilityCommandNounsDoubleQuote | Where-Object { $_ -like """F*"}
+            $utilityCommandNounsWithConvertToVerb = $allUtilityCommandNouns | Where-Object { $_ -in 'CliXml', 'Csv', 'Html', 'Json', 'Xml' }
+            $utilityCommandNounsWithConvertToVerbSingleQuote = $allUtilityCommandNounsSingleQuote | Where-Object { $_ -in "'CliXml'", "'Csv'", "'Html'", "'Json'", "'Xml'" }
+            $utilityCommandNounsWithConvertToVerbDoubleQuote = $allUtilityCommandNounsDoubleQuote | Where-Object { $_ -in """CliXml""", """Csv""", """Html""", """Json""", """Xml""" }
+            $utilityCommandNounsWithConvertToVerbStartingWithC = $allUtilityCommandNouns | Where-Object { $_ -in 'CliXml', 'Csv' }
+            $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote = $allUtilityCommandNounsSingleQuote | Where-Object { $_ -in "'CliXml'", "'Csv'" }
+            $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote = $allUtilityCommandNounsDoubleQuote | Where-Object { $_ -in """CliXml""", """Csv""" }
         }
 
         It "Should complete Noun for '<TextInput>'" -TestCases @(
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun "; ExpectedNouns = $allUtilityCommandNouns }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun '"; ExpectedNouns = $allUtilityCommandNounsSingleQuote }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun """; ExpectedNouns = $allUtilityCommandNounsDoubleQuote }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun F"; ExpectedNouns = $utilityCommandNounsStartingWithF  }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun 'F"; ExpectedNouns = $utilityCommandNounsStartingWithFSingleQuote }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Noun ""F"; ExpectedNouns = $utilityCommandNounsStartingWithFDoubleQuote }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun "; ExpectedNouns = $utilityCommandNounsWithConvertToVerb  }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun '"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbSingleQuote }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun """; ExpectedNouns = $utilityCommandNounsWithConvertToVerbDoubleQuote }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithC  }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun 'C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote }
-            @{ TextInput = "Get-Command -Module Microsoft.PowerShell.Utility -Verb ConvertTo -Noun ""C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Noun "; ExpectedNouns = $allUtilityCommandNouns }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Noun '"; ExpectedNouns = $allUtilityCommandNounsSingleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Noun """; ExpectedNouns = $allUtilityCommandNounsDoubleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Noun F"; ExpectedNouns = $utilityCommandNounsStartingWithF  }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Noun 'F"; ExpectedNouns = $utilityCommandNounsStartingWithFSingleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Noun ""F"; ExpectedNouns = $utilityCommandNounsStartingWithFDoubleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun "; ExpectedNouns = $utilityCommandNounsWithConvertToVerb  }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun '"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbSingleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun """; ExpectedNouns = $utilityCommandNounsWithConvertToVerbDoubleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithC  }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun 'C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCSingleQuote }
+            @{ TextInput = "Get-Command -Module $utilityModuleName -Verb ConvertTo -Noun ""C"; ExpectedNouns = $utilityCommandNounsWithConvertToVerbStartingWithCDoubleQuote }
         ) {
             param($TextInput, $ExpectedNouns)
             $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length
             $completionText = $res.CompletionMatches.CompletionText
-            $completionText -join ' ' | Should -BeExactly $ExpectedNouns
+            $completionText -join ' ' | Should -BeExactly ($ExpectedNouns -join ' ')
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Use `CompletionCompleters.GetMatchingResults` in `NounArgumentCompleter` so `-Noun` parameter for `Get-Command` has support for single/double quotes.

Also made the following improvements:

- When `-Verb` is used, only get nouns which are possible with the following verbs.
- use `SortedSet<string>` with `StringComparer.IgnoreCase` to ensure all nouns are unique and sorted and case insensitive. Also removed previous LINQ `Order()` call with this change.
- Wrap `Get-Command` logic into `CompletionCompleters.GetCommandInfo` method. This can probably be used elsewhere and potentially reduce duplication of command querying code in completers. Also add `using` for creating powershell instance so its automatically disposed.

I also added some tab completion tests which seem to be missing for this completer.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Related to #24873

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
