### PR TITLE
Refactor Verb, Noun & PropertyType Argument Completers to use `InvokeCommand` method

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -270,7 +270,7 @@ namespace Microsoft.PowerShell.Commands
                 commandName: "Resolve-Path",
                 commandParameters: new Dictionary<string, object>
                 {
-                    { isLiteralPath ? "LiteralPath" : "Path", path }
+                    { isLiteralPath ? "LiteralPath" : "Path", path },
                 });
     }
 #endif

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -268,7 +268,8 @@ namespace Microsoft.PowerShell.Commands
         private static Collection<PathInfo> ResolvePath(object path, bool isLiteralPath)
             => CompletionCompleters.InvokeCommand<PathInfo>(
                 commandName: "Resolve-Path",
-                commandParameters: new Dictionary<string, object> {
+                commandParameters: new Dictionary<string, object>
+                {
                     { isLiteralPath ? "LiteralPath" : "Path", path }
                 });
     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -266,16 +266,11 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="isLiteralPath">Specifies if path is literal path.</param>
         /// <returns>Collection of Pathinfo objects.</returns>
         private static Collection<PathInfo> ResolvePath(object path, bool isLiteralPath)
-        {
-            using var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-
-            ps.AddCommand("Microsoft.PowerShell.Management\\Resolve-Path");
-            ps.AddParameter(isLiteralPath ? "LiteralPath" : "Path", path);
-
-            Collection<PathInfo> output = ps.Invoke<PathInfo>();
-
-            return output;
-        }
+            => CompletionCompleters.InvokeCommand<PathInfo>(
+                commandName: "Resolve-Path",
+                commandParameters: new Dictionary<string, object> {
+                    { isLiteralPath ? "LiteralPath" : "Path", path }
+                });
     }
 #endif
 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2683,9 +2683,9 @@ namespace Microsoft.PowerShell.Commands
                 // e.g if powershell was given, resolve to powershell.exe to get verbs
                 Collection<CommandInfo> commands = CompletionCompleters.InvokeCommand<CommandInfo>(
                     commandName: "Get-Command",
-                    commandParameters: new Dictionary<string, object> { 
-                        { "Name", filePath }, 
-                        { "CommandType", CommandTypes.Application } 
+                    commandParameters: new Dictionary<string, object> {
+                        { "Name", filePath },
+                        { "CommandType", CommandTypes.Application }
                     });
 
                 // Start-Process & Get-Command select first found application based on PATHEXT environment variable

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2681,15 +2681,12 @@ namespace Microsoft.PowerShell.Commands
 
                 // Otherwise check if command is an Application to resolve executable full path with extension
                 // e.g if powershell was given, resolve to powershell.exe to get verbs
-                using var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-
-                var commandInfo = new CmdletInfo("Get-Command", typeof(GetCommandCommand));
-
-                ps.AddCommand(commandInfo);
-                ps.AddParameter("Name", filePath);
-                ps.AddParameter("CommandType", CommandTypes.Application);
-
-                Collection<CommandInfo> commands = ps.Invoke<CommandInfo>();
+                Collection<CommandInfo> commands = CompletionCompleters.InvokeCommand<CommandInfo>(
+                    commandName: "Get-Command",
+                    commandParameters: new Dictionary<string, object> { 
+                        { "Name", filePath }, 
+                        { "CommandType", CommandTypes.Application } 
+                    });
 
                 // Start-Process & Get-Command select first found application based on PATHEXT environment variable
                 if (commands.Count >= 1)

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2683,9 +2683,10 @@ namespace Microsoft.PowerShell.Commands
                 // e.g if powershell was given, resolve to powershell.exe to get verbs
                 Collection<CommandInfo> commands = CompletionCompleters.InvokeCommand<CommandInfo>(
                     commandName: "Get-Command",
-                    commandParameters: new Dictionary<string, object> {
+                    commandParameters: new Dictionary<string, object>
+                    {
                         { "Name", filePath },
-                        { "CommandType", CommandTypes.Application }
+                        { "CommandType", CommandTypes.Application },
                     });
 
                 // Start-Process & Get-Command select first found application based on PATHEXT environment variable

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8423,24 +8423,24 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Invokes command by name to get results of any type.
-        /// Sets command parameters or includes specific parameters.
+        /// Sets command parameters or selects specific parameters.
         /// </summary>
         /// <param name="commandName">The command name.</param>
         /// <param name="commandParameters">The command parameters.</param>
-        /// <param name="parametersToInclude">The parameters to include in command.</param>
+        /// <param name="selectedParameters">The optional parameters to be selected in command..</param>
         /// <returns>Collection of results returned from invoked command.</returns>
         internal static Collection<T> InvokeCommand<T>(
             string commandName,
             IDictionary commandParameters,
-            params string[] parametersToInclude)
+            params string[] selectedParameters)
         {
             using var ps = PowerShell.Create(RunspaceMode.CurrentRunspace);
 
             ps.AddCommand(commandName);
 
-            if (parametersToInclude.Length > 0)
+            if (selectedParameters.Length > 0)
             {
-                foreach (string parameter in parametersToInclude)
+                foreach (string parameter in selectedParameters)
                 {
                     if (commandParameters.Contains(parameter))
                     {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8438,9 +8438,13 @@ namespace System.Management.Automation
 
             ps.AddCommand(commandName);
 
-            if (selectedParameters.Length > 0)
+            IEnumerable<string> parametersToAdd = selectedParameters.Length > 0
+                ? selectedParameters
+                : commandParameters?.Keys.Cast<string>();
+
+            if (parametersToAdd != null)
             {
-                foreach (string parameter in selectedParameters)
+                foreach (string parameter in parametersToAdd)
                 {
                     if (commandParameters.Contains(parameter))
                     {
@@ -8448,17 +8452,8 @@ namespace System.Management.Automation
                     }
                 }
             }
-            else
-            {
-                foreach (DictionaryEntry entry in commandParameters)
-                {
-                    ps.AddParameter(entry.Key.ToString(), entry.Value);
-                }
-            }
 
-            Collection<T> commands = ps.Invoke<T>();
-
-            return commands;
+            return ps.Invoke<T>();
         }
 
         internal static bool IsSplattedVariable(Ast targetExpr)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8422,7 +8422,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Invokes command by name to get command info objects.
+        /// Invokes command by name to get results of any type.
         /// Sets command parameters which exist in fake bound parameters.
         /// </summary>
         /// <param name="commandName">The command name.</param>

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8442,7 +8442,7 @@ namespace System.Management.Automation
                 ? selectedParameters
                 : commandParameters?.Keys.Cast<string>();
 
-            if (parametersToAdd != null)
+            if (parametersToAdd is not null)
             {
                 foreach (string parameter in parametersToAdd)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8422,18 +8422,21 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Invokes Get-Command to get command info objects.
+        /// Invokes command by name to get command info objects.
+        /// Sets command parameters which exist in fake bound parameters.
         /// </summary>
+        /// <param name="commandName">The command name.</param>
         /// <param name="fakeBoundParameters">The fake bound parameters.</param>
         /// <param name="parametersToAdd">The parameters to add.</param>
         /// <returns>Collection of command info objects.</returns>
-        internal static Collection<T> InvokeGetCommand<T>(
+        internal static Collection<T> InvokeCommand<T>(
+            string commandName,
             IDictionary fakeBoundParameters, 
-            params string[] parametersToAdd) where T : CommandInfo
+            params string[] parametersToAdd)
         {
             using var ps = PowerShell.Create(RunspaceMode.CurrentRunspace);
 
-            ps.AddCommand("Get-Command");
+            ps.AddCommand(commandName);
 
             foreach (string parameter in parametersToAdd)
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8423,26 +8423,36 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Invokes command by name to get results of any type.
-        /// Sets command parameters which exist in fake bound parameters.
+        /// Sets command parameters or includes specific parameters.
         /// </summary>
         /// <param name="commandName">The command name.</param>
-        /// <param name="fakeBoundParameters">The fake bound parameters.</param>
-        /// <param name="parametersToAdd">The parameters to add.</param>
-        /// <returns>Collection of command info objects.</returns>
+        /// <param name="commandParameters">The command parameters.</param>
+        /// <param name="parametersToInclude">The parameters to include in command.</param>
+        /// <returns>Collection of results returned from invoked command.</returns>
         internal static Collection<T> InvokeCommand<T>(
             string commandName,
-            IDictionary fakeBoundParameters, 
-            params string[] parametersToAdd)
+            IDictionary commandParameters,
+            params string[] parametersToInclude)
         {
             using var ps = PowerShell.Create(RunspaceMode.CurrentRunspace);
 
             ps.AddCommand(commandName);
 
-            foreach (string parameter in parametersToAdd)
+            if (parametersToInclude.Length > 0)
             {
-                if (fakeBoundParameters.Contains(parameter))
+                foreach (string parameter in parametersToInclude)
                 {
-                    ps.AddParameter(parameter, fakeBoundParameters[parameter]);
+                    if (commandParameters.Contains(parameter))
+                    {
+                        ps.AddParameter(parameter, commandParameters[parameter]);
+                    }
+                }
+            }
+            else
+            {
+                foreach (DictionaryEntry entry in commandParameters)
+                {
+                    ps.AddParameter(entry.Key.ToString(), entry.Value);
                 }
             }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8422,14 +8422,14 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Calls Get-Command to get command info objects.
+        /// Invokes Get-Command to get command info objects.
         /// </summary>
         /// <param name="fakeBoundParameters">The fake bound parameters.</param>
         /// <param name="parametersToAdd">The parameters to add.</param>
         /// <returns>Collection of command info objects.</returns>
-        internal static Collection<CommandInfo> GetCommandInfo(
+        internal static Collection<T> InvokeGetCommand<T>(
             IDictionary fakeBoundParameters, 
-            params string[] parametersToAdd)
+            params string[] parametersToAdd) where T : CommandInfo
         {
             using var ps = PowerShell.Create(RunspaceMode.CurrentRunspace);
 
@@ -8443,7 +8443,7 @@ namespace System.Management.Automation
                 }
             }
 
-            Collection<CommandInfo> commands = ps.Invoke<CommandInfo>();
+            Collection<T> commands = ps.Invoke<T>();
 
             return commands;
         }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1723,7 +1723,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Sorted set of command nouns.</returns>
         private static SortedSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
         {
-            Collection<CommandInfo> commands = CompletionCompleters.GetCommandInfo(fakeBoundParameters, "Module", "Verb");
+            Collection<CommandInfo> commands = CompletionCompleters.InvokeGetCommand<CommandInfo>(fakeBoundParameters, "Module", "Verb");
             SortedSet<string> nouns = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (CommandInfo command in commands)

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1723,7 +1723,12 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Sorted set of command nouns.</returns>
         private static SortedSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
         {
-            Collection<CommandInfo> commands = CompletionCompleters.InvokeCommand<CommandInfo>("Get-Command", fakeBoundParameters, "Module", "Verb");
+            Collection<CommandInfo> commands = CompletionCompleters.InvokeCommand<CommandInfo>(
+                commandName: "Get-Command", 
+                commandParameters: fakeBoundParameters, 
+                "Module", 
+                "Verb");
+
             SortedSet<string> nouns = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (CommandInfo command in commands)

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1726,8 +1726,7 @@ namespace Microsoft.PowerShell.Commands
             Collection<CommandInfo> commands = CompletionCompleters.InvokeCommand<CommandInfo>(
                 commandName: "Get-Command", 
                 commandParameters: fakeBoundParameters, 
-                "Module", 
-                "Verb");
+                "Module", "Verb");
 
             SortedSet<string> nouns = new(StringComparer.OrdinalIgnoreCase);
 

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1723,7 +1723,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>Sorted set of command nouns.</returns>
         private static SortedSet<string> GetCommandNouns(IDictionary fakeBoundParameters)
         {
-            Collection<CommandInfo> commands = CompletionCompleters.InvokeGetCommand<CommandInfo>(fakeBoundParameters, "Module", "Verb");
+            Collection<CommandInfo> commands = CompletionCompleters.InvokeCommand<CommandInfo>("Get-Command", fakeBoundParameters, "Module", "Verb");
             SortedSet<string> nouns = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (CommandInfo command in commands)

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1517,7 +1517,7 @@ namespace System.Management.Automation
                 else if (commandName.Equals("Get-Command", StringComparison.OrdinalIgnoreCase)
                          && fakeBoundParameters.Contains("Noun"))
                 {
-                    Collection<CmdletInfo> commands = CompletionCompleters.InvokeGetCommand<CmdletInfo>(fakeBoundParameters, "Noun", "Module");
+                    Collection<CmdletInfo> commands = CompletionCompleters.InvokeCommand<CmdletInfo>("Get-Command", fakeBoundParameters, "Noun", "Module");
                     return CompleteVerbWithCommands(wordToComplete, commands);
                 }
 

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1520,8 +1520,7 @@ namespace System.Management.Automation
                     Collection<CmdletInfo> commands = CompletionCompleters.InvokeCommand<CmdletInfo>(
                         commandName: "Get-Command",
                         commandParameters: fakeBoundParameters,
-                         "Noun",
-                         "Module");
+                        "Noun", "Module");
 
                     return CompleteVerbWithCommands(wordToComplete, commands);
                 }

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1517,7 +1517,12 @@ namespace System.Management.Automation
                 else if (commandName.Equals("Get-Command", StringComparison.OrdinalIgnoreCase)
                          && fakeBoundParameters.Contains("Noun"))
                 {
-                    Collection<CmdletInfo> commands = CompletionCompleters.InvokeCommand<CmdletInfo>("Get-Command", fakeBoundParameters, "Noun", "Module");
+                    Collection<CmdletInfo> commands = CompletionCompleters.InvokeCommand<CmdletInfo>(
+                        commandName: "Get-Command",
+                        commandParameters: fakeBoundParameters,
+                         "Noun",
+                         "Module");
+
                     return CompleteVerbWithCommands(wordToComplete, commands);
                 }
 

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1517,20 +1517,7 @@ namespace System.Management.Automation
                 else if (commandName.Equals("Get-Command", StringComparison.OrdinalIgnoreCase)
                          && fakeBoundParameters.Contains("Noun"))
                 {
-                    using var ps = PowerShell.Create(RunspaceMode.CurrentRunspace);
-
-                    var commandInfo = new CmdletInfo("Get-Command", typeof(GetCommandCommand));
-
-                    ps.AddCommand(commandInfo);
-                    ps.AddParameter("Noun", fakeBoundParameters["Noun"]);
-
-                    if (fakeBoundParameters.Contains("Module"))
-                    {
-                        ps.AddParameter("Module", fakeBoundParameters["Module"]);
-                    }
-
-                    Collection<CmdletInfo> commands = ps.Invoke<CmdletInfo>();
-
+                    Collection<CmdletInfo> commands = CompletionCompleters.InvokeGetCommand<CmdletInfo>(fakeBoundParameters, "Noun", "Module");
                     return CompleteVerbWithCommands(wordToComplete, commands);
                 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Renamed `GetCommandInfo` to generic `InvokeCommand` and use method for Verb, Noun & PropertyType argument completers. Given all these completers invoke commands, it makes sense to ensure they use the same method to avoid too much duplicate invoke code. It also can be used in future if other commands like `Get-ExperimentalFeature` need to be called.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
