### PR TITLE
Update Component Manifest

### DIFF
--- a/tools/cgmanifest.json
+++ b/tools/cgmanifest.json
@@ -24,8 +24,8 @@
       "Component": {
         "Type": "nuget",
         "Nuget": {
-          "Name": "JetBrains.Annotations",
-          "Version": "2021.2.0"
+          "Name": "Humanizer.Core",
+          "Version": "2.14.1"
         }
       },
       "DevelopmentDependency": false
@@ -35,7 +35,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "Json.More.Net",
-          "Version": "1.9.3"
+          "Version": "2.0.2"
         }
       },
       "DevelopmentDependency": false
@@ -45,7 +45,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "JsonPointer.Net",
-          "Version": "3.0.3"
+          "Version": "5.0.2"
         }
       },
       "DevelopmentDependency": false
@@ -55,7 +55,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "JsonSchema.Net",
-          "Version": "5.2.7"
+          "Version": "7.0.4"
         }
       },
       "DevelopmentDependency": false
@@ -105,7 +105,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "Microsoft.CodeAnalysis.Common",
-          "Version": "4.8.0"
+          "Version": "4.9.2"
         }
       },
       "DevelopmentDependency": false
@@ -115,7 +115,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "Microsoft.CodeAnalysis.CSharp",
-          "Version": "4.8.0"
+          "Version": "4.9.2"
         }
       },
       "DevelopmentDependency": false
@@ -125,7 +125,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "Microsoft.Extensions.ObjectPool",
-          "Version": "8.0.8"
+          "Version": "8.0.13"
         }
       },
       "DevelopmentDependency": false
@@ -155,7 +155,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "Microsoft.Security.Extensions",
-          "Version": "1.2.0"
+          "Version": "1.3.0"
         }
       },
       "DevelopmentDependency": false
@@ -195,7 +195,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "Microsoft.Windows.Compatibility",
-          "Version": "8.0.8"
+          "Version": "8.0.13"
         }
       },
       "DevelopmentDependency": false
@@ -345,7 +345,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Collections.Immutable",
-          "Version": "7.0.0"
+          "Version": "8.0.0"
         }
       },
       "DevelopmentDependency": false
@@ -375,7 +375,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Configuration.ConfigurationManager",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -385,7 +385,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Data.Odbc",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -395,7 +395,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Data.OleDb",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -425,7 +425,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Diagnostics.EventLog",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -435,7 +435,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Diagnostics.PerformanceCounter",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -445,7 +445,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.DirectoryServices.AccountManagement",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -475,7 +475,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Drawing.Common",
-          "Version": "8.0.8"
+          "Version": "8.0.13"
         }
       },
       "DevelopmentDependency": false
@@ -485,7 +485,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Formats.Asn1",
-          "Version": "8.0.1"
+          "Version": "8.0.2"
         }
       },
       "DevelopmentDependency": false
@@ -495,7 +495,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.IO.Packaging",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -575,7 +575,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Reflection.Metadata",
-          "Version": "7.0.0"
+          "Version": "8.0.0"
         }
       },
       "DevelopmentDependency": false
@@ -585,7 +585,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Runtime.Caching",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -615,7 +615,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Security.Cryptography.Pkcs",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -635,7 +635,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Security.Cryptography.Xml",
-          "Version": "8.0.1"
+          "Version": "8.0.2"
         }
       },
       "DevelopmentDependency": false
@@ -725,7 +725,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.ServiceProcess.ServiceController",
-          "Version": "8.0.0"
+          "Version": "8.0.1"
         }
       },
       "DevelopmentDependency": false
@@ -756,16 +756,6 @@
         "Nuget": {
           "Name": "System.Text.Encodings.Web",
           "Version": "8.0.0"
-        }
-      },
-      "DevelopmentDependency": false
-    },
-    {
-      "Component": {
-        "Type": "nuget",
-        "Nuget": {
-          "Name": "System.Text.Json",
-          "Version": "8.0.4"
         }
       },
       "DevelopmentDependency": false


### PR DESCRIPTION
This pull request updates multiple NuGet package dependencies in the `tools/cgmanifest.json` file. The updates include changing the versions of existing packages to newer versions and removing one package.

Updates to NuGet package dependencies:

* `JetBrains.Annotations` replaced with `Humanizer.Core` version 2.14.1
* Updated `Json.More.Net` to version 2.0.2
* Updated `JsonPointer.Net` to version 5.0.2
* Updated `JsonSchema.Net` to version 7.0.4
* Updated `Microsoft.CodeAnalysis.Common` to version 4.9.2
* Updated `Microsoft.CodeAnalysis.CSharp` to version 4.9.2
* Updated `Microsoft.Extensions.ObjectPool` to version 8.0.13
* Updated `Microsoft.Security.Extensions` to version 1.3.0
* Updated `Microsoft.Windows.Compatibility` to version 8.0.13
* Updated `System.Collections.Immutable` to version 8.0.0
* Updated `System.Configuration.ConfigurationManager` to version 8.0.1
* Updated `System.Data.Odbc` to version 8.0.1
* Updated `System.Data.OleDb` to version 8.0.1
* Updated `System.Diagnostics.EventLog` to version 8.0.1
* Updated `System.Diagnostics.PerformanceCounter` to version 8.0.1
* Updated `System.DirectoryServices.AccountManagement` to version 8.0.1
* Updated `System.Drawing.Common` to version 8.0.13
* Updated `System.Formats.Asn1` to version 8.0.2
* Updated `System.IO.Packaging` to version 8.0.1
* Updated `System.Reflection.Metadata` to version 8.0.0
* Updated `System.Runtime.Caching` to version 8.0.1
* Updated `System.Security.Cryptography.Pkcs` to version 8.0.1
* Updated `System.Security.Cryptography.Xml` to version 8.0.2
* Updated `System.ServiceProcess.ServiceController` to version 8.0.1

Removal of NuGet package dependency:

* Removed `System.Text.Json` version 8.0.4