### PR TITLE
Add setup dotnet action to the build composite action

### DIFF
--- a/.github/actions/build/ci/action.yml
+++ b/.github/actions/build/ci/action.yml
@@ -13,7 +13,7 @@ runs:
     shell: pwsh
   - uses: actions/setup-dotnet@v4
     with:
-      global-json-file: ./powershell/global.json
+      global-json-file: ./global.json
   - name: Bootstrap
     if: success()
     run: |-

--- a/.github/actions/build/ci/action.yml
+++ b/.github/actions/build/ci/action.yml
@@ -11,6 +11,9 @@ runs:
     if: github.event_name != 'PullRequest'
     run: Write-Host "##vso[build.updatebuildnumber]$env:BUILD_SOURCEBRANCHNAME-$env:BUILD_SOURCEVERSION-$((get-date).ToString("yyyyMMddhhmmss"))"
     shell: pwsh
+  - uses: actions/setup-dotnet@v4
+    with:
+      global-json-file: ./powershell/global.json
   - name: Bootstrap
     if: success()
     run: |-

--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -30,7 +30,11 @@ runs:
     continue-on-error: true
     run: Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
     shell: pwsh
-
+    
+  - uses: actions/setup-dotnet@v4
+    with:
+      global-json-file: ./global.json
+      
   - name: Bootstrap
     shell: pwsh
     run: |-


### PR DESCRIPTION
This pull request includes updates to the CI and test action workflows to set up the .NET environment using the `actions/setup-dotnet@v4` action.

Changes in CI and test action workflows:

* [`.github/actions/build/ci/action.yml`](diffhunk://#diff-171e2a2b0efe271c81e5ba3d95656a9dd088c57b51765fd0034617326edd35fcR14-R16): Added the `actions/setup-dotnet@v4` action to set up the .NET environment using the `global.json` file.
* [`.github/actions/test/nix/action.yml`](diffhunk://#diff-ce613df0a0f3c35f27cac9c72c5ac0d1a63070013b29d51fa04b9cf9b7f18e19R34-R37): Added the `actions/setup-dotnet@v4` action to set up the .NET environment using the `global.json` file.