### PR TITLE
[release/v7.4]Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,72 +6,60 @@
 # Area: Performance
 # @adityapatwardhan 
 
-# Area: Portability
-# @JamesWTruher
-
 # Area: Security
-# @TravisEz13 @PaulHigin
-src/System.Management.Automation/security/wldpNativeMethods.cs @TravisEz13 @PaulHigin
+src/System.Management.Automation/security/wldpNativeMethods.cs @TravisEz13 @seeminglyscience
 
-# Area: Documentation
-.github/    @joeyaiello @TravisEz13
-
-# Area: Test
-# @JamesWTruher @TravisEz13 @adityapatwardhan
-
-# Area: Cmdlets Core
-# @JamesWTruher @SteveL-MSFT @anmenaga
+# Area: CI Build
+.github/workflows    @PowerShell/powershell-maintainers
+.github/actions      @PowerShell/powershell-maintainers
 
 # Now, areas that should have paths or filters, although we might not have them defined
 # According to the docs, order here must be by precedence of the filter, with later rules overwritting
 # but the feature seems to make taking a union of all the matching rules.
 
 # Area: Cmdlets Management
-src/Microsoft.PowerShell.Commands.Management/      @daxian-dbw @adityapatwardhan
+# src/Microsoft.PowerShell.Commands.Management/      @daxian-dbw @adityapatwardhan
 
 # Area: Utility Cmdlets
-src/Microsoft.PowerShell.Commands.Utility/         @JamesWTruher @PaulHigin
+# src/Microsoft.PowerShell.Commands.Utility/         
 
 # Area: Console
-src/Microsoft.PowerShell.ConsoleHost/              @daxian-dbw @anmenaga @TylerLeonhardt
-
-# Area: Demos
-demos/                                             @joeyaiello @SteveL-MSFT @HemantMahawar
+# src/Microsoft.PowerShell.ConsoleHost/              @daxian-dbw
 
 # Area: DSC
-src/System.Management.Automation/DscSupport        @TravisEz13 @SteveL-MSFT
+# src/System.Management.Automation/DscSupport        @TravisEz13 @SteveL-MSFT
 
 # Area: Engine
 # src/System.Management.Automation/engine            @daxian-dbw
 
 # Area: Debugging
 # Must be below engine to override
-src/System.Management.Automation/engine/debugger/  @PaulHigin
+# src/System.Management.Automation/engine/debugger/  
 
 # Area: Help
-src/System.Management.Automation/help              @adityapatwardhan
+src/System.Management.Automation/help              @adityapatwardhan @daxian-dbw
 
 # Area: Intellisense
 # @daxian-dbw
 
 # Area: Language
-src/System.Management.Automation/engine/parser     @daxian-dbw
+src/System.Management.Automation/engine/parser     @daxian-dbw @seeminglyscience
 
 # Area: Providers
-src/System.Management.Automation/namespaces        @anmenaga
+# src/System.Management.Automation/namespaces        
 
 # Area: Remoting
-src/System.Management.Automation/engine/remoting    @PaulHigin
+src/System.Management.Automation/engine/remoting    @daxian-dbw @TravisEz13
 
 # Areas: Build
 # Must be last
-*.config   @daxian-dbw @TravisEz13 @adityapatwardhan @anmenaga @PaulHigin
-*.props    @daxian-dbw @TravisEz13 @adityapatwardhan @anmenaga @PaulHigin
-*.yml      @daxian-dbw @TravisEz13 @adityapatwardhan @anmenaga @PaulHigin
-*.csproj   @daxian-dbw @TravisEz13 @adityapatwardhan @anmenaga @PaulHigin
-build.*    @daxian-dbw @TravisEz13 @adityapatwardhan @anmenaga @PaulHigin
-tools/     @daxian-dbw @TravisEz13 @adityapatwardhan @anmenaga @PaulHigin
-docker/    @daxian-dbw @TravisEz13 @adityapatwardhan @anmenaga @PaulHigin
+*.config   @PowerShell/powershell-maintainers 
+*.props    @PowerShell/powershell-maintainers 
+*.yml      @PowerShell/powershell-maintainers 
+*.csproj   @PowerShell/powershell-maintainers 
+build.*    @PowerShell/powershell-maintainers 
+tools/     @PowerShell/powershell-maintainers 
+# docker/    @PowerShell/powershell-maintainers 
 
 # Area: Compliance
 tools/terms    @TravisEz13


### PR DESCRIPTION
Backport #24989

This pull request includes several changes to the `.github/CODEOWNERS` file, primarily focusing on updating the ownership assignments for various areas of the codebase. The most important changes include reassigning ownership for security-related files, CI build-related files, and specific areas within the `System.Management.Automation` directory.

Ownership updates:

* [`src/System.Management.Automation/security/wldpNativeMethods.cs`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L9-R62): Ownership changed from `@TravisEz13` and `@PaulHigin` to `@TravisEz13` and `@seeminglyscience`.
* `.github/workflows` and `.github/actions`: Ownership assigned to `@PowerShell/powershell-maintainers`.
* [`src/System.Management.Automation/help`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L9-R62): Added `@daxian-dbw` as an additional owner.
* [`src/System.Management.Automation/engine/parser`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L9-R62): Added `@seeminglyscience` as an additional owner.
* Various build-related files (`*.config`, `*.props`, `*.yml`, `*.csproj`, `build.*`, `tools/`, `docker/`): Ownership assigned to `@PowerShell/powershell-maintainers`.