### PR TITLE
[release/v7.4]Create Change log for 7.4.8

### DIFF
--- a/CHANGELOG/7.4.md
+++ b/CHANGELOG/7.4.md
@@ -1,5 +1,47 @@
 # 7.4 Changelog
 
+## [7.4.8]
+
+### Notes
+
+*This release is internal only.  It is not available for download.*
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update .NET SDK to 8.0.406</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release  (#25085) (#24884)</li>
+<li>Add UseDotnet task for installing dotnet (#25080)</li>
+<li>Add Justin Chung as PowerShell team member in <code>releaseTools.psm1</code> (#25074)</li>
+<li>Fix V-Pack download package name (#25078)</li>
+<li>Fix MSIX stage in release pipeline (#25079)</li>
+<li>Give the pipeline runs meaningful names (#25081)</li>
+<li>Make sure the vPack pipeline does not produce an empty package (#25082)</li>
+<li>Update CODEOWNERS (#25083)</li>
+<li>Add setup dotnet action to the build composite action (#25084)</li>
+<li>Remove AzDO credscan as it is now in GitHub (#25077)</li>
+<li>Use workload identity service connection to download makeappx tool from storage account (#25075)</li>
+<li>Update .NET SDK (#24993)</li>
+<li>Fix GitHub Action filter overmatching (#24957)</li>
+<li>Fix release branch filters (#24960)</li>
+<li>Convert powershell/PowerShell-CI-macos to GitHub Actions (#24955)</li>
+<li>Convert powershell/PowerShell-CI-linux to GitHub Actions (#24945)</li>
+<li>Convert powershell/PowerShell-Windows-CI to GitHub Actions (#24932)</li>
+<li>PMC parse state correctly from update command's response (#24860)</li>
+<li>Add EV2 support for publishing PowerShell packages to PMC (#24857)</li>
+</ul>
+
+</details>
+
+[7.4.8]: https://github.com/PowerShell/PowerShell/compare/v7.4.7...v7.4.8
+
 ## [7.4.7]
 
 ### Build and Packaging Improvements
@@ -13,8 +55,8 @@
 </summary>
 
 <ul>
-<li>[release/v7.4] Update branch for release  - Transitive - true - minor (#24546)</li>
-<li>[release/v7.4] Fix backport mistake in #24429 (#24545)</li>
+<li>Update branch for release  - Transitive - true - minor (#24546)</li>
+<li>Fix backport mistake in #24429 (#24545)</li>
 <li>Fix seed max value for Container Linux CI (#24510) (#24543)</li>
 <li>Add a way to use only NuGet feed sources (#24528) (#24542)</li>
 <li>Bump Microsoft.PowerShell.PSResourceGet to 1.0.6 (#24419)</li>
@@ -28,13 +70,13 @@
 <li>Update changelog for v7.4.6 release (Internal 32983)</li>
 <li>Fix backport issues with release pipeline (#24835)</li>
 <li>Remove duplicated parameter (#24832)</li>
-<li>[release/v7.4] Make the <code>AssemblyVersion</code> not change for servicing releases 7.4.7 and onward (#24821)</li>
+<li>Make the <code>AssemblyVersion</code> not change for servicing releases 7.4.7 and onward (#24821)</li>
 <li>Add *.props and sort path filters for windows CI  (#24822) (#24823)</li>
 <li>Take the newest windows signature nuget packages (#24818)</li>
 <li>Use work load identity service connection to download makeappx tool from storage account (#24817) (#24820)</li>
 <li>Update path filters for Windows CI (#24809) (#24819)</li>
 <li>Fixed release pipeline errors and switched to KS3 (#24751) (#24816)</li>
-<li>[release/v7.4] Update branch for release  - Transitive - true - minor (#24806)</li>
+<li>Update branch for release  - Transitive - true - minor (#24806)</li>
 <li>Add ability to capture MSBuild Binary logs when restore fails (#24128) (#24799)</li>
 <li>Download package from package build for generating vpack (#24481) (#24801)</li>
 <li>Add a parameter that skips verify packages step (#24763) (#24803)</li>


### PR DESCRIPTION
Backport #25089

This pull request includes updates to the `CHANGELOG/7.4.md` file to document the changes in the 7.4.8 release. The most important changes include updates to the .NET SDK, improvements to the release pipeline, and various fixes and enhancements.

### Build and Packaging Improvements:

* Updated .NET SDK to 8.0.406 and added a UseDotnet task for installing dotnet.
* Fixed V-Pack download package name and MSIX stage in the release pipeline.
* Converted PowerShell CI pipelines to GitHub Actions.
* Added EV2 support for publishing PowerShell packages to PMC.

### Fixes and Enhancements:

* Fixed GitHub Action filter overmatching and release branch filters.
* Fixed backport issues with the release pipeline and removed duplicated parameters.
* Made the `AssemblyVersion` not change for servicing releases 7.4.7 and onward.