### PR TITLE
Make GitHub Workflows work in the internal mirror

### DIFF
--- a/.github/actions/infrastructure/path-filters/action.yml
+++ b/.github/actions/infrastructure/path-filters/action.yml
@@ -1,0 +1,84 @@
+name: Path Filters
+description: 'Path Filters'
+outputs:
+  source:
+    description: 'Source code changes (composite of all changes)'
+    value: ${{ steps.filter.outputs.source }}
+  githubChanged:
+    description: 'GitHub workflow changes'
+    value: ${{ steps.filter.outputs.githubChanged }}
+  toolsChanged:
+    description: 'Tools changes'
+    value: ${{ steps.filter.outputs.toolsChanged }}
+  propsChanged:
+    description: 'Props changes'
+    value: ${{ steps.filter.outputs.propsChanged }}
+  testsChanged:
+    description: 'Tests changes'
+    value: ${{ steps.filter.outputs.testsChanged }}
+  mainSourceChanged:
+    description: 'Main source code changes (any changes in src/)'
+    value: ${{ steps.filter.outputs.mainSourceChanged }}
+  buildModuleChanged:
+    description: 'Build module changes'
+    value: ${{ steps.filter.outputs.buildModuleChanged }}
+runs:
+  using: composite
+  steps:
+    - name: Check if GitHubWorkflowChanges is present
+      id: filter
+      uses: actions/github-script@v7.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          // Fetch the list of files changed in the PR
+          let files = [];
+          let page = 1;
+          let fetchedFiles;
+          do {
+            fetchedFiles = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+              page: page++
+            });
+            files = files.concat(fetchedFiles.data);
+          } while (fetchedFiles.data.length > 0);
+
+          const actionsChanged = files.some(file => file.filename.startsWith('.github/actions'));
+          const workflowsChanged = files.some(file => file.filename.startsWith('.github/workflows'));
+          const githubChanged = actionsChanged || workflowsChanged;
+
+          const toolsCiPsm1Changed = files.some(file => file.filename.startsWith('tools/ci.psm1'));
+          const toolsBuildCommonChanged = files.some(file => file.filename.startsWith('tools/buildCommon/'));
+          const toolsChanged = toolsCiPsm1Changed || toolsBuildCommonChanged;
+
+          const propsChanged = files.some(file => file.filename.endsWith('.props'));
+
+          const testsChanged = files.some(file => file.filename.startsWith('test/powershell/') || file.filename.startsWith('test/tools/') || file.filename.startsWith('test/xUnit/'));
+
+          const mainSourceChanged = files.some(file => file.filename.startsWith('src/'));
+
+          const buildModuleChanged = files.some(file => file.filename.startsWith('build.psm1'));
+
+          const source = mainSourceChanged || toolsChanged || githubChanged || propsChanged || testsChanged;
+
+          core.setOutput('toolsChanged', toolsChanged);
+          core.setOutput('githubChanged', githubChanged);
+          core.setOutput('propsChanged', propsChanged);
+          core.setOutput('testsChanged', testsChanged);
+          core.setOutput('mainSourceChanged', mainSourceChanged);
+          core.setOutput('buildModuleChanged', buildModuleChanged);
+          core.setOutput('source', source);
+
+    - name: Capture outputs
+      run: |
+        Write-Verbose -Verbose "source: ${{ steps.filter.outputs.source }}"
+        Write-Verbose -Verbose "github: ${{ steps.filter.outputs.githubChanged }}"
+        Write-Verbose -Verbose "tools: ${{ steps.filter.outputs.toolsChanged }}"
+        Write-Verbose -Verbose "props: ${{ steps.filter.outputs.propsChanged }}"
+        Write-Verbose -Verbose "tests: ${{ steps.filter.outputs.testsChanged }}"
+        Write-Verbose -Verbose "mainSource: ${{ steps.filter.outputs.mainSourceChanged }}"
+        Write-Verbose -Verbose "buildModule: ${{ steps.filter.outputs.buildModuleChanged }}"
+      shell: pwsh

--- a/.github/actions/infrastructure/path-filters/action.yml
+++ b/.github/actions/infrastructure/path-filters/action.yml
@@ -1,5 +1,9 @@
 name: Path Filters
 description: 'Path Filters'
+inputs:
+  GITHUB_TOKEN:
+    description: 'GitHub token'
+    required: true
 outputs:
   source:
     description: 'Source code changes (composite of all changes)'
@@ -29,7 +33,7 @@ runs:
       id: filter
       uses: actions/github-script@v7.0.1
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.GITHUB_TOKEN }}
         script: |
           // Fetch the list of files changed in the PR
           let files = [];

--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -21,7 +21,7 @@ runs:
   - name: Capture Environment
     if: success() || failure()
     run: |-
-      ./Import-Module ./build.psm1
+      Import-Module ./build.psm1
       Write-LogGroupStart -Title 'Environment'
       Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
       Write-LogGroupEnd -Title 'Environment'
@@ -35,7 +35,7 @@ runs:
   - name: Capture Artifacts Directory
     continue-on-error: true
     run: |-
-      ./Import-Module ./build.psm1
+      Import-Module ./build.psm1
       Write-LogGroupStart -Title 'Artifacts Directory'
       Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
       Write-LogGroupEnd -Title 'Artifacts Directory'
@@ -48,7 +48,7 @@ runs:
   - name: Bootstrap
     shell: pwsh
     run: |-
-      ./Import-Module ./build.psm1
+      Import-Module ./build.psm1
       Write-LogGroupStart -Title 'Bootstrap'
       Import-Module ./tools/ci.psm1
       Invoke-CIInstall -SkipUser
@@ -82,7 +82,7 @@ runs:
   - name: Capture Extracted Build ZIP
     continue-on-error: true
     run: |-
-      ./Import-Module ./build.psm1
+      Import-Module ./build.psm1
       Write-LogGroupStart -Title 'Extracted Build ZIP'
       Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
       Write-LogGroupEnd -Title 'Extracted Build ZIP'

--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -20,15 +20,25 @@ runs:
   steps:
   - name: Capture Environment
     if: success() || failure()
-    run: 'Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose'
+    run: |-
+      ./Import-Module ./build.psm1
+      Write-LogGroupStart -Title 'Environment'
+      Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
+      Write-LogGroupEnd -Title 'Environment'
     shell: pwsh
+
   - name: Download Build Artifacts
     uses: actions/download-artifact@v4
     with:
       path: "${{ github.workspace }}"
+
   - name: Capture Artifacts Directory
     continue-on-error: true
-    run: Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
+    run: |-
+      ./Import-Module ./build.psm1
+      Write-LogGroupStart -Title 'Artifacts Directory'
+      Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
+      Write-LogGroupEnd -Title 'Artifacts Directory'
     shell: pwsh
 
   - uses: actions/setup-dotnet@v4
@@ -38,8 +48,11 @@ runs:
   - name: Bootstrap
     shell: pwsh
     run: |-
+      ./Import-Module ./build.psm1
+      Write-LogGroupStart -Title 'Bootstrap'
       Import-Module ./tools/ci.psm1
       Invoke-CIInstall -SkipUser
+      Write-LogGroupEnd -Title 'Bootstrap'
 
   - name: Extract Files
     uses: actions/github-script@v7.0.0
@@ -68,26 +81,12 @@ runs:
 
   - name: Capture Extracted Build ZIP
     continue-on-error: true
-    run: Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
+    run: |-
+      ./Import-Module ./build.psm1
+      Write-LogGroupStart -Title 'Extracted Build ZIP'
+      Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
+      Write-LogGroupEnd -Title 'Extracted Build ZIP'
     shell: pwsh
-
-  - name: Setup Culture
-    shell: pwsh
-    run: |
-      $culture = Get-Culture
-      Write-Verbose -Verbose "Current culture is $($culture.Name)"
-      if ($culture.Name -ne 'en-US') {
-        Write-Verbose -Verbose "Setting culture to en-US"
-        sudo update-locale LANG=en_US.UTF-8
-        "LANG=en_US.UTF-8" >> $GITHUB_ENV
-        "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
-      }
-
-  - name: Capture Culture
-    shell: pwsh
-    run: |
-      $culture = Get-Culture
-      Write-Verbose -Verbose "Current culture is $($culture.Name)"
 
   - name: Test
     if: success()

--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -88,12 +88,6 @@ runs:
     run: |
       $culture = Get-Culture
       Write-Verbose -Verbose "Current culture is $($culture.Name)"
-      if ($culture.Name -ne 'en-US') {
-        Write-Verbose -Verbose "Setting culture to en-US"
-        sudo update-locale LANG=en_US.UTF-8
-        "LANG=en_US.UTF-8" >> $GITHUB_ENV
-        "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
-      }
 
   - name: Test
     if: success()

--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -30,11 +30,11 @@ runs:
     continue-on-error: true
     run: Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
     shell: pwsh
-    
+
   - uses: actions/setup-dotnet@v4
     with:
       global-json-file: ./global.json
-      
+
   - name: Bootstrap
     shell: pwsh
     run: |-
@@ -70,6 +70,30 @@ runs:
     continue-on-error: true
     run: Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
     shell: pwsh
+
+  - name: Setup Culture
+    shell: pwsh
+    run: |
+      $culture = Get-Culture
+      Write-Verbose -Verbose "Current culture is $($culture.Name)"
+      if ($culture.Name -ne 'en-US') {
+        Write-Verbose -Verbose "Setting culture to en-US"
+        sudo update-locale LANG=en_US.UTF-8
+        "LANG=en_US.UTF-8" >> $GITHUB_ENV
+        "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
+      }
+
+  - name: Capture Culture
+    shell: pwsh
+    run: |
+      $culture = Get-Culture
+      Write-Verbose -Verbose "Current culture is $($culture.Name)"
+      if ($culture.Name -ne 'en-US') {
+        Write-Verbose -Verbose "Setting culture to en-US"
+        sudo update-locale LANG=en_US.UTF-8
+        "LANG=en_US.UTF-8" >> $GITHUB_ENV
+        "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
+      }
 
   - name: Test
     if: success()

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -27,7 +27,7 @@ runs:
 
   # this task only takes / as directory separators
   - name: Publish Test Report
-    uses: ctrf-io/github-test-reporter@v1
+    uses: ctrf-io/github-test-reporter@d1e394283c0ca33d34c9b6d8983aaef6945b52ec
     with:
       report-path: './${{ inputs.ctrfFolder }}/*.json'
       exit-on-fail: true

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -18,7 +18,34 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Log Summary
+    run: |
+      $testCaseCount = 0
+      $testErrorCount = 0
+      $testFailureCount = 0
+      $testDisabledCount = 0
+      Get-ChildItem -Path "${{ inputs.testResultsFolder }}/*.xml" -Recurse | ForEach-Object {
+        $results = [xml] (get-content $_.FullName)
+        $testCaseCount += $results.testsuites.tests
+        $testErrorCount += $results.testsuites.errors
+        $testFailureCount += $results.testsuites.failures
+        $testDisabledCount += $results.testsuites.disabled
+      }
+
+      @"
+
+      # Summary of ${{ inputs.name }}
+
+      - Total Tests: $testCaseCount
+      - Total Errors: $testErrorCount
+      - Total Failures: $testFailureCount
+      - Total Disabled: $testDisabledCount
+
+      "@ >> $GITHUB_STEP_SUMMARY
+    shell: pwsh
+
   - name: Convert JUnit to CTRF
+    if: github.repository_owner == 'PowerShell'
     run: |-
       Get-ChildItem -Path "${{ inputs.testResultsFolder }}/*.xml" -Recurse | ForEach-Object {
         npx --yes junit-to-ctrf $_.FullName --output ./${{ inputs.ctrfFolder }}/$($_.BaseName).json --tool Pester

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -20,6 +20,11 @@ runs:
   steps:
   - name: Log Summary
     run: |
+      if (-not $env:GITHUB_STEP_SUMMARY) {
+        Write-Error "GITHUB_STEP_SUMMARY is not set. Ensure this workflow is running in a GitHub Actions environment."
+        exit 1
+      }
+
       $testCaseCount = 0
       $testErrorCount = 0
       $testFailureCount = 0
@@ -41,7 +46,10 @@ runs:
       - Total Failures: $testFailureCount
       - Total Disabled: $testDisabledCount
 
-      "@ >> $GITHUB_STEP_SUMMARY
+      "@ | Out-File -FilePath $ENV:GITHUB_STEP_SUMMARY -Append
+
+      Write-Host "Summary written to $ENV:GITHUB_STEP_SUMMARY"
+      Get-Content $ENV:GITHUB_STEP_SUMMARY
     shell: pwsh
 
   - name: Upload testResults artifact

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -54,7 +54,7 @@ runs:
 
   # this task only takes / as directory separators
   - name: Publish Test Report
-    if: github.repository_owner == 'PowerShell'
+    if: always() && github.repository_owner == 'PowerShell'
     uses: ctrf-io/github-test-reporter@d1e394283c0ca33d34c9b6d8983aaef6945b52ec
     with:
       report-path: './${{ inputs.ctrfFolder }}/*.json'
@@ -75,7 +75,6 @@ runs:
       pull-request-report: false
       commit-report: false
       custom-report: false
-    if: always()
 
   - name: Upload testResults artifact
     if: always()

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -44,48 +44,9 @@ runs:
       "@ >> $GITHUB_STEP_SUMMARY
     shell: pwsh
 
-  - name: Convert JUnit to CTRF
-    if: github.repository_owner == 'PowerShell'
-    run: |-
-      Get-ChildItem -Path "${{ inputs.testResultsFolder }}/*.xml" -Recurse | ForEach-Object {
-        npx --yes junit-to-ctrf $_.FullName --output ./${{ inputs.ctrfFolder }}/$($_.BaseName).json --tool Pester
-      }
-    shell: pwsh
-
-  # this task only takes / as directory separators
-  - name: Publish Test Report
-    if: always() && github.repository_owner == 'PowerShell'
-    uses: ctrf-io/github-test-reporter@d1e394283c0ca33d34c9b6d8983aaef6945b52ec
-    with:
-      report-path: './${{ inputs.ctrfFolder }}/*.json'
-      exit-on-fail: true
-      summary-report: true
-      test-report: false
-      test-list-report: false
-      failed-report: false
-      fail-rate-report: false
-      flaky-report: false
-      flaky-rate-report: false
-      failed-folded-report: true
-      previous-results-report: false
-      ai-report: true
-      skipped-report: false
-      suite-folded-report: false
-      suite-list-report: false
-      pull-request-report: false
-      commit-report: false
-      custom-report: false
-
   - name: Upload testResults artifact
     if: always()
     uses: actions/upload-artifact@v4
     with:
       name: junit-pester-${{ inputs.name }}
       path: ${{ runner.workspace }}/testResults
-
-  - name: Upload ctrf artifact
-    if: always()
-    uses: actions/upload-artifact@v4
-    with:
-      name: ctrf-pester-${{ inputs.name }}
-      path: ${{ inputs.ctrfFolder }}

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -27,6 +27,7 @@ runs:
 
   # this task only takes / as directory separators
   - name: Publish Test Report
+    if: github.repository_owner == 'PowerShell'
     uses: ctrf-io/github-test-reporter@d1e394283c0ca33d34c9b6d8983aaef6945b52ec
     with:
       report-path: './${{ inputs.ctrfFolder }}/*.json'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -45,12 +45,15 @@ jobs:
     # Required permissions
     permissions:
       pull-requests: read
+
     # Set job outputs to values from filter step
     outputs:
       source: ${{ steps.filter.outputs.source }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
         # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -45,6 +45,7 @@ jobs:
     # Required permissions
     permissions:
       pull-requests: read
+      contents: read
 
     # Set job outputs to values from filter step
     outputs:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -58,7 +58,6 @@ jobs:
 
         # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0
-        if: github.repository_owner == 'PowerShell'
         id: filter
         with:
           list-files: json

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - release/**
+      - github-mirror
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -19,6 +20,7 @@ on:
     branches:
       - master
       - release/**
+      - github-mirror
 # Path filters for PRs need to go into the changes job
 
 concurrency:
@@ -52,6 +54,7 @@ jobs:
 
         # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0
+        if: github.repository_owner == 'PowerShell'
         id: filter
         with:
           list-files: json
@@ -72,7 +75,7 @@ jobs:
     name: Build PowerShell
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
+    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -86,7 +89,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
+    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -103,7 +106,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
+    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -120,7 +123,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
+    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -137,7 +140,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
+    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -154,7 +157,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
+    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -172,7 +175,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.source == 'true' }}
+    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -118,7 +118,7 @@ jobs:
     name: Build PowerShell
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
+    if: ${{ needs.changes.outputs.source == 'true' }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
+    if: ${{ needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -149,7 +149,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
+    if: ${{ needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -166,7 +166,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
+    if: ${{ needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -183,7 +183,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
+    if: ${{ needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -200,7 +200,7 @@ jobs:
     needs:
       - ci_build
       - changes
-    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
+    if: ${{ needs.changes.outputs.source == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -218,7 +218,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ startsWith(github.repository_owner, 'azure') || needs.changes.outputs.source == 'true' }}
+    if: ${{ needs.changes.outputs.source == 'true' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -56,63 +56,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check if GitHubWorkflowChanges is present
+      - name: Change Detection
         id: filter
-        uses: actions/github-script@v7.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // Fetch the list of files changed in the PR
-            let files = [];
-            let page = 1;
-            let fetchedFiles;
-            do {
-              fetchedFiles = await github.rest.pulls.listFiles({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                per_page: 100,
-                page: page++
-              });
-              files = files.concat(fetchedFiles.data);
-            } while (fetchedFiles.data.length > 0);
-
-            const actionsChanged = files.some(file => file.filename.startsWith('.github/actions'));
-            const workflowsChanged = files.some(file => file.filename.startsWith('.github/workflows'));
-            const githubChanged = actionsChanged || workflowsChanged;
-
-            const toolsCiPsm1Changed = files.some(file => file.filename.startsWith('tools/ci.psm1'));
-            const toolsBuildCommonChanged = files.some(file => file.filename.startsWith('tools/buildCommon/'));
-            const toolsChanged = toolsCiPsm1Changed || toolsBuildCommonChanged;
-
-            const propsChanged = files.some(file => file.filename.endsWith('.props'));
-
-            const testsChanged = files.some(file => file.filename.startsWith('test/powershell/') || file.filename.startsWith('test/tools/') || file.filename.startsWith('test/xUnit/'));
-
-            const mainSourceChanged = files.some(file => file.filename.startsWith('src/'));
-
-            const buildModuleChanged = files.some(file => file.filename.startsWith('build.psm1'));
-
-            const source = mainSourceChanged || toolsChanged || githubChanged || propsChanged || testsChanged;
-
-            core.setOutput('toolsChanged', toolsChanged);
-            core.setOutput('githubChanged', githubChanged);
-            core.setOutput('propsChanged', propsChanged);
-            core.setOutput('testsChanged', testsChanged);
-            core.setOutput('mainSourceChanged', mainSourceChanged);
-            core.setOutput('buildModuleChanged', buildModuleChanged);
-            core.setOutput('source', source);
-
-      - name: Capture outputs
-        run: |
-          Write-Verbose -Verbose "source: ${{ steps.filter.outputs.source }}"
-          Write-Verbose -Verbose "github: ${{ steps.filter.outputs.githubChanged }}"
-          Write-Verbose -Verbose "tools: ${{ steps.filter.outputs.toolsChanged }}"
-          Write-Verbose -Verbose "props: ${{ steps.filter.outputs.propsChanged }}"
-          Write-Verbose -Verbose "tests: ${{ steps.filter.outputs.testsChanged }}"
-          Write-Verbose -Verbose "mainSource: ${{ steps.filter.outputs.mainSourceChanged }}"
-          Write-Verbose -Verbose "buildModule: ${{ steps.filter.outputs.buildModuleChanged }}"
-        shell: pwsh
+        uses: "./.github/actions/infrastructure/path-filters"
 
   ci_build:
     name: Build PowerShell

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Change Detection
         id: filter
         uses: "./.github/actions/infrastructure/path-filters"
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ci_build:
     name: Build PowerShell

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -56,23 +56,62 @@ jobs:
         with:
           persist-credentials: false
 
-        # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0
-        if: github.repository_owner == 'PowerShell'
+      - name: Check if GitHubWorkflowChanges is present
         id: filter
+        uses: actions/github-script@v7.0.1
         with:
-          list-files: json
-          filters: .github/action-filters.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Fetch the list of files changed in the PR
+            let files = [];
+            let page = 1;
+            let fetchedFiles;
+            do {
+              fetchedFiles = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+                page: page++
+              });
+              files = files.concat(fetchedFiles.data);
+            } while (fetchedFiles.data.length > 0);
+
+            const actionsChanged = files.some(file => file.filename.startsWith('.github/actions'));
+            const workflowsChanged = files.some(file => file.filename.startsWith('.github/workflows'));
+            const githubChanged = actionsChanged || workflowsChanged;
+
+            const toolsCiPsm1Changed = files.some(file => file.filename.startsWith('tools/ci.psm1'));
+            const toolsBuildCommonChanged = files.some(file => file.filename.startsWith('tools/buildCommon/'));
+            const toolsChanged = toolsCiPsm1Changed || toolsBuildCommonChanged;
+
+            const propsChanged = files.some(file => file.filename.endsWith('.props'));
+
+            const testsChanged = files.some(file => file.filename.startsWith('test/powershell/') || file.filename.startsWith('test/tools/') || file.filename.startsWith('test/xUnit/'));
+
+            const mainSourceChanged = files.some(file => file.filename.startsWith('src/'));
+
+            const buildModuleChanged = files.some(file => file.filename.startsWith('build.psm1'));
+
+            const source = mainSourceChanged || toolsChanged || githubChanged || propsChanged || testsChanged;
+
+            core.setOutput('toolsChanged', toolsChanged);
+            core.setOutput('githubChanged', githubChanged);
+            core.setOutput('propsChanged', propsChanged);
+            core.setOutput('testsChanged', testsChanged);
+            core.setOutput('mainSourceChanged', mainSourceChanged);
+            core.setOutput('buildModuleChanged', buildModuleChanged);
+            core.setOutput('source', source);
 
       - name: Capture outputs
         run: |
-          "source: ${{ steps.filter.outputs.source }}"
-          "github: ${{ steps.filter.outputs.github }}"
-          "tools: ${{ steps.filter.outputs.tools }}"
-          "props: ${{ steps.filter.outputs.props }}"
-          "tests: ${{ steps.filter.outputs.tests }}"
-          "mainSource: ${{ steps.filter.outputs.mainSource }}"
-          "buildModule: ${{ steps.filter.outputs.buildModule }}"
+          Write-Verbose -Verbose "source: ${{ steps.filter.outputs.source }}"
+          Write-Verbose -Verbose "github: ${{ steps.filter.outputs.githubChanged }}"
+          Write-Verbose -Verbose "tools: ${{ steps.filter.outputs.toolsChanged }}"
+          Write-Verbose -Verbose "props: ${{ steps.filter.outputs.propsChanged }}"
+          Write-Verbose -Verbose "tests: ${{ steps.filter.outputs.testsChanged }}"
+          Write-Verbose -Verbose "mainSource: ${{ steps.filter.outputs.mainSourceChanged }}"
+          Write-Verbose -Verbose "buildModule: ${{ steps.filter.outputs.buildModuleChanged }}"
         shell: pwsh
 
   ci_build:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
         # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -58,6 +58,7 @@ jobs:
 
         # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0
+        if: github.repository_owner == 'PowerShell'
         id: filter
         with:
           list-files: json

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Change Detection
         id: filter
         uses: "./.github/actions/infrastructure/path-filters"
-
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ci_build:
     name: Build PowerShell

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -36,6 +36,7 @@ env:
   __SuppressAnsiEscapeSequences: 1
   nugetMultiFeedWarnLevel: none
   system_debug: 'false'
+
 jobs:
   changes:
     name: Change Detection
@@ -44,6 +45,8 @@ jobs:
     # Required permissions
     permissions:
       pull-requests: read
+      contents: read
+
     # Set job outputs to values from filter step
     outputs:
       source: ${{ steps.filter.outputs.source }}

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -49,23 +49,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-        # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0
+      - name: Change Detection
         id: filter
-        with:
-          list-files: json
-          filters: .github/action-filters.yml
+        uses: "./.github/actions/infrastructure/path-filters"
 
-      - name: Capture outputs
-        run: |
-          "source: ${{ steps.filter.outputs.source }}"
-          "github: ${{ steps.filter.outputs.github }}"
-          "tools: ${{ steps.filter.outputs.tools }}"
-          "props: ${{ steps.filter.outputs.props }}"
-          "tests: ${{ steps.filter.outputs.tests }}"
-          "mainSource: ${{ steps.filter.outputs.mainSource }}"
-          "buildModule: ${{ steps.filter.outputs.buildModule }}"
-        shell: pwsh
 
   ci_build:
     name: Build PowerShell

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - release/**
+      - github-mirror
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -17,6 +18,7 @@ on:
     branches:
       - master
       - release/**
+      - github-mirror
 # Path filters for PRs need to go into the changes job
 
 concurrency:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Change Detection
         id: filter
         uses: "./.github/actions/infrastructure/path-filters"
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ci_build:
     name: Build PowerShell

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release/**
+      - github-mirror
     paths:
       - "**"
       - "!.vsts-ci/misc-analysis.yml"
@@ -16,6 +17,8 @@ on:
     branches:
       - master
       - release/**
+      - github-mirror
+
 # Path filters for PRs need to go into the changes job
 
 concurrency:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -46,6 +46,8 @@ jobs:
     # Required permissions
     permissions:
       pull-requests: read
+      contents: read
+
     # Set job outputs to values from filter step
     outputs:
       source: ${{ steps.filter.outputs.source }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -50,23 +50,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-        # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.2.0
+      - name: Change Detection
         id: filter
-        with:
-          list-files: json
-          filters: .github/action-filters.yml
-
-      - name: Capture outputs
-        run: |
-          "source: ${{ steps.filter.outputs.source }}"
-          "github: ${{ steps.filter.outputs.github }}"
-          "tools: ${{ steps.filter.outputs.tools }}"
-          "props: ${{ steps.filter.outputs.props }}"
-          "tests: ${{ steps.filter.outputs.tests }}"
-          "mainSource: ${{ steps.filter.outputs.mainSource }}"
-          "buildModule: ${{ steps.filter.outputs.buildModule }}"
-        shell: pwsh
+        uses: "./.github/actions/infrastructure/path-filters"
 
   ci_build:
     name: Build PowerShell

--- a/build.psm1
+++ b/build.psm1
@@ -2693,6 +2693,10 @@ function script:Write-Log
     if ($isError)
     {
         Write-Host -Foreground Red $message
+        if($env:GITHUB_WORKFLOW)
+        {
+            Write-Host "::error::${message}"
+        }
     }
     else
     {

--- a/build.psm1
+++ b/build.psm1
@@ -179,6 +179,8 @@ function Get-EnvironmentInformation
         $environment += @{'IsUbuntu16' = $environment.IsUbuntu -and $LinuxInfo.VERSION_ID -match '16.04'}
         $environment += @{'IsUbuntu18' = $environment.IsUbuntu -and $LinuxInfo.VERSION_ID -match '18.04'}
         $environment += @{'IsUbuntu20' = $environment.IsUbuntu -and $LinuxInfo.VERSION_ID -match '20.04'}
+        $environment += @{'IsUbuntu22' = $environment.IsUbuntu -and $LinuxInfo.VERSION_ID -match '22.04'}
+        $environment += @{'IsUbuntu24' = $environment.IsUbuntu -and $LinuxInfo.VERSION_ID -match '24.04'}
         $environment += @{'IsCentOS' = $LinuxInfo.ID -match 'centos' -and $LinuxInfo.VERSION_ID -match '7'}
         $environment += @{'IsFedora' = $LinuxInfo.ID -match 'fedora' -and $LinuxInfo.VERSION_ID -ge 24}
         $environment += @{'IsOpenSUSE' = $LinuxInfo.ID -match 'opensuse'}
@@ -2705,6 +2707,59 @@ function script:Write-Log
     #reset colors for older package to at return to default after error message on a compilation error
     [console]::ResetColor()
 }
+
+function script:Write-LogGroup {
+    param
+    (
+        [Parameter(Position = 0, Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string[]] $Message,
+        [Parameter(Mandatory)]
+        [string] $Title
+    )
+
+
+    Write-LogGroupStart -Title $Title
+
+    foreach ($line in $Message) {
+        Write-Log -Message $line
+    }
+
+    Write-LogGroupEnd -Title $Title
+}
+
+$script:logGroupColor = [System.ConsoleColor]::Cyan
+
+function script:Write-LogGroupStart {
+    param
+    (
+        [Parameter(Mandatory)]
+        [string] $Title
+    )
+
+    if ($env:GITHUB_WORKFLOW) {
+        Write-Host "::group::${Title}"
+    }
+    else {
+        Write-Host -ForegroundColor $script:logGroupColor "=== BEGIN: $Title ==="
+    }
+}
+
+function script:Write-LogGroupEnd {
+    param
+    (
+        [Parameter(Mandatory)]
+        [string] $Title
+    )
+
+    if ($env:GITHUB_WORKFLOW) {
+        Write-Host "::endgroup::"
+    }
+    else {
+        Write-Host -ForegroundColor $script:logGroupColor "==== END: $Title ===="
+    }
+}
+
 function script:precheck([string]$command, [string]$missedMessage) {
     $c = Get-Command $command -ErrorAction Ignore
     if (-not $c) {
@@ -3623,22 +3678,50 @@ function Set-PipelineNugetAuthentication {
 
 function Set-CorrectLocale
 {
+    Write-LogGroupStart -Title "Set-CorrectLocale"
+
     if (-not $IsLinux)
     {
+        Write-LogGroupEnd -Title "Set-CorrectLocale"
         return
     }
 
     $environment = Get-EnvironmentInformation
-    if ($environment.IsUbuntu -and $environment.IsUbuntu20)
-    {
+    if ($environment.IsUbuntu16 -or $environment.IsUbuntu18) {
+        Write-Verbose -Message "Don't set locale before Ubuntu 20" -Verbose
+        Write-LogGroupEnd -Title "Set-CorrectLocale"
+        Write-Locale
+        return
+    }
+
+    if ($environment.IsUbuntu) {
+        Write-Log -Message "Setting locale to en_US.UTF-8"
         $env:LC_ALL = 'en_US.UTF-8'
         $env:LANG = 'en_US.UTF-8'
         sudo locale-gen $env:LANG
-        sudo update-locale
+        if ($environment.IsUbuntu20) {
+            Write-Log -Message "Updating locale for Ubuntu 20"
+            sudo update-locale
+        } else {
+            Write-Log -Message "Updating locale for Ubuntu 22 and newer"
+            sudo update-locale LANG=$env:LANG LC_ALL=$env:LC_ALL
+        }
+    }
+
+    Write-LogGroupEnd -Title "Set-CorrectLocale"
+    Write-Locale
+
+}
+
+function Write-Locale {
+    if (-not $IsLinux -and -not $IsMacOS) {
+        Write-Verbose -Message "only supported on Linux and macOS" -Verbose
+        return
     }
 
     # Output the locale to log it
-    locale
+    $localOutput = & locale
+    Write-LogGroup -Title "Capture Locale" -Message $localOutput
 }
 
 function Install-AzCopy {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request includes several changes to GitHub Actions workflows and the `build.psm1` script to improve logging, environment detection, and path filtering. The most important changes are summarized below:

### GitHub Actions Workflows Improvements:

* [`.github/actions/infrastructure/path-filters/action.yml`](diffhunk://#diff-a6cc18371942fc6db5262c08db979964d83f46a1a694ca439860167a5809e4dcR1-R88): Added a new composite action to filter paths and capture various types of changes in the repository, such as source code, GitHub workflows, tools, props, tests, and build modules.
* [`.github/actions/test/nix/action.yml`](diffhunk://#diff-ce613df0a0f3c35f27cac9c72c5ac0d1a63070013b29d51fa04b9cf9b7f18e19L23-R41): Enhanced logging by adding `Write-LogGroupStart` and `Write-LogGroupEnd` around several steps to improve readability and organization of logs. [[1]](diffhunk://#diff-ce613df0a0f3c35f27cac9c72c5ac0d1a63070013b29d51fa04b9cf9b7f18e19L23-R41) [[2]](diffhunk://#diff-ce613df0a0f3c35f27cac9c72c5ac0d1a63070013b29d51fa04b9cf9b7f18e19R51-R55) [[3]](diffhunk://#diff-ce613df0a0f3c35f27cac9c72c5ac0d1a63070013b29d51fa04b9cf9b7f18e19L71-R88)
* [`.github/actions/test/process-pester-results/action.yml`](diffhunk://#diff-c78ac092fabb982eaff3e37c872e1c601476b0e4ca97b6387863a684767fe412L21-L64): Replaced the JUnit to CTRF conversion step with a summary logging step that captures and logs the test results summary, including total tests, errors, failures, and disabled tests.

### Workflow Configuration Updates:

* `.github/workflows/linux-ci.yml`, `.github/workflows/macos-ci.yml`, `.github/workflows/windows-ci.yml`: Added `github-mirror` branch to the list of branches to trigger the workflows and updated permissions to include `contents: read`. Also, replaced the `dorny/paths-filter` action with the new `path-filters` composite action. [[1]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fR12) [[2]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fR23) [[3]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fR48-R63) [[4]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aR10) [[5]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aR21) [[6]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aR39) [[7]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aR48-R61) [[8]](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37R8) [[9]](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37R20-R21) [[10]](diffhunk://#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37R49-R62)

### Build Script Enhancements:

* [`build.psm1`](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR182-R183): Added support for Ubuntu 22.04 and 24.04 in the environment detection function and improved logging with `Write-LogGroup` functions to group log messages and support GitHub Actions log grouping. [[1]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR182-R183) [[2]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR2698-R2701) [[3]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR2710-R2762) [[4]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR3681-R3724)

## PR Context

1. Removed use of 3rd party actions in key workflows so the workflows can be used in internal mirrors
   * wrote simplified version of these workflows
3. Added branch names for our internal mirror.
4. Added helpers to write log groups to GitHub workflows

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

      - [ ] Issue filed: <!-- Number/link of that issue here -->
