### PR TITLE
Use parameter HelpMessage for tool tip completion

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -865,9 +865,9 @@ namespace System.Management.Automation
             {
                 return ResourceManagerCache.GetResourceString(assembly, attr.HelpMessageBaseName, attr.HelpMessageResourceId)?.Trim();
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                return $"Failed to find the help message: {e.Message}";
+                return null;
             }
         }
 #nullable disable

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -671,9 +671,9 @@ namespace System.Management.Automation
             Diagnostics.Assert(bindingInfo.InfoType.Equals(PseudoBindingInfoType.PseudoBindingSucceed), "The pseudo binding should succeed");
             List<CompletionResult> result = new List<CompletionResult>();
             Assembly commandAssembly = null;
-            if (bindingInfo.CommandInfo is CmdletInfo)
+            if (bindingInfo.CommandInfo is CmdletInfo cmdletInfo)
             {
-                commandAssembly = bindingInfo.CommandInfo.CommandMetadata.CommandType.Assembly;
+                commandAssembly = cmdletInfo.CommandMetadata.CommandType.Assembly;
             }
 
             if (parameterName == string.Empty)
@@ -812,7 +812,7 @@ namespace System.Management.Automation
             string colonSuffix = withColon ? ":" : string.Empty;
             if (pattern.IsMatch(matchedParameterName))
             {
-                string completionText = "-" + matchedParameterName + colonSuffix;
+                string completionText = $"-{matchedParameterName}{colonSuffix}";
                 string tooltip = $"{parameterType}{matchedParameterName}{helpMessage}";
                 result.Add(new CompletionResult(completionText, matchedParameterName, CompletionResultType.ParameterName, tooltip));
             }
@@ -938,7 +938,7 @@ namespace System.Management.Automation
 
                     if (showToUser)
                     {
-                        string completionText = "-" + name + colonSuffix;
+                        string completionText = $"-{name}{colonSuffix}";
                         string tooltip = $"{type}{name}{helpMessage}";
                         listInUse.Add(new CompletionResult(completionText, name, CompletionResultType.ParameterName,
                                                            tooltip));

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -802,7 +802,10 @@ namespace System.Management.Automation
                         helpMessage = GetParameterHelpMessage(
                             pattr,
                             commandAssembly);
-                        break;
+                        if (!string.IsNullOrEmpty(helpMessage))
+                        {
+                            break;
+                        }
                     }
                 }
             }
@@ -919,14 +922,17 @@ namespace System.Management.Automation
                             {
                                 continue;
                             }
-
-                            helpMessage = GetParameterHelpMessage(pattr, commandAssembly);
                             if (pattr.DontShow)
                             {
                                 showToUser = false;
                                 addCommonParameters = false;
+                                break;
                             }
-                            break;
+
+                            if (string.IsNullOrWhiteSpace(helpMessage))
+                            {
+                                helpMessage = GetParameterHelpMessage(pattr, commandAssembly);    
+                            }
                         }
                     }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -670,7 +670,11 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(bindingInfo.InfoType.Equals(PseudoBindingInfoType.PseudoBindingSucceed), "The pseudo binding should succeed");
             List<CompletionResult> result = new List<CompletionResult>();
-            Assembly commandAssembly = bindingInfo.CommandInfo.CommandMetadata.CommandType.Assembly;
+            Assembly commandAssembly = null;
+            if (bindingInfo.CommandInfo is CmdletInfo)
+            {
+                commandAssembly = bindingInfo.CommandInfo.CommandMetadata.CommandType.Assembly;
+            }
 
             if (parameterName == string.Empty)
             {
@@ -809,7 +813,7 @@ namespace System.Management.Automation
             if (pattern.IsMatch(matchedParameterName))
             {
                 string completionText = "-" + matchedParameterName + colonSuffix;
-                string tooltip = parameterType + matchedParameterName + helpMessage;
+                string tooltip = $"{parameterType}{matchedParameterName}{helpMessage}";
                 result.Add(new CompletionResult(completionText, matchedParameterName, CompletionResultType.ParameterName, tooltip));
             }
             else
@@ -823,7 +827,7 @@ namespace System.Management.Automation
                             $"-{alias}{colonSuffix}",
                             alias,
                             CompletionResultType.ParameterName,
-                            parameterType + alias + helpMessage));
+                            $"{parameterType}{alias}{helpMessage}"));
                     }
                 }
             }
