### PR TITLE
[release/v7.4]Give the pipeline runs meaningful names

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -1,4 +1,4 @@
-name: UnifiedPackageBuild-$(Build.BuildId)
+name: bins-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 trigger: none
 
 parameters:

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -24,6 +24,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
+    
+name: pkgs-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -14,6 +14,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     type: string
     default: 'NO'
 
+name: ev2-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
+
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)]

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -26,6 +26,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     type: boolean
     default: false
 
+name: release-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
+
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)]

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -1,5 +1,3 @@
-name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
-
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
@@ -27,6 +25,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   type: string
   displayName: 'Release Tag Var:'
   default: 'fromBranch'
+
+name: vPack_${{ parameters.architecture }}_$(date:yyMM).$(date:dd)$(rev:rrr)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT


### PR DESCRIPTION
Backport #24987

This pull request includes several changes to the naming conventions in the pipeline YAML files to improve consistency and clarity. The changes primarily involve updating the `name` fields to include the source branch name and build ID.

Changes to naming conventions:

* [`.pipelines/PowerShell-Coordinated_Packages-Official.yml`](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL1-R1): Updated the `name` field to `bins-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)`.
* [`.pipelines/PowerShell-Packages-Official.yml`](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R28-R29): Added a `name` field with the value `pkgs-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)`.
* [`.pipelines/PowerShell-Release-Official-Azure.yml`](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eR17-R18): Added a `name` field with the value `ev2-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)`.
* [`.pipelines/PowerShell-Release-Official.yml`](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR29-R30): Added a `name` field with the value `release-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)`.
* [`.pipelines/PowerShell-vPack-Official.yml`](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L1-L2): Updated the `name` field to `vPack_${{ parameters.architecture }}_$(date:yyMM).$(date:dd)$(rev:rrr)`. [[1]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L1-L2) [[2]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4R29-R30)