### PR TITLE
WIP: Adding IsEssential property to ProgressRecord

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteProgressCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteProgressCmdlet.cs
@@ -65,6 +65,12 @@ namespace Microsoft.PowerShell.Commands
         public int ParentId { get; set; } = -1;
 
         /// <summary>
+        /// Specifies that the activity is non-essential, and may be discarded by the host to improve performance.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter NonEssential { get; set; }
+
+        /// <summary>
         /// Identifies whether the activity has completed (and the display for it should be removed),
         /// or if it is proceeding (and the display for it should be shown).
         /// </summary>
@@ -122,7 +128,8 @@ namespace Microsoft.PowerShell.Commands
             pr.PercentComplete = PercentComplete;
             pr.SecondsRemaining = SecondsRemaining;
             pr.CurrentOperation = CurrentOperation;
-            pr.RecordType = this.Completed ? ProgressRecordType.Completed : ProgressRecordType.Processing;
+            pr.IsEssential = !NonEssential;
+            pr.RecordType = this.Completed ? ProgressRecordType.Completed : ProgressRecordType.Processing;            
 
             WriteProgress(SourceId, pr);
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -89,14 +89,14 @@ namespace Microsoft.PowerShell
                 if (_progPaneUpdateTimer == null)
                 {
                     // Show a progress pane at the first time we've received a progress record
-                    progPaneUpdateFlag = 1;
+                    _progPaneUpdateFlag = 1;
 
                     // The timer will be auto restarted every 'UpdateTimerThreshold' ms
                     _progPaneUpdateTimer = new Timer(new TimerCallback(ProgressPaneUpdateTimerElapsed), null, UpdateTimerThreshold, UpdateTimerThreshold);
                 }
             }
 
-            if (Interlocked.CompareExchange(ref progPaneUpdateFlag, 0, 1) == 1 || record.RecordType == ProgressRecordType.Completed)
+            if (record.IsEssential || record.RecordType == ProgressRecordType.Completed || Interlocked.CompareExchange(ref _progPaneUpdateFlag, 0, 1) == 1)
             {
                 // Update the progress pane only when the timer set up the update flag or WriteProgress is completed.
                 // As a result, we do not block WriteProgress and whole script and eliminate unnecessary console locks and updates.
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell
         void
         ProgressPaneUpdateTimerElapsed(object sender)
         {
-            Interlocked.CompareExchange(ref progPaneUpdateFlag, 1, 0);
+            Interlocked.CompareExchange(ref _progPaneUpdateFlag, 1, 0);
         }
 
         private
@@ -209,6 +209,7 @@ namespace Microsoft.PowerShell
 
         private const int UpdateTimerThreshold = 200;
 
-        private int progPaneUpdateFlag = 0;
+        // The flag to indicate whether we need to update 'ProgressPane' 0: no update, 1: need update
+        private int _progPaneUpdateFlag = 0;
     }
 }   // namespace

--- a/src/System.Management.Automation/engine/ProgressRecord.cs
+++ b/src/System.Management.Automation/engine/ProgressRecord.cs
@@ -100,13 +100,7 @@ namespace System.Management.Automation
         /// </summary>
         public
         int
-        ActivityId
-        {
-            get
-            {
-                return id;
-            }
-        }
+        ActivityId => id;
 
         /// <summary>
         /// Gets and sets the Id of the activity for which this record is a subordinate.
@@ -202,17 +196,9 @@ namespace System.Management.Automation
         string
         CurrentOperation
         {
-            get
-            {
-                return currentOperation;
-            }
-
-            set
-            {
-                // null or empty string is allowed
-
-                currentOperation = value;
-            }
+            get => currentOperation;
+            // null or empty string is allowed
+            set => currentOperation = value;
         }
 
         /// <summary>
@@ -223,10 +209,7 @@ namespace System.Management.Automation
         int
         PercentComplete
         {
-            get
-            {
-                return percent;
-            }
+            get => percent;
 
             set
             {
@@ -256,17 +239,9 @@ namespace System.Management.Automation
         int
         SecondsRemaining
         {
-            get
-            {
-                return secondsRemaining;
-            }
-
-            set
-            {
-                // negative values are allowed
-
-                secondsRemaining = value;
-            }
+            get => secondsRemaining;
+            // negative values are allowed
+            set => secondsRemaining = value;
         }
 
         /// <summary>
@@ -276,10 +251,7 @@ namespace System.Management.Automation
         ProgressRecordType
         RecordType
         {
-            get
-            {
-                return type;
-            }
+            get => type;
 
             set
             {
@@ -290,6 +262,18 @@ namespace System.Management.Automation
 
                 type = value;
             }
+        }
+
+        /// <summary>
+        /// <see langword="true"/> if this record is essential for correct progress reporting; otherwise <see langword="false"/>.
+        /// 
+        /// <para/>
+        /// If this property is <see langword="true"/>, the host should not suppress this record even if it is not the most recent record.
+        /// </summary>
+        public bool IsEssential
+        {
+            get => isEssential;
+            set => isEssential = value;
         }
 
         /// <summary>
@@ -453,6 +437,9 @@ namespace System.Management.Automation
         [DataMember]
         private ProgressRecordType type = ProgressRecordType.Processing;
 
+        [DataMember]
+        private bool isEssential = true;
+
         #endregion
 
         #region Serialization / deserialization for remoting
@@ -489,6 +476,7 @@ namespace System.Management.Automation
             result.PercentComplete = RemotingDecoder.GetPropertyValue<int>(progressAsPSObject, RemoteDataNameStrings.ProgressRecord_PercentComplete);
             result.RecordType = RemotingDecoder.GetPropertyValue<ProgressRecordType>(progressAsPSObject, RemoteDataNameStrings.ProgressRecord_Type);
             result.SecondsRemaining = RemotingDecoder.GetPropertyValue<int>(progressAsPSObject, RemoteDataNameStrings.ProgressRecord_SecondsRemaining);
+            result.IsEssential = RemotingDecoder.GetPropertyValueOrDefault(progressAsPSObject, RemoteDataNameStrings.ProgressRecord_IsEssential, false);
 
             return result;
         }
@@ -515,6 +503,7 @@ namespace System.Management.Automation
             progressAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ProgressRecord_PercentComplete, this.PercentComplete));
             progressAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ProgressRecord_Type, this.RecordType));
             progressAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ProgressRecord_SecondsRemaining, this.SecondsRemaining));
+            progressAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ProgressRecord_IsEssential, this.IsEssential));
 
             return progressAsPSObject;
         }

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -248,6 +248,7 @@ namespace System.Management.Automation
         internal const string ProgressRecord_Type = "Type";
         internal const string ProgressRecord_SecondsRemaining = "SecondsRemaining";
         internal const string ProgressRecord_StatusDescription = "StatusDescription";
+        internal const string ProgressRecord_IsEssential = "IsEssential";
 
         #endregion
     }
@@ -1551,6 +1552,25 @@ namespace System.Management.Automation
             object propertyValue = property.Value;
             return ConvertPropertyValueTo<T>(propertyName, propertyValue);
         }
+
+#nullable enable
+        internal static T? GetPropertyValueOrDefault<T>(PSObject psObject, string propertyName, T defaultValue)
+        {
+            if (psObject == null)
+            {
+                throw PSTraceSource.NewArgumentNullException(nameof(psObject));
+            }
+
+            if (propertyName == null)
+            {
+                throw PSTraceSource.NewArgumentNullException(nameof(propertyName));
+            }
+
+            PSPropertyInfo? property = psObject.Properties[propertyName];
+            
+            return property.Value is null ? defaultValue : ConvertPropertyValueTo<T>(propertyName, property.Value);
+        }
+#nullable disable
 
         internal static IEnumerable<T> EnumerateListProperty<T>(PSObject psObject, string propertyName)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment that can't be seen after creating the Pull Request. -->
Issue: #24728
# PR Summary

Adding the `IsEssential` property to ProgressRecord indicates to a host that it should not skip displaying the record.


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Progress records are skipped if written within 200 ms of a previous progress record. This can be confusing to developers who just notice that some progress seems to disappear.

By having a property, `IsEssential`, on ProgressRecord, a developer of a cmdlet can indicate if a ProgressRecord could or shouldn't be skipped by the host when rendering. 

High volume progress messages should have IsEssential = false.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
