### PR TITLE
Enable `SA1014`, `SA1015`

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1630,7 +1630,7 @@ dotnet_diagnostic.SA1013.severity = none
 
 # SA1014: Opening generic brackets should be spaced correctly
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
-dotnet_diagnostic.SA1014.severity = none
+dotnet_diagnostic.SA1014.severity = warning
 
 # SA1015: Closing generic brackets should be spaced correctly
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md

--- a/.globalconfig
+++ b/.globalconfig
@@ -1634,7 +1634,7 @@ dotnet_diagnostic.SA1014.severity = warning
 
 # SA1015: Closing generic brackets should be spaced correctly
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
-dotnet_diagnostic.SA1015.severity = none
+dotnet_diagnostic.SA1015.severity = warning
 
 # SA1016: Opening attribute brackets should be spaced correctly
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4122,7 +4122,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Returns all string values bound to a parameter except the one the cursor is currently at.
         /// </summary>
-        private static HashSet<string>GetParameterValues(AstPair parameter, int cursorOffset)
+        private static HashSet<string> GetParameterValues(AstPair parameter, int cursorOffset)
         {
             var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var parameterValues = parameter.Argument.FindAll(ast => !(cursorOffset >= ast.Extent.StartOffset && cursorOffset <= ast.Extent.EndOffset) && ast is StringConstantExpressionAst, searchNestedScriptBlocks: false);

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4738,7 +4738,7 @@ namespace System.Management.Automation
                 {
                     basePath = null;
                 }
-                IEnumerable <FileSystemInfo> fileSystemObjects = containersOnly
+                IEnumerable<FileSystemInfo> fileSystemObjects = containersOnly
                     ? dirInfo.EnumerateDirectories(filterText, enumerationOptions)
                     : dirInfo.EnumerateFileSystemInfos(filterText, enumerationOptions);
 

--- a/test/xUnit/csharp/test_RemoteHyperV.cs
+++ b/test/xUnit/csharp/test_RemoteHyperV.cs
@@ -572,7 +572,8 @@ namespace PSTests.Sequential
             var expectedClientSends = CreateVersionNegotiationClientSends();
             expectedClientSends.Add((message: "TOKEN " + token, encoding: Encoding.ASCII));
 
-            var serverResponses = new List<(string message, Encoding encoding)>{
+            var serverResponses = new List<(string message, Encoding encoding)>
+            {
                 (message: version, encoding: Encoding.ASCII), // Response to VERSION
                 (message: "PASS", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "PASS", encoding: Encoding.ASCII) // Response to token
@@ -643,13 +644,15 @@ namespace PSTests.Sequential
         {
             int port = 50000 + (int)(DateTime.Now.Ticks % 10000);
 
-            var expectedClientSends = new List<(string message, Encoding encoding)>{
+            var expectedClientSends = new List<(string message, Encoding encoding)>
+            {
                 (message: "VERSION", encoding: Encoding.ASCII), // Response to VERSION
                 (message: "VERSION_2", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: $"TOKEN {token}", encoding: Encoding.ASCII)
             };
 
-            var serverResponses = new List<(string message, Encoding encoding)>{
+            var serverResponses = new List<(string message, Encoding encoding)>
+            {
                 (message: "VERSION_2", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "PASS", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "PASS", encoding: Encoding.ASCII) // Response to token
@@ -678,13 +681,15 @@ namespace PSTests.Sequential
             string expectedToken = token;
             int port = 50000 + (int)(DateTime.Now.Ticks % 10000);
 
-            var expectedClientSends = new List<(string message, Encoding encoding, int delayMs)>{
+            var expectedClientSends = new List<(string message, Encoding encoding, int delayMs)>
+            {
                 (message: "VERSION", encoding: Encoding.ASCII, delayMs: timeoutMs), // Response to VERSION
                 (message: "VERSION_2", encoding: Encoding.ASCII, delayMs: timeoutMs), // Response to VERSION_2
                 (message: $"TOKEN {token}", encoding: Encoding.ASCII, delayMs: 1)
             };
 
-            var serverResponses = new List<(string message, Encoding encoding)>{
+            var serverResponses = new List<(string message, Encoding encoding)>
+            {
                 (message: "VERSION_2", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "PASS", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "PASS", encoding: Encoding.ASCII) // Response to token
@@ -726,7 +731,8 @@ namespace PSTests.Sequential
             string expectedToken = token;
             int port = 50000 + (int)(DateTime.Now.Ticks % 10000);
 
-            var expectedClientSends = new List<(string message, Encoding encoding, int delayMs)>{
+            var expectedClientSends = new List<(string message, Encoding encoding, int delayMs)>
+            {
                 (message: "VERSION", encoding: Encoding.ASCII, delayMs: 1), // Response to VERSION
                 (message: "VERSION_2", encoding: Encoding.ASCII, delayMs: 1), // Response to VERSION_2
                 (message: $"TOKEN {token}", encoding: Encoding.ASCII, delayMs: 1),
@@ -737,7 +743,8 @@ namespace PSTests.Sequential
                 (message: string.Empty, encoding: Encoding.ASCII, delayMs: 103)  // Send some data after the handshake
             };
 
-            var serverResponses = new List<(string message, Encoding encoding)>{
+            var serverResponses = new List<(string message, Encoding encoding)>
+            {
                 (message: "VERSION_2", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "PASS", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "PASS", encoding: Encoding.ASCII), // Response to token
@@ -775,13 +782,15 @@ namespace PSTests.Sequential
         {
             int port = 50000 + (int)(DateTime.Now.Ticks % 10000);
 
-            var expectedClientSends = new List<(string message, Encoding encoding)>{
+            var expectedClientSends = new List<(string message, Encoding encoding)>
+            {
                 (message: "VERSION", encoding: Encoding.ASCII), // Initial request
                 (message: "VERSION_2", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: $"TOKEN {token}", encoding: Encoding.ASCII)
             };
 
-            var serverResponses = new List<(string message, Encoding encoding)>{
+            var serverResponses = new List<(string message, Encoding encoding)>
+            {
                 (message: "VERSION_2", encoding: Encoding.ASCII), // Response to VERSION
                 (message: "PASS", encoding: Encoding.ASCII), // Response to VERSION_2
                 (message: "FAIL", encoding: Encoding.ASCII) // Response to token


### PR DESCRIPTION
* Enable `SA1014`: Opening generic brackets should not be preceded by a space (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md)
* Enable `SA1015`: Closing generic bracket should be followed by a space (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md)
