### PR TITLE
Support registering a cover-all completer for native commands

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2580,9 +2580,9 @@ namespace System.Management.Automation
                     }
                 }
 
-                // For a native command, if a cover-all completer is registered, then return it.
+                // For a native command, if a fallback completer is registered, then return it.
                 // For example, the 'Microsoft.PowerShell.UnixTabCompletion' module.
-                if (isNative && registeredCompleters.TryGetValue("*", out scriptBlock))
+                if (isNative && registeredCompleters.TryGetValue(RegisterArgumentCompleterCommand.FallbackCompleterKey, out scriptBlock))
                 {
                     return scriptBlock;
                 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2567,9 +2567,8 @@ namespace System.Management.Automation
                 }
             }
 
-            var registeredCompleters = optionKey.Equals("NativeArgumentCompleters", StringComparison.OrdinalIgnoreCase)
-                ? context.NativeArgumentCompleters
-                : context.CustomArgumentCompleters;
+            bool isNative = optionKey.Equals("NativeArgumentCompleters", StringComparison.OrdinalIgnoreCase);
+            var registeredCompleters = isNative ? context.NativeArgumentCompleters : context.CustomArgumentCompleters;
 
             if (registeredCompleters != null)
             {
@@ -2579,6 +2578,13 @@ namespace System.Management.Automation
                     {
                         return scriptBlock;
                     }
+                }
+
+                // For a native command, if a cover-all completer is registered, then return it.
+                // For example, the 'Microsoft.PowerShell.UnixTabCompletion' module.
+                if (isNative && registeredCompleters.TryGetValue("*", out scriptBlock))
+                {
+                    return scriptBlock;
                 }
             }
 

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -1067,9 +1067,9 @@ namespace System.Management.Automation.Runspaces
         /// ExecutionContext, if it available in TLS
         /// Null, if ExecutionContext is not available in TLS
         /// </returns>
-        internal static System.Management.Automation.ExecutionContext GetExecutionContextFromTLS()
+        internal static ExecutionContext GetExecutionContextFromTLS()
         {
-            System.Management.Automation.Runspaces.Runspace runspace = Runspace.DefaultRunspace;
+            Runspace runspace = Runspace.DefaultRunspace;
             if (runspace == null)
             {
                 return null;

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -104,7 +104,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="script">The string to compile.</param>
         public static ScriptBlock Create(string script) => Create(
-            parser: new Language.Parser(),
+            parser: new Parser(),
             fileName: null,
             fileContents: script);
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1772,8 +1772,12 @@ param([ValidatePattern(
 
     Context NativeCommand {
         BeforeAll {
-            $nativeCommand = (Get-Command -CommandType Application -TotalCount 1).Name
+            ## Find a native command that is not 'pwsh'. We will use 'pwsh' for cover-all completer tests later.
+            $nativeCommand = Get-Command -CommandType Application -TotalCount 2 |
+                Where-Object Name -NotLike pwsh* |
+                Select-Object -First 1
         }
+
         It 'Completes native commands with -' {
             Register-ArgumentCompleter -Native -CommandName $nativeCommand -ScriptBlock {
                 param($wordToComplete, $ast, $cursorColumn)

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1772,7 +1772,7 @@ param([ValidatePattern(
 
     Context NativeCommand {
         BeforeAll {
-            ## Find a native command that is not 'pwsh'. We will use 'pwsh' for cover-all completer tests later.
+            ## Find a native command that is not 'pwsh'. We will use 'pwsh' for fallback completer tests later.
             $nativeCommand = Get-Command -CommandType Application -TotalCount 2 |
                 Where-Object Name -NotLike pwsh* |
                 Select-Object -First 1
@@ -1851,8 +1851,8 @@ param([ValidatePattern(
                 }
             }
 
-            ## Register a cover-all native command completer.
-            Register-ArgumentCompleter -Native -CommandName '*' -ScriptBlock {
+            ## Register a fallback native command completer.
+            Register-ArgumentCompleter -NativeFallback -ScriptBlock {
                 param($wordToComplete, $ast, $cursorColumn)
                 if ($wordToComplete -eq '-t') {
                     return "-testing"
@@ -1865,7 +1865,7 @@ param([ValidatePattern(
             $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches.CompletionText | Should -BeExactly "-terminal"
 
-            ## Otherwise, the cover-all completer will kick in.
+            ## Otherwise, the fallback completer will kick in.
             $line = "pwsh -t"
             $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
             $res.CompletionMatches | Should -HaveCount 1
@@ -1874,16 +1874,16 @@ param([ValidatePattern(
             ## Remove the completer for $nativeCommand.
             Register-ArgumentCompleter -Native -CommandName $nativeCommand -ScriptBlock $null
 
-            ## The cover-all completer will be used for $nativeCommand.
+            ## The fallback completer will be used for $nativeCommand.
             $line = "$nativeCommand -t"
             $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
             $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches.CompletionText | Should -BeExactly "-testing"
 
-            ## Remove the cover-all completer for $nativeCommand.
-            Register-ArgumentCompleter -Native -CommandName '*' -ScriptBlock $null
+            ## Remove the fallback completer for $nativeCommand.
+            Register-ArgumentCompleter -NativeFallback -ScriptBlock $null
 
-            ## The cover-all completer will be used for $nativeCommand.
+            ## The fallback completer will be used for $nativeCommand.
             $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
             $res.CompletionMatches | Should -HaveCount 0
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR contains the following changes:
1. Refactor `Register-ArgumentCompleter` to make it
    - Easier to read and run faster for native command registration
    - Not insert keys that are empty string or containing only white spaces.
    - Remove a registration when value to `-ScriptBlock` is `null` (currently it keeps the key value pair but only set the value to null)

2. Add the parameter `-NativeFallback` to support registering a cover-all completer for native commands.
    - When a native command doesn't have a specific completer for it, the cover-all completer will be used for it.
    - This will make it easy for a module like `Microsoft.PowerShell.UnixTabCompletion` to hook up with PowerShell to provide tab completion for many native commands on Linux and macOS systems.

With this change, a new parameter set gets added (which includes the parameter `-NativeFallback`)

```
PS C:\> gcm Register-ArgumentCompleter -Syntax

Register-ArgumentCompleter -CommandName <string[]> -ScriptBlock <scriptblock> [-Native] [<CommonParameters>]

Register-ArgumentCompleter -ParameterName <string> -ScriptBlock <scriptblock> [-CommandName <string[]>] [<CommonParameters>]

Register-ArgumentCompleter -ScriptBlock <scriptblock> [-NativeFallback] [<CommonParameters>]
```
 
## PR Context

The module `Microsoft.PowerShell.UnixTabCompletion` is designed to leverage the completion system of `Bash` and `Zsh` to provide tab completion for native utilities on Linux and macOS systems that already have completion support for `Bash` or `Zsh`. However, today, a native command completer has to be associated with a specific command, so the `UnixTabCompletion` module needs to discover all native utilities ahead of time and register a proxy completer for each of them, which not only takes time but also cannot pick up any utilities installed later. It will be helpful to support a cover-all completer so that if there is no specific completer registered for a native command, then we fall back to the cover-all completer for it.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/12321
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
  - [x] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
