### PR TITLE
Improve the type inference for binary expressions

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -718,16 +718,18 @@ namespace System.Management.Automation
 
         object ICustomAstVisitor.VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
         {
-            // TODO: Handle other kinds of expressions on the right side.
-            if (binaryExpressionAst.Operator == TokenKind.As && binaryExpressionAst.Right is TypeExpressionAst typeExpression)
-            {
-                var type = typeExpression.TypeName.GetReflectionType();
-                var psTypeName = type != null ? new PSTypeName(type) : new PSTypeName(typeExpression.TypeName.FullName);
-                return new[] { psTypeName };
-            }
-
             switch (binaryExpressionAst.Operator)
             {
+                case TokenKind.As:
+                    // TODO: Handle other kinds of expressions on the right side.
+                    if (binaryExpressionAst.Right is TypeExpressionAst typeExpression)
+                    {
+                        var type = typeExpression.TypeName.GetReflectionType();
+                        var psTypeName = type != null ? new PSTypeName(type) : new PSTypeName(typeExpression.TypeName.FullName);
+                        return new[] { psTypeName };
+                    }
+                    break;
+
                 case TokenKind.Xor:
                 case TokenKind.And:
                 case TokenKind.Or:
@@ -749,12 +751,12 @@ namespace System.Management.Automation
                 case TokenKind.Ireplace:
                 case TokenKind.Creplace:
                     // Always returns a string
-                    return new PSTypeName[] { new(typeof(string)) };
+                    return BinaryExpressionAst.StringTypeNameArray;
 
                 case TokenKind.Isplit:
                 case TokenKind.Csplit:
                     // Always returns a string array
-                    return new PSTypeName[] { new(typeof(string[])) };
+                    return BinaryExpressionAst.StringArrayTypeNameArray;
 
                 case TokenKind.Ieq:
                 case TokenKind.Ine:

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -835,8 +835,8 @@ namespace System.Management.Automation
             }
 
             List<PSTypeName> rhsTypes = InferTypes(binaryExpressionAst.Right).ToList();
-            var addedReturnTypes = new HashSet<string>();
-            var result = new List<PSTypeName>();
+            HashSet<string> addedReturnTypes = [];
+            List<PSTypeName> result = [];
             foreach (var lType in lhsTypes)
             {
                 if (lType.Type is null)
@@ -867,19 +867,17 @@ namespace System.Management.Automation
                         continue;
                     }
 
-                    bool addType = false;
                     foreach (PSTypeName rType in rhsTypes)
                     {
                         if (rType.Type is not null && rType.Type.IsAssignableTo(methodParams[1].ParameterType))
                         {
-                            addType = true;
+                            if (addedReturnTypes.Add(method.ReturnType.FullName))
+                            {
+                                result.Add(new PSTypeName(method.ReturnType));
+                            }
+
                             break;
                         }
-                    }
-
-                    if (addType && addedReturnTypes.Add(method.ReturnType.FullName))
-                    {
-                        result.Add(new PSTypeName(method.ReturnType));
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -835,8 +835,8 @@ namespace System.Management.Automation
             }
 
             List<PSTypeName> rhsTypes = InferTypes(binaryExpressionAst.Right).ToList();
-            HashSet<string> addedReturnTypes = [];
-            List<PSTypeName> result = [];
+            HashSet<string> addedReturnTypes = new HashSet<string>();
+            List<PSTypeName> result = new List<PSTypeName>();
             foreach (var lType in lhsTypes)
             {
                 if (lType.Type is null)

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -837,7 +837,7 @@ namespace System.Management.Automation
             List<PSTypeName> rhsTypes = InferTypes(binaryExpressionAst.Right).ToList();
             HashSet<string> addedReturnTypes = new HashSet<string>();
             List<PSTypeName> result = new List<PSTypeName>();
-            foreach (var lType in lhsTypes)
+            foreach (PSTypeName lType in lhsTypes)
             {
                 if (lType.Type is null)
                 {

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -720,6 +720,22 @@ namespace System.Management.Automation
         {
             switch (binaryExpressionAst.Operator)
             {
+                case TokenKind.And:
+                case TokenKind.Ccontains:
+                case TokenKind.Cin:
+                case TokenKind.Cnotcontains:
+                case TokenKind.Cnotin:
+                case TokenKind.Icontains:
+                case TokenKind.Iin:
+                case TokenKind.Inotcontains:
+                case TokenKind.Inotin:
+                case TokenKind.Is:
+                case TokenKind.IsNot:
+                case TokenKind.Or:
+                case TokenKind.Xor:
+                    // Always returns a bool
+                    return BinaryExpressionAst.BoolTypeNameArray;
+
                 case TokenKind.As:
                     // TODO: Handle other kinds of expressions on the right side.
                     if (binaryExpressionAst.Right is TypeExpressionAst typeExpression)
@@ -730,58 +746,42 @@ namespace System.Management.Automation
                     }
                     break;
 
-                case TokenKind.Xor:
-                case TokenKind.And:
-                case TokenKind.Or:
-                case TokenKind.Icontains:
-                case TokenKind.Inotcontains:
-                case TokenKind.Ccontains:
-                case TokenKind.Cnotcontains:
-                case TokenKind.Iin:
-                case TokenKind.Inotin:
-                case TokenKind.Cin:
-                case TokenKind.Cnotin:
-                case TokenKind.Is:
-                case TokenKind.IsNot:
-                    // Always returns a bool
-                    return BinaryExpressionAst.BoolTypeNameArray;
-
-                case TokenKind.Format:
-                case TokenKind.Join:
-                case TokenKind.Ireplace:
-                case TokenKind.Creplace:
-                    // Always returns a string
-                    return BinaryExpressionAst.StringTypeNameArray;
-
-                case TokenKind.Isplit:
-                case TokenKind.Csplit:
-                    // Always returns a string array
-                    return BinaryExpressionAst.StringArrayTypeNameArray;
-
-                case TokenKind.Ieq:
-                case TokenKind.Ine:
-                case TokenKind.Ige:
-                case TokenKind.Igt:
-                case TokenKind.Ilt:
-                case TokenKind.Ile:
-                case TokenKind.Ilike:
-                case TokenKind.Inotlike:
-                case TokenKind.Imatch:
-                case TokenKind.Inotmatch:
                 case TokenKind.Ceq:
-                case TokenKind.Cne:
                 case TokenKind.Cge:
                 case TokenKind.Cgt:
-                case TokenKind.Clt:
                 case TokenKind.Cle:
                 case TokenKind.Clike:
-                case TokenKind.Cnotlike:
+                case TokenKind.Clt:
                 case TokenKind.Cmatch:
+                case TokenKind.Cne:
+                case TokenKind.Cnotlike:
                 case TokenKind.Cnotmatch:
+                case TokenKind.Ieq:
+                case TokenKind.Ige:
+                case TokenKind.Igt:
+                case TokenKind.Ile:
+                case TokenKind.Ilike:
+                case TokenKind.Ilt:
+                case TokenKind.Imatch:
+                case TokenKind.Ine:
+                case TokenKind.Inotlike:
+                case TokenKind.Inotmatch:
                     // Returns a bool or filtered output from the left hand side if it's enumerable
                     var comparisonOutput = new List<PSTypeName>() { new(typeof(bool)) };
                     comparisonOutput.AddRange(InferTypes(binaryExpressionAst.Left));
                     return comparisonOutput;
+
+                case TokenKind.Creplace:
+                case TokenKind.Format:
+                case TokenKind.Ireplace:
+                case TokenKind.Join:
+                    // Always returns a string
+                    return BinaryExpressionAst.StringTypeNameArray;
+
+                case TokenKind.Csplit:
+                case TokenKind.Isplit:
+                    // Always returns a string array
+                    return BinaryExpressionAst.StringArrayTypeNameArray;
 
                 case TokenKind.QuestionQuestion:
                     // Can return left or right hand side
@@ -802,8 +802,8 @@ namespace System.Management.Automation
             string methodName;
             switch (binaryExpressionAst.Operator)
             {
-                case TokenKind.Plus:
-                    methodName = "op_Addition";
+                case TokenKind.Divide:
+                    methodName = "op_Division";
                     break;
 
                 case TokenKind.Minus:
@@ -814,8 +814,8 @@ namespace System.Management.Automation
                     methodName = "op_Multiply";
                     break;
 
-                case TokenKind.Divide:
-                    methodName = "op_Division";
+                case TokenKind.Plus:
+                    methodName = "op_Addition";
                     break;
 
                 case TokenKind.Rem:

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7591,6 +7591,8 @@ namespace System.Management.Automation.Language
         }
 
         internal static readonly PSTypeName[] BoolTypeNameArray = new PSTypeName[] { new PSTypeName(typeof(bool)) };
+        internal static readonly PSTypeName[] StringTypeNameArray = new PSTypeName[] { new PSTypeName(typeof(string)) };
+        internal static readonly PSTypeName[] StringArrayTypeNameArray = new PSTypeName[] { new PSTypeName(typeof(string[])) };
 
         #region Visitors
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR improves the type inference for binary expressions by adding special cases for operators where we always know the return type, like `-is` or `-contains` which always returns bools.
It also checks if an operator has been overriden by a type and uses this information to find the correct output type, for example `System.DateTime` will return a timespan when subtracting two dates: `(Get-Date) - (Get-Date)`
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/4501
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
