### PR TITLE
Move .NET method invocation logging to after the needed type conversion is done for method arguments

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7563,7 +7563,6 @@ namespace System.Management.Automation.Language
             }
         }
 
-#nullable enable
         private static Expression AddMemberInvocationLogging(
             Expression expr,
             string targetName,
@@ -7579,6 +7578,7 @@ namespace System.Management.Automation.Language
             {
                 invocationArgs[i] = args[i].Cast(typeof(object));
             }
+
             return Expression.Block(
                 Expression.Call(
                     CachedReflectionInfo.MemberInvocationLoggingOps_LogMemberInvocation,
@@ -7609,7 +7609,6 @@ namespace System.Management.Automation.Language
                 Expression.NewArrayInit(typeof(object), invocationArgs)));
 #endif
         }
-#nullable disable
 
         #endregion
     }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7205,8 +7205,7 @@ namespace System.Management.Automation.Language
                         copyOutTemps.Add(Expression.Assign(psRefValue, temp.Cast(typeof(object))));
 
                         argExprs[i] = temp;
-                        // Log the PSReference type, or its actual value in this case?
-                        argsToLog.Add(args[i].Expression);
+                        argsToLog.Add(temp);
                     }
                     else
                     {

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -6943,12 +6943,6 @@ namespace System.Management.Automation.Language
                     expr = Expression.Block(expr, ExpressionCache.AutomationNullConstant);
                 }
 
-                // Expression block runs two expressions in order:
-                //  - Log method invocation to AMSI Notifications (can throw PSSecurityException)
-                //  - Invoke method
-                string targetName = methodInfo.ReflectedType?.FullName ?? string.Empty;
-                expr = MaybeAddMemberInvocationLogging(expr, targetName, name, args);
-
                 // If we're calling SteppablePipeline.{Begin|Process|End}, we don't want
                 // to wrap exceptions - this is very much a special case to help error
                 // propagation and ensure errors are attributed to the correct code (the
@@ -7255,6 +7249,12 @@ namespace System.Management.Automation.Language
                 }
             }
 
+            // We need to add one expression to log the .NET invocation before actually invoking:
+            //  - Log method invocation to AMSI Notifications (can throw PSSecurityException)
+            //  - Invoke method
+            string targetName = mi.ReflectedType?.FullName ?? string.Empty;
+            string methodName = mi.Name is ".ctor" ? "new" : mi.Name;
+
             if (temps.Count > 0)
             {
                 if (call.Type != typeof(void) && copyOutTemps.Count > 0)
@@ -7265,7 +7265,12 @@ namespace System.Management.Automation.Language
                     copyOutTemps.Add(retValue);
                 }
 
+                AddMemberInvocationLogging(initTemps, targetName, methodName, argExprs);
                 call = Expression.Block(call.Type, temps, initTemps.Append(call).Concat(copyOutTemps));
+            }
+            else
+            {
+                call = AddMemberInvocationLogging(call, targetName, methodName, argExprs);
             }
 
             return call;
@@ -7559,20 +7564,20 @@ namespace System.Management.Automation.Language
         }
 
 #nullable enable
-        private static Expression MaybeAddMemberInvocationLogging(
+        private static Expression AddMemberInvocationLogging(
             Expression expr,
             string targetName,
             string name,
-            DynamicMetaObject[] args)
+            Expression[] args)
         {
-#if UNIX && !DEBUG
-            // For efficiency this is a no-op on non-Windows platforms in release builds.
+#if UNIX
+            // For efficiency this is a no-op on non-Windows platforms.
             return expr;
 #else
             Expression[] invocationArgs = new Expression[args.Length];
             for (int i = 0; i < args.Length; i++)
             {
-                invocationArgs[i] = args[i].Expression.Cast(typeof(object));
+                invocationArgs[i] = args[i].Cast(typeof(object));
             }
             return Expression.Block(
                 Expression.Call(
@@ -7581,6 +7586,27 @@ namespace System.Management.Automation.Language
                     Expression.Constant(name),
                     Expression.NewArrayInit(typeof(object), invocationArgs)),
                 expr);
+#endif
+        }
+
+        private static void AddMemberInvocationLogging(
+            List<Expression> exprs,
+            string targetName,
+            string name,
+            Expression[] args)
+        {
+#if !UNIX
+            Expression[] invocationArgs = new Expression[args.Length];
+            for (int i = 0; i < args.Length; i++)
+            {
+                invocationArgs[i] = args[i].Cast(typeof(object));
+            }
+
+            exprs.Add(Expression.Call(
+                CachedReflectionInfo.MemberInvocationLoggingOps_LogMemberInvocation,
+                Expression.Constant(targetName),
+                Expression.Constant(name),
+                Expression.NewArrayInit(typeof(object), invocationArgs)));
 #endif
         }
 #nullable disable

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7139,7 +7139,8 @@ namespace System.Management.Automation.Language
                                     mi.Name,
                                     allowCastingToByRefLikeType: false,
                                     temps,
