### PR TITLE
Switch to ubuntu-lastest for CI

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -87,7 +87,7 @@ jobs:
       - ci_build
       - changes
     if: ${{ needs.changes.outputs.source == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
       - ci_build
       - changes
     if: ${{ needs.changes.outputs.source == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
       - ci_build
       - changes
     if: ${{ needs.changes.outputs.source == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
       - ci_build
       - changes
     if: ${{ needs.changes.outputs.source == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -70,7 +70,7 @@ jobs:
 
   ci_build:
     name: Build PowerShell
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
     steps:


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/linux-ci.yml` file to ensure the CI builds use the latest Ubuntu version. The most important changes involve modifying the `runs-on` parameter for several jobs.

Changes to CI build configuration:

* Updated `runs-on` parameter from `ubuntu-20.04` to `ubuntu-latest` for the `ci_build` job. (.github/workflows/linux-ci.yml)
* Updated `runs-on` parameter from `ubuntu-20.04` to `ubuntu-latest` for the job that depends on `ci_build` and `changes`. (.github/workflows/linux-ci.yml) [[1]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL90-R90) [[2]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL107-R107) [[3]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL124-R124) [[4]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fL141-R141)

## Updates 2025-04-02

### Context

GitHub is removing support for `20.04` and was having brownouts at the time of this PR to force migration.