### PR TITLE
[release/v7.4]Use workload identity service connection to download makeappx tool from storage account

### DIFF
--- a/.pipelines/templates/release-create-msix.yml
+++ b/.pipelines/templates/release-create-msix.yml
@@ -28,39 +28,24 @@ jobs:
       displayName: Download x86 msix
       patterns: '**/*.msix'
 
-    # This needs to run before any AzurePowerShell@ task
-    - pwsh: |
-        $azureRmModule = Get-InstalledModule AzureRM -ErrorAction SilentlyContinue -Verbose
-        if ($azureRmModule) {
-          Write-Host 'AzureRM module exists. Removing it'
-          Uninstall-AzureRm
-          Write-Host 'AzureRM module removed'
-        }
-
-        Install-Module -Name Az.Storage -Force -AllowClobber -Scope CurrentUser -Verbose
-      displayName: Remove AzRM modules and install Az.Storage
-
-    - pwsh: |
-        $cmd = Get-Command makeappx.exe -ErrorAction Ignore
-        if ($cmd) {
-            Write-Verbose -Verbose 'makeappx available in PATH'
-            $exePath = $cmd.Source
-        } else {
-            $toolsDir = '$(Pipeline.Workspace)\releasePipeline\tools'
-            New-Item $toolsDir -Type Directory -Force > $null
-            Invoke-RestMethod -Uri '$(makeappUrl)' -OutFile "$toolsDir\makeappx.zip"
-            Expand-Archive "$toolsDir\makeappx.zip" -DestinationPath "$toolsDir\makeappx" -Force
-            $exePath = "$toolsDir\makeappx\makeappx.exe"
-    
-            Write-Verbose -Verbose 'makeappx was installed:'
-            Get-ChildItem -Path $toolsDir -Recurse
-        }
-    
-        $vstsCommandString = "vso[task.setvariable variable=MakeAppxPath]$exePath"
-        Write-Host "sending " + $vstsCommandString
-        Write-Host "##$vstsCommandString"
+    - task: AzurePowerShell@5
       displayName: Install makeappx tool
       retryCountOnTaskFailure: 1
+      inputs:
+        azureSubscription: az-blob-cicd-infra
+        scriptType: inlineScript
+        azurePowerShellVersion: LatestVersion
+        pwsh: true
+        inline: |
+          $toolsDir = '$(Pipeline.Workspace)\releasePipeline\tools'
+          New-Item $toolsDir -Type Directory -Force > $null
+          Invoke-RestMethod -Uri '$(makeappUrlDirect)' -OutFile "$toolsDir\makeappx.zip"
+          Expand-Archive "$toolsDir\makeappx.zip" -DestinationPath "$toolsDir\makeappx" -Force
+          $exePath = "$toolsDir\makeappx\makeappx.exe"
+
+          $vstsCommandString = "vso[task.setvariable variable=MakeAppxPath]$exePath"
+          Write-Host "sending " + $vstsCommandString
+          Write-Host "##$vstsCommandString"
 
     - pwsh: |
         $sourceDir = '$(Pipeline.Workspace)\releasePipeline\msix'


### PR DESCRIPTION


Backport #24817

This pull request includes a significant update to the `.pipelines/templates/release-create-msix.yml` file, focusing on improving the installation process for the `makeappx` tool and removing outdated AzureRM modules.

Pipeline improvements:

* [`.pipelines/templates/release-create-msix.yml`](diffhunk://#diff-9cc831b9876377ff38572eacdb3d885fc0d526800cb17abaeac45e95a9a8d4e7L31-L63): Removed the script to uninstall AzureRM modules and install `Az.Storage`, and replaced it with a task to install the `makeappx` tool using `AzurePowerShell@5`. This change simplifies the pipeline and ensures the use of the latest Azure PowerShell version.
* [`.pipelines/templates/release-create-msix.yml`](diffhunk://#diff-9cc831b9876377ff38572eacdb3d885fc0d526800cb17abaeac45e95a9a8d4e7L31-L63): Updated the URL variable from `$(makeappUrl)` to `$(makeappUrlDirect)` for downloading the `makeappx` tool, providing a more direct and reliable download link.