### PR TITLE
[release/v7.4] Add Justin Chung as PowerShell team member in `releaseTools.psm1`

### DIFF
--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -43,6 +43,7 @@ $Script:powershell_team = @(
     "Patrick Meinecke"
     "Steven Bucher"
     "PowerShell Team Bot"
+    "Justin Chung"
 )
 
 # They are very active contributors, so we keep their email-login mappings here to save a few queries to Github.


### PR DESCRIPTION
Backport #24672

This pull request includes a small change to the `tools/releaseTools.psm1` file. The change adds Justin Chung to the list of members in the PowerShell team.

* [`tools/releaseTools.psm1`](diffhunk://#diff-ba04f14b3aa7dbb2ebc4dc9158fcd7651396acbd2a382b604ed5525d4f4ff89bR46): Added "Justin Chung" to the PowerShell team members list.