### PR TITLE
[release/v7.4]Make sure the vPack pipeline does not produce an empty package

### DIFF
--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -142,18 +142,27 @@ extends:
               $vstsCommandString = "vso[task.setvariable variable=PackageArtifactName]$packageArtifactName"
               Write-Host "sending " + $vstsCommandString
               Write-Host "##$vstsCommandString"
-            displayName: 'Set package artifact name'
+
+              $packageArtifactPath = '$(Pipeline.Workspace)\PSPackagesOfficial'
+              $vstsCommandString = "vso[task.setvariable variable=PackageArtifactPath]$packageArtifactPath"
+              Write-Host "sending " + $vstsCommandString
+              Write-Host "##$vstsCommandString"
+            displayName: 'Set package artifact variables'
 
           - download: PSPackagesOfficial
             artifact: $(PackageArtifactName)
             displayName: Download package
 
-          - pwsh: 'Get-ChildItem $(System.ArtifactsDirectory)\* -recurse | Select-Object -ExpandProperty Name'
+          - pwsh: 'Get-ChildItem $(PackageArtifactPath)\* -recurse | Select-Object -ExpandProperty Name'
             displayName: 'Capture Artifact Listing'
 
           - pwsh: |
               $message = @()
-              Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -include *.zip, *.msi | ForEach-Object {
+              $packages = Get-ChildItem $(PackageArtifactPath)\* -recurse -include *.zip, *.msi
+
+              if($packages.count -eq 0) {throw "No packages found in $(PackageArtifactPath)"}
+
+              $packages | ForEach-Object {
                   if($_.Name -notmatch 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(fxdependent|x64|arm64|x86|fxdependentWinDesktop)\.(msi|zip){1}')
                   {
                         $messageInstance = "$($_.Name) is not a valid package name"
@@ -166,7 +175,7 @@ extends:
             displayName: 'Validate Zip and MSI Package Names'
 
           - pwsh: |
-              Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -include *.zip, *.msi | ForEach-Object {
+              Get-ChildItem $(PackageArtifactPath)\* -recurse -include *.zip | ForEach-Object {
                   if($_.Name -match 'PowerShell-\d+\.\d+\.\d+\-([a-z]*.\d+\-)?win\-(${{ parameters.architecture }})\.(zip){1}')
                   {
                       Expand-Archive -Path $_.FullName -DestinationPath $(ob_outputDirectory)
@@ -197,7 +206,11 @@ extends:
 
           - pwsh: |
               Write-Verbose "VPack Version: $(ob_createvpack_version)" -Verbose
-              Get-ChildItem -Path $(ob_outputDirectory)\* -Recurse
+              $vpackFiles = Get-ChildItem -Path $(ob_outputDirectory)\* -Recurse
+              if($vpackFiles.Count -eq 0) {
+                  throw "No files found in $(ob_outputDirectory)"
+              }
+              $vpackFiles
             displayName: Debug Output Directory and Version
             condition: succeededOrFailed()
 
@@ -207,5 +220,5 @@ extends:
               command: 'sign'
               signing_environment: 'azure-ado'
               cp_code: $(windows_build_tools_cert_id)
-              files_to_sign: '**/*.exe;**/*.dll;**/*.ps1;**/*.psm1'
+              files_to_sign: '**/*.exe;**/System.Management.Automation.dll'
               search_root: $(ob_outputDirectory)


### PR DESCRIPTION
Backport #24988

This pull request includes several important changes to the `.pipelines/PowerShell-vPack-Official.yml` file to improve the handling of package artifacts and ensure proper validation and signing of files. The key changes involve setting new variables, updating paths, adding error handling, and refining file selection for signing.

### Improvements to package artifact handling:

* Added a new variable `PackageArtifactPath` and updated commands to use this variable instead of `System.ArtifactsDirectory`. This change ensures that the correct path is used consistently throughout the pipeline.
* Included error handling to throw an exception if no packages are found in the specified path, improving the robustness of the pipeline. [[1]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L145-R165) [[2]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L200-R213)

### Validation and signing refinements:

* Modified the file selection pattern for signing to include only `System.Management.Automation.dll` and exclude other `.dll` and script files. This change ensures that only the necessary files are signed.
* Updated the validation step to focus on `.zip` packages and ensure that the correct architecture is used. This change helps in maintaining the integrity of the package validation process.