### PR TITLE
Move common helper methods to `CompletionHelpers` class and refactor existing quoting code for matching results

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.Commands
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
                 => IsRegistryProvider(fakeBoundParameters)
-                    ? CompletionCompleters.GetMatchingResults(
+                    ? CompletionHelpers.GetMatchingResults(
                         wordToComplete,
                         possibleCompletionValues: s_RegistryPropertyTypes,
                         toolTipMapping: GetRegistryPropertyTypeToolTip,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2736,7 +2736,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="filePath">The file path to get verbs.</param>
         /// <returns>List of file verbs to complete.</returns>
         private static IEnumerable<CompletionResult> CompleteFileVerbs(string wordToComplete, string filePath)
-            => CompletionCompleters.GetMatchingResults(
+            => CompletionHelpers.GetMatchingResults(
                 wordToComplete,
                 possibleCompletionValues: new ProcessStartInfo(filePath).Verbs);
     }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8594,10 +8594,11 @@ namespace System.Management.Automation
             bool escapeGlobbingPathChars = false)
         {
             string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
 
             foreach (string value in possibleCompletionValues)
             {
-                if (value.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
+                if (pattern.IsMatch(value))
                 {
                     string completionText = QuoteCompletionText(completionText: value, quote, escapeGlobbingPathChars);
                     string listItemText = value;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -89,7 +89,7 @@ namespace System.Management.Automation
             var addAmpersandIfNecessary = IsAmpersandNeeded(context, false);
 
             string commandName = context.WordToComplete;
-            string quote = HandleDoubleAndSingleQuote(ref commandName);
+            string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref commandName);
 
             List<CompletionResult> commandResults = null;
 
@@ -234,7 +234,7 @@ namespace System.Management.Automation
             syntax = string.IsNullOrEmpty(syntax) ? name : syntax;
             bool needAmpersand;
 
-            if (CompletionRequiresQuotes(name, false))
+            if (CompletionHelpers.CompletionRequiresQuotes(name, escapeGlobbingPathChars: false))
             {
                 needAmpersand = quote == string.Empty && addAmpersandIfNecessary;
                 string quoteInUse = quote == string.Empty ? "'" : quote;
@@ -443,7 +443,7 @@ namespace System.Management.Automation
         {
             var wordToComplete = context.WordToComplete ?? string.Empty;
             var result = new List<CompletionResult>();
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             // Indicates if we should search for modules where the last part of the name matches the input text
             // eg: Host<Tab> finds Microsoft.PowerShell.Host
@@ -524,7 +524,7 @@ namespace System.Management.Automation
                                   + moduleInfo.ModuleType.ToString() + "\r\nPath: "
                                   + moduleInfo.Path;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -1809,7 +1809,7 @@ namespace System.Management.Automation
                     RemoveLastNullCompletionResult(result);
 
                     string wordToComplete = context.WordToComplete ?? string.Empty;
-                    string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+                    string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
                     var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
                     var setList = new List<string>();
@@ -1846,7 +1846,7 @@ namespace System.Management.Automation
                         string completionText = entry;
                         if (quote == string.Empty)
                         {
-                            if (CompletionRequiresQuotes(entry, false))
+                            if (CompletionHelpers.CompletionRequiresQuotes(entry, escapeGlobbingPathChars: false))
                             {
                                 realEntry = CodeGeneration.EscapeSingleQuotedStringContent(entry);
                                 completionText = "'" + realEntry + "'";
@@ -1886,7 +1886,7 @@ namespace System.Management.Automation
                 }
 
                 string wordToComplete = context.WordToComplete ?? string.Empty;
-                string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+                string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
                 var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
                 var enumList = new List<string>();
@@ -3198,7 +3198,7 @@ namespace System.Management.Automation
                 RemoveLastNullCompletionResult(result);
 
                 var logName = context.WordToComplete ?? string.Empty;
-                var quote = HandleDoubleAndSingleQuote(ref logName);
+                var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref logName);
 
                 if (!logName.EndsWith('*'))
                 {
@@ -3220,7 +3220,7 @@ namespace System.Management.Automation
                         var completionText = eventLog.Log.ToString();
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3249,7 +3249,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3311,7 +3311,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3336,7 +3336,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3386,7 +3386,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3470,7 +3470,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3526,7 +3526,7 @@ namespace System.Management.Automation
                         continue;
 
                     uniqueSet.Add(completionText);
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3561,7 +3561,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var providerName = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref providerName);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref providerName);
 
             if (!providerName.EndsWith('*'))
             {
@@ -3579,7 +3579,7 @@ namespace System.Management.Automation
                 var completionText = providerInfo.Name;
                 var listItemText = completionText;
 
-                if (CompletionRequiresQuotes(completionText, false))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")
@@ -3605,7 +3605,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3627,7 +3627,7 @@ namespace System.Management.Automation
                     var completionText = driveInfo.Name;
                     var listItemText = completionText;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3652,7 +3652,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3678,7 +3678,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.DisplayName;
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3709,7 +3709,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3739,7 +3739,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var variableName = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref variableName);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref variableName);
             if (!variableName.EndsWith('*'))
             {
                 variableName += "*";
@@ -3765,7 +3765,8 @@ namespace System.Management.Automation
                     completionText = completionText.Replace("*", "`*");
                 }
 
-                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionRequiresQuotes(completionText, false))
+                if (!completionText.Equals("$", StringComparison.Ordinal)
+                    && CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                 {
                     var quoteInUse = effectiveQuote == string.Empty ? "'" : effectiveQuote;
                     if (quoteInUse == "'")
@@ -3798,7 +3799,7 @@ namespace System.Management.Automation
             if (paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
                 var commandName = context.WordToComplete ?? string.Empty;
-                var quote = HandleDoubleAndSingleQuote(ref commandName);
+                var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref commandName);
 
                 if (!commandName.EndsWith('*'))
                 {
@@ -3815,7 +3816,7 @@ namespace System.Management.Automation
                         var completionText = aliasInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3859,7 +3860,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var traceSourceName = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref traceSourceName);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref traceSourceName);
 
             if (!traceSourceName.EndsWith('*'))
             {
@@ -3878,7 +3879,7 @@ namespace System.Management.Automation
                 var completionText = trace.Name;
                 var listItemText = completionText;
 
-                if (CompletionRequiresQuotes(completionText, false))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText, escapeGlobbingPathChars: false))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")
@@ -4493,7 +4494,7 @@ namespace System.Management.Automation
         internal static IEnumerable<CompletionResult> CompleteFilename(CompletionContext context, bool containerOnly, HashSet<string> extension)
         {
             var wordToComplete = context.WordToComplete;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             // Matches file shares with and without the provider name and with either slash direction.
             // Avoids matching Windows device paths like \\.\CDROM0 and \\?\Volume{b8f3fc1c-5cd6-4553-91e2-d6814c4cd375}\
@@ -6936,7 +6937,7 @@ namespace System.Management.Automation
             Diagnostics.Assert(controlBodyType is not null, "This should never happen unless a new Format-* cmdlet is added");
 
             var wordToComplete = context.WordToComplete;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
             WildcardPattern viewPattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
 
             var uniqueNames = new HashSet<string>();
@@ -8544,73 +8545,6 @@ namespace System.Management.Automation
             return null;
         }
 
-        internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
-        {
-            string quote = string.Empty;
-
-            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
-            {
-                char frontQuote = wordToComplete[0];
-                int length = wordToComplete.Length;
-
-                if (length == 1)
-                {
-                    wordToComplete = string.Empty;
-                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                }
-                else if (length > 1)
-                {
-                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
-                    {
-                        wordToComplete = wordToComplete.Substring(1, length - 2);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
-                    {
-                        wordToComplete = wordToComplete.Substring(1);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                }
-            }
-
-            return quote;
-        }
-
-        /// <summary>
-        /// Get matching completions from word to complete.
-        /// This makes it easier to handle different variations of completions with consideration of quotes.
-        /// </summary>
-        /// <param name="wordToComplete">The word to complete.</param>
-        /// <param name="possibleCompletionValues">The possible completion values to iterate.</param>
-        /// <param name="toolTipMapping">The optional tool tip mapping delegate.</param>
-        /// <param name="listItemTextMapping">The optional list item text mapping delegate.</param>
-        /// <param name="resultType">The optional completion result type. Default is Text.</param>
-        /// <param name="escapeGlobbingPathChars">The optional toggle to escape globbing path chars.</param>
-        /// <returns>Collection of matched completion results.</returns>
-        internal static IEnumerable<CompletionResult> GetMatchingResults(
-            string wordToComplete,
-            IEnumerable<string> possibleCompletionValues,
-            Func<string, string> toolTipMapping = null,
-            Func<string, string> listItemTextMapping = null,
-            CompletionResultType resultType = CompletionResultType.Text,
-            bool escapeGlobbingPathChars = false)
-        {
-            string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
-            var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
-
-            foreach (string value in possibleCompletionValues)
-            {
-                if (!string.IsNullOrEmpty(value) && pattern.IsMatch(value))
-                {
-                    string completionText = QuoteCompletionText(completionText: value, quote, escapeGlobbingPathChars);
-                    string listItemText = listItemTextMapping?.Invoke(value) ?? value;
-                    string toolTip = toolTipMapping?.Invoke(value) ?? value;
-
-                    yield return new CompletionResult(completionText, listItemText, resultType, toolTip);
-                }
-            }
-        }
-
         /// <summary>
         /// Calls Get-Command to get command info objects.
         /// </summary>
@@ -8806,74 +8740,6 @@ namespace System.Management.Automation
             }
 
             return false;
-        }
-
-        private static readonly SearchValues<char> s_defaultCharsToCheck = SearchValues.Create("$`");
-        private static readonly SearchValues<char> s_escapeGlobbingPathCharsToCheck = SearchValues.Create("$[]`");
-
-        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escapeGlobbingPathChars)
-            => text.ContainsAny(escapeGlobbingPathChars ? s_escapeGlobbingPathCharsToCheck : s_defaultCharsToCheck);
-
-        internal static bool CompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars)
-        {
-            // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
-            // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
-
-            Parser.ParseInput(completion, out Token[] tokens, out ParseError[] errors);
-
-            // Expect no errors and 2 tokens (1 is for our completion, the other is eof)
-            // Or if the completion is a keyword, we ignore the errors
-            bool requireQuote = !(errors.Length == 0 && tokens.Length == 2);
-            if ((!requireQuote && tokens[0] is StringToken) ||
-                (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
-            {
-                requireQuote = ContainsCharsToCheck(tokens[0].Text, escapeGlobbingPathChars);
-            }
-
-            return requireQuote;
-        }
-
-        /// <summary>
-        /// Quotes and optionally escapes the specified completion text based on the provided parameters.
-        /// </summary>
-        /// <param name="completionText">
-        /// The text to be quoted and potentially escaped.
-        /// </param>
-        /// <param name="quote">
-        /// The quote character to use for quoting the completion text. If this is null or empty,
-        /// a single quote character (<c>'</c>) is used by default.
-        /// </param>
-        /// <param name="escapeGlobbingPathChars">
-        /// A boolean value indicating whether globbing path characters should be escaped.
-        /// If <c>true</c>, globbing-specific escape sequences will be applied to the text.
-        /// </param>
-        /// <returns>
-        /// The quoted (and optionally escaped) version of the provided completion text.
-        /// </returns>
-        internal static string QuoteCompletionText(
-            string completionText,
-            string quote,
-            bool escapeGlobbingPathChars)
-        {
-            if (CompletionRequiresQuotes(completionText, escapeGlobbingPathChars))
-            {
-                string quoteInUse = string.IsNullOrEmpty(quote) ? "'" : quote;
-
-                completionText = quoteInUse == "'"
-                    ? completionText.Replace("'", "''")
-                    : completionText.Replace("`", "``").Replace("$", "`$");
-
-                if (escapeGlobbingPathChars)
-                {
-                    completionText = quoteInUse == "'"
-                        ? completionText.Replace("[", "`[").Replace("]", "`]")
-                        : completionText.Replace("[", "``[").Replace("]", "``]");
-                }
-
-                return quoteInUse + completionText + quoteInUse;
-            }
-
-            return quote + completionText + quote;
         }
 
         private static bool ProviderSpecified(string path)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8600,7 +8600,7 @@ namespace System.Management.Automation
 
             foreach (string value in possibleCompletionValues)
             {
-                if (pattern.IsMatch(value))
+                if (!string.IsNullOrEmpty(value) && pattern.IsMatch(value))
                 {
                     string completionText = QuoteCompletionText(completionText: value, quote, escapeGlobbingPathChars);
                     string listItemText = listItemTextMapping?.Invoke(value) ?? value;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8583,6 +8583,7 @@ namespace System.Management.Automation
         /// <param name="wordToComplete">The word to complete.</param>
         /// <param name="possibleCompletionValues">The possible completion values to iterate.</param>
         /// <param name="toolTipMapping">The optional tool tip mapping delegate.</param>
+        /// <param name="listItemTextMapping">The optional list item text mapping delegate.</param>
         /// <param name="resultType">The optional completion result type. Default is Text.</param>
         /// <param name="escapeGlobbingPathChars">The optional toggle to escape globbing path chars.</param>
         /// <returns></returns>
@@ -8590,6 +8591,7 @@ namespace System.Management.Automation
             string wordToComplete,
             IEnumerable<string> possibleCompletionValues,
             Func<string, string> toolTipMapping = null,
+            Func<string, string> listItemTextMapping = null,
             CompletionResultType resultType = CompletionResultType.Text,
             bool escapeGlobbingPathChars = false)
         {
@@ -8601,7 +8603,7 @@ namespace System.Management.Automation
                 if (pattern.IsMatch(value))
                 {
                     string completionText = QuoteCompletionText(completionText: value, quote, escapeGlobbingPathChars);
-                    string listItemText = value;
+                    string listItemText = listItemTextMapping?.Invoke(value) ?? value;
                     string toolTip = toolTipMapping?.Invoke(value) ?? value;
 
                     yield return new CompletionResult(completionText, listItemText, resultType, toolTip);

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -8586,7 +8586,7 @@ namespace System.Management.Automation
         /// <param name="listItemTextMapping">The optional list item text mapping delegate.</param>
         /// <param name="resultType">The optional completion result type. Default is Text.</param>
         /// <param name="escapeGlobbingPathChars">The optional toggle to escape globbing path chars.</param>
-        /// <returns></returns>
+        /// <returns>Collection of matched completion results.</returns>
         internal static IEnumerable<CompletionResult> GetMatchingResults(
             string wordToComplete,
             IEnumerable<string> possibleCompletionValues,

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -73,34 +73,40 @@ namespace System.Management.Automation
         /// </remarks>
         internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
         {
-            string quote = string.Empty;
-
-            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
+            if (string.IsNullOrEmpty(wordToComplete))
             {
-                char frontQuote = wordToComplete[0];
-                int length = wordToComplete.Length;
-
-                if (length == 1)
-                {
-                    wordToComplete = string.Empty;
-                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                }
-                else if (length > 1)
-                {
-                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
-                    {
-                        wordToComplete = wordToComplete.Substring(1, length - 2);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
-                    {
-                        wordToComplete = wordToComplete.Substring(1);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                }
+                return string.Empty;
             }
 
-            return quote;
+            char frontQuote = wordToComplete[0];
+
+            bool hasFrontQuote = frontQuote.IsSingleQuote() || frontQuote.IsDoubleQuote();
+
+            if (!hasFrontQuote)
+            {
+                return string.Empty;
+            }
+
+            string quoteInUse = frontQuote.IsSingleQuote() ? "'" : "\"";
+
+            int length = wordToComplete.Length;
+
+            if (length == 1)
+            {
+                wordToComplete = string.Empty;
+                return quoteInUse;
+            }
+
+            char backQuote = wordToComplete[length - 1];
+
+            bool hasFrontAndBackSingleQuote = frontQuote.IsSingleQuote() && backQuote.IsSingleQuote();
+            bool hasFrontAndBackDoubleQuote = frontQuote.IsDoubleQuote() && backQuote.IsDoubleQuote();
+
+            wordToComplete = hasFrontAndBackSingleQuote || hasFrontAndBackDoubleQuote
+                ? wordToComplete.Substring(1, length - 2)
+                : wordToComplete.Substring(1);
+
+            return quoteInUse;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -73,40 +73,34 @@ namespace System.Management.Automation
         /// </remarks>
         internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
         {
-            if (string.IsNullOrEmpty(wordToComplete))
+            string quote = string.Empty;
+
+            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
             {
-                return string.Empty;
+                char frontQuote = wordToComplete[0];
+                int length = wordToComplete.Length;
+
+                if (length == 1)
+                {
+                    wordToComplete = string.Empty;
+                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                }
+                else if (length > 1)
+                {
+                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
+                    {
+                        wordToComplete = wordToComplete.Substring(1, length - 2);
+                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                    }
+                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
+                    {
+                        wordToComplete = wordToComplete.Substring(1);
+                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                    }
+                }
             }
 
-            char frontQuote = wordToComplete[0];
-
-            bool hasFrontQuote = frontQuote.IsSingleQuote() || frontQuote.IsDoubleQuote();
-
-            if (!hasFrontQuote)
-            {
-                return string.Empty;
-            }
-
-            string quoteInUse = frontQuote.IsSingleQuote() ? "'" : "\"";
-
-            int length = wordToComplete.Length;
-
-            if (length == 1)
-            {
-                wordToComplete = string.Empty;
-                return quoteInUse;
-            }
-
-            char backQuote = wordToComplete[length - 1];
-
-            bool hasFrontAndBackSingleQuote = frontQuote.IsSingleQuote() && backQuote.IsSingleQuote();
-            bool hasFrontAndBackDoubleQuote = frontQuote.IsDoubleQuote() && backQuote.IsDoubleQuote();
-
-            wordToComplete = hasFrontAndBackSingleQuote || hasFrontAndBackDoubleQuote
-                ? wordToComplete.Substring(1, length - 2)
-                : wordToComplete.Substring(1);
-
-            return quoteInUse;
+            return quote;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+
+namespace System.Management.Automation
+{
+    /// <summary>
+    /// Shared helper class for common completion helper methods.
+    /// </summary>
+    internal static class CompletionHelpers
+    {
+        /// <summary>
+        /// Defines the default set of characters to check for quoting.
+        /// </summary>
+        private static readonly SearchValues<char> s_defaultCharsToCheck = SearchValues.Create("$`");
+
+        /// <summary>
+        /// Defines the set of characters to check for quoting when escaping globbing path characters.
+        /// </summary>
+        private static readonly SearchValues<char> s_escapeGlobbingPathCharsToCheck = SearchValues.Create("$[]`");
+
+        /// <summary>
+        /// Get matching completions from word to complete.
+        /// This makes it easier to handle different variations of completions with consideration of quotes.
+        /// </summary>
+        /// <param name="wordToComplete">The word to complete.</param>
+        /// <param name="possibleCompletionValues">The possible completion values to iterate.</param>
+        /// <param name="toolTipMapping">The optional tool tip mapping delegate.</param>
+        /// <param name="listItemTextMapping">The optional list item text mapping delegate.</param>
+        /// <param name="resultType">The optional completion result type. Default is Text.</param>
+        /// <param name="escapeGlobbingPathChars">The optional toggle to escape globbing path chars.</param>
+        /// <returns>Collection of matched completion results.</returns>
+        internal static IEnumerable<CompletionResult> GetMatchingResults(
+            string wordToComplete,
+            IEnumerable<string> possibleCompletionValues,
+            Func<string, string> toolTipMapping = null,
+            Func<string, string> listItemTextMapping = null,
+            CompletionResultType resultType = CompletionResultType.Text,
+            bool escapeGlobbingPathChars = false)
+        {
+            string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
+
+            foreach (string value in possibleCompletionValues)
+            {
+                if (!string.IsNullOrEmpty(value) && pattern.IsMatch(value))
+                {
+                    string completionText = QuoteCompletionText(completionText: value, quote, escapeGlobbingPathChars);
+                    string listItemText = listItemTextMapping?.Invoke(value) ?? value;
+                    string toolTip = toolTipMapping?.Invoke(value) ?? value;
+
+                    yield return new CompletionResult(completionText, listItemText, resultType, toolTip);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Processes a given string to handle leading and trailing single or double quotes.
+        /// </summary>
+        /// <param name="wordToComplete">A reference to the string to process. 
+        /// If the input starts and ends with matching quotes, the quotes are removed.
+        /// If only the starting quote exists, it is retained.</param>
+        /// <returns>
+        /// A string representing the type of quote that was removed ("'" for single quote or "\"" for double quote),
+        /// or an empty string if no quote was processed.
+        /// </returns>
+        /// <remarks>
+        /// The method ensures that quotes are properly identified and handled based on their position and type.
+        /// The input string is modified in-place.
+        /// </remarks>
+        internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
+        {
+            string quote = string.Empty;
+
+            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
+            {
+                char frontQuote = wordToComplete[0];
+                int length = wordToComplete.Length;
+
+                if (length == 1)
+                {
+                    wordToComplete = string.Empty;
+                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                }
+                else if (length > 1)
+                {
+                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
+                    {
+                        wordToComplete = wordToComplete.Substring(1, length - 2);
+                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                    }
+                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
+                    {
+                        wordToComplete = wordToComplete.Substring(1);
+                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                    }
+                }
+            }
+
+            return quote;
+        }
+
+        /// <summary>
+        /// Determines whether a given string completion requires quoting based on its content, parsing results, 
+        /// and specific character checks.
+        /// </summary>
+        /// <param name="completion">The string to analyze for quoting requirements.</param>
+        /// <param name="escapeGlobbingPathChars">
+        /// A boolean flag indicating whether globbing path characters (e.g., *, ?, [, ]) should be escaped.
+        /// </param>
+        /// <returns>
+        /// Returns <c>true</c> if the completion requires quoting; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// This method parses the input string to check for errors, token count, and content. 
+        /// Quoting is determined based on the presence of errors, the number of tokens, 
+        /// keywords, or specific special characters defined by the helper method.
+        /// </remarks>
+        internal static bool CompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars)
+        {
+            // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
+            // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
+
+            Parser.ParseInput(completion, out Token[] tokens, out ParseError[] errors);
+
+            // Expect no errors and 2 tokens (1 is for our completion, the other is eof)
+            // Or if the completion is a keyword, we ignore the errors
+            bool requireQuote = !(errors.Length == 0 && tokens.Length == 2);
+            if ((!requireQuote && tokens[0] is StringToken) ||
+                (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
+            {
+                requireQuote = ContainsCharsToCheck(tokens[0].Text, escapeGlobbingPathChars);
+            }
+
+            return requireQuote;
+        }
+
+        /// <summary>
+        /// Checks if the specified text contains any characters requiring quoting.
+        /// </summary>
+        /// <param name="text">The text to evaluate for special characters.</param>
+        /// <param name="escapeGlobbingPathChars">
+        /// A boolean flag indicating whether to use the globbing-specific set of characters to check.
+        /// </param>
+        /// <returns>
+        /// Returns <c>true</c> if the text contains characters that require quoting; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// This method evaluates the text against a pre-defined set of characters for different contexts 
+        /// (default or globbing path characters) to determine if quoting is necessary.
+        /// </remarks>
+        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escapeGlobbingPathChars)
+            => text.ContainsAny(escapeGlobbingPathChars ? s_escapeGlobbingPathCharsToCheck : s_defaultCharsToCheck);
+
+        /// <summary>
+        /// Quotes and optionally escapes the specified completion text based on the provided parameters.
+        /// </summary>
+        /// <param name="completionText">
+        /// The text to be quoted and potentially escaped.
+        /// </param>
+        /// <param name="quote">
+        /// The quote character to use for quoting the completion text. If this is null or empty,
+        /// a single quote character (<c>'</c>) is used by default.
+        /// </param>
+        /// <param name="escapeGlobbingPathChars">
+        /// A boolean value indicating whether globbing path characters should be escaped.
+        /// If <c>true</c>, globbing-specific escape sequences will be applied to the text.
+        /// </param>
+        /// <returns>
+        /// The quoted (and optionally escaped) version of the provided completion text.
+        /// </returns>
+        internal static string QuoteCompletionText(
+            string completionText,
+            string quote,
+            bool escapeGlobbingPathChars)
+        {
+            if (CompletionRequiresQuotes(completionText, escapeGlobbingPathChars))
+            {
+                string quoteInUse = string.IsNullOrEmpty(quote) ? "'" : quote;
+
+                completionText = quoteInUse == "'"
+                    ? completionText.Replace("'", "''")
+                    : completionText.Replace("`", "``").Replace("$", "`$");
+
+                if (escapeGlobbingPathChars)
+                {
+                    completionText = quoteInUse == "'"
+                        ? completionText.Replace("[", "`[").Replace("]", "`]")
+                        : completionText.Replace("[", "``[").Replace("]", "``]");
+                }
+
+                return quoteInUse + completionText + quoteInUse;
+            }
+
+            return quote + completionText + quote;
+        }
+    }
+}

--- a/src/System.Management.Automation/engine/CommandCompletion/ScopeArgumentCompleter.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ScopeArgumentCompleter.cs
@@ -29,7 +29,7 @@ namespace System.Management.Automation
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: s_Scopes);
     }

--- a/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.Commands
                 expirmentalFeatures.Add(feature.Name);
             }
 
-            return CompletionCompleters.GetMatchingResults(wordToComplete, expirmentalFeatures);
+            return CompletionHelpers.GetMatchingResults(wordToComplete, expirmentalFeatures);
         }
 
         private static Collection<ExperimentalFeature> GetExperimentalFeatures()

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1712,7 +1712,7 @@ namespace Microsoft.PowerShell.Commands
             string parameterName,
             string wordToComplete,
             CommandAst commandAst,
-            IDictionary fakeBoundParameters) => CompletionCompleters.GetMatchingResults(
+            IDictionary fakeBoundParameters) => CompletionHelpers.GetMatchingResults(
                 wordToComplete,
                 possibleCompletionValues: GetCommandNouns(fakeBoundParameters));
 

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2741,7 +2741,7 @@ namespace Microsoft.PowerShell.Commands
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: s_strictModeVersions);
     }

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -605,6 +605,6 @@ namespace Microsoft.PowerShell.Commands
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters) 
-                => CompletionCompleters.GetMatchingResults(wordToComplete, possibleCompletionValues: Utils.AllowedEditionValues);
+                => CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues: Utils.AllowedEditionValues);
     }
 }

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1550,7 +1550,7 @@ namespace System.Management.Automation
                 {
                     if (GroupsContainVerbType(groups, verbType))
                     {
-                        foreach (CompletionResult result in CompletionCompleters.GetMatchingResults(
+                        foreach (CompletionResult result in CompletionHelpers.GetMatchingResults(
                             wordToComplete,
                             possibleCompletionValues: EnumerateFieldNamesFromVerbType(verbType)))
                         {
@@ -1567,7 +1567,7 @@ namespace System.Management.Automation
             /// <param name="commands">The list of commands.</param>
             /// <returns>List of completions for verb.</returns>
             private static IEnumerable<CompletionResult> CompleteVerbWithCommands(string wordToComplete, Collection<CmdletInfo> commands)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: EnumerateCommandVerbNames(commands));
 
@@ -1577,7 +1577,7 @@ namespace System.Management.Automation
             /// <param name="wordToComplete">The word to complete.</param>
             /// <returns>List of completions for verb.</returns>
             private static IEnumerable<CompletionResult> CompleteVerbForAllTypes(string wordToComplete)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: EnumerateFieldNamesFromAllVerbTypes());
         }

--- a/test/xUnit/csharp/test_CompletionHelpers.cs
+++ b/test/xUnit/csharp/test_CompletionHelpers.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Management.Automation;
+using Xunit;
+
+namespace PSTests.Parallel
+{
+    public class CompletionHelpersTests
+    {
+        [Theory]
+        [InlineData("", "", "")]
+        [InlineData("\"", "", "\"")]
+        [InlineData("'", "", "'")]
+        [InlineData("\"word\"", "word", "\"")]
+        [InlineData("'word'", "word", "'")]
+        [InlineData("\"word", "word", "\"")]
+        [InlineData("'word", "word", "'")]
+        [InlineData("word\"", "word\"", "")]
+        [InlineData("word'", "word'", "")]
+        [InlineData("\"word's\"", "word's", "\"")]
+        [InlineData("'word\"", "'word\"", "")]
+        [InlineData("\"word'", "\"word'", "")]
+        public void TestHandleDoubleAndSingleQuote(string wordToComplete, string expectedWordToComplete, string expectedQuote)
+        {
+            string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
+            Assert.Equal(expectedQuote, quote);
+            Assert.Equal(expectedWordToComplete, wordToComplete);
+        }
+
+        [Theory]
+        [InlineData("", false, true)]
+        [InlineData("simpleWord", false, false)]
+        [InlineData("word1 word2", false, true)]
+        [InlineData("keyword", false, false)]
+        [InlineData("word*", true, false)]
+        [InlineData("word*", false, false)]
+        [InlineData("\"alreadyQuoted\"", false, false)]
+        [InlineData("var-name", false, false)]
+        [InlineData("${variable}", false, false)]
+        [InlineData("${variable}", true, false)]
+        [InlineData("file[name]", false, false)]
+        [InlineData("file[name]", true, true)]
+        [InlineData("`command`", false, true)]
+        [InlineData("word`command`", false, true)]
+        [InlineData("`unmatchedBacktick", false, true)]
+        [InlineData("`", false, true)]
+        [InlineData("word1 `word2`", false, true)]
+        [InlineData("`command with spaces`", false, true)]
+        [InlineData("word`another`word", false, true)]
+        public void TestCompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars, bool expected)
+        {
+            bool result = CompletionHelpers.CompletionRequiresQuotes(completion, escapeGlobbingPathChars);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("word", "'", false, "'word'")]
+        [InlineData("word", "\"", false, "\"word\"")]
+        [InlineData("word's", "'", false, "'word''s'")]
+        [InlineData("`command`", "\"", false, "\"``command``\"")]
+        [InlineData("word$", "\"", false, "\"word`$\"")]
+        [InlineData("[word]", "'", true, "'`[word`]\'")]
+        [InlineData("[word]", "\"", true, "\"``[word``]\"")]
+        [InlineData("word", "", false, "word")]
+        [InlineData("word [value]", "'", true, "'word `[value`]\'")]
+        [InlineData("word [value]", "'", false, "'word [value]'")]
+        [InlineData("", "'", false, "''")]
+        [InlineData("", "", false, "''")]
+        public void TestQuoteCompletionText(string completionText, string quote, bool escapeGlobbingPathChars, string expected)
+        {
+            string result = CompletionHelpers.QuoteCompletionText(completionText, quote, escapeGlobbingPathChars);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_BasicMatch()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2", "anotherWord" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_NoMatch()
+        {
+            string wordToComplete = "noMatch";
+            var possibleCompletionValues = new[] { "word", "word2", "anotherWord" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_EscapeGlobbingPathChars_Enabled()
+        {
+            string wordToComplete = "file";
+            var possibleCompletionValues = new[] { "file[name]", "file[other]", "file*" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, escapeGlobbingPathChars: true).ToList();
+
+            Assert.Equal(3, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "'file`[name`]'");
+            Assert.Contains(results, r => r.CompletionText == "'file`[other`]'");
+            Assert.Contains(results, r => r.CompletionText == "file*");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_EscapeGlobbingPathChars_Disabled()
+        {
+            string wordToComplete = "file";
+            var possibleCompletionValues = new[] { "file[name]", "file[other]", "file*" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, escapeGlobbingPathChars: false).ToList();
+
+            Assert.Equal(3, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "file[name]");
+            Assert.Contains(results, r => r.CompletionText == "file[other]");
+            Assert.Contains(results, r => r.CompletionText == "file*");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_WithToolTipMapping()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+            Func<string, string> toolTipMapping = value => $"Tooltip for {value}";
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, toolTipMapping: toolTipMapping).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.Contains(results, r => r.ToolTip == "Tooltip for word");
+            Assert.Contains(results, r => r.ToolTip == "Tooltip for word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_WithListItemTextMapping()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+            Func<string, string> listItemTextMapping = value => $"Item: {value}";
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, listItemTextMapping: listItemTextMapping).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.Contains(results, r => r.ListItemText == "Item: word");
+            Assert.Contains(results, r => r.ListItemText == "Item: word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_SingleQuote()
+        {
+            string wordToComplete = "'word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "'word'");
+            Assert.Contains(results, r => r.CompletionText == "'word2'");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_DoubleQuote()
+        {
+            string wordToComplete = "\"word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "\"word\"");
+            Assert.Contains(results, r => r.CompletionText == "\"word2\"");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_MixedCasesAndPatternMatch()
+        {
+            string wordToComplete = "Word";
+            var possibleCompletionValues = new[] { "word1", "Word2", "anotherWord" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word1");
+            Assert.Contains(results, r => r.CompletionText == "Word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void GetMatchingResults_WithParameterValueResultType()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+            CompletionResultType resultType = CompletionResultType.ParameterValue;
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, resultType: resultType).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.ParameterValue, r.ResultType));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Move common helper methods out of `CompletionCompleters` class into `CompletionHelpers` class and refactor existing quoting code for matching results. Related to https://github.com/PowerShell/PowerShell/pull/25116#issuecomment-2699998553 which will help with `IArgumentCompleter` interface expansion down the line.

Also includes `QuoteCompletionText` method which will be a common quoting method that is called in `GetMatchingResults`. I think it is simple enough for now we can add to it as needed without escape code becoming too complex.

Common methods which are now in `CompletionHelpers` class:

- `GetMatchingResults`
- `HandleDoubleAndSingleQuote`
- `CompletionRequiresQuotes`
- `QuoteCompletionText`

Also made some refactoring fixes:

- Rename parameter `escape` to `escapeGlobbingPathChars` for clarity.
- Other small cleanup to make code more succinct such as using `Func<string, string>.Invoke()` for Tooltip mapping.
- Include `listItemTextMapping` so we can also map values for list item text in completers.

Also added Xunit tests to make sure these methods have adequate test coverage.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
