### PR TITLE
Make Component Manifest Updater use neutral target in addition to RID target

### DIFF
--- a/tools/findMissingNotices.ps1
+++ b/tools/findMissingNotices.ps1
@@ -203,28 +203,34 @@ function Get-CGRegistrations {
         "alpine-.*" {
             $folder = $unixProjectName
             $target = "$dotnetTargetName|$Runtime"
+            $neutralTarget = "$dotnetTargetName"
         }
         "linux-.*" {
             $folder = $unixProjectName
             $target = "$dotnetTargetName|$Runtime"
+            $neutralTarget = "$dotnetTargetName"
         }
         "osx-.*" {
             $folder = $unixProjectName
             $target = "$dotnetTargetName|$Runtime"
+            $neutralTarget = "$dotnetTargetName"
         }
         "win-x*" {
             $sdkToUse = $winDesktopSdk
             $folder = $windowsProjectName
             $target = "$dotnetTargetNameWin7|$Runtime"
+            $neutralTarget = "$dotnetTargetNameWin7"
         }
         "win-.*" {
             $folder = $windowsProjectName
             $target = "$dotnetTargetNameWin7|$Runtime"
+            $neutralTarget = "$dotnetTargetNameWin7"
         }
         "modules" {
             $folder = "modules"
             $actualRuntime = 'linux-x64'
             $target = "$dotnetTargetName|$actualRuntime"
+            $neutralTarget = "$dotnetTargetName"
         }
         Default {
             throw "Invalid runtime name: $Runtime"
@@ -241,6 +247,7 @@ function Get-CGRegistrations {
         $null = New-PADrive -Path $PSScriptRoot\..\src\$folder\obj\project.assets.json -Name $folder
         try {
             $targets = Get-ChildItem -Path "${folder}:/targets/$target" -ErrorAction Stop | Where-Object { $_.Type -eq 'package' }  | select-object -ExpandProperty name
+            $targets += Get-ChildItem -Path "${folder}:/targets/$neutralTarget" -ErrorAction Stop | Where-Object { $_.Type -eq 'project' }  | select-object -ExpandProperty name
         } catch {
             Get-ChildItem -Path "${folder}:/targets" | Out-String | Write-Verbose -Verbose
             throw
@@ -250,27 +257,51 @@ function Get-CGRegistrations {
         Get-PSDrive -Name $folder -ErrorAction Ignore | Remove-PSDrive
     }
 
+    # Name to skip for TPN generation
+    $skipNames = @(
+        "Microsoft.PowerShell.Native"
+        "Microsoft.Management.Infrastructure.Runtime.Unix"
+        "Microsoft.Management.Infrastructure"
+        "Microsoft.PowerShell.Commands.Diagnostics"
+        "Microsoft.PowerShell.Commands.Management"
+        "Microsoft.PowerShell.Commands.Utility"
+        "Microsoft.PowerShell.ConsoleHost"
+        "Microsoft.PowerShell.SDK"
+        "Microsoft.PowerShell.Security"
+        "Microsoft.Management.Infrastructure.CimCmdlets"
+        "Microsoft.WSMan.Management"
+        "Microsoft.WSMan.Runtime"
+        "System.Management.Automation"
+    )
+
+    Write-Verbose "Found $($targets.Count) targets to process..." -Verbose
     $targets | ForEach-Object {
         $target = $_
         $parts = ($target -split '\|')
         $name = $parts[0]
-        $targetVersion = $parts[1]
-        $publicVersion = Get-NuGetPublicVersion -Name $name -Version $targetVersion
 
-        # Add the registration to the cgmanifest if the TPN does not contain the name of the target OR
-        # the exisitng CG contains the registration, because if the existing CG contains the registration,
-        # that might be the only reason it is in the TPN.
-        if (!$RegistrationTable.ContainsKey($target)) {
-            $DevelopmentDependency = $false
-            if (!$existingRegistrationTable.ContainsKey($name) -or $existingRegistrationTable.$name.Component.Version() -ne $publicVersion) {
-                $registrationChanged = $true
-            }
-            if ($existingRegistrationTable.ContainsKey($name) -and $existingRegistrationTable.$name.DevelopmentDependency) {
-                $DevelopmentDependency = $true
-            }
+        if ($name -in $skipNames) {
+            Write-Verbose "Skipping $name..."
 
-            $registration = New-NugetComponent -Name $name -Version $publicVersion -DevelopmentDependency:$DevelopmentDependency
-            $RegistrationTable.Add($target, $registration)
+        } else {
+            $targetVersion = $parts[1]
+            $publicVersion = Get-NuGetPublicVersion -Name $name -Version $targetVersion
+
+            # Add the registration to the cgmanifest if the TPN does not contain the name of the target OR
+            # the exisitng CG contains the registration, because if the existing CG contains the registration,
+            # that might be the only reason it is in the TPN.
+            if (!$RegistrationTable.ContainsKey($target)) {
+                $DevelopmentDependency = $false
+                if (!$existingRegistrationTable.ContainsKey($name) -or $existingRegistrationTable.$name.Component.Version() -ne $publicVersion) {
+                    $registrationChanged = $true
+                }
+                if ($existingRegistrationTable.ContainsKey($name) -and $existingRegistrationTable.$name.DevelopmentDependency) {
+                    $DevelopmentDependency = $true
+                }
+
+                $registration = New-NugetComponent -Name $name -Version $publicVersion -DevelopmentDependency:$DevelopmentDependency
+                $RegistrationTable.Add($target, $registration)
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary


This pull request includes several changes to the `Get-CGRegistrations` function in the `tools/findMissingNotices.ps1` file to improve the handling of target paths and to skip specific names during TPN (Third Party Notices) generation.

### Improvements to target path handling:
* Added a new variable `$neutralTarget` for each runtime pattern to handle neutral targets.
* Updated the `Get-ChildItem` command to include items from the `$neutralTarget` path.

### Enhancements to TPN generation:
* Introduced a list of names to skip during TPN generation, stored in the `$skipNames` array.
* Added logic to skip processing for names in the `$skipNames` array and included verbose logging for skipped names. [[1]](diffhunk://#diff-7a793f5a08946f6924095e2745da692c4d9e9dd7d0112fd67a4886c8f0d36fe6R260-R286) [[2]](diffhunk://#diff-7a793f5a08946f6924095e2745da692c4d9e9dd7d0112fd67a4886c8f0d36fe6R306)

## PR Context

.NET started using multiple targets in .NET 8.  This makes this script miss some components.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
