### PR TITLE
Make sure the vPack pipeline does not produce an empty package

### DIFF
--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -142,18 +142,27 @@ extends:
               $vstsCommandString = "vso[task.setvariable variable=PackageArtifactName]$packageArtifactName"
               Write-Host "sending " + $vstsCommandString
               Write-Host "##$vstsCommandString"
-            displayName: 'Set package artifact name'
+
+              $packageArtifactPath = '$(Pipeline.Workspace)\PSPackagesOfficial'
+              $vstsCommandString = "vso[task.setvariable variable=PackageArtifactPath]$packageArtifactPath"
+              Write-Host "sending " + $vstsCommandString
+              Write-Host "##$vstsCommandString"
+            displayName: 'Set package artifact variables'
 
           - download: PSPackagesOfficial
             artifact: $(PackageArtifactName)
             displayName: Download package
 
-          - pwsh: 'Get-ChildItem $(System.ArtifactsDirectory)\* -recurse | Select-Object -ExpandProperty Name'
+          - pwsh: 'Get-ChildItem $(PackageArtifactPath)\* -recurse | Select-Object -ExpandProperty Name'
             displayName: 'Capture Artifact Listing'
 
           - pwsh: |
               $message = @()
-              Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -include *.zip, *.msi | ForEach-Object {
+              $packages = Get-ChildItem $(PackageArtifactPath)\* -recurse -include *.zip, *.msi
+
+              if($packages.count -eq 0) {throw "No packages found in $(PackageArtifactPath)"}
+
+              $packages | ForEach-Object {
                   if($_.Name -notmatch 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
                   {
                         $messageInstance = "$($_.Name) is not a valid package name"
@@ -166,7 +175,7 @@ extends:
             displayName: 'Validate Zip and MSI Package Names'
 
           - pwsh: |
-              Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -include *.zip, *.msi | ForEach-Object {
+              Get-ChildItem $(PackageArtifactPath)\* -recurse -include *.zip | ForEach-Object {
                   if($_.Name -match 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(${{ parameters.architecture }})\.(zip){1}')
                   {
                       Expand-Archive -Path $_.FullName -DestinationPath $(ob_outputDirectory)
@@ -197,7 +206,11 @@ extends:
 
           - pwsh: |
               Write-Verbose "VPack Version: $(ob_createvpack_version)" -Verbose
-              Get-ChildItem -Path $(ob_outputDirectory)\* -Recurse
+              $vpackFiles = Get-ChildItem -Path $(ob_outputDirectory)\* -Recurse
+              if($vpackFiles.Count -eq 0) {
+                  throw "No files found in $(ob_outputDirectory)"
+              }
+              $vpackFiles
             displayName: Debug Output Directory and Version
             condition: succeededOrFailed()
 

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -220,5 +220,5 @@ extends:
               command: 'sign'
               signing_environment: 'azure-ado'
               cp_code: $(windows_build_tools_cert_id)
-              files_to_sign: '**/*.exe;**/*.dll;**/*.ps1;**/*.psm1'
+              files_to_sign: '**/*.exe;**/System.Management.Automation.dll'
               search_root: $(ob_outputDirectory)


### PR DESCRIPTION
This pull request includes several changes to the `.pipelines/PowerShell-vPack-Official.yml` file to improve the handling of package artifacts and validation processes. The most important changes involve setting new package artifact variables, updating paths for artifact listings, and adding error handling for missing files.

Improvements to package artifact handling:

* Updated the script to set `PackageArtifactPath` and included the corresponding variable in the pipeline.
* Changed the path for capturing artifact listings to use `PackageArtifactPath` instead of `System.ArtifactsDirectory`.

Validation and error handling enhancements:

* Added error handling to throw an exception if no packages are found in the specified path.
* Included a check to ensure that the `ob_outputDirectory` contains files before proceeding, throwing an error if none are found.

Signing configuration update:

* Modified the `files_to_sign` parameter to include only `System.Management.Automation.dll` instead of all `.dll` and other file types.