### PR TITLE
Move common completion methods to CompletionHelpers class

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/NewPropertyCommand.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.Commands
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
                 => IsRegistryProvider(fakeBoundParameters)
-                    ? CompletionCompleters.GetMatchingResults(
+                    ? CompletionHelpers.GetMatchingResults(
                         wordToComplete,
                         possibleCompletionValues: s_RegistryPropertyTypes,
                         toolTipMapping: GetRegistryPropertyTypeToolTip,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2736,7 +2736,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="filePath">The file path to get verbs.</param>
         /// <returns>List of file verbs to complete.</returns>
         private static IEnumerable<CompletionResult> CompleteFileVerbs(string wordToComplete, string filePath)
-            => CompletionCompleters.GetMatchingResults(
+            => CompletionHelpers.GetMatchingResults(
                 wordToComplete,
                 possibleCompletionValues: new ProcessStartInfo(filePath).Verbs);
     }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -89,7 +89,7 @@ namespace System.Management.Automation
             var addAmpersandIfNecessary = IsAmpersandNeeded(context, false);
 
             string commandName = context.WordToComplete;
-            string quote = HandleDoubleAndSingleQuote(ref commandName);
+            string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref commandName);
 
             List<CompletionResult> commandResults = null;
 
@@ -234,7 +234,7 @@ namespace System.Management.Automation
             syntax = string.IsNullOrEmpty(syntax) ? name : syntax;
             bool needAmpersand;
 
-            if (CompletionRequiresQuotes(name, false))
+            if (CompletionHelpers.CompletionRequiresQuotes(name, false))
             {
                 needAmpersand = quote == string.Empty && addAmpersandIfNecessary;
                 string quoteInUse = quote == string.Empty ? "'" : quote;
@@ -443,7 +443,7 @@ namespace System.Management.Automation
         {
             var wordToComplete = context.WordToComplete ?? string.Empty;
             var result = new List<CompletionResult>();
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             // Indicates if we should search for modules where the last part of the name matches the input text
             // eg: Host<Tab> finds Microsoft.PowerShell.Host
@@ -524,7 +524,7 @@ namespace System.Management.Automation
                                   + moduleInfo.ModuleType.ToString() + "\r\nPath: "
                                   + moduleInfo.Path;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -1809,7 +1809,7 @@ namespace System.Management.Automation
                     RemoveLastNullCompletionResult(result);
 
                     string wordToComplete = context.WordToComplete ?? string.Empty;
-                    string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+                    string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
                     var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
                     var setList = new List<string>();
@@ -1846,7 +1846,7 @@ namespace System.Management.Automation
                         string completionText = entry;
                         if (quote == string.Empty)
                         {
-                            if (CompletionRequiresQuotes(entry, false))
+                            if (CompletionHelpers.CompletionRequiresQuotes(entry, false))
                             {
                                 realEntry = CodeGeneration.EscapeSingleQuotedStringContent(entry);
                                 completionText = "'" + realEntry + "'";
@@ -1886,7 +1886,7 @@ namespace System.Management.Automation
                 }
 
                 string wordToComplete = context.WordToComplete ?? string.Empty;
-                string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+                string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
                 var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
                 var enumList = new List<string>();
@@ -3198,7 +3198,7 @@ namespace System.Management.Automation
                 RemoveLastNullCompletionResult(result);
 
                 var logName = context.WordToComplete ?? string.Empty;
-                var quote = HandleDoubleAndSingleQuote(ref logName);
+                var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref logName);
 
                 if (!logName.EndsWith('*'))
                 {
@@ -3220,7 +3220,7 @@ namespace System.Management.Automation
                         var completionText = eventLog.Log.ToString();
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3249,7 +3249,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3311,7 +3311,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3336,7 +3336,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3386,7 +3386,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3470,7 +3470,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3526,7 +3526,7 @@ namespace System.Management.Automation
                         continue;
 
                     uniqueSet.Add(completionText);
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3561,7 +3561,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var providerName = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref providerName);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref providerName);
 
             if (!providerName.EndsWith('*'))
             {
@@ -3579,7 +3579,7 @@ namespace System.Management.Automation
                 var completionText = providerInfo.Name;
                 var listItemText = completionText;
 
-                if (CompletionRequiresQuotes(completionText, false))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")
@@ -3605,7 +3605,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3627,7 +3627,7 @@ namespace System.Management.Automation
                     var completionText = driveInfo.Name;
                     var listItemText = completionText;
 
-                    if (CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3652,7 +3652,7 @@ namespace System.Management.Automation
                 return;
 
             var wordToComplete = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith('*'))
             {
@@ -3678,7 +3678,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.DisplayName;
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3709,7 +3709,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3739,7 +3739,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var variableName = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref variableName);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref variableName);
             if (!variableName.EndsWith('*'))
             {
                 variableName += "*";
@@ -3765,7 +3765,7 @@ namespace System.Management.Automation
                     completionText = completionText.Replace("*", "`*");
                 }
 
-                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionRequiresQuotes(completionText, false))
+                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                 {
                     var quoteInUse = effectiveQuote == string.Empty ? "'" : effectiveQuote;
                     if (quoteInUse == "'")
@@ -3798,7 +3798,7 @@ namespace System.Management.Automation
             if (paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
                 var commandName = context.WordToComplete ?? string.Empty;
-                var quote = HandleDoubleAndSingleQuote(ref commandName);
+                var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref commandName);
 
                 if (!commandName.EndsWith('*'))
                 {
@@ -3815,7 +3815,7 @@ namespace System.Management.Automation
                         var completionText = aliasInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3859,7 +3859,7 @@ namespace System.Management.Automation
             RemoveLastNullCompletionResult(result);
 
             var traceSourceName = context.WordToComplete ?? string.Empty;
-            var quote = HandleDoubleAndSingleQuote(ref traceSourceName);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref traceSourceName);
 
             if (!traceSourceName.EndsWith('*'))
             {
@@ -3878,7 +3878,7 @@ namespace System.Management.Automation
                 var completionText = trace.Name;
                 var listItemText = completionText;
 
-                if (CompletionRequiresQuotes(completionText, false))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")
@@ -4493,7 +4493,7 @@ namespace System.Management.Automation
         internal static IEnumerable<CompletionResult> CompleteFilename(CompletionContext context, bool containerOnly, HashSet<string> extension)
         {
             var wordToComplete = context.WordToComplete;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
 
             // Matches file shares with and without the provider name and with either slash direction.
             // Avoids matching Windows device paths like \\.\CDROM0 and \\?\Volume{b8f3fc1c-5cd6-4553-91e2-d6814c4cd375}\
@@ -6936,7 +6936,7 @@ namespace System.Management.Automation
             Diagnostics.Assert(controlBodyType is not null, "This should never happen unless a new Format-* cmdlet is added");
 
             var wordToComplete = context.WordToComplete;
-            var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
             WildcardPattern viewPattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
 
             var uniqueNames = new HashSet<string>();
@@ -8544,77 +8544,6 @@ namespace System.Management.Automation
             return null;
         }
 
-        internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
-        {
-            string quote = string.Empty;
-
-            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
-            {
-                char frontQuote = wordToComplete[0];
-                int length = wordToComplete.Length;
-
-                if (length == 1)
-                {
-                    wordToComplete = string.Empty;
-                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                }
-                else if (length > 1)
-                {
-                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
-                    {
-                        wordToComplete = wordToComplete.Substring(1, length - 2);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
-                    {
-                        wordToComplete = wordToComplete.Substring(1);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                }
-            }
-
-            return quote;
-        }
-
-        /// <summary>
-        /// Get matching completions from word to complete.
-        /// This makes it easier to handle different variations of completions with consideration of quotes.
-        /// </summary>
-        /// <param name="wordToComplete">The word to complete.</param>
-        /// <param name="possibleCompletionValues">The possible completion values to iterate.</param>
-        /// <param name="toolTipMapping">The optional tool tip mapping delegate.</param>
-        /// <param name="resultType">The optional completion result type. Default is Text.</param>
-        /// <returns></returns>
-        internal static IEnumerable<CompletionResult> GetMatchingResults(
-            string wordToComplete,
-            IEnumerable<string> possibleCompletionValues,
-            Func<string, string> toolTipMapping = null,
-            CompletionResultType resultType = CompletionResultType.Text)
-        {
-            string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
-            var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
-
-            foreach (string value in possibleCompletionValues)
-            {
-                if (pattern.IsMatch(value))
-                {
-                    string completionText = quote == string.Empty
-                        ? value
-                        : quote + value + quote;
-
-                    string listItemText = value;
-
-                    yield return new CompletionResult(
-                        completionText,
-                        listItemText,
-                        resultType,
-                        toolTip: toolTipMapping is null
-                            ? listItemText
-                            : toolTipMapping(value));
-                }
-            }
-        }
-
         /// <summary>
         /// Calls Get-Command to get command info objects.
         /// </summary>
@@ -8810,33 +8739,6 @@ namespace System.Management.Automation
             }
 
             return false;
-        }
-
-        private static readonly SearchValues<char> s_defaultCharsToCheck = SearchValues.Create("$`");
-        private static readonly SearchValues<char> s_escapeCharsToCheck = SearchValues.Create("$[]`");
-
-        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escape) 
-            => text.ContainsAny(escape ? s_escapeCharsToCheck : s_defaultCharsToCheck);
-
-        private static bool CompletionRequiresQuotes(string completion, bool escape)
-        {
-            // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
-            // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
-
-            Language.Token[] tokens;
-            ParseError[] errors;
-            Language.Parser.ParseInput(completion, out tokens, out errors);
-
-            // Expect no errors and 2 tokens (1 is for our completion, the other is eof)
-            // Or if the completion is a keyword, we ignore the errors
-            bool requireQuote = !(errors.Length == 0 && tokens.Length == 2);
-            if ((!requireQuote && tokens[0] is StringToken) ||
-                (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
-            {
-                requireQuote = ContainsCharsToCheck(tokens[0].Text, escape);
-            }
-
-            return requireQuote;
         }
 
         private static bool ProviderSpecified(string path)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+
+namespace System.Management.Automation
+{
+    /// <summary>
+    /// Shared helper class for common completion helper methods.
+    /// </summary>
+    internal static class CompletionHelpers
+    {
+        private static readonly SearchValues<char> s_defaultCharsToCheck = SearchValues.Create("$`");
+
+        private static readonly SearchValues<char> s_escapeCharsToCheck = SearchValues.Create("$[]`");
+
+        /// <summary>
+        /// Get matching completions from word to complete.
+        /// This makes it easier to handle different variations of completions with consideration of quotes.
+        /// </summary>
+        /// <param name="wordToComplete">The word to complete.</param>
+        /// <param name="possibleCompletionValues">The possible completion values to iterate.</param>
+        /// <param name="toolTipMapping">The optional tool tip mapping delegate.</param>
+        /// <param name="resultType">The optional completion result type. Default is Text.</param>
+        /// <returns></returns>
+        internal static IEnumerable<CompletionResult> GetMatchingResults(
+            string wordToComplete,
+            IEnumerable<string> possibleCompletionValues,
+            Func<string, string> toolTipMapping = null,
+            CompletionResultType resultType = CompletionResultType.Text)
+        {
+            string quote = HandleDoubleAndSingleQuote(ref wordToComplete);
+            var pattern = WildcardPattern.Get(wordToComplete + "*", WildcardOptions.IgnoreCase);
+
+            foreach (string value in possibleCompletionValues)
+            {
+                if (pattern.IsMatch(value))
+                {
+                    string completionText = quote == string.Empty
+                        ? value
+                        : quote + value + quote;
+
+                    string listItemText = value;
+
+                    yield return new CompletionResult(
+                        completionText,
+                        listItemText,
+                        resultType,
+                        toolTip: toolTipMapping is null
+                            ? listItemText
+                            : toolTipMapping(value));
+                }
+            }
+        }
+
+        internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
+        {
+            string quote = string.Empty;
+
+            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
+            {
+                char frontQuote = wordToComplete[0];
+                int length = wordToComplete.Length;
+
+                if (length == 1)
+                {
+                    wordToComplete = string.Empty;
+                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                }
+                else if (length > 1)
+                {
+                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
+                    {
+                        wordToComplete = wordToComplete.Substring(1, length - 2);
+                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                    }
+                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
+                    {
+                        wordToComplete = wordToComplete.Substring(1);
+                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
+                    }
+                }
+            }
+
+            return quote;
+        }
+
+        internal static bool CompletionRequiresQuotes(string completion, bool escape)
+        {
+            // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
+            // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
+
+            Language.Token[] tokens;
+            ParseError[] errors;
+            Language.Parser.ParseInput(completion, out tokens, out errors);
+
+            // Expect no errors and 2 tokens (1 is for our completion, the other is eof)
+            // Or if the completion is a keyword, we ignore the errors
+            bool requireQuote = !(errors.Length == 0 && tokens.Length == 2);
+            if ((!requireQuote && tokens[0] is StringToken) ||
+                (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
+            {
+                requireQuote = ContainsCharsToCheck(tokens[0].Text, escape);
+            }
+
+            return requireQuote;
+        }
+
+        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escape)
+            => text.ContainsAny(escape ? s_escapeCharsToCheck : s_defaultCharsToCheck);
+
+        internal static string QuoteCompletionText(
+            string completionText,
+            string quote,
+            bool escape)
+        {
+            if (CompletionRequiresQuotes(completionText, escape))
+            {
+                string quoteInUse = string.IsNullOrEmpty(quote) ? "'" : quote;
+
+                completionText = quoteInUse == "'"
+                    ? completionText.Replace("'", "''")
+                    : completionText.Replace("`", "``").Replace("$", "`$");
+
+                if (escape)
+                {
+                    completionText = quoteInUse == "'"
+                        ? completionText.Replace("[", "`[").Replace("]", "`]")
+                        : completionText.Replace("[", "``[").Replace("]", "``]");
+                }
+
+                return quoteInUse + completionText + quoteInUse;
+            }
+
+            return quote + completionText + quote;
+        }
+    }
+}

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -110,31 +110,5 @@ namespace System.Management.Automation
 
         private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escape)
             => text.ContainsAny(escape ? s_escapeCharsToCheck : s_defaultCharsToCheck);
-
-        internal static string QuoteCompletionText(
-            string completionText,
-            string quote,
-            bool escape)
-        {
-            if (CompletionRequiresQuotes(completionText, escape))
-            {
-                string quoteInUse = string.IsNullOrEmpty(quote) ? "'" : quote;
-
-                completionText = quoteInUse == "'"
-                    ? completionText.Replace("'", "''")
-                    : completionText.Replace("`", "``").Replace("$", "`$");
-
-                if (escape)
-                {
-                    completionText = quoteInUse == "'"
-                        ? completionText.Replace("[", "`[").Replace("]", "`]")
-                        : completionText.Replace("[", "``[").Replace("]", "``]");
-                }
-
-                return quoteInUse + completionText + quoteInUse;
-            }
-
-            return quote + completionText + quote;
-        }
     }
 }

--- a/src/System.Management.Automation/engine/CommandCompletion/ScopeArgumentCompleter.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ScopeArgumentCompleter.cs
@@ -29,7 +29,7 @@ namespace System.Management.Automation
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: s_Scopes);
     }