@@ -899,7 +903,7 @@ namespace System.Management.Automation
 
                 string name = param.Parameter.Name;
                 string type = "[" + ToStringCodeMethods.Type(param.Parameter.Type, dropNamespaces: true) + "] ";
-                string helpMessage = string.Empty;
+                string helpMessage = null;
                 bool isCommonParameter = Cmdlet.CommonParameters.Contains(name, StringComparer.OrdinalIgnoreCase);
                 List<CompletionResult> listInUse = isCommonParameter ? commonParamResult : result;
 
@@ -924,7 +928,7 @@ namespace System.Management.Automation
                                     break;
                                 }
                                 
-                                if (helpMessage is not null && TryGetParameterHelpMessage(pattr, commandAssembly, out string attrHelpMessage))
+                                if (helpMessage is null && TryGetParameterHelpMessage(pattr, commandAssembly, out string attrHelpMessage))
                                 {
                                     helpMessage = $" - {attrHelpMessage}";
                                 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1228,6 +1228,52 @@ param([ValidatePattern(
         $res.CompletionText | Should -BeExactly '-Activity'
         $res.ToolTip | Should -BeExactly $expected
     }
+    
+    It 'Should use first valid HelpMessage with multiple parameter attributes by direct match' {
+        Function Test-Function {
+            [CmdletBinding(DefaultParameterSetName = 'Default')]
+            param (
+                [Parameter(ParameterSetName = 'Foo', HelpMessage = 'Foo')]
+                [Parameter(ParameterSetName = 'Default')]
+                [string]
+                $Param,
+                
+                [Parameter(ParameterSetName = 'Foo')]
+                [switch]
+                $Foo
+            )
+        }
+        
+        $expected = '[string] Param - Foo'
+        $Script = 'Test-Function -Param'
+        $res = (TabExpansion2 -inputScript $Script).CompletionMatches
+        $res.Count | Should -Be 1
+        $res.CompletionText | Should -BeExactly '-Param'
+        $res.ToolTip | Should -BeExactly $expected
+    }
+    
+    It 'Should use first valid HelpMessage with multiple parameter attributes by multiple match' {
+        Function Test-Function {
+            [CmdletBinding(DefaultParameterSetName = 'Default')]
+            param (
+                [Parameter(ParameterSetName = 'Foo', HelpMessage = 'Foo')]
+                [Parameter(ParameterSetName = 'Default')]
+                [string]
+                $Param,
+                
+                [Parameter(ParameterSetName = 'Foo')]
+                [switch]
+                $Foo
+            )
+        }
+        
+        $expected = '[string] Param - Foo'
+        $Script = 'Test-Function -'
+        $res = (TabExpansion2 -inputScript $Script).CompletionMatches | Where-Object CompletionText -eq '-Param'
+        $res.Count | Should -Be 1
+        $res.CompletionText | Should -BeExactly '-Param'
+        $res.ToolTip | Should -BeExactly $expected
+    }
 
     Context 'Start-Process -Verb parameter completion' {
         BeforeAll {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1192,41 +1192,41 @@ param([ValidatePattern(
         Function Test-Function {
             param (
                 [Parameter()]
-                $WithAttribute,
+                $WithParamAttribute,
 
-                $WithoutAttribute
+                $WithoutParamAttribute
             )
         }
 
         $Script = 'Test-Function -'
         $res = (TabExpansion2 -inputScript $Script).CompletionMatches |
-            Where-Object CompletionText -in '-WithAttribute', '-WithoutAttribute' |
+            Where-Object CompletionText -in '-WithParamAttribute', '-WithoutParamAttribute' |
             Sort-Object CompletionText
         $res.Count | Should -Be 2
 
-        $res.CompletionText[0] | Should -BeExactly '-WithAttribute'
-        $res.ToolTip[0] | Should -BeExactly '[Object] WithAttribute'
+        $res.CompletionText[0] | Should -BeExactly '-WithoutParamAttribute'
+        $res.ToolTip[0] | Should -BeExactly '[Object] WithoutParamAttribute'
 
-        $res.CompletionText[1] | Should -BeExactly '-WithoutAttribute'
-        $res.ToolTip[1] | Should -BeExactly '[Object] WithoutAttribute'
+        $res.CompletionText[1] | Should -BeExactly '-WithParamAttribute'
+        $res.ToolTip[1] | Should -BeExactly '[Object] WithParamAttribute'
     }
 
     It 'Should include help resource message in parameter tool tip by direct match' {
-        $expected = '[string] Activity - Text to describe the activity for which progress is being reported.'
+        $expected = '`[string`] Activity - *'
         $Script = 'Write-Progress -Activity'
         $res = (TabExpansion2 -inputScript $Script).CompletionMatches
         $res.Count | Should -Be 1
         $res.CompletionText | Should -BeExactly '-Activity'
-        $res.ToolTip | Should -BeExactly $expected
+        $res.ToolTip | Should -BeLikeExactly $expected
     }
 
     It 'Should include help resource message in parameter tool tip by multiple matches' {
-        $expected = '[string] Activity - Text to describe the activity for which progress is being reported.'
+        $expected = '`[string`] Activity - *'
         $Script = 'Write-Progress -'
         $res = (TabExpansion2 -inputScript $Script).CompletionMatches | Where-Object CompletionText -eq '-Activity'
         $res.Count | Should -Be 1
         $res.CompletionText | Should -BeExactly '-Activity'
-        $res.ToolTip | Should -BeExactly $expected
+        $res.ToolTip | Should -BeLikeExactly $expected
     }
     
     It 'Should use first valid HelpMessage with multiple parameter attributes by direct match' {
@@ -1272,6 +1272,22 @@ param([ValidatePattern(
         $res = (TabExpansion2 -inputScript $Script).CompletionMatches | Where-Object CompletionText -eq '-Param'
         $res.Count | Should -Be 1
         $res.CompletionText | Should -BeExactly '-Param'
+        $res.ToolTip | Should -BeExactly $expected
+    }
+    
+    It 'Should ignore errors when faling to get HelpMessage resource' {
+        Function Test-Function {
+            param (
+                [Parameter(HelpMessageBaseName="invalid", HelpMessageResourceId="SomeId")]
+                $Foo
+            )
+        }
+        
+        $expected = '[Object] Foo'
+        $Script = 'Test-Function -Foo'
+        $res = (TabExpansion2 -inputScript $Script).CompletionMatches
+        $res.Count | Should -Be 1
+        $res.CompletionText | Should -BeExactly '-Foo'
         $res.ToolTip | Should -BeExactly $expected
     }
 


### PR DESCRIPTION
# PR Summary
Use the help message on the parameter in the completion tool tip to provide better completion help. This can be utilised by other tools to provide more context for a parameter outside of the current type and parameter name which is quite minimal.

## PR Context
The current tool tip provided by `MenuComplete` for parameter is not too useful as it has just the parameter name and type. With this change it will also include the `HelpMessage` (or `HelpMessageBaseName` and `HelpMessageResourceId` on compiled cmdlets).

For example here is the output of `Write-Progress` today

![image](https://github.com/user-attachments/assets/8f0e9715-5775-4cb8-9fef-3cf3d6b1e17a)

Now this is the output with the changes in this PR.

![image](https://github.com/user-attachments/assets/2f6bb58e-b2bd-4130-b67a-7bcef1b5158b)

I went with using `HelpMessage` for a few reasons:

+ It's available in the completion code so no expensive lookups
+ It can be used for dynamic parameters as they build the `ParameterAttribute` at runtime
+ The constraints around attribute field strings would mean it would most likely be a shortened description making it nice for the console to display

The final point I think is pretty important as CBH or MAML help could have quite long descriptions for a parameter which can be messy to display in the console. By having the `HelpMessage` set we can reserve the more detailed help for things like `Get-Help` to show but use this attribute field for things that display the tool tip (tip being short here).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