-                                    initTemps));
+                                    initTemps))
+                            .ToList();
 
                         argExprs[i] = Expression.NewArrayInit(paramElementType, elements);
                         // User specified the element arguments, so we log them instead of the compiler-created array.

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -7582,6 +7582,7 @@ namespace System.Management.Automation.Language
             }
         }
 
+#nullable enable
         private static Expression AddMemberInvocationLogging(
             Expression expr,
             string targetName,
@@ -7628,6 +7629,7 @@ namespace System.Management.Automation.Language
                 Expression.NewArrayInit(typeof(object), invocationArgs)));
 #endif
         }
+#nullable disable
 
         #endregion
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

This PR is to fix a MSRC report about a bug in the .NET method logging implementation. The report is not considered a vulnerability, so I'm submitting the fix in GitHub.

The .NET method invocation logging is currently called before PowerShell does any of the needed type conversion for the method arguments, and it results in inaccurate information being logged to AMSI.

The fix is to move .NET method invocation logging to after the needed type conversion is done for method arguments.
The following is the comparison between before and after the fix when turning on the console logging for the AMSI notification feature:

_**Before the fix**_ -- it logs `.GetType(<Foo>)`

```
C:\>pwsh -noprofile
PowerShell 7.4.6
PS C:\>
class Foo {
>>     [string] ToString() {
>>         return "System.Management.Automation." + ([char[]]@(0x41, 0x6D, 0x73, 0x69, 0x55, 0x74, 0x69, 0x6C, 0x73) -join "")
>>     }
>> }
PS C:\>
$utilTypeName = [Foo]::new()

=== Amsi notification report content ===
<Foo>.new()
=== Amsi notification report success: True ===

=== Amsi notification report content ===
<System.Object>.new()
=== Amsi notification report success: True ===
PS C:\>
$utilType = [PSObject].Assembly.GetType($utilTypeName)

=== Amsi notification report content ===
<System.Reflection.RuntimeAssembly>.GetType(<Foo>)
=== Amsi notification report success: True ===
PS C:\>
exit
```

_**After the fix**_ -- it logs `.GetType(<System.Management.Automation.AmsiUtils>)`

```
C:\>E:\arena\source\PowerShell\src\powershell-win-core\bin\Debug\net9.0\win7-x64\publish\pwsh.exe -noprofile
PowerShell 7.5.0-preview.3-197-g36740ab4a21a1cd51f8cd795f295a86aa5c91d34
PS C:\>
class Foo {
>>     [string] ToString() {
>>         return "System.Management.Automation." + ([char[]]@(0x41, 0x6D, 0x73, 0x69, 0x55, 0x74, 0x69, 0x6C, 0x73) -join "")
>>     }
>> }
PS C:\>
$utilTypeName = [Foo]::new()

=== Amsi notification report content ===
<Foo>.new()
=== Amsi notification report success: True ===

=== Amsi notification report content ===
<System.Object>.new()
=== Amsi notification report success: True ===
PS C:\>
$utilType = [PSObject].Assembly.GetType($utilTypeName)

=== Amsi notification report content ===
<System.Reflection.RuntimeAssembly>.GetType(<System.Management.Automation.AmsiUtils>)
=== Amsi notification report success: True ===
PS C:\>
exit
```

## PR Context

PowerShell 7.3 added a new feature that will log any .NET method calls and provide it to the IAntimalwareProvider2.Notify call. As an example running the following will result in the string below being provided to the AMSI provider to check before running

```
$foo = 'bar'
[Console]::WriteLine($foo)
```

```
<System.Console>.WriteLine(<bar>)
```

This allows antimalware providers registered with AMSI to be able to detect the runtime values provided to .NET methods even if they are obfuscated in the code and missed by any static analysis of the scriptblock text being run.

A bug in the implementation means that the provided args in the [LogMemberInvocation method that builds the string to provide to AMSI](https://github.com/PowerShell/PowerShell/blob/0e62b7ae6793832b9235c000ca8762f936382b25/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs#L3695-L3744) are the ones before they are casted when actually invoking them.

For any .NET method that accepts a string we can now provide a custom class with a `ToString` method that returns the value we want to provide to the .NET call but the AMSI notify string value will just be the class name. With this we can now bypass the checks that may be in place to stop things like the below which would typically be picked up by AMSI due to the presence of the keyword `AmsiUtils` in the string.

```
[PSObject].Assembly.GetType("System.Management.Automation.AmsiUtils")
```

### Repro Steps

Run the following PowerShell script

```
class Foo {
    [string] ToString() {
        return "System.Management.Automation." + ([char[]]@(0x41, 0x6D, 0x73, 0x69, 0x55, 0x74, 0x69, 0x6C, 0x73) -join "")
    }
}
$utilTypeName = [Foo]::new()
$utilType = [PSObject].Assembly.GetType($utilTypeName)
```

The type name string provided at runtime to `GetType` is `System.Management.Automation.AmsiUtils` but AMSI will see the following in the member invocation log, masking the true intention of the call.

```
<System.Reflection.RuntimeAssembly>.GetType(<Foo>)
```