--- a/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.Commands
                 expirmentalFeatures.Add(feature.Name);
             }
 
-            return CompletionCompleters.GetMatchingResults(wordToComplete, expirmentalFeatures);
+            return CompletionHelpers.GetMatchingResults(wordToComplete, expirmentalFeatures);
         }
 
         private static Collection<ExperimentalFeature> GetExperimentalFeatures()

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -1712,7 +1712,7 @@ namespace Microsoft.PowerShell.Commands
             string parameterName,
             string wordToComplete,
             CommandAst commandAst,
-            IDictionary fakeBoundParameters) => CompletionCompleters.GetMatchingResults(
+            IDictionary fakeBoundParameters) => CompletionHelpers.GetMatchingResults(
                 wordToComplete,
                 possibleCompletionValues: GetCommandNouns(fakeBoundParameters));
 

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2741,7 +2741,7 @@ namespace Microsoft.PowerShell.Commands
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: s_strictModeVersions);
     }

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -605,6 +605,6 @@ namespace Microsoft.PowerShell.Commands
             string wordToComplete,
             CommandAst commandAst,
             IDictionary fakeBoundParameters) 
-                => CompletionCompleters.GetMatchingResults(wordToComplete, possibleCompletionValues: Utils.AllowedEditionValues);
+                => CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues: Utils.AllowedEditionValues);
     }
 }

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -1550,7 +1550,7 @@ namespace System.Management.Automation
                 {
                     if (GroupsContainVerbType(groups, verbType))
                     {
-                        foreach (CompletionResult result in CompletionCompleters.GetMatchingResults(
+                        foreach (CompletionResult result in CompletionHelpers.GetMatchingResults(
                             wordToComplete,
                             possibleCompletionValues: EnumerateFieldNamesFromVerbType(verbType)))
                         {
@@ -1567,7 +1567,7 @@ namespace System.Management.Automation
             /// <param name="commands">The list of commands.</param>
             /// <returns>List of completions for verb.</returns>
             private static IEnumerable<CompletionResult> CompleteVerbWithCommands(string wordToComplete, Collection<CmdletInfo> commands)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: EnumerateCommandVerbNames(commands));
 
@@ -1577,7 +1577,7 @@ namespace System.Management.Automation
             /// <param name="wordToComplete">The word to complete.</param>
             /// <returns>List of completions for verb.</returns>
             private static IEnumerable<CompletionResult> CompleteVerbForAllTypes(string wordToComplete)
-                => CompletionCompleters.GetMatchingResults(
+                => CompletionHelpers.GetMatchingResults(
                     wordToComplete,
                     possibleCompletionValues: EnumerateFieldNamesFromAllVerbTypes());
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Moved common completion methods from `CompletionCompleters` to `CompletionHelpers` class.

Methods:

- `GetMatchingResults`
- `HandleDoubleAndSingleQuote`
- `CompletionRequiresQuotes`

Also changed all the parts of the code which use these methods to reference the helpers static class.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
These methods can then be used in a public API.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
