### PR TITLE
Fix edge cases in CSV cmdlets

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -70,7 +70,7 @@ a,b,c
 
 Describe "ConvertFrom-Csv DRT Unit Tests" -Tags "CI" {
     It "Test ConvertFrom-Csv with pipelined InputObject and Header" {
-        $inputObject = [pscustomobject]@{ First = 1; Second = 2 }
+        $inputObject = [PSCustomObject]@{ First = 1; Second = 2 }
         $res = $inputObject | ConvertTo-Csv
         $result = $res | ConvertFrom-Csv -Header "Header1","Header2"
 
@@ -78,5 +78,119 @@ Describe "ConvertFrom-Csv DRT Unit Tests" -Tags "CI" {
         $result[0].Header2 | Should -BeExactly "Second"
         $result[1].Header1 | Should -BeExactly "1"
         $result[1].Header2 | Should -BeExactly "2"
+    }
+}
+
+Describe "ConvertFrom-Csv with empty and null values" -Tags "CI" {
+    It 'ConvertFrom-Csv correctly deserializes input CSV - <Test>' -TestCases  @(
+        @{
+            Test     = '1a'
+            Expected = [PSCustomObject] @{ P1 = '' }
+            InputCsv = @'
+"P1"
+""
+'@
+        }
+        @{
+            Test     = '1b'
+            Expected = [PSCustomObject] @{ P1 = '' }, [PSCustomObject] @{ P1 = '' }, [PSCustomObject] @{ P1 = '' }
+            InputCsv = @'
+"P1"
+""
+""
+""
+'@
+        }
+        @{
+            Test     = '2a'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = $null }
+            InputCsv = @'
+"P1","P2"
+"",
+'@
+        }
+        @{
+            Test     = '2b'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = '' }, [PSCustomObject] @{ P1 = ''; P2 = $null }
+            InputCsv = @'
+"P1","P2"
+"",
+"",
+'@
+        }
+        @{
+            Test     = '3a'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = $null }
+            InputCsv = @'
+"P1","P2"
+,
+'@
+        }
+        @{
+            Test     = '3b'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = '' }, [PSCustomObject] @{ P1 = ''; P2 = $null }
+            InputCsv = @'
+"P1","P2"
+,
+,
+'@
+        }
+        @{
+            Test     = '4a'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = '' }
+            InputCsv = @'
+"P1","P2"
+,""
+'@
+        }
+        @{
+            Test     = '4b'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = '' }, [PSCustomObject] @{ P1 = ''; P2 = '' }
+            InputCsv = @'
+"P1","P2"
+,""
+,""
+'@
+        }
+        @{
+            Test     = '5a'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = '' }
+            InputCsv = @'
+"P1","P2"
+"",""
+'@
+        }
+        @{
+            Test     = '5b'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = '' }, [PSCustomObject] @{ P1 = ''; P2 = '' }
+            InputCsv = @'
+"P1","P2"
+"",""
+"",""
+'@
+        }
+        @{
+            Test     = '6a'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = ''; P3 = $null }
+            InputCsv = @'
+"P1","P2","P3"
+,,
+'@
+        }
+        @{
+            Test     = '6b'
+            Expected = [PSCustomObject] @{ P1 = ''; P2 = ''; P3 = '' }, [PSCustomObject] @{ P1 = ''; P2 = ''; P3 = $null }
+            InputCsv = @'
+"P1","P2","P3"
+,,
+,,
+'@
+        }
+        ) {
+        param($Test, $Expected, $InputCsv)
+        $expectedResult = $Expected | ConvertTo-Csv
+        $actualResult = $InputCsv | ConvertFrom-Csv | ConvertTo-Csv
+
+        $actualResult | Should -BeExactly $expectedResult
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -171,7 +171,7 @@ Describe "Import-Csv with different newlines" -Tags "CI" {
         param($newline)
         $csvFile = Join-Path $TestDrive -ChildPath $((New-Guid).Guid)
         $delimiter = ','
-        "h1,h2,h3$($newline)11,12,13$($newline)21,22,23$($newline)" | Out-File -FilePath $csvFile
+        "h1,h2,h3$($newline)11,12,13$($newline)$($newline)21,22,23$($newline)" | Out-File -FilePath $csvFile
         $returnObject = Import-Csv -Path $csvFile -Delimiter $delimiter
         $returnObject.Count | Should -Be 2
         $returnObject[0].h1 | Should -Be 11


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
