### PR TITLE
CA1859: Fix JsonObject methods to return concrete types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -119,6 +119,9 @@ csharp_prefer_simple_default_expression = true:suggestion
 
 dotnet_code_quality_unused_parameters = non_public:suggestion
 
+# https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = warning
+
 # CSharp code style settings:
 [*.cs]
 

--- a/.globalconfig
+++ b/.globalconfig
@@ -1072,6 +1072,10 @@ dotnet_diagnostic.CA5402.severity = none
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
 dotnet_diagnostic.CA5403.severity = none
 
+# CA1859: Use concrete types when possible for improved performance
+# https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+dotnet_diagnostic.CA1859.severity = warning
+
 # IL3000: Avoid using accessing Assembly file path when publishing as a single-file
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
 dotnet_diagnostic.IL3000.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -1072,10 +1072,6 @@ dotnet_diagnostic.CA5402.severity = none
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
 dotnet_diagnostic.CA5403.severity = none
 
-# CA1859: Use concrete types when possible for improved performance
-# https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1859
-dotnet_diagnostic.CA1859.severity = warning
-
 # IL3000: Avoid using accessing Assembly file path when publishing as a single-file
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/il3000
 dotnet_diagnostic.IL3000.severity = warning

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // This function is a clone of PopulateFromList using JArray as input.
-        private static ICollection<object> PopulateFromJArray(JArray list, out ErrorRecord error)
+        private static object[] PopulateFromJArray(JArray list, out ErrorRecord error)
         {
             error = null;
             var result = new object[list.Count];
@@ -375,7 +375,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // This function is a clone of PopulateFromDictionary using JObject as an input.
-        private static Hashtable PopulateHashTableFromJDictionary(JObject entries, out ErrorRecord error)
+        private static OrderedHashtable PopulateHashTableFromJDictionary(JObject entries, out ErrorRecord error)
         {
             error = null;
             OrderedHashtable result = new(entries.Count);
@@ -432,7 +432,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // This function is a clone of PopulateFromList using JArray as input.
-        private static ICollection<object> PopulateHashTableFromJArray(JArray list, out ErrorRecord error)
+        private static object[] PopulateHashTableFromJArray(JArray list, out ErrorRecord error)
         {
             error = null;
             var result = new object[list.Count];
@@ -744,7 +744,7 @@ namespace Microsoft.PowerShell.Commands
         /// Return an alternate representation of the specified dictionary that serializes the same JSON, except
         /// that any contained properties that cannot be evaluated are treated as having the value null.
         /// </summary>
-        private static object ProcessDictionary(IDictionary dict, int depth, in ConvertToJsonContext context)
+        private static Dictionary<string, object> ProcessDictionary(IDictionary dict, int depth, in ConvertToJsonContext context)
         {
             Dictionary<string, object> result = new(dict.Count);
 
@@ -781,7 +781,7 @@ namespace Microsoft.PowerShell.Commands
         /// Return an alternate representation of the specified collection that serializes the same JSON, except
         /// that any contained properties that cannot be evaluated are treated as having the value null.
         /// </summary>
-        private static object ProcessEnumerable(IEnumerable enumerable, int depth, in ConvertToJsonContext context)
+        private static List<object> ProcessEnumerable(IEnumerable enumerable, int depth, in ConvertToJsonContext context)
         {
             List<object> result = new();
 
@@ -801,7 +801,7 @@ namespace Microsoft.PowerShell.Commands
         /// are represented.  If any exception occurs while retrieving the value of a field or property, that entity
         /// is included in the output dictionary with a value of null.
         /// </summary>
-        private static object ProcessCustomObject<T>(object o, int depth, in ConvertToJsonContext context)
+        private static Dictionary<string, object> ProcessCustomObject<T>(object o, int depth, in ConvertToJsonContext context)
         {
             Dictionary<string, object> result = new();
             Type t = o.GetType();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

So some of these methods have this warning: https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1859

I changed the methods to return concrete type which is actually being built in the method to improve performance. My understanding is changing the type has no effect on the behavior of the code, but it improves its performance.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
