### PR TITLE
WIP: Allow Start-Process to redirect stdout and stderr to the same file

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2034,13 +2034,6 @@ namespace Microsoft.PowerShell.Commands
                 {
                     _redirectstandarderror = ResolveFilePath(_redirectstandarderror);
                     _redirectstandardoutput = ResolveFilePath(_redirectstandardoutput);
-                    if (_redirectstandardoutput.Equals(_redirectstandarderror, StringComparison.OrdinalIgnoreCase))
-                    {
-                        message = StringUtil.Format(ProcessResources.DuplicateEntry, "RedirectStandardOutput", "RedirectStandardError");
-                        ErrorRecord er = new(new InvalidOperationException(message), "InvalidOperationException", ErrorCategory.InvalidOperation, null);
-                        WriteError(er);
-                        return;
-                    }
                 }
             }
             else if (ParameterSetName.Equals("UseShellExecute"))
@@ -2309,8 +2302,14 @@ namespace Microsoft.PowerShell.Commands
                 _redirectstandarderror = ResolveFilePath(_redirectstandarderror);
                 p.ErrorDataReceived += new DataReceivedEventHandler(StdErrorHandler);
 
-                // Can't do StreamWriter(string) in coreCLR
-                _errorWriter = new StreamWriter(new FileStream(_redirectstandarderror, FileMode.Create));
+                if (_redirectstandarderror.Equals(_redirectstandardoutput, StringComparison.OrdinalIgnoreCase) && _outputWriter != null) {
+                    _errorWriter = _outputWriter;
+                }
+                else
+                {
+                    // Can't do StreamWriter(string) in coreCLR
+                    _errorWriter = new StreamWriter(new FileStream(_redirectstandarderror, FileMode.Create));
+                }
             }
             else
             {
@@ -2430,7 +2429,14 @@ namespace Microsoft.PowerShell.Commands
                 hasRedirection = true;
                 startinfo.RedirectStandardError = true;
                 _redirectstandarderror = ResolveFilePath(_redirectstandarderror);
-                lpStartupInfo.hStdError = GetSafeFileHandleForRedirection(_redirectstandarderror, FileMode.Create);
+                if (_redirectstandarderror.Equals(_redirectstandardoutput, StringComparison.OrdinalIgnoreCase) && lpStartupInfo.hStdOutput != null)
+                {
+                    lpStartupInfo.hStdError = lpStartupInfo.hStdOutput;
+                }
+                else
+                {
+                    lpStartupInfo.hStdError = GetSafeFileHandleForRedirection(_redirectstandarderror, FileMode.Create);
+                }
             }
 
             if (hasRedirection)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -19,7 +19,13 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
         New-Item $tempDirectory -ItemType Directory  -Force
         $assetsFile = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath assets) -ChildPath SortTest.txt
         $PWSH = (Get-Process -Id $PID).MainModule.FileName
-        $pwshParam = "-NoProfile -Command &{ [Console]::Out.WriteLine('stdout'); [Console]::Error.WriteLine('stderr') }"
+        $pwshParam = "-NoProfile -Command &{
+            [Console]::Out.WriteLine('stdout1');
+            [Console]::Error.WriteLine('stderr1');
+            [Console]::Out.WriteLine('stdout2');
+            [Console]::Error.WriteLine('stderr2')
+        }"
+        $nl = [System.Environment]::NewLine
         if ($IsWindows) {
             $pingParam = "-n 2 localhost"
         }
@@ -85,25 +91,25 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
 
     It "Should handle stderr redirection without error" {
         $output = & $PWSH -NoProfile -Command "&{ Start-Process $PWSH -ArgumentList `"$pwshParam`" -Wait -NoNewWindow -RedirectStandardError $tempFile }"
-        $output | Should -BeExactly "stdout"
-        Get-Content -Path $tempFile | Should -BeExactly "stderr"
+        $output | Should -BeExactly @("stdout1", "stdout2")
+        Get-Content -Raw -Path $tempFile | Should -BeExactly "stderr1${nl}stderr2${nl}"
     }
 
     It "Should handle stdout redirection without error" {
         $output = & $PWSH -NoProfile -Command "&{ Start-Process $PWSH -ArgumentList `"$pwshParam`" -Wait -NoNewWindow -RedirectStandardOutput $tempFile }" 2>&1
-        $output | Should -BeExactly "stderr"
-        Get-Content -Path $tempFile | Should -BeExactly "stdout"
+        $output | Should -BeExactly @("stderr1", "stderr2")
+        Get-Content -Raw -Path $tempFile | Should -BeExactly "stdout1${nl}stdout2${nl}"
     }
 
     It "Should handle stdout,stderr redirections without error" {
         Start-Process $PWSH -ArgumentList $pwshParam -Wait -RedirectStandardError $tempFile -RedirectStandardOutput "$TESTDRIVE/output"
-        Get-Content -Path "$TESTDRIVE/output" | Should -BeExactly "stdout"
-        Get-Content -Path $tempFile | Should -BeExactly "stderr"
+        Get-Content -Raw -Path "$TESTDRIVE/output" | Should -BeExactly "stdout1${nl}stdout2${nl}"
+        Get-Content -Raw -Path $tempFile | Should -BeExactly "stderr1${nl}stderr2${nl}"
     }
 
     It "Should handle stdout,stderr redirections to the same file without error" {
         Start-Process $PWSH -ArgumentList $pwshParam -Wait -RedirectStandardError $tempFile -RedirectStandardOutput $tempFile
-        Get-Content -Path $tempFile | Should -BeExactly @('stdout', 'stderr')
+        Get-Content -Raw -Path $tempFile | Should -BeExactly "stdout1${nl}stderr1${nl}stdout2${nl}stderr2${nl}"
     }
 
     It "Should handle stdin redirection without error" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -95,6 +95,12 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
         $dirEntry.Length | Should -BeGreaterThan 0
     }
 
+    It "Should handle stdout,stderr redirections to the same file without error" {
+        $process = Start-Process ping -ArgumentList $pingParam -Wait -RedirectStandardOutput $tempFile -RedirectStandardError $tempFile  @extraArgs
+        $dirEntry = Get-ChildItem $tempFile
+        $dirEntry.Length | Should -BeGreaterThan 0
+    }
+
     It "Should handle stdin redirection without error" {
         $process = Start-Process sort -Wait -RedirectStandardOutput $tempFile -RedirectStandardInput $assetsFile  @extraArgs
         $dirEntry = Get-ChildItem $tempFile


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When redirecting stdout and stderr to different files, it is not possible to link errors to the standard output after completion.
This Pull Request makes it possible to get a similar output file to what a user would see if the process were executed manually.

to merge after https://github.com/PowerShell/PowerShell/pull/25061

## PR Context

This stdout/stderr exclusion has been present since Process.cs was added to the repository (https://github.com/PowerShell/PowerShell/commit/60b3b304f2e1042bcf773d7e2ae3530a1f5d52f0?diff=split#diff-a87e81856755f9e2a0f6002cf90c4cc3d0a4d1e81394bee7ac61543f71138b71R2161-R2165)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
