### PR TITLE
Set standard handles explicitly when starting a process with `-NoNewWindow`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2407,9 +2407,10 @@ namespace Microsoft.PowerShell.Commands
         private void SetStartupInfo(ProcessStartInfo startinfo, ref ProcessNativeMethods.STARTUPINFO lpStartupInfo, ref int creationFlags)
         {
             // If we are starting a process using the current console window, we need to set its standard handlers
-            // explicitly when they are not redirected because otherwise they won't be set.
+            // explicitly when they are not redirected because otherwise they won't be set and the new process will
+            // fail with the "invalid handler" error.
             //
-            // However, if we are starting a process with a new cosnole window, we should not explicitly set those
+            // However, if we are starting a process with a new console window, we should not explicitly set those
             // standard handlers when they are not redirected, but instead let Windows figure out the default to use
             // when creating the process. Otherwise, the standard input handlers of the current window and the new
             // window will get weirdly tied together and cause problems.

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2412,7 +2412,7 @@ namespace Microsoft.PowerShell.Commands
             //
             // However, if we are starting a process with a new console window, we should not explicitly set those
             // standard handles when they are not redirected, but instead let Windows figure out the default to use
-            // when creating the process. Otherwise, the standard input handlers of the current window and the new
+            // when creating the process. Otherwise, the standard input handles of the current window and the new
             // window will get weirdly tied together and cause problems.
             bool hasRedirection = startinfo.CreateNoWindow
                 || _redirectstandardinput is not null

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2406,12 +2406,12 @@ namespace Microsoft.PowerShell.Commands
 
         private void SetStartupInfo(ProcessStartInfo startinfo, ref ProcessNativeMethods.STARTUPINFO lpStartupInfo, ref int creationFlags)
         {
-            // If we are starting a process using the current console window, we need to set its standard handlers
+            // If we are starting a process using the current console window, we need to set its standard handles
             // explicitly when they are not redirected because otherwise they won't be set and the new process will
-            // fail with the "invalid handler" error.
+            // fail with the "invalid handle" error.
             //
             // However, if we are starting a process with a new console window, we should not explicitly set those
-            // standard handlers when they are not redirected, but instead let Windows figure out the default to use
+            // standard handles when they are not redirected, but instead let Windows figure out the default to use
             // when creating the process. Otherwise, the standard input handlers of the current window and the new
             // window will get weirdly tied together and cause problems.
             bool hasRedirection = startinfo.CreateNoWindow

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -241,3 +241,17 @@ Describe "Environment Tests" -Tags "Feature" {
         }
     }
 }
+
+Describe "Bug fixes" -Tags "CI" {
+
+    ## https://github.com/PowerShell/PowerShell/issues/24986
+    It "Error redirection along with '-NoNewWindow' should work for Start-Process" -Skip:(!$IsWindows) {
+        $errorFile = Join-Path -Path $TestDrive -ChildPath error.txt
+        $out = pwsh -noprofile -c "Start-Process -Wait -NoNewWindow -RedirectStandardError $errorFile -FilePath cmd -ArgumentList '/C echo Hello'"
+
+        ## 'Hello' should be sent to standard output; 'error.txt' file should be created but empty.
+        $out | Should -BeExactly "Hello"
+        Test-Path -Path $errorFile | Should -BeTrue
+        (Get-Item $errorFile).Length | Should -Be 0
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #24986

This is a follow-up fix to the changes introduced by #20853.

- If we are starting a process with a new window, we should leave the standard handles unset when they are not redirected and let Windows figure out the default to use creating the process. Otherwise, the standard input of the new window will be tied with the old window for some reason and causes the new window to be unusable.
- If we are starting a process re-using the current window (with `-NoNewWindow`), then we need to explicitly set all the standard handles, especially when any of them is redirected. Otherwise, the un-redirected handles will become invalid.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
