### PR TITLE
Make the use of Oxford commas even more consistent

### DIFF
--- a/assets/manpage/pwsh.1.ronn
+++ b/assets/manpage/pwsh.1.ronn
@@ -40,7 +40,7 @@ Some parameters have abbreviated forms
 * `-Command` | `-c`:
   Executes the specified commands (and any parameters) as though they were
   typed at the PowerShell command prompt, and then exits, unless NoExit is
-  specified. The value of Command can be `-`, a string or a script block. If
+  specified. The value of Command can be `-`, a string, or a script block. If
   the value of Command is `-`, the command text is read from standard input. If
   the value of Command is a script block, the script block must be enclosed in
   braces (`{}`). You can specify a script block only when running PowerShell in
@@ -171,7 +171,7 @@ Some parameters have abbreviated forms
 
 * `-WindowStyle` | `-w`
   Sets the window style for the session. Valid values are Normal, Minimized,
-  Maximized and Hidden. This parameter only applies to Windows. Using this
+  Maximized, and Hidden. This parameter only applies to Windows. Using this
   parameter on non-Windows platforms results in an error.
 
 * `-WorkingDirectory` | `-wd` | `-wo`


### PR DESCRIPTION
ManagedEntranceStrings.resx has a comma here for the exact same string. Just making the two consistent.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Added two commas

## PR Context

The commas are consistent with the previous use of a comma in ManagedEntranceStrings.resx and my proposed additional comma there in https://github.com/PowerShell/PowerShell/pull/25139.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [X] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->