### PR TITLE
Fix type inference of parameters in classic functions

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2922,7 +2922,7 @@ namespace System.Management.Automation
             internal bool RedirectionAssignment;
 
             /// <summary>
-            /// The Ast of the scope we are currently analyzing
+            /// The Ast of the scope we are currently analyzing.
             /// </summary>
             internal Ast ScopeDefinitionAst;
             internal int StopSearchOffset;

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2451,6 +2451,14 @@ namespace System.Management.Automation
             {
                 if (currentAst is IParameterMetadataProvider)
                 {
+                    if (currentAst is ScriptBlockAst && currentAst.Parent is FunctionDefinitionAst)
+                    {
+                        // If this scriptblock belongs to a function we want to visit that instead so we can get the parameters
+                        // function X ($Param1){}
+                        currentAst = currentAst.Parent;
+                    }
+
+                    assignmentVisitor.ScopeDefinitionAst = currentAst;
                     currentAst.Visit(assignmentVisitor);
 
                     if (assignmentVisitor.LocalScopeOnly
@@ -2901,6 +2909,11 @@ namespace System.Management.Automation
             /// Whether or not the last assignment was via command redirection.
             /// </summary>
             internal bool RedirectionAssignment;
+
+            /// <summary>
+            /// The Ast of the scope we are currently analyzing
+            /// </summary>
+            internal Ast ScopeDefinitionAst;
             internal int StopSearchOffset;
             private int LastAssignmentOffset = -1;
 
@@ -3248,7 +3261,9 @@ namespace System.Management.Automation
 
             public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
             {
-                return AstVisitAction.SkipChildren;
+                return functionDefinitionAst == ScopeDefinitionAst
+                    ? AstVisitAction.Continue
+                    : AstVisitAction.SkipChildren;
             }
         }
     }

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -268,6 +268,16 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be 'System.Management.ManagementObject#root\cimv2\Win32_Process'
     }
 
+    It "Infers type from parameter in classic function definition" {
+        $res = [AstTypeInference]::InferTypeOf(({
+            function MyFunction ([int]$param1)
+            {
+                $param1
+            }
+        }.Ast.FindAll({param($Ast) $Ast -is [Language.VariableExpressionAst]}, $true) | Select-Object -Last 1 ))
+        $res.Name | Should -Be 'System.Int32'
+    }
+
     It "Infers type from binary expression with a bool operator as bool" {
         $res = [AstTypeInference]::InferTypeOf( {
                 (1..10) -contains 5


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes type inference for parameters in classic function definitions where the parameters outside the scriptblock definition: `function X ([string]$Param1){}`
<!-- Summarize your PR between here and the checklist. -->

## PR Context
I broke it with: https://github.com/PowerShell/PowerShell/pull/19830
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
