### PR TITLE
Add experimental feature completion single/double quote support for `-Name` parameter

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
@@ -112,26 +113,28 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="commandAst">The command AST.</param>
         /// <param name="fakeBoundParameters">The fake bound parameters.</param>
         /// <returns>List of Completion Results.</returns>
-        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters)
         {
-            if (fakeBoundParameters == null)
+            SortedSet<string> expirmentalFeatures = new(StringComparer.OrdinalIgnoreCase);
+
+            foreach (ExperimentalFeature feature in GetExperimentalFeatures())
             {
-                throw PSTraceSource.NewArgumentNullException(nameof(fakeBoundParameters));
+                expirmentalFeatures.Add(feature.Name);
             }
 
-            var commandInfo = new CmdletInfo("Get-ExperimentalFeature", typeof(GetExperimentalFeatureCommand));
-            var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace)
-                .AddCommand(commandInfo)
-                .AddParameter("Name", wordToComplete + "*");
+            return CompletionCompleters.GetMatchingResults(wordToComplete, expirmentalFeatures);
+        }
 
-            HashSet<string> names = new HashSet<string>();
-            var results = ps.Invoke<ExperimentalFeature>();
-            foreach (var result in results)
-            {
-                names.Add(result.Name);
-            }
-
-            return names.Order().Select(static name => new CompletionResult(name, name, CompletionResultType.Text, name));
+        private static Collection<ExperimentalFeature> GetExperimentalFeatures()
+        {
+            using var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
+            ps.AddCommand("Get-ExperimentalFeature");
+            return ps.Invoke<ExperimentalFeature>();
         }
     }
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1179,9 +1179,6 @@ ConstructorTestClass(int i, bool b)
             $experimentalFeaturesStartingWithPS = $allExperimentalFeatures | Where-Object { $_ -like 'PS*'}
             $experimentalFeaturesStartingWithPSSingleQuote = $allExperimentalFeaturesSingleQuote | Where-Object { $_ -like "'PS*" }
             $experimentalFeaturesStartingWithPSDoubleQuote = $allExperimentalFeaturesDoubleQuote | Where-Object { $_ -like """PS*" }
-            $experimentalFeaturesStartingWithPSNative = $allExperimentalFeatures | Where-Object { $_ -like 'PSNative*'}
-            $experimentalFeaturesStartingWithPSNativeSingleQuote = $allExperimentalFeaturesSingleQuote | Where-Object { $_ -like "'PSNative*" }
-            $experimentalFeaturesStartingWithPSNativeDoubleQuote = $allExperimentalFeaturesDoubleQuote | Where-Object { $_ -like """PSNative*" }
         }
 
         It "Should complete Name for '<TextInput>'" -TestCases @(
@@ -1191,9 +1188,6 @@ ConstructorTestClass(int i, bool b)
             @{ TextInput = "Get-ExperimentalFeature -Name PS"; ExpectedExperimentalFeatureNames = $experimentalFeaturesStartingWithPS }
             @{ TextInput = "Get-ExperimentalFeature -Name 'PS"; ExpectedExperimentalFeatureNames = $experimentalFeaturesStartingWithPSSingleQuote }
             @{ TextInput = "Get-ExperimentalFeature -Name ""PS"; ExpectedExperimentalFeatureNames = $experimentalFeaturesStartingWithPSDoubleQuote }
-            @{ TextInput = "Get-ExperimentalFeature -Name PSNative"; ExpectedExperimentalFeatureNames = $experimentalFeaturesStartingWithPSNative }
-            @{ TextInput = "Get-ExperimentalFeature -Name 'PSNative"; ExpectedExperimentalFeatureNames = $experimentalFeaturesStartingWithPSNativeSingleQuote }
-            @{ TextInput = "Get-ExperimentalFeature -Name ""PSNative"; ExpectedExperimentalFeatureNames = $experimentalFeaturesStartingWithPSNativeDoubleQuote }
         ) {
             param($TextInput, $ExpectedExperimentalFeatureNames)
             $res = TabExpansion2 -inputScript $TextInput -cursorColumn $TextInput.Length


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Use `CompletionCompleters.GetMatchingResults` in `ExperimentalFeatureNameCompleter` so `-Name` parameter for `Get-ExperimentalFeature` has support for single/double quotes.

Also made the following improvements:

- use `SortedSet<string>` with `StringComparer.IgnoreCase` to ensure all features are unique and sorted and case insensitive. Also removed previous LINQ `Order()` call with this change.

I also added some tab completion tests which seem to be missing for this completer.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

Related to #24873

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
