### PR TITLE
[release/v7.4]Fix V-Pack download package name

### DIFF
--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -138,7 +138,7 @@ extends:
               installationPath: $(Agent.ToolsDirectory)/dotnet
 
           - pwsh: |
-              $packageArtifactName = 'drop_windows_package_package_${{ parameters.architecture }}'
+              $packageArtifactName = 'drop_windows_package_package_win_${{ parameters.architecture }}'
               $vstsCommandString = "vso[task.setvariable variable=PackageArtifactName]$packageArtifactName"
               Write-Host "sending " + $vstsCommandString
               Write-Host "##$vstsCommandString"


### PR DESCRIPTION
Backport #24866

This pull request includes a small change to the `.pipelines/PowerShell-vPack-Official.yml` file. The change updates the `packageArtifactName` variable to include a more specific identifier for the Windows architecture.

* [`.pipelines/PowerShell-vPack-Official.yml`](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L141-R141): Changed `packageArtifactName` from 'drop_windows_package_package_${{ parameters.architecture }}' to 'drop_windows_package_package_win_${{ parameters.architecture }}' to better specify the Windows architecture.