### PR TITLE
Create backport workflow using dotnet/arcade

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,7 @@ jobs:
             if (match) {
               const version = match[1];
               const label = `Backport-${version}.x-Consider`;
-              console.log(result);
+              console.log(label);
             } else {
               throw new Error("No version found in comment");
             }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,49 @@
+name: Backport PR to branch
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # once a day at 13:00 UTC to cleanup old runs
+    - cron: '0 13 * * *'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  backport:
+    if: ${{ contains(github.event.comment.body, '/backport to') || github.event_name == 'schedule' }}
+    uses: dotnet/arcade/.github/workflows/backport-base.yml@main
+    with:
+      repository_owners: powershell
+      pr_description_template: |
+        Backport of #%source_pr_number% to %target_branch%
+
+        <-- $$$originalpr:%source_pr_number$$$ -->
+
+        /cc %cc_users%
+
+        ## Customer Impact
+
+        - [ ] Customer reported
+        - [ ] Found internally
+
+        [Select one or both of the boxes. Describe how this issue impacts customers, citing the expected and actual behaviors and scope of the issue. If customer-reported, provide the issue number.]
+
+        ## Regression
+
+        - [ ] Yes
+        - [ ] No
+
+        [If yes, specify when the regression was introduced. Provide the PR or commit if known.]
+
+        ## Testing
+
+        [How was the fix verified? How was the issue missed previously? What tests were added?]
+
+        ## Risk
+
+        [High/Medium/Low. Justify the indication by mentioning how risks were measured and addressed.]
+

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -42,7 +42,7 @@ jobs:
     if: ${{ contains(github.event.comment.body, '/backport to') || github.event_name == 'schedule' }}
     uses: dotnet/arcade/.github/workflows/backport-base.yml@main
     with:
-      repository_owners: 'powershell,travisez13'
+      repository_owners: 'powershell'
       pr_description_template: |
         Backport of #%source_pr_number% to %target_branch%
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,7 +24,7 @@ jobs:
             const match = comment.match(/\/backport to release\/v(.*)/);
             
             if (match) {
-              const version = match;
+              const version = match[1];
               const result = `Backport-${version}.x-Consider`;
               console.log(result);
             } else {

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,13 +25,12 @@ jobs:
             
             if (match) {
               const version = match[1];
-              const result = `Backport-${version}.x-Consider`;
+              const label = `Backport-${version}.x-Consider`;
               console.log(result);
             } else {
               throw new Error("No version found in comment");
             }
             
-            const label = "Backport-${version}.x-Consider";
             github.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,11 +13,37 @@ permissions:
   actions: write
 
 jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const comment = context.payload.comment.body;
+            const match = comment.match(/\/backport to release\/v(.*)/);
+            
+            if (match) {
+              const version = match;
+              const result = `Backport-${version}.x-Consider`;
+              console.log(result);
+            } else {
+              throw new Error("No version found in comment");
+            }
+            
+            const label = "Backport-${version}.x-Consider";
+            github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["LABEL_NAME"]
+            })
   backport:
+    needs: label
     if: ${{ contains(github.event.comment.body, '/backport to') || github.event_name == 'schedule' }}
     uses: dotnet/arcade/.github/workflows/backport-base.yml@main
     with:
-      repository_owners: powershell
+      repository_owners: 'powershell,travisez13'
       pr_description_template: |
         Backport of #%source_pr_number% to %target_branch%
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,7 +36,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: ["LABEL_NAME"]
+              labels: [label]
             })
   backport:
     needs: label


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary


This pull request introduces a new GitHub Actions workflow to automate the backporting of pull requests to specific branches. The most important changes include the addition of a new workflow file and the configuration of job permissions and triggers.

New GitHub Actions workflow:

* [`.github/workflows/backport.yml`](diffhunk://#diff-1b2ad8b0da1ad4fac7eb4ef8cdeed82b48d00a80eb531a6f31db11f73182f491R1-R49): Added a new workflow to backport pull requests based on issue comments or a scheduled cron job. The workflow includes permissions settings and uses a template for the pull request description.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
