### PR TITLE
Fix `TypeName.GetReflectionType()` to work when the `TypeName` instance represents a generic type definition within a `GenericTypeName`

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1487,7 +1487,7 @@ namespace System.Management.Automation.Language
                 rBracketToken = null;
             }
 
-            var openGenericType = new TypeName(genericTypeName.Extent, genericTypeName.Text);
+            var openGenericType = new TypeName(genericTypeName.Extent, genericTypeName.Text, genericArguments.Count);
             var result = new GenericTypeName(
                 ExtentOf(genericTypeName.Extent, ExtentFromFirstOf(rBracketToken, genericArguments.LastOrDefault(), firstToken)),
                 openGenericType,

--- a/src/System.Management.Automation/engine/parser/SymbolResolver.cs
+++ b/src/System.Management.Automation/engine/parser/SymbolResolver.cs
@@ -697,26 +697,6 @@ namespace System.Management.Automation.Language
             if (foundType != null)
             {
                 ((ISupportsTypeCaching)genericTypeName).CachedType = foundType;
-
-                // When the generic type is in cache, we won't go through the code path that resolves
-                // 'genericTypeName.TypeName', which represents the generic type definition.
-                //
-                // - We could get the type definition by 'genericTypeName.TypeName.GetReflectionType()'
-                //   in some cases, for example, when the generic type is 'System.Tuple[string, string]',
-                //   calling 'GetReflectionType()' returns the 'System.Tuple' type.
-                //
-                // - But in much more other cases, calling that method won't return the type definition,
-                //   for example, when the generic type is 'System.Collections.Generic.List[string]',
-                //   the call returns 'null' because 'System.Collections.Generic.List' is not a valid type.
-                //
-                // In the latter cases, given that we already have the generic type, we can get the type
-                // definition and assign it to the cached type of 'genericTypeName.TypeName'.
-                var genericDefinition = genericTypeName.TypeName;
-                if (genericDefinition.GetReflectionType() is null)
-                {
-                    ((ISupportsTypeCaching)genericDefinition).CachedType = foundType.GetGenericTypeDefinition();
-                }
-
                 return true;
             }
 

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -8494,6 +8494,8 @@ namespace System.Management.Automation.Language
         internal TypeName(IScriptExtent extent, string name, int genericArgumentCount)
             : this(extent, name)
         {
+            ArgumentOutOfRangeException.ThrowIfLessThan(genericArgumentCount, 0);
+
             if (genericArgumentCount > 0 && !_name.Contains('`'))
             {
                 _genericArgumentCount = genericArgumentCount;

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -8580,6 +8580,11 @@ namespace System.Management.Automation.Language
 
                 if (type is null && _genericArgumentCount > 0)
                 {
+                    // We try an alternate name only if it failed to resolve with the original name.
+                    // This is because for a generic type like `System.Tuple<type1, type2>`, the original name `System.Tuple`
+                    // can be resolved and hence `genericTypeName.TypeName.GetReflectionType()` in that case has always been
+                    // returning the type `System.Tuple`. If we change to directly use the alternate name for resolution, the
+                    // return value will become 'System.Tuple`1' in that case, and that's a breaking change.
                     TypeName newTypeName = new(
                         _extent,
                         string.Create(CultureInfo.InvariantCulture, $"{_name}`{_genericArgumentCount}"))

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -8629,9 +8629,7 @@ namespace System.Management.Automation.Language
             var result = GetReflectionType();
             if (result == null || !typeof(Attribute).IsAssignableFrom(result))
             {
-                TypeName attrTypeName = new(
-                    _extent,
-                    $"{_name}Attribute", _genericArgumentCount)
+                TypeName attrTypeName = new(_extent, $"{_name}Attribute", _genericArgumentCount)
                 {
                     AssemblyName = AssemblyName
                 };

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7263,7 +7263,7 @@ namespace System.Management.Automation.Language
                         FunctionName.Extent,
                         new TypeName(
                             FunctionName.Extent,
-                            typeof(System.Management.Automation.Language.DynamicKeyword).FullName)),
+                            typeof(DynamicKeyword).FullName)),
                     new StringConstantExpressionAst(
                         FunctionName.Extent,
                         "GetKeyword",
@@ -8422,9 +8422,11 @@ namespace System.Management.Automation.Language
     /// </summary>
     public sealed class TypeName : ITypeName, ISupportsTypeCaching
     {
-        internal readonly string _name;
-        internal Type _type;
-        internal readonly IScriptExtent _extent;
+        private readonly string _name;
+        private readonly IScriptExtent _extent;
+        private readonly int _genericArgumentCount;
+        private Type _type;
+
         internal TypeDefinitionAst _typeDefinitionAst;
 
         /// <summary>
@@ -8481,6 +8483,21 @@ namespace System.Management.Automation.Language
             }
 
             AssemblyName = assembly;
+        }
+
+        /// <summary>
+        /// Construct a typename that represents a generic type definition.
+        /// </summary>
+        /// <param name="extent">The extent of the typename.</param>
+        /// <param name="name">The name of the type.</param>
+        /// <param name="genericArgumentCount">The number of generic arguments.</param>
+        internal TypeName(IScriptExtent extent, string name, int genericArgumentCount)
+            : this(extent, name)
+        {
+            if (genericArgumentCount > 0 && !_name.Contains('`'))
+            {
+                _genericArgumentCount = genericArgumentCount;
+            }
         }
 
         /// <summary>
@@ -8559,8 +8576,20 @@ namespace System.Management.Automation.Language
         {
             if (_type == null)
             {
-                Exception e;
-                Type type = _typeDefinitionAst != null ? _typeDefinitionAst.Type : TypeResolver.ResolveTypeName(this, out e);
+                Type type = _typeDefinitionAst != null ? _typeDefinitionAst.Type : TypeResolver.ResolveTypeName(this, out _);
+
+                if (type is null && _genericArgumentCount > 0)
+                {
+                    TypeName newTypeName = new(
+                        _extent,
+                        string.Create(CultureInfo.InvariantCulture, $"{_name}`{_genericArgumentCount}"))
+                    {
+                        AssemblyName = AssemblyName
+                    };
+
+                    type = TypeResolver.ResolveTypeName(newTypeName, out _);
+                }
+
                 if (type != null)
                 {
                     try
@@ -8595,7 +8624,13 @@ namespace System.Management.Automation.Language
             var result = GetReflectionType();
             if (result == null || !typeof(Attribute).IsAssignableFrom(result))
             {
-                var attrTypeName = new TypeName(_extent, FullName + "Attribute");
+                TypeName attrTypeName = new(
+                    _extent,
+                    $"{_name}Attribute", _genericArgumentCount)
+                {
+                    AssemblyName = AssemblyName
+                };
+
                 result = attrTypeName.GetReflectionType();
                 if (result != null && !typeof(Attribute).IsAssignableFrom(result))
                 {
@@ -8888,8 +8923,13 @@ namespace System.Management.Automation.Language
             {
                 if (!TypeName.FullName.Contains('`'))
                 {
-                    var newTypeName = new TypeName(Extent,
-                        string.Create(CultureInfo.InvariantCulture, $"{TypeName.FullName}`{GenericArguments.Count}"));
+                    TypeName newTypeName = new(
+                        Extent,
+                        string.Create(CultureInfo.InvariantCulture, $"{TypeName.Name}`{GenericArguments.Count}"))
+                    {
+                        AssemblyName = TypeName.AssemblyName
+                    };
+
                     generic = newTypeName.GetReflectionType();
                 }
             }
@@ -8915,8 +8955,13 @@ namespace System.Management.Automation.Language
                 {
                     if (!TypeName.FullName.Contains('`'))
                     {
-                        var newTypeName = new TypeName(Extent,
-                            string.Create(CultureInfo.InvariantCulture, $"{TypeName.FullName}Attribute`{GenericArguments.Count}"));
+                        TypeName newTypeName = new(
+                            Extent,
+                            string.Create(CultureInfo.InvariantCulture, $"{TypeName.Name}Attribute`{GenericArguments.Count}"))
+                        {
+                            AssemblyName = TypeName.AssemblyName
+                        };
+
                         generic = newTypeName.GetReflectionType();
                     }
                 }

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -683,6 +683,31 @@ Describe "Additional tests" -Tag CI {
         $result.EndBlock.Statements[0].PipelineElements[0].Expression.TypeName.FullName | Should -Be 'System.Tuple[System.String[],System.Int32[]]'
     }
 
+    It "Should correctly set the generic type definition to the 'TypeName' property of a 'GenericTypeName' instance" {
+        $tks = $null
+        $ers = $null
+        $Script = '[System.Collections.Generic.List[string]]'
+
+        ## See https://github.com/PowerShell/PowerShell/issues/24982 for details about the issue.
+        $result = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $typeExpr = $result.EndBlock.Statements[0].PipelineElements[0].Expression
+        $typeExpr.TypeName.FullName | Should -Be 'System.Collections.Generic.List[string]'
+        $typeExpr.TypeName.TypeName.FullName | Should -Be 'System.Collections.Generic.List'
+        $typeExpr.TypeName.TypeName.GetReflectionType() | Should -Not -BeNullOrEmpty
+        $typeExpr.TypeName.TypeName.GetReflectionType().FullName | Should -Be 'System.Collections.Generic.List`1'
+
+        $result2 = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $typeExpr2 = $result2.EndBlock.Statements[0].PipelineElements[0].Expression
+        $typeExpr2.TypeName.FullName | Should -Be 'System.Collections.Generic.List[string]'
+        $typeExpr2.TypeName.TypeName.FullName | Should -Be 'System.Collections.Generic.List'
+        $typeExpr2.TypeName.TypeName.GetReflectionType() | Should -Not -BeNullOrEmpty
+        $typeExpr2.TypeName.TypeName.GetReflectionType().FullName | Should -Be 'System.Collections.Generic.List`1'
+
+        $Script = '[System.Tuple[System.String[],System.Int32[]]]'
+        $result3 = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $result3.EndBlock.Statements[0].PipelineElements[0].Expression.TypeName.TypeName.GetReflectionType().FullName | Should -Be 'System.Tuple'
+    }
+
     It "Should get correct offsets for number constant parsing error" {
         $tks = $null
         $ers = $null

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -706,6 +706,28 @@ Describe "Additional tests" -Tag CI {
         $Script = '[System.Tuple[System.String[],System.Int32[]]]'
         $result3 = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
         $result3.EndBlock.Statements[0].PipelineElements[0].Expression.TypeName.TypeName.GetReflectionType().FullName | Should -Be 'System.Tuple'
+
+        ## Generic type with assembly name can be resolved.
+        [System.Collections.Generic.List[string], System.Private.CoreLib].FullName | Should -BeLike 'System.Collections.Generic.List``1`[`[System.String, *`]`]'
+
+        $Script = '[System.Collections.Generic.List[string], System.Private.CoreLib]'
+        $result4 = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $typeExpr4 = $result4.EndBlock.Statements[0].PipelineElements[0].Expression
+        $typeExpr4.TypeName.FullName | Should -Be 'System.Collections.Generic.List[string],System.Private.CoreLib'
+        $typeExpr4.TypeName.TypeName.FullName | Should -Be 'System.Collections.Generic.List,System.Private.CoreLib'
+        $typeExpr4.TypeName.TypeName.GetReflectionType() | Should -Not -BeNullOrEmpty
+        $typeExpr4.TypeName.TypeName.GetReflectionType().FullName | Should -Be 'System.Collections.Generic.List`1'
+
+        ## Generic type with '`<n>' in name can be resolved.
+        [System.Collections.Generic.List`1[string]].FullName | Should -BeLike 'System.Collections.Generic.List``1`[`[System.String, *`]`]'
+
+        $Script = '[System.Collections.Generic.List`1[string]]'
+        $result5 = [System.Management.Automation.Language.Parser]::ParseInput($Script, [ref]$tks, [ref]$ers)
+        $typeExpr5 = $result5.EndBlock.Statements[0].PipelineElements[0].Expression
+        $typeExpr5.TypeName.FullName | Should -Be 'System.Collections.Generic.List`1[string]'
+        $typeExpr5.TypeName.TypeName.FullName | Should -Be 'System.Collections.Generic.List`1'
+        $typeExpr5.TypeName.TypeName.GetReflectionType() | Should -Not -BeNullOrEmpty
+        $typeExpr5.TypeName.TypeName.GetReflectionType().FullName | Should -Be 'System.Collections.Generic.List`1'
     }
 
     It "Should get correct offsets for number constant parsing error" {

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -683,7 +683,7 @@ Describe "Additional tests" -Tag CI {
         $result.EndBlock.Statements[0].PipelineElements[0].Expression.TypeName.FullName | Should -Be 'System.Tuple[System.String[],System.Int32[]]'
     }
 
-    It "Should correctly set the generic type definition to the 'TypeName' property of a 'GenericTypeName' instance" {
+    It "Should correctly set the cached type for 'GenericTypeName.TypeName' as needed when the generic type is found in cache" {
         $tks = $null
         $ers = $null
         $Script = '[System.Collections.Generic.List[string]]'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #24982

When a generic type expression is parsed for the second time, the generic type can be found in cache, and hence the symbol resolver won't go through the code path to resolve `genericTypeName.TypeName`, which represents the generic type definition. Therefore, unlike the first-time parsing, the cached type for `genericTypeName.TypeName` won't be set during the symbol resolving process for the second parsing.

However, the type resolution in `TypeName.GetReflectionType()` doesn't work for a generic type definition in most cases, for example, when the generic type expression is `[System.Collections.Generic.List[string]]`, `genericTypeName.TypeName` will be a `TypeName` instance with the full name `System.Collections.Generic.List` which will fail to be resolved. That's why the second time you parse the same generic type expression, `genericTypeName.TypeName.GetReflectionType()` will return null.

Why `genericTypeName.TypeName` can be resolved in the first-time resolution of `genericTypeName`, but doesn't work when directly calling `genericTypeName.TypeName.GetReflectionType()`? That's because for the former, within `VisitGenericTypeName(...)`, it uses a `TypeResolutionState` instance as the resolution context, which is constructed with the information from the `genericTypeName` (see [code here](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/parser/SymbolResolver.cs#L655-L657)). But when directly calling `genericTypeName.TypeName.GetReflectionType()`, it doesn't have that information and thus cannot use the same/equivalent `TypeResolutionState` instance as the context for type resolution.

The fix is to pass the generic argument count to `TypeName` when constructing a `GenericTypeName` instance, so that the `TypeName` instance can try resolving with an alternate name (i.e. ``typename`<n>``) when the original name fails to resolve.

The changes also fix another issue:

Before: assembly-qualified name `[System.Collections.Generic.List[string], System.Private.CoreLib]` cannot be resolved.
After: `[System.Collections.Generic.List[string], System.Private.CoreLib]` can be resolved as expected.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
