### PR TITLE
Fix infinite loop in variable type inference

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2930,7 +2930,7 @@ namespace System.Management.Automation
 
             private void SetLastAssignment(Ast ast, bool enumerate = false, bool redirectionAssignment = false)
             {
-                if (LastAssignmentOffset < ast.Extent.StartOffset)
+                if (LastAssignmentOffset < ast.Extent.StartOffset && !VariableTarget.Extent.IsWithin(ast.Extent))
                 {
                     ClearAssignmentData();
                     LastAssignment = ast;

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2932,6 +2932,8 @@ namespace System.Management.Automation
             {
                 if (LastAssignmentOffset < ast.Extent.StartOffset && !VariableTarget.Extent.IsWithin(ast.Extent))
                 {
+                    // If the variable we are inferring the value of is inside this assignment then the assignment is invalid
+                    // For example: $x = Get-Random; $x = $x.Where{$_.<Tab>} here the value should be inferred based on Get-Random and not $x = $x...
                     ClearAssignmentData();
                     LastAssignment = ast;
                     EnumerateAssignment = enumerate;

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2940,13 +2940,13 @@ namespace System.Management.Automation
                 }
             }
 
-            private void SetLastAssignmentType(PSTypeName typeName, IScriptExtent assignmentExtent)
+            private void SetLastAssignmentType(PSTypeName typeName, int assignmentOffset)
             {
-                if (LastAssignmentOffset < assignmentExtent.StartOffset && !VariableTarget.Extent.IsWithin(assignmentExtent))
+                if (LastAssignmentOffset < assignmentOffset)
                 {
                     ClearAssignmentData();
                     LastAssignmentType = typeName;
-                    LastAssignmentOffset = assignmentExtent.StartOffset;
+                    LastAssignmentOffset = assignmentOffset;
                 }
             }
 
@@ -3107,17 +3107,17 @@ namespace System.Management.Automation
                             {
                                 case "ErrorVariable":
                                 case "ev":
-                                    SetLastAssignmentType(new PSTypeName(typeof(List<ErrorRecord>)), commandAst.Extent);
+                                    SetLastAssignmentType(new PSTypeName(typeof(List<ErrorRecord>)), commandAst.Extent.StartOffset);
                                     break;
 
                                 case "WarningVariable":
                                 case "wv":
-                                    SetLastAssignmentType(new PSTypeName(typeof(List<WarningRecord>)), commandAst.Extent);
+                                    SetLastAssignmentType(new PSTypeName(typeof(List<WarningRecord>)), commandAst.Extent.StartOffset);
                                     break;
 
                                 case "InformationVariable":
                                 case "iv":
-                                    SetLastAssignmentType(new PSTypeName(typeof(List<InformationalRecord>)), commandAst.Extent);
+                                    SetLastAssignmentType(new PSTypeName(typeof(List<InformationalRecord>)), commandAst.Extent.StartOffset);
                                     break;
 
                                 case "OutVariable":
@@ -3164,23 +3164,23 @@ namespace System.Management.Automation
                         switch (fileRedirection.FromStream)
                         {
                             case RedirectionStream.Error:
-                                SetLastAssignmentType(new PSTypeName(typeof(ErrorRecord)), commandAst.Extent);
+                                SetLastAssignmentType(new PSTypeName(typeof(ErrorRecord)), commandAst.Extent.StartOffset);
                                 break;
 
                             case RedirectionStream.Warning:
-                                SetLastAssignmentType(new PSTypeName(typeof(WarningRecord)), commandAst.Extent);
+                                SetLastAssignmentType(new PSTypeName(typeof(WarningRecord)), commandAst.Extent.StartOffset);
                                 break;
 
                             case RedirectionStream.Verbose:
-                                SetLastAssignmentType(new PSTypeName(typeof(VerboseRecord)), commandAst.Extent);
+                                SetLastAssignmentType(new PSTypeName(typeof(VerboseRecord)), commandAst.Extent.StartOffset);
                                 break;
 
                             case RedirectionStream.Debug:
-                                SetLastAssignmentType(new PSTypeName(typeof(DebugRecord)), commandAst.Extent);
+                                SetLastAssignmentType(new PSTypeName(typeof(DebugRecord)), commandAst.Extent.StartOffset);
                                 break;
 
                             case RedirectionStream.Information:
-                                SetLastAssignmentType(new PSTypeName(typeof(InformationRecord)), commandAst.Extent);
+                                SetLastAssignmentType(new PSTypeName(typeof(InformationRecord)), commandAst.Extent.StartOffset);
                                 break;
 
                             default:

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2940,13 +2940,13 @@ namespace System.Management.Automation
                 }
             }
 
-            private void SetLastAssignmentType(PSTypeName typeName, int assignmentOffset)
+            private void SetLastAssignmentType(PSTypeName typeName, IScriptExtent assignmentExtent)
             {
-                if (LastAssignmentOffset < assignmentOffset)
+                if (LastAssignmentOffset < assignmentExtent.StartOffset && !VariableTarget.Extent.IsWithin(assignmentExtent))
                 {
                     ClearAssignmentData();
                     LastAssignmentType = typeName;
-                    LastAssignmentOffset = assignmentOffset;
+                    LastAssignmentOffset = assignmentExtent.StartOffset;
                 }
             }
 
@@ -3107,17 +3107,17 @@ namespace System.Management.Automation
                             {
                                 case "ErrorVariable":
                                 case "ev":
-                                    SetLastAssignmentType(new PSTypeName(typeof(List<ErrorRecord>)), commandAst.Extent.StartOffset);
+                                    SetLastAssignmentType(new PSTypeName(typeof(List<ErrorRecord>)), commandAst.Extent);
                                     break;
 
                                 case "WarningVariable":
                                 case "wv":
-                                    SetLastAssignmentType(new PSTypeName(typeof(List<WarningRecord>)), commandAst.Extent.StartOffset);
+                                    SetLastAssignmentType(new PSTypeName(typeof(List<WarningRecord>)), commandAst.Extent);
                                     break;
 
                                 case "InformationVariable":
                                 case "iv":
-                                    SetLastAssignmentType(new PSTypeName(typeof(List<InformationalRecord>)), commandAst.Extent.StartOffset);
+                                    SetLastAssignmentType(new PSTypeName(typeof(List<InformationalRecord>)), commandAst.Extent);
                                     break;
 
                                 case "OutVariable":
@@ -3164,23 +3164,23 @@ namespace System.Management.Automation
                         switch (fileRedirection.FromStream)
                         {
                             case RedirectionStream.Error:
-                                SetLastAssignmentType(new PSTypeName(typeof(ErrorRecord)), commandAst.Extent.StartOffset);
+                                SetLastAssignmentType(new PSTypeName(typeof(ErrorRecord)), commandAst.Extent);
                                 break;
 
                             case RedirectionStream.Warning:
-                                SetLastAssignmentType(new PSTypeName(typeof(WarningRecord)), commandAst.Extent.StartOffset);
+                                SetLastAssignmentType(new PSTypeName(typeof(WarningRecord)), commandAst.Extent);
                                 break;
 
                             case RedirectionStream.Verbose:
-                                SetLastAssignmentType(new PSTypeName(typeof(VerboseRecord)), commandAst.Extent.StartOffset);
+                                SetLastAssignmentType(new PSTypeName(typeof(VerboseRecord)), commandAst.Extent);
                                 break;
 
                             case RedirectionStream.Debug:
-                                SetLastAssignmentType(new PSTypeName(typeof(DebugRecord)), commandAst.Extent.StartOffset);
+                                SetLastAssignmentType(new PSTypeName(typeof(DebugRecord)), commandAst.Extent);
                                 break;
 
                             case RedirectionStream.Information:
-                                SetLastAssignmentType(new PSTypeName(typeof(InformationRecord)), commandAst.Extent.StartOffset);
+                                SetLastAssignmentType(new PSTypeName(typeof(InformationRecord)), commandAst.Extent);
                                 break;
 
                             default:

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -1203,6 +1203,12 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Guid
     }
 
+    It 'Ignores assignment when a variable is declared and used within the same commandAst' {
+        $variableAst = { Get-Random 2>variable:RandomError1 -InputObject ($RandomError1) }.Ast.FindAll({ param($a) $a -is [Language.VariableExpressionAst] }, $true) | select -Last 1
+        $res = [AstTypeInference]::InferTypeOf($variableAst)
+        $res.Count | Should -Be 0
+    }
+
     $catchClauseTypes = @(
         @{ Type = 'System.ArgumentException' }
         @{ Type = 'System.ArgumentNullException' }

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -1203,12 +1203,6 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Guid
     }
 
-    It 'Ignores assignment when a variable is declared and used within the same commandAst' {
-        $variableAst = { Get-Random 2>variable:RandomError1 -InputObject ($RandomError1) }.Ast.FindAll({ param($a) $a -is [Language.VariableExpressionAst] }, $true) | select -Last 1
-        $res = [AstTypeInference]::InferTypeOf($variableAst)
-        $res.Count | Should -Be 0
-    }
-
     $catchClauseTypes = @(
         @{ Type = 'System.ArgumentException' }
         @{ Type = 'System.ArgumentNullException' }

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -1197,6 +1197,12 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.String
     }
 
+    It 'Ignores the last assignment when a variable is reused' {
+        $variableAst = { $x = New-Guid; $x = $x.Where{$_} }.Ast.FindAll({ param($a) $a -is [Language.VariableExpressionAst] }, $true) | select -Last 1
+        $res = [AstTypeInference]::InferTypeOf($variableAst)
+        $res.Name | Should -Be System.Guid
+    }
+
     $catchClauseTypes = @(
         @{ Type = 'System.ArgumentException' }
         @{ Type = 'System.ArgumentNullException' }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fixes a crash due to an infinite loop when inferring the type of a variable that is being reused, like here: `$x = Get-Random; $x = $x.Where{$_}` where the last assignment of `$x` was considered the `$x.Where...` statement instead of `Get-Random`.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/25205
Regression was added in https://github.com/PowerShell/PowerShell/pull/19830 and https://github.com/PowerShell/PowerShell/pull/21143
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [X] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
  - **OR**
  - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
    - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
    - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
      - [ ] Issue filed: <!-- Number/link of that issue here -->
