### PR TITLE
Remove CompletionHelpers `escape` parameter from `CompletionRequiresQuotes`

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -234,7 +234,7 @@ namespace System.Management.Automation
             syntax = string.IsNullOrEmpty(syntax) ? name : syntax;
             bool needAmpersand;
 
-            if (CompletionHelpers.CompletionRequiresQuotes(name))
+            if (CompletionHelpers.CompletionRequiresQuotes(name, false))
             {
                 needAmpersand = quote == string.Empty && addAmpersandIfNecessary;
                 string quoteInUse = quote == string.Empty ? "'" : quote;
@@ -524,7 +524,7 @@ namespace System.Management.Automation
                                   + moduleInfo.ModuleType.ToString() + "\r\nPath: "
                                   + moduleInfo.Path;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -1846,7 +1846,7 @@ namespace System.Management.Automation
                         string completionText = entry;
                         if (quote == string.Empty)
                         {
-                            if (CompletionHelpers.CompletionRequiresQuotes(entry))
+                            if (CompletionHelpers.CompletionRequiresQuotes(entry, false))
                             {
                                 realEntry = CodeGeneration.EscapeSingleQuotedStringContent(entry);
                                 completionText = "'" + realEntry + "'";
@@ -3220,7 +3220,7 @@ namespace System.Management.Automation
                         var completionText = eventLog.Log.ToString();
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3311,7 +3311,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3386,7 +3386,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3526,7 +3526,7 @@ namespace System.Management.Automation
                         continue;
 
                     uniqueSet.Add(completionText);
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3579,7 +3579,7 @@ namespace System.Management.Automation
                 var completionText = providerInfo.Name;
                 var listItemText = completionText;
 
-                if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")
@@ -3627,7 +3627,7 @@ namespace System.Management.Automation
                     var completionText = driveInfo.Name;
                     var listItemText = completionText;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3678,7 +3678,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.DisplayName;
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3709,7 +3709,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3765,7 +3765,7 @@ namespace System.Management.Automation
                     completionText = completionText.Replace("*", "`*");
                 }
 
-                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionHelpers.CompletionRequiresQuotes(completionText))
+                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                 {
                     var quoteInUse = effectiveQuote == string.Empty ? "'" : effectiveQuote;
                     if (quoteInUse == "'")
@@ -3815,7 +3815,7 @@ namespace System.Management.Automation
                         var completionText = aliasInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3878,7 +3878,7 @@ namespace System.Management.Automation
                 var completionText = trace.Name;
                 var listItemText = completionText;
 
-                if (CompletionHelpers.CompletionRequiresQuotes(completionText))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -234,7 +234,7 @@ namespace System.Management.Automation
             syntax = string.IsNullOrEmpty(syntax) ? name : syntax;
             bool needAmpersand;
 
-            if (CompletionHelpers.CompletionRequiresQuotes(name, false))
+            if (CompletionHelpers.CompletionRequiresQuotes(name))
             {
                 needAmpersand = quote == string.Empty && addAmpersandIfNecessary;
                 string quoteInUse = quote == string.Empty ? "'" : quote;
@@ -524,7 +524,7 @@ namespace System.Management.Automation
                                   + moduleInfo.ModuleType.ToString() + "\r\nPath: "
                                   + moduleInfo.Path;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -1846,7 +1846,7 @@ namespace System.Management.Automation
                         string completionText = entry;
                         if (quote == string.Empty)
                         {
-                            if (CompletionHelpers.CompletionRequiresQuotes(entry, false))
+                            if (CompletionHelpers.CompletionRequiresQuotes(entry))
                             {
                                 realEntry = CodeGeneration.EscapeSingleQuotedStringContent(entry);
                                 completionText = "'" + realEntry + "'";
@@ -3220,7 +3220,7 @@ namespace System.Management.Automation
                         var completionText = eventLog.Log.ToString();
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3311,7 +3311,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3386,7 +3386,7 @@ namespace System.Management.Automation
                     var completionText = psJob.Name;
                     var listItemText = completionText;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3526,7 +3526,7 @@ namespace System.Management.Automation
                         continue;
 
                     uniqueSet.Add(completionText);
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3579,7 +3579,7 @@ namespace System.Management.Automation
                 var completionText = providerInfo.Name;
                 var listItemText = completionText;
 
-                if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")
@@ -3627,7 +3627,7 @@ namespace System.Management.Automation
                     var completionText = driveInfo.Name;
                     var listItemText = completionText;
 
-                    if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                    if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                     {
                         var quoteInUse = quote == string.Empty ? "'" : quote;
                         if (quoteInUse == "'")
@@ -3678,7 +3678,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.DisplayName;
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3709,7 +3709,7 @@ namespace System.Management.Automation
                         var completionText = serviceInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3765,7 +3765,7 @@ namespace System.Management.Automation
                     completionText = completionText.Replace("*", "`*");
                 }
 
-                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                if (!completionText.Equals("$", StringComparison.Ordinal) && CompletionHelpers.CompletionRequiresQuotes(completionText))
                 {
                     var quoteInUse = effectiveQuote == string.Empty ? "'" : effectiveQuote;
                     if (quoteInUse == "'")
@@ -3815,7 +3815,7 @@ namespace System.Management.Automation
                         var completionText = aliasInfo.Name;
                         var listItemText = completionText;
 
-                        if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                        if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
                             if (quoteInUse == "'")
@@ -3878,7 +3878,7 @@ namespace System.Management.Automation
                 var completionText = trace.Name;
                 var listItemText = completionText;
 
-                if (CompletionHelpers.CompletionRequiresQuotes(completionText, false))
+                if (CompletionHelpers.CompletionRequiresQuotes(completionText))
                 {
                     var quoteInUse = quote == string.Empty ? "'" : quote;
                     if (quoteInUse == "'")

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -14,7 +14,7 @@ namespace System.Management.Automation
     {
         private static readonly SearchValues<char> s_defaultCharsToCheck = SearchValues.Create("$`");
 
-        private static readonly SearchValues<char> s_escapeCharsToCheck = SearchValues.Create("$[]`");
+        private static readonly SearchValues<char> s_escapeGlobbingPathCharsToCheck = SearchValues.Create("$[]`");
 
         /// <summary>
         /// Get matching completions from word to complete.
@@ -87,14 +87,12 @@ namespace System.Management.Automation
             return quote;
         }
 
-        internal static bool CompletionRequiresQuotes(string completion, bool escape)
+        internal static bool CompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars)
         {
             // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
             // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
 
-            Language.Token[] tokens;
-            ParseError[] errors;
-            Language.Parser.ParseInput(completion, out tokens, out errors);
+            Parser.ParseInput(completion, out Token[] tokens, out ParseError[] errors);
 
             // Expect no errors and 2 tokens (1 is for our completion, the other is eof)
             // Or if the completion is a keyword, we ignore the errors
@@ -102,13 +100,13 @@ namespace System.Management.Automation
             if ((!requireQuote && tokens[0] is StringToken) ||
                 (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
             {
-                requireQuote = ContainsCharsToCheck(tokens[0].Text, escape);
+                requireQuote = ContainsCharsToCheck(tokens[0].Text, escapeGlobbingPathChars);
             }
 
             return requireQuote;
         }
 
-        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escape)
-            => text.ContainsAny(escape ? s_escapeCharsToCheck : s_defaultCharsToCheck);
+        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escapeGlobbingPathChars)
+            => text.ContainsAny(escapeGlobbingPathChars ? s_escapeGlobbingPathCharsToCheck : s_defaultCharsToCheck);
     }
 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -14,8 +14,6 @@ namespace System.Management.Automation
     {
         private static readonly SearchValues<char> s_defaultCharsToCheck = SearchValues.Create("$`");
 
-        private static readonly SearchValues<char> s_escapeGlobbingPathCharsToCheck = SearchValues.Create("$[]`");
-
         /// <summary>
         /// Get matching completions from word to complete.
         /// This makes it easier to handle different variations of completions with consideration of quotes.
@@ -87,7 +85,7 @@ namespace System.Management.Automation
             return quote;
         }
 
-        internal static bool CompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars)
+        internal static bool CompletionRequiresQuotes(string completion)
         {
             // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
             // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
@@ -100,13 +98,13 @@ namespace System.Management.Automation
             if ((!requireQuote && tokens[0] is StringToken) ||
                 (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
             {
-                requireQuote = ContainsCharsToCheck(tokens[0].Text, escapeGlobbingPathChars);
+                requireQuote = ContainsCharsToCheck(tokens[0].Text);
             }
 
             return requireQuote;
         }
 
-        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escapeGlobbingPathChars)
-            => text.ContainsAny(escapeGlobbingPathChars ? s_escapeGlobbingPathCharsToCheck : s_defaultCharsToCheck);
+        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text)
+            => text.ContainsAny(s_defaultCharsToCheck);
     }
 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -14,6 +14,8 @@ namespace System.Management.Automation
     {
         private static readonly SearchValues<char> s_defaultCharsToCheck = SearchValues.Create("$`");
 
+        private static readonly SearchValues<char> s_escapeGlobbingPathCharsToCheck = SearchValues.Create("$[]`");
+
         /// <summary>
         /// Get matching completions from word to complete.
         /// This makes it easier to handle different variations of completions with consideration of quotes.
@@ -85,7 +87,7 @@ namespace System.Management.Automation
             return quote;
         }
 
-        internal static bool CompletionRequiresQuotes(string completion)
+        internal static bool CompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars)
         {
             // If the tokenizer sees the completion as more than two tokens, or if there is some error, then
             // some form of quoting is necessary (if it's a variable, we'd need ${}, filenames would need [], etc.)
@@ -98,13 +100,13 @@ namespace System.Management.Automation
             if ((!requireQuote && tokens[0] is StringToken) ||
                 (tokens.Length == 2 && (tokens[0].TokenFlags & TokenFlags.Keyword) != 0))
             {
-                requireQuote = ContainsCharsToCheck(tokens[0].Text);
+                requireQuote = ContainsCharsToCheck(tokens[0].Text, escapeGlobbingPathChars);
             }
 
             return requireQuote;
         }
 
-        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text)
-            => text.ContainsAny(s_defaultCharsToCheck);
+        private static bool ContainsCharsToCheck(ReadOnlySpan<char> text, bool escapeGlobbingPathChars)
+            => text.ContainsAny(escapeGlobbingPathChars ? s_escapeGlobbingPathCharsToCheck : s_defaultCharsToCheck);
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Just minor refactor to removed unused `escape` parameter from `CompletionRequiresQuotes` method. Given this parameter was meant to be used for escaping globbing characters `[` & `]` which is not set to `true` anywhere in the code base, it makes sense to remove it to clean up the code and simplify how this method gets used.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This code came from Windows PowerShell 1bd99193253a1d7fa1dd99164e8054140062f760 as dead and has not been used until now.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
