### PR TITLE
WIP: Add XUnit test for `GetMatchingResults` in CompletionHelpers class

### DIFF
--- a/test/xUnit/csharp/test_CompletionHelpers.cs
+++ b/test/xUnit/csharp/test_CompletionHelpers.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Management.Automation;
+using Xunit;
+
+namespace PSTests.Parallel
+{
+    public class CompletionHelpersTests
+    {
+        [Theory]
+        [InlineData("", "", "")]
+        [InlineData("\"", "", "\"")]
+        [InlineData("'", "", "'")]
+        [InlineData("\"word\"", "word", "\"")]
+        [InlineData("'word'", "word", "'")]
+        [InlineData("\"word", "word", "\"")]
+        [InlineData("'word", "word", "'")]
+        [InlineData("word\"", "word\"", "")]
+        [InlineData("word'", "word'", "")]
+        [InlineData("\"word's\"", "word's", "\"")]
+        [InlineData("'word\"", "'word\"", "")]
+        [InlineData("\"word'", "\"word'", "")]
+        public void TestHandleDoubleAndSingleQuote(string wordToComplete, string expectedWordToComplete, string expectedQuote)
+        {
+            string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
+            Assert.Equal(expectedQuote, quote);
+            Assert.Equal(expectedWordToComplete, wordToComplete);
+        }
+
+        [Theory]
+        [InlineData("", false, true)]
+        [InlineData("simpleWord", false, false)]
+        [InlineData("word1 word2", false, true)]
+        [InlineData("keyword", false, false)]
+        [InlineData("word*", true, false)]
+        [InlineData("word*", false, false)]
+        [InlineData("\"alreadyQuoted\"", false, false)]
+        [InlineData("var-name", false, false)]
+        [InlineData("${variable}", false, false)]
+        [InlineData("${variable}", true, false)]
+        [InlineData("file[name]", false, false)]
+        [InlineData("file[name]", true, true)]
+        [InlineData("`command`", false, true)]
+        [InlineData("word`command`", false, true)]
+        [InlineData("`unmatchedBacktick", false, true)]
+        [InlineData("`", false, true)]
+        [InlineData("word1 `word2`", false, true)]
+        [InlineData("`command with spaces`", false, true)]
+        [InlineData("word`another`word", false, true)]
+        public void TestCompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars, bool expected)
+        {
+            bool result = CompletionHelpers.CompletionRequiresQuotes(completion, escapeGlobbingPathChars);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("word", "'", false, "'word'")]
+        [InlineData("word", "\"", false, "\"word\"")]
+        [InlineData("word's", "'", false, "'word''s'")]
+        [InlineData("`command`", "\"", false, "\"``command``\"")]
+        [InlineData("word$", "\"", false, "\"word`$\"")]
+        [InlineData("[word]", "'", true, "'`[word`]\'")]
+        [InlineData("[word]", "\"", true, "\"``[word``]\"")]
+        [InlineData("word", "", false, "word")]
+        [InlineData("word [value]", "'", true, "'word `[value`]\'")]
+        [InlineData("word [value]", "'", false, "'word [value]'")]
+        [InlineData("", "'", false, "''")]
+        [InlineData("", "", false, "''")]
+        public void TestQuoteCompletionText(string completionText, string quote, bool escapeGlobbingPathChars, string expected)
+        {
+            string result = CompletionHelpers.QuoteCompletionText(completionText, quote, escapeGlobbingPathChars);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_BasicMatch()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2", "anotherWord" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_NoMatch()
+        {
+            string wordToComplete = "noMatch";
+            var possibleCompletionValues = new[] { "word", "word2", "anotherWord" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_EscapeGlobbingPathChars_Enabled()
+        {
+            string wordToComplete = "file";
+            var possibleCompletionValues = new[] { "file[name]", "file[other]", "file*" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, escapeGlobbingPathChars: true).ToList();
+
+            Assert.Equal(3, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "'file`[name`]'");
+            Assert.Contains(results, r => r.CompletionText == "'file`[other`]'");
+            Assert.Contains(results, r => r.CompletionText == "file*");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_EscapeGlobbingPathChars_Disabled()
+        {
+            string wordToComplete = "file";
+            var possibleCompletionValues = new[] { "file[name]", "file[other]", "file*" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, escapeGlobbingPathChars: false).ToList();
+
+            Assert.Equal(3, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "file[name]");
+            Assert.Contains(results, r => r.CompletionText == "file[other]");
+            Assert.Contains(results, r => r.CompletionText == "file*");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_WithToolTipMapping()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+            Func<string, string> toolTipMapping = value => $"Tooltip for {value}";
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, toolTipMapping: toolTipMapping).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.Contains(results, r => r.ToolTip == "Tooltip for word");
+            Assert.Contains(results, r => r.ToolTip == "Tooltip for word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_WithListItemTextMapping()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+            Func<string, string> listItemTextMapping = value => $"Item: {value}";
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, listItemTextMapping: listItemTextMapping).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.Contains(results, r => r.ListItemText == "Item: word");
+            Assert.Contains(results, r => r.ListItemText == "Item: word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_SingleQuote()
+        {
+            string wordToComplete = "'word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "'word'");
+            Assert.Contains(results, r => r.CompletionText == "'word2'");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_DoubleQuote()
+        {
+            string wordToComplete = "\"word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "\"word\"");
+            Assert.Contains(results, r => r.CompletionText == "\"word2\"");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void TestGetMatchingResults_MixedCasesAndPatternMatch()
+        {
+            string wordToComplete = "Word";
+            var possibleCompletionValues = new[] { "word1", "Word2", "anotherWord" };
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word1");
+            Assert.Contains(results, r => r.CompletionText == "Word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
+        }
+
+        [Fact]
+        public void GetMatchingResults_WithParameterValueResultType()
+        {
+            string wordToComplete = "word";
+            var possibleCompletionValues = new[] { "word", "word2" };
+            CompletionResultType resultType = CompletionResultType.ParameterValue;
+
+            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, resultType: resultType).ToList();
+
+            Assert.Equal(2, results.Count);
+            Assert.Contains(results, r => r.CompletionText == "word");
+            Assert.Contains(results, r => r.CompletionText == "word2");
+            Assert.All(results, r => Assert.Equal(CompletionResultType.ParameterValue, r.ResultType));
+        }
+    }
+}

--- a/test/xUnit/csharp/test_CompletionHelpers.cs
+++ b/test/xUnit/csharp/test_CompletionHelpers.cs
@@ -10,71 +10,6 @@ namespace PSTests.Parallel
 {
     public class CompletionHelpersTests
     {
-        [Theory]
-        [InlineData("", "", "")]
-        [InlineData("\"", "", "\"")]
-        [InlineData("'", "", "'")]
-        [InlineData("\"word\"", "word", "\"")]
-        [InlineData("'word'", "word", "'")]
-        [InlineData("\"word", "word", "\"")]
-        [InlineData("'word", "word", "'")]
-        [InlineData("word\"", "word\"", "")]
-        [InlineData("word'", "word'", "")]
-        [InlineData("\"word's\"", "word's", "\"")]
-        [InlineData("'word\"", "'word\"", "")]
-        [InlineData("\"word'", "\"word'", "")]
-        public void TestHandleDoubleAndSingleQuote(string wordToComplete, string expectedWordToComplete, string expectedQuote)
-        {
-            string quote = CompletionHelpers.HandleDoubleAndSingleQuote(ref wordToComplete);
-            Assert.Equal(expectedQuote, quote);
-            Assert.Equal(expectedWordToComplete, wordToComplete);
-        }
-
-        [Theory]
-        [InlineData("", false, true)]
-        [InlineData("simpleWord", false, false)]
-        [InlineData("word1 word2", false, true)]
-        [InlineData("keyword", false, false)]
-        [InlineData("word*", true, false)]
-        [InlineData("word*", false, false)]
-        [InlineData("\"alreadyQuoted\"", false, false)]
-        [InlineData("var-name", false, false)]
-        [InlineData("${variable}", false, false)]
-        [InlineData("${variable}", true, false)]
-        [InlineData("file[name]", false, false)]
-        [InlineData("file[name]", true, true)]
-        [InlineData("`command`", false, true)]
-        [InlineData("word`command`", false, true)]
-        [InlineData("`unmatchedBacktick", false, true)]
-        [InlineData("`", false, true)]
-        [InlineData("word1 `word2`", false, true)]
-        [InlineData("`command with spaces`", false, true)]
-        [InlineData("word`another`word", false, true)]
-        public void TestCompletionRequiresQuotes(string completion, bool escapeGlobbingPathChars, bool expected)
-        {
-            bool result = CompletionHelpers.CompletionRequiresQuotes(completion, escapeGlobbingPathChars);
-            Assert.Equal(expected, result);
-        }
-
-        [Theory]
-        [InlineData("word", "'", false, "'word'")]
-        [InlineData("word", "\"", false, "\"word\"")]
-        [InlineData("word's", "'", false, "'word''s'")]
-        [InlineData("`command`", "\"", false, "\"``command``\"")]
-        [InlineData("word$", "\"", false, "\"word`$\"")]
-        [InlineData("[word]", "'", true, "'`[word`]\'")]
-        [InlineData("[word]", "\"", true, "\"``[word``]\"")]
-        [InlineData("word", "", false, "word")]
-        [InlineData("word [value]", "'", true, "'word `[value`]\'")]
-        [InlineData("word [value]", "'", false, "'word [value]'")]
-        [InlineData("", "'", false, "''")]
-        [InlineData("", "", false, "''")]
-        public void TestQuoteCompletionText(string completionText, string quote, bool escapeGlobbingPathChars, string expected)
-        {
-            string result = CompletionHelpers.QuoteCompletionText(completionText, quote, escapeGlobbingPathChars);
-            Assert.Equal(expected, result);
-        }
-
         [Fact]
         public void TestGetMatchingResults_BasicMatch()
         {
@@ -101,36 +36,6 @@ namespace PSTests.Parallel
         }
 
         [Fact]
-        public void TestGetMatchingResults_EscapeGlobbingPathChars_Enabled()
-        {
-            string wordToComplete = "file";
-            var possibleCompletionValues = new[] { "file[name]", "file[other]", "file*" };
-
-            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, escapeGlobbingPathChars: true).ToList();
-
-            Assert.Equal(3, results.Count);
-            Assert.Contains(results, r => r.CompletionText == "'file`[name`]'");
-            Assert.Contains(results, r => r.CompletionText == "'file`[other`]'");
-            Assert.Contains(results, r => r.CompletionText == "file*");
-            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
-        }
-
-        [Fact]
-        public void TestGetMatchingResults_EscapeGlobbingPathChars_Disabled()
-        {
-            string wordToComplete = "file";
-            var possibleCompletionValues = new[] { "file[name]", "file[other]", "file*" };
-
-            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, escapeGlobbingPathChars: false).ToList();
-
-            Assert.Equal(3, results.Count);
-            Assert.Contains(results, r => r.CompletionText == "file[name]");
-            Assert.Contains(results, r => r.CompletionText == "file[other]");
-            Assert.Contains(results, r => r.CompletionText == "file*");
-            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
-        }
-
-        [Fact]
         public void TestGetMatchingResults_WithToolTipMapping()
         {
             string wordToComplete = "word";
@@ -144,23 +49,6 @@ namespace PSTests.Parallel
             Assert.Contains(results, r => r.CompletionText == "word2");
             Assert.Contains(results, r => r.ToolTip == "Tooltip for word");
             Assert.Contains(results, r => r.ToolTip == "Tooltip for word2");
-            Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
-        }
-
-        [Fact]
-        public void TestGetMatchingResults_WithListItemTextMapping()
-        {
-            string wordToComplete = "word";
-            var possibleCompletionValues = new[] { "word", "word2" };
-            Func<string, string> listItemTextMapping = value => $"Item: {value}";
-
-            var results = CompletionHelpers.GetMatchingResults(wordToComplete, possibleCompletionValues, listItemTextMapping: listItemTextMapping).ToList();
-
-            Assert.Equal(2, results.Count);
-            Assert.Contains(results, r => r.CompletionText == "word");
-            Assert.Contains(results, r => r.CompletionText == "word2");
-            Assert.Contains(results, r => r.ListItemText == "Item: word");
-            Assert.Contains(results, r => r.ListItemText == "Item: word2");
             Assert.All(results, r => Assert.Equal(CompletionResultType.Text, r.ResultType));
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

So to make sure the `GetMatchingResults` method in CompletionHelpers class is covered from regression, I have added tests to ensure code is covered by regressions.

Similar to https://github.com/PowerShell/PowerShell/pull/25181

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
