### PR TITLE
Make some `SystemPolicy` APIs visible but non-op on Unix so that they can be included in `PowerShellStandard.Library`

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -431,7 +431,7 @@ namespace System.Management.Automation.Security
     /// <summary>
     /// Application white listing security policies only affect Windows OSs.
     /// </summary>
-    internal sealed class SystemPolicy
+    public sealed class SystemPolicy
     {
         private SystemPolicy() { }
 
@@ -455,7 +455,7 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Gets the system lockdown policy.
         /// </summary>
-        /// <remarks>Always return SystemEnforcementMode.None in CSS (trusted)</remarks>
+        /// <remarks>Always return SystemEnforcementMode.None on non-Windows platforms.</remarks>
         public static SystemEnforcementMode GetSystemLockdownPolicy()
         {
             return SystemEnforcementMode.None;
@@ -464,7 +464,7 @@ namespace System.Management.Automation.Security
         /// <summary>
         /// Gets lockdown policy as applied to a file.
         /// </summary>
-        /// <remarks>Always return SystemEnforcementMode.None in CSS (trusted)</remarks>
+        /// <remarks>Always return SystemEnforcementMode.None on non-Windows platforms.</remarks>
         public static SystemEnforcementMode GetLockdownPolicy(string path, System.Runtime.InteropServices.SafeHandle handle)
         {
             return SystemEnforcementMode.None;
@@ -493,7 +493,7 @@ namespace System.Management.Automation.Security
     /// <summary>
     /// How the policy is being enforced.
     /// </summary>
-    internal enum SystemEnforcementMode
+    public enum SystemEnforcementMode
     {
         /// Not enforced at all
         None = 0,

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -477,7 +477,7 @@ namespace System.Management.Automation.Security
 
         /// <summary>
         /// Gets the system wide script file policy enforcement for an open file.
-        /// Based on system WDAC (Windows Defender Application Control) or AppLocker policies.
+        /// Based on system WDAC (Windows Defender Application Control) policies.
         /// </summary>
         /// <param name="filePath">Script file path for policy check.</param>
         /// <param name="fileStream">FileStream object to script file path.</param>

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -477,7 +477,7 @@ namespace System.Management.Automation.Security
 
         /// <summary>
         /// Gets the system wide script file policy enforcement for an open file.
-        /// Based on system WDAC (Windows Defender Application Control) policies.
+        /// Based on system WDAC (Windows Defender Application Control) or AppLocker policies.
         /// </summary>
         /// <param name="filePath">Script file path for policy check.</param>
         /// <param name="fileStream">FileStream object to script file path.</param>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Some `SystemPolicy` APIs are useful outside of PowerShell, for example, the `ThreadJob` module depends on them to determine when to block a thread job from running. However, they are not included in the `PowerShellStandard.Library` package because they are Windows-only API so far. So, it's hard for a module to use it -- it has to invoke those method with reflection.

In order to include them in the `PowerShellStandard.Library` package, those APIs need to be available on both Windows and Unix platforms, so this PR make them visible but non-op on Unix, so that they can be included in `PowerShellStandard.Library` the next time we update that package.

```c#
class SystemPolicy
{
    public static SystemEnforcementMode GetSystemLockdownPolicy();
    public static SystemEnforcementMode GetLockdownPolicy(string path, SafeHandle handle);
    public static SystemScriptFileEnforcement GetFilePolicyEnforcement(string filePath, FileStream fileStream);
}
```

**[Update]** As pointed out in https://github.com/PowerShell/PowerShell/pull/25051#issuecomment-2667494354, the `GetFilePolicyEnforcement` method is not available in Windows 5.1 on Win10 or Windows Server 2022. So, we probably should only include `GetSystemLockdownPolicy` and `GetLockdownPolicy` in `PowerShellStandard.Library` for the short/middle term. After Windows 10 and Windows Server 2022 reach EOL (or when the method becomes available on them) we can then add the `GetFilePolicyEnforcement` method to the package.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
