### PR TITLE
Refactor CompletionHelpers `HandleDoubleAndSingleQuote` to have less nesting logic

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -55,6 +55,24 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// Handles and processes a string that starts and/or ends with single or double quotes.
+        /// Removes the front quote if present, and optionally the back quote if it matches the front quote.
+        /// Updates the input string by reference and returns the type of quote used.
+        /// </summary>
+        /// <param name="wordToComplete">
+        /// The string to process, which may be surrounded by single or double quotes.
+        /// This parameter is passed by reference and is updated to exclude processed quotes.
+        /// </param>
+        /// <returns>
+        /// Returns a string representing the quote type used (' or ") if a front quote is detected.
+        /// Returns an empty string if no front quote is found or if the input is empty.
+        /// </returns>
+        /// <remarks>
+        /// The method detects single (' or ') and double (" or ") quotes, removes them as needed,
+        /// and modifies the input string in-place. It ensures quotes are matched and only strips
+        /// the back quote if it matches the front quote.
+        /// </remarks>
         internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
         {
             if (string.IsNullOrEmpty(wordToComplete))

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -56,22 +56,20 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Handles and processes a string that starts and/or ends with single or double quotes.
-        /// Removes the front quote if present, and optionally the back quote if it matches the front quote.
-        /// Updates the input string by reference and returns the type of quote used.
+        /// Removes wrapping quotes from a string and returns the quote used, if present.
         /// </summary>
         /// <param name="wordToComplete">
-        /// The string to process, which may be surrounded by single or double quotes.
-        /// This parameter is passed by reference and is updated to exclude processed quotes.
+        /// The string to process, potentially surrounded by single or double quotes.
+        /// This parameter is updated in-place to exclude the removed quotes.
         /// </param>
         /// <returns>
-        /// Returns a string representing the quote type used (single or double) if a front quote is detected.
-        /// Returns an empty string if no front quote is found or if the input is empty.
+        /// The type of quote detected (single or double), or an empty string if no quote is found.
         /// </returns>
         /// <remarks>
-        /// The method detects single (' or ') and double (" or ") quotes, removes them as needed,
-        /// and modifies the input string in-place. It ensures quotes are matched and only strips
-        /// the back quote if it matches the front quote.
+        /// This method checks for single or double quotes at the start and end of the string.
+        /// If wrapping quotes are detected and match, both are removed; otherwise, only the front quote is removed.
+        /// The string is updated in-place, and only matching front-and-back quotes are stripped.
+        /// If no quotes are detected or the input is empty, the original string remains unchanged.
         /// </remarks>
         internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
         {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -79,13 +79,10 @@ namespace System.Management.Automation
             }
 
             char frontQuote = wordToComplete[0];
-
             bool hasFrontSingleQuote = frontQuote.IsSingleQuote();
             bool hasFrontDoubleQuote = frontQuote.IsDoubleQuote();
 
-            bool hasFrontQuote = hasFrontSingleQuote || hasFrontDoubleQuote;
-
-            if (!hasFrontQuote)
+            if (!hasFrontSingleQuote && !hasFrontDoubleQuote)
             {
                 return string.Empty;
             }
@@ -93,7 +90,6 @@ namespace System.Management.Automation
             string quoteInUse = hasFrontSingleQuote ? "'" : "\"";
 
             int length = wordToComplete.Length;
-
             if (length == 1)
             {
                 wordToComplete = string.Empty;
@@ -101,20 +97,28 @@ namespace System.Management.Automation
             }
 
             char backQuote = wordToComplete[length - 1];
-
             bool hasBackSingleQuote = backQuote.IsSingleQuote();
             bool hasBackDoubleQuote = backQuote.IsDoubleQuote();
 
-            bool hasFrontAndBackSingleQuote = hasFrontSingleQuote && hasBackSingleQuote;
-            bool hasFrontAndBackDoubleQuote = hasFrontDoubleQuote && hasBackDoubleQuote;
+            bool hasMatchingFrontAndBackQuote =
+                (hasFrontSingleQuote && hasBackSingleQuote) || (hasFrontDoubleQuote && hasBackDoubleQuote);
 
-            bool hasMatchingFrontAndBackQuote = hasFrontAndBackSingleQuote || hasFrontAndBackDoubleQuote;
+            if (hasMatchingFrontAndBackQuote)
+            {
+                wordToComplete = wordToComplete.Substring(1, length - 2);
+                return quoteInUse;
+            }
 
-            wordToComplete = hasMatchingFrontAndBackQuote
-                ? wordToComplete.Substring(1, length - 2)
-                : wordToComplete.Substring(1);
+            bool hasValidFrontQuoteAndNoMatchingBackQuote = 
+                (hasFrontSingleQuote || hasFrontDoubleQuote) && !hasBackSingleQuote && !hasBackDoubleQuote;
 
-            return quoteInUse;
+            if (hasValidFrontQuoteAndNoMatchingBackQuote)
+            {
+                wordToComplete = wordToComplete.Substring(1);
+                return quoteInUse;
+            }
+
+            return string.Empty;
         }
 
         internal static bool CompletionRequiresQuotes(string completion, bool escape)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -65,7 +65,7 @@ namespace System.Management.Automation
         /// This parameter is passed by reference and is updated to exclude processed quotes.
         /// </param>
         /// <returns>
