### PR TITLE
Add Runtime search property

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -171,15 +171,30 @@
     <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
   </PropertyGroup>
 
-  <!-- Define all OS, debug configuration properties -->
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DebugType>portable</DebugType>
+  <!-- Define non-windows, all configuration properties -->
+  <PropertyGroup Condition=" '$(IsWindows)' != 'true' ">
+    <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Define properties for Framework dependent deployments in Packages
+        Packages should not use DOTNET_ROOT so we set the search to Global
+  -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'FddPackage' ">
+    <AppHostDotNetSearch>Global</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <!-- Define properties for releases except for Framework dependent deployments as tools
+        Including archives and dotnet tools.
+
+        These tools should use should not be Ready To Run because that will make them runtime specific
+  -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' and '$(AppDeployment)' != 'FddTool' ">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>
 
   <!-- Define all OS, release configuration properties -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <Optimize>true</Optimize>
     <DebugType>portable</DebugType>
   </PropertyGroup>

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -186,7 +186,7 @@
   <!-- Define properties for releases except for framework-dependent deployments as tools,
         including archives and dotnet tools.
 
-        These tools should use should not be Ready To Run because that will make them runtime specific
+        These tools should not be Ready-to-Run because that will make them runtime specific.
   -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' and '$(AppDeployment)' != 'FddTool' ">
     <PublishReadyToRun>true</PublishReadyToRun>

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -171,10 +171,10 @@
     <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
   </PropertyGroup>
 
-  <!-- Define non-windows, all configuration properties -->
-  <PropertyGroup Condition=" '$(IsWindows)' != 'true' ">
-    <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
-  </PropertyGroup>
+  <!-- Define all OS, debug configuration properties -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>portable</DebugType>
+  </PropertyGroup>```
 
   <!-- Define properties for Framework dependent deployments in Packages
         Packages should not use DOTNET_ROOT so we set the search to Global

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -183,8 +183,8 @@
     <AppHostDotNetSearch>Global</AppHostDotNetSearch>
   </PropertyGroup>
 
-  <!-- Define properties for releases except for Framework dependent deployments as tools
-        Including archives and dotnet tools.
+  <!-- Define properties for releases except for framework-dependent deployments as tools,
+        including archives and dotnet tools.
 
         These tools should use should not be Ready To Run because that will make them runtime specific
   -->

--- a/build.psm1
+++ b/build.psm1
@@ -490,11 +490,11 @@ Fix steps:
         $Arguments += "/property:IsWindows=false"
     }
 
-    # Framework Dependent builds do not support ReadyToRun as it needs a specific runtime to optimize for.
-    # The property is set in Powershell.Common.props file.
-    # We override the property through the build command line.
+    # Different deployment types build with different properties.
+    # We pass in the AppDeployment property to indicate which type of deployment we are doing.
+    # This allows the PowerShell.Common.props to set the correct properties for the build.
     if(($Options.Runtime -like 'fxdependent*' -or $ForMinimalSize) -and $Options.Runtime -notmatch $optimizedFddRegex) {
-        $Arguments += "/property:PublishReadyToRun=false"
+        $Arguments += "/property:AppDeployment=FddTool"
     }
 
     $Arguments += "--configuration", $Options.Configuration
@@ -511,6 +511,7 @@ Fix steps:
     } elseif ($Options.Runtime -match $optimizedFddRegex) {
         $runtime = $Options.Runtime -replace 'fxdependent-', ''
         $Arguments += "--runtime", $runtime
+        $Arguments += "/property:AppDeployment=FddPackage"
     }
 
     if ($ReleaseTag) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary


This pull request includes changes to the build configuration and deployment properties in the `PowerShell.Common.props` and `build.psm1` files. The main goal is to refine the build and deployment process for different types of deployments.

### Build and Deployment Configuration Improvements:

* [`PowerShell.Common.props`](diffhunk://#diff-e63303dba71f6f8537ceef1486078a2e19181bfcb15b7574c828bd7d3410eb6bL174-R197): Added new property groups to handle different deployment types, specifically for Framework dependent deployments (`FddPackage`) and tools (`FddTool`). This includes setting the `AppHostDotNetSearch` property and handling the `PublishReadyToRun` property appropriately based on the deployment type.

* [`build.psm1`](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL493-R497): Updated the build script to pass the `AppDeployment` property, allowing the `PowerShell.Common.props` file to set the correct properties for different deployment types. This includes changes to handle `FddTool` and `FddPackage` deployments. [[1]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL493-R497) [[2]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR514)

## PR Context

This property is only for Mariner currently.  
.NET tools are expected to respect `DOTNET_ROOT`. However, the package for Mariner should not use `DOTNET_ROOT`, but use a system defined dotnet runtime instead.
Self-Contained Deployments (SCD) installs don't support this new property.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