-        /// Returns a string representing the quote type used (' or ") if a front quote is detected.
+        /// Returns a string representing the quote type used (single or double) if a front quote is detected.
         /// Returns an empty string if no front quote is found or if the input is empty.
         /// </returns>
         /// <remarks>

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -100,19 +100,19 @@ namespace System.Management.Automation
             bool hasBackSingleQuote = backQuote.IsSingleQuote();
             bool hasBackDoubleQuote = backQuote.IsDoubleQuote();
 
-            bool hasMatchingFrontAndBackQuote =
+            bool hasBothFrontAndBackQuotes =
                 (hasFrontSingleQuote && hasBackSingleQuote) || (hasFrontDoubleQuote && hasBackDoubleQuote);
 
-            if (hasMatchingFrontAndBackQuote)
+            if (hasBothFrontAndBackQuotes)
             {
                 wordToComplete = wordToComplete.Substring(1, length - 2);
                 return quoteInUse;
             }
 
-            bool hasValidFrontQuoteAndNoMatchingBackQuote = 
+            bool hasFrontQuoteAndNoBackQuote = 
                 (hasFrontSingleQuote || hasFrontDoubleQuote) && !hasBackSingleQuote && !hasBackDoubleQuote;
 
-            if (hasValidFrontQuoteAndNoMatchingBackQuote)
+            if (hasFrontQuoteAndNoBackQuote)
             {
                 wordToComplete = wordToComplete.Substring(1);
                 return quoteInUse;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -64,14 +64,17 @@ namespace System.Management.Automation
 
             char frontQuote = wordToComplete[0];
 
-            bool hasFrontQuote = frontQuote.IsSingleQuote() || frontQuote.IsDoubleQuote();
+            bool isFrontQuoteSingleQuote = frontQuote.IsSingleQuote();
+            bool isFrontQuoteDoubleQuote = frontQuote.IsDoubleQuote();
+
+            bool hasFrontQuote = isFrontQuoteSingleQuote || isFrontQuoteDoubleQuote;
 
             if (!hasFrontQuote)
             {
                 return string.Empty;
             }
 
-            string quoteInUse = frontQuote.IsSingleQuote() ? "'" : "\"";
+            string quoteInUse = isFrontQuoteSingleQuote ? "'" : "\"";
 
             int length = wordToComplete.Length;
 
@@ -83,10 +86,15 @@ namespace System.Management.Automation
 
             char backQuote = wordToComplete[length - 1];
 
-            bool hasFrontAndBackSingleQuote = frontQuote.IsSingleQuote() && backQuote.IsSingleQuote();
-            bool hasFrontAndBackDoubleQuote = frontQuote.IsDoubleQuote() && backQuote.IsDoubleQuote();
+            bool isBackQuoteSingleQuote = backQuote.IsSingleQuote();
+            bool isBackQuoteDoubleQuote = backQuote.IsDoubleQuote();
 
-            wordToComplete = hasFrontAndBackSingleQuote || hasFrontAndBackDoubleQuote
+            bool hasFrontAndBackSingleQuote = isFrontQuoteSingleQuote && isBackQuoteSingleQuote;
+            bool hasFrontAndBackDoubleQuote = isFrontQuoteDoubleQuote && isBackQuoteDoubleQuote;
+
+            bool hasMatchingFrontAndBackQuote = hasFrontAndBackSingleQuote || hasFrontAndBackDoubleQuote;
+
+            wordToComplete = hasMatchingFrontAndBackQuote
                 ? wordToComplete.Substring(1, length - 2)
                 : wordToComplete.Substring(1);
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -64,17 +64,17 @@ namespace System.Management.Automation
 
             char frontQuote = wordToComplete[0];
 
-            bool isFrontQuoteSingleQuote = frontQuote.IsSingleQuote();
-            bool isFrontQuoteDoubleQuote = frontQuote.IsDoubleQuote();
+            bool hasFrontSingleQuote = frontQuote.IsSingleQuote();
+            bool hasFrontDoubleQuote = frontQuote.IsDoubleQuote();
 
-            bool hasFrontQuote = isFrontQuoteSingleQuote || isFrontQuoteDoubleQuote;
+            bool hasFrontQuote = hasFrontSingleQuote || hasFrontDoubleQuote;
 
             if (!hasFrontQuote)
             {
                 return string.Empty;
             }
 
-            string quoteInUse = isFrontQuoteSingleQuote ? "'" : "\"";
+            string quoteInUse = hasFrontSingleQuote ? "'" : "\"";
 
             int length = wordToComplete.Length;
 
@@ -86,11 +86,11 @@ namespace System.Management.Automation
 
             char backQuote = wordToComplete[length - 1];
 
-            bool isBackQuoteSingleQuote = backQuote.IsSingleQuote();
-            bool isBackQuoteDoubleQuote = backQuote.IsDoubleQuote();
+            bool hasBackSingleQuote = backQuote.IsSingleQuote();
+            bool hasBackDoubleQuote = backQuote.IsDoubleQuote();
 
-            bool hasFrontAndBackSingleQuote = isFrontQuoteSingleQuote && isBackQuoteSingleQuote;
-            bool hasFrontAndBackDoubleQuote = isFrontQuoteDoubleQuote && isBackQuoteDoubleQuote;
+            bool hasFrontAndBackSingleQuote = hasFrontSingleQuote && hasBackSingleQuote;
+            bool hasFrontAndBackDoubleQuote = hasFrontDoubleQuote && hasBackDoubleQuote;
 
             bool hasMatchingFrontAndBackQuote = hasFrontAndBackSingleQuote || hasFrontAndBackDoubleQuote;
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionHelpers.cs
@@ -57,34 +57,40 @@ namespace System.Management.Automation
 
         internal static string HandleDoubleAndSingleQuote(ref string wordToComplete)
         {
-            string quote = string.Empty;
-
-            if (!string.IsNullOrEmpty(wordToComplete) && (wordToComplete[0].IsSingleQuote() || wordToComplete[0].IsDoubleQuote()))
+            if (string.IsNullOrEmpty(wordToComplete))
             {
-                char frontQuote = wordToComplete[0];
-                int length = wordToComplete.Length;
-
-                if (length == 1)
-                {
-                    wordToComplete = string.Empty;
-                    quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                }
-                else if (length > 1)
-                {
-                    if ((wordToComplete[length - 1].IsDoubleQuote() && frontQuote.IsDoubleQuote()) || (wordToComplete[length - 1].IsSingleQuote() && frontQuote.IsSingleQuote()))
-                    {
-                        wordToComplete = wordToComplete.Substring(1, length - 2);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                    else if (!wordToComplete[length - 1].IsDoubleQuote() && !wordToComplete[length - 1].IsSingleQuote())
-                    {
-                        wordToComplete = wordToComplete.Substring(1);
-                        quote = frontQuote.IsSingleQuote() ? "'" : "\"";
-                    }
-                }
+                return string.Empty;
             }
 
-            return quote;
+            char frontQuote = wordToComplete[0];
+
+            bool hasFrontQuote = frontQuote.IsSingleQuote() || frontQuote.IsDoubleQuote();
+
+            if (!hasFrontQuote)
+            {
+                return string.Empty;
+            }
+
+            string quoteInUse = frontQuote.IsSingleQuote() ? "'" : "\"";
+
+            int length = wordToComplete.Length;
+
+            if (length == 1)
+            {
+                wordToComplete = string.Empty;
+                return quoteInUse;
+            }
+
+            char backQuote = wordToComplete[length - 1];
+
+            bool hasFrontAndBackSingleQuote = frontQuote.IsSingleQuote() && backQuote.IsSingleQuote();
+            bool hasFrontAndBackDoubleQuote = frontQuote.IsDoubleQuote() && backQuote.IsDoubleQuote();
+
+            wordToComplete = hasFrontAndBackSingleQuote || hasFrontAndBackDoubleQuote
+                ? wordToComplete.Substring(1, length - 2)
+                : wordToComplete.Substring(1);
+
+            return quoteInUse;
         }
 
         internal static bool CompletionRequiresQuotes(string completion, bool escape)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Refactor `HandleDoubleAndSingleQuote` method to have less nesting logic so it is easier to understand.

The current code is very hard to understand in comparison to the flatter version which has less nesting and more clearer variable names and intention. 

Obviously just a preference, I am happy to close this PR if people don't find the new refactoring an improvement.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
