### PR TITLE
[release/v7.5] Add UseDotnet task for installing dotnet

### DIFF
--- a/.github/actions/test/linux-packaging/action.yml
+++ b/.github/actions/test/linux-packaging/action.yml
@@ -27,7 +27,7 @@ runs:
   - name: Bootstrap
     run: |-
       Import-Module ./build.psm1
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
     shell: pwsh
   - name: Capture Artifacts Directory
     continue-on-error: true

--- a/.github/actions/test/windows/action.yml
+++ b/.github/actions/test/windows/action.yml
@@ -31,6 +31,10 @@ runs:
     run: Get-ChildItem "${{ github.workspace }}\build\*" -Recurse
     shell: pwsh
 
+  - uses: actions/setup-dotnet@v4
+    with:
+      global-json-file: .\global.json
+
   - name: Bootstrap
     shell: powershell
     run: |-
@@ -50,7 +54,6 @@ runs:
     if: success()
     run: |-
       Import-Module .\build.psm1 -force
-      Start-PSBootstrap
       Import-Module .\tools\ci.psm1
       Restore-PSOptions -PSOptionsPath '${{ github.workspace }}\build\psoptions.json'
       $options = (Get-PSOptions)

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 1000
+
       - name: Build
         uses: "./.github/actions/build/ci"
   linux_test_unelevated_ci:
@@ -186,6 +187,10 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: '0'
+
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: ./global.json
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -174,7 +174,7 @@ jobs:
       if: success() || failure()
       run: |-
         import-module ./build.psm1
-        start-psbootstrap -package
+        start-psbootstrap -Scenario package
       shell: pwsh
   ready_to_merge:
     name: macos ready to merge

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -61,14 +61,12 @@ jobs:
       parameters:
         repoRoot: '$(repoRoot)'
 
-    - pwsh: |
-        Import-Module .\build.psm1 -force
-        Start-PSBootstrap
-      workingDirectory: '$(repoRoot)'
-      retryCountOnTaskFailure: 2
-      displayName: 'Bootstrap'
-      env:
-        __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        useGlobalJson: true
+        packageType: 'sdk'
+        workingDirectory: $(Build.SourcesDirectory)"
 
     - pwsh: |
         Import-Module .\build.psm1 -force

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -103,7 +103,7 @@ jobs:
       Import-Module "$repoRoot/build.psm1"
       Import-Module "$repoRoot/tools/packaging"
 
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
 
       $psOptionsPath = "$(Pipeline.Workspace)/CoOrdinatedBuildPipeline/${unsignedDrop}/psoptions/psoptions.json"
 

--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -62,6 +62,13 @@ jobs:
       AnalyzeInPipeline: true
       Language: csharp
 
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+      workingDirectory: $(PowerShellRoot)
+    env:
+      ob_restore_phase: true
+
   - pwsh: |
       $runtime = $env:RUNTIME
 
@@ -75,7 +82,6 @@ jobs:
       Import-Module -Name $(PowerShellRoot)/build.psm1 -Force
       $buildWithSymbolsPath = New-Item -ItemType Directory -Path $(Pipeline.Workspace)/Symbols_$(Runtime) -Force
 
-      Start-PSBootstrap
       $null = New-Item -ItemType Directory -Path $buildWithSymbolsPath -Force -Verbose
 
       $ReleaseTagParam = @{}

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -110,7 +110,7 @@ jobs:
         Write-Verbose -Message "LTS Release: $LTS"
       }
 
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
 
       $macosRuntime = "osx-$buildArch"
 

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -39,9 +39,16 @@ jobs:
       sudo chown $env:USER "$(Agent.TempDirectory)/PowerShell"
     displayName: 'Create $(Agent.TempDirectory)/PowerShell'
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+      workingDirectory: $(PowerShellRoot)
+
   - pwsh: |
       Import-Module $(PowerShellRoot)/build.psm1 -Force
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
     displayName: 'Bootstrap VM'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -97,11 +97,16 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet.exe'
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+      workingDirectory: '$(PowerShellRoot)'
+
   - pwsh: |
       Set-Location -Path '$(PowerShellRoot)'
       Import-Module "$(PowerShellRoot)/build.psm1" -Force
-
-      Start-PSBootstrap -Verbose
 
       $sharedModules = @('Microsoft.PowerShell.Commands.Management',
                         'Microsoft.PowerShell.Commands.Utility',

--- a/.pipelines/templates/release-validate-fxdpackages.yml
+++ b/.pipelines/templates/release-validate-fxdpackages.yml
@@ -44,38 +44,12 @@ jobs:
         Get-ChildItem "$(Pipeline.Workspace)/PSPackagesOfficial/$artifactName" -Recurse
       displayName: 'Capture Downloaded Artifacts'
 
-    - pwsh: |
-        $repoRoot = "$(Build.SourcesDirectory)/PowerShell"
-        $dotnetMetadataPath = "$repoRoot/DotnetRuntimeMetadata.json"
-        $dotnetMetadataJson = Get-Content $dotnetMetadataPath -Raw | ConvertFrom-Json
-
-        # Channel is like: $Channel = "5.0.1xx-preview2"
-        $Channel = $dotnetMetadataJson.sdk.channel
-
-        $sdkVersion = (Get-Content "$repoRoot/global.json" -Raw | ConvertFrom-Json).sdk.version
-        Import-Module "$repoRoot/build.psm1" -Force
-
-        Find-Dotnet
-
-        if(-not (Get-PackageSource -Name 'dotnet' -ErrorAction SilentlyContinue))
-        {
-            $nugetFeed = ([xml](Get-Content $repoRoot/nuget.config -Raw)).Configuration.packagesources.add | Where-Object { $_.Key -eq 'dotnet' } | Select-Object -ExpandProperty Value
-            if ($nugetFeed) {
-              Register-PackageSource -Name 'dotnet' -Location $nugetFeed -ProviderName NuGet
-              Write-Verbose -Message "Register new package source 'dotnet'" -verbose
-            }
-        }
-
-        ## Install latest version from the channel
-
-        #Install-Dotnet -Channel "$Channel" -Version $sdkVersion
-        Start-PSBootstrap
-
-        Write-Verbose -Message "Installing .NET SDK completed." -Verbose
-
-      displayName: Install .NET
-      env:
-        __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        useGlobalJson: true
+        packageType: 'sdk'
+        workingDirectory: $(Build.SourcesDirectory)/PowerShell"
 
     - pwsh: |
         $artifactName = '$(artifactName)'

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -38,44 +38,15 @@ jobs:
         Get-ChildItem "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg" -Recurse
       displayName: 'Capture Downloaded Artifacts'
 
-    - pwsh: |
-        $repoRoot = "$(Build.SourcesDirectory)/PowerShell"
-        $dotnetMetadataPath = "$repoRoot/DotnetRuntimeMetadata.json"
-        $dotnetMetadataJson = Get-Content $dotnetMetadataPath -Raw | ConvertFrom-Json
-
-        # Channel is like: $Channel = "5.0.1xx-preview2"
-        $Channel = $dotnetMetadataJson.sdk.channel
-
-        $sdkVersion = (Get-Content "$repoRoot/global.json" -Raw | ConvertFrom-Json).sdk.version
-        Import-Module "$repoRoot/build.psm1" -Force
-
-        Find-Dotnet
-
-        if(-not (Get-PackageSource -Name 'dotnet' -ErrorAction SilentlyContinue))
-        {
-            $nugetFeed = ([xml](Get-Content $repoRoot/nuget.config -Raw)).Configuration.packagesources.add | Where-Object { $_.Key -eq 'dotnet' } | Select-Object -ExpandProperty Value
-            if ($nugetFeed) {
-              Register-PackageSource -Name 'dotnet' -Location $nugetFeed -ProviderName NuGet
-              Write-Verbose -Message "Register new package source 'dotnet'" -verbose
-            }
-        }
-
-        ## Install latest version from the channel
-
-        #Install-Dotnet -Channel "$Channel" -Version $sdkVersion
-        Start-PSBootstrap
-
-        Write-Verbose -Message "Installing .NET SDK completed." -Verbose
-
-      displayName: Install .NET
-      env:
-        __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        useGlobalJson: true
+        packageType: 'sdk'
+        workingDirectory: $(REPOROOT)
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"
-        $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-        Import-Module "$repoRoot/build.psm1" -Force
-        Start-PSBootstrap
 
         $toolPath = New-Item -ItemType Directory "$(System.DefaultWorkingDirectory)/toolPath" | Select-Object -ExpandProperty FullName
 
@@ -108,8 +79,6 @@ jobs:
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"
-        Import-Module "$repoRoot/build.psm1" -Force
-        Start-PSBootstrap
 
         $exeName = if ($IsWindows) { "pwsh.exe" } else { "pwsh" }
 

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -46,47 +46,17 @@ jobs:
         Get-ChildItem "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg" -Recurse
       displayName: 'Capture Downloaded Artifacts'
 
-    - pwsh: |
-        $repoRoot = "$(Build.SourcesDirectory)"
-
-        $dotnetMetadataPath = "$repoRoot/DotnetRuntimeMetadata.json"
-        $dotnetMetadataJson = Get-Content $dotnetMetadataPath -Raw | ConvertFrom-Json
-
-        # Channel is like: $Channel = "5.0.1xx-preview2"
-        $Channel = $dotnetMetadataJson.sdk.channel
-
-        $sdkVersion = (Get-Content "$repoRoot/global.json" -Raw | ConvertFrom-Json).sdk.version
-        Import-Module "$repoRoot/build.psm1" -Force
-
-        Find-Dotnet
-
-        if(-not (Get-PackageSource -Name 'dotnet' -ErrorAction SilentlyContinue))
-        {
-            $nugetFeed = ([xml](Get-Content $repoRoot/nuget.config -Raw)).Configuration.packagesources.add | Where-Object { $_.Key -eq 'dotnet' } | Select-Object -ExpandProperty Value
-
-            if ($nugetFeed) {
-              Register-PackageSource -Name 'dotnet' -Location $nugetFeed -ProviderName NuGet
-              Write-Verbose -Message "Register new package source 'dotnet'" -verbose
-            }
-        }
-
-        ## Install latest version from the channel
-        #Install-Dotnet -Channel "$Channel" -Version $sdkVersion
-
-        Start-PSBootstrap
-
-        Write-Verbose -Message "Installing .NET SDK completed." -Verbose
-
-      displayName: Install .NET
-      env:
-        __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        useGlobalJson: true
+        packageType: 'sdk'
+        workingDirectory: $(REPOROOT)
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)"
 
         $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-        Import-Module "$repoRoot/build.psm1" -Force
-        Start-PSBootstrap
 
         $localLocation = "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg"
         $xmlElement = @"

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -30,12 +30,13 @@ jobs:
       repoRoot: $(Build.SourcesDirectory)/PowerShell
       ob_restore_phase: true
 
-  - pwsh: |
-      Import-Module $(Build.SourcesDirectory)/PowerShell/build.psm1
-      Start-PSBootstrap
-    displayName: Bootstrap
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+      workingDirectory: $(Build.SourcesDirectory)/PowerShell"
     env:
-      __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
       ob_restore_phase: true
 
   - pwsh: |
@@ -97,12 +98,13 @@ jobs:
       repoRoot: $(Build.SourcesDirectory)/PowerShell
       ob_restore_phase: true
 
-  - pwsh: |
-      Import-Module $(Build.SourcesDirectory)/PowerShell/build.psm1
-      Start-PSBootstrap
-    displayName: Bootstrap
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+      workingDirectory: $(Build.SourcesDirectory)/PowerShell"
     env:
-      __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
       ob_restore_phase: true
 
   - pwsh: |

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -63,6 +63,13 @@ jobs:
       AnalyzeInPipeline: true
       Language: csharp
 
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+      workingDirectory: $(PowerShellRoot)
+    env:
+      ob_restore_phase: true
+
   - pwsh: |
       $runtime = switch ($env:Architecture)
         {
@@ -86,7 +93,7 @@ jobs:
       Import-Module -Name $(PowerShellRoot)/build.psm1 -Force
       $buildWithSymbolsPath = New-Item -ItemType Directory -Path $(Pipeline.Workspace)/Symbols_$(Architecture) -Force
 
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
       $null = New-Item -ItemType Directory -Path $buildWithSymbolsPath -Force -Verbose
 
       $ReleaseTagParam = @{}
@@ -135,7 +142,6 @@ jobs:
         }
 
       Import-Module -Name $(PowerShellRoot)/build.psm1 -Force
-      Start-PSBootstrap
 
       ## Build global tool
       Write-Verbose -Message "Building PowerShell global tool for Windows.x64" -Verbose
@@ -229,8 +235,6 @@ jobs:
           After that, we repack using Compress-Archive and rename it back to a nupkg.
         #>
 
-      Import-Module -Name $(PowerShellRoot)/build.psm1 -Force
-      Start-PSBootstrap
       $packagingStrings = Import-PowerShellDataFile "$(PowerShellRoot)\tools\packaging\packaging.strings.psd1"
 
       $outputPath = Join-Path '$(ob_outputDirectory)' 'globaltool'

--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -78,6 +78,13 @@ jobs:
     env:
       ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+      workingDirectory: $(REPOROOT)
+    env:
+      ob_restore_phase: true
+
   - pwsh: |
       $msixUrl = '$(makeappUrl)'
       Invoke-RestMethod -Uri $msixUrl -OutFile '$(Pipeline.Workspace)\makeappx.zip'
@@ -105,7 +112,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
 
       $signedFilesPath, $psoptionsFilePath = if ($env:RUNTIME -eq 'minsize') {
           "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_x64_${runtime}\$signedFolder"
@@ -136,7 +143,7 @@ jobs:
         Write-Verbose -Message "LTS Release: $LTS"
       }
 
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
 
       $WindowsRuntime = switch ($runtime) {
         'x64' { 'win7-x64' }

--- a/.vsts-ci/linux/templates/packaging.yml
+++ b/.vsts-ci/linux/templates/packaging.yml
@@ -13,6 +13,12 @@ jobs:
   displayName: ${{ parameters.name }} packaging
 
   steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+
   - pwsh: |
       Get-ChildItem -Path env:
     displayName: Capture Environment
@@ -33,7 +39,7 @@ jobs:
 
   - pwsh: |
       Import-Module .\build.psm1
-      Start-PSBootstrap -Package
+      Start-PSBootstrap -Scenario Package
     displayName: Bootstrap
 
   - pwsh: |

--- a/.vsts-ci/mac.yml
+++ b/.vsts-ci/mac.yml
@@ -110,6 +110,6 @@ stages:
           clean: true
         - pwsh: |
             import-module ./build.psm1
-            start-psbootstrap -package
+            start-psbootstrap -Scenario package
           displayName: Bootstrap packaging
           condition: succeededOrFailed()

--- a/.vsts-ci/psresourceget-acr.yml
+++ b/.vsts-ci/psresourceget-acr.yml
@@ -137,7 +137,6 @@ stages:
 
     - pwsh: |
         Import-Module .\build.psm1 -force
-        Start-PSBootstrap
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         $options = (Get-PSOptions)

--- a/.vsts-ci/templates/ci-build.yml
+++ b/.vsts-ci/templates/ci-build.yml
@@ -57,6 +57,12 @@ jobs:
   - ${{ if ne(variables['UseAzDevOpsFeed'], '') }}:
     - template: /tools/releaseBuild/azureDevOps/templates/insert-nuget-config-azfeed.yml
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+
   - pwsh: |
       Import-Module .\tools\ci.psm1
       Invoke-CIInstall -SkipUser

--- a/.vsts-ci/templates/nix-test.yml
+++ b/.vsts-ci/templates/nix-test.yml
@@ -13,6 +13,12 @@ jobs:
   displayName: ${{ parameters.name }} Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
 
   steps:
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        useGlobalJson: true
+        packageType: 'sdk'
+
     - template: ./test/nix-test-steps.yml
       parameters:
         purpose: ${{ parameters.purpose }}

--- a/.vsts-ci/templates/test/nix-container-test.yml
+++ b/.vsts-ci/templates/test/nix-container-test.yml
@@ -23,6 +23,12 @@ jobs:
   displayName: ${{ parameters.name }} Test - ${{ parameters.purpose }} - ${{ parameters.tagSet }}
 
   steps:
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        useGlobalJson: true
+        packageType: 'sdk'
+
     - template: ./nix-test-steps.yml
       parameters:
         purpose: ${{ parameters.purpose }}

--- a/.vsts-ci/templates/windows-test.yml
+++ b/.vsts-ci/templates/windows-test.yml
@@ -54,6 +54,13 @@ jobs:
     displayName: 'Capture Artifacts Directory'
     continueOnError: true
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+      workingDirectory: $(Build.SourcesDirectory)"
+
   # must be run frow Windows PowerShell
   - powershell: |
       # Remove "Program Files\dotnet" from the env variable PATH, so old SDKs won't affect us.
@@ -74,7 +81,6 @@ jobs:
 
   - pwsh: |
       Import-Module .\build.psm1 -force
-      Start-PSBootstrap
       Import-Module .\tools\ci.psm1
       Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
       $options = (Get-PSOptions)

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -93,6 +93,13 @@ stages:
       displayName: Bootstrap
       condition: succeededOrFailed()
 
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core sdk'
+      inputs:
+        useGlobalJson: true
+        packageType: 'sdk'
+        workingDirectory: $(Build.SourcesDirectory)"
+
     - pwsh: |
         Import-Module .\build.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
@@ -104,7 +111,6 @@ stages:
 
     - pwsh: |
         Import-Module .\build.psm1
-        Start-PSBootstrap
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose UnelevatedPesterTests -TagSet CI
@@ -113,7 +119,6 @@ stages:
 
     - pwsh: |
         Import-Module .\build.psm1
-        Start-PSBootstrap
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose ElevatedPesterTests -TagSet CI
@@ -122,7 +127,6 @@ stages:
 
     - pwsh: |
         Import-Module .\build.psm1
-        Start-PSBootstrap
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose UnelevatedPesterTests -TagSet Others
@@ -131,7 +135,6 @@ stages:
 
     - pwsh: |
         Import-Module .\build.psm1
-        Start-PSBootstrap
         Import-Module .\tools\ci.psm1
         Restore-PSOptions -PSOptionsPath '$(System.ArtifactsDirectory)\build\psoptions.json'
         Invoke-CITest -Purpose ElevatedPesterTests -TagSet Others

--- a/.vsts-ci/windows/templates/windows-packaging.yml
+++ b/.vsts-ci/windows/templates/windows-packaging.yml
@@ -54,6 +54,13 @@ jobs:
     condition: succeeded()
     workingDirectory: $(repoPath)
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      useGlobalJson: true
+      packageType: 'sdk'
+      workingDirectory: $(repoPath)
+
   - pwsh: |
       Import-Module .\tools\ci.psm1
       Invoke-CIInstall -SkipUser

--- a/build.psm1
+++ b/build.psm1
@@ -2226,10 +2226,12 @@ function Start-PSBootstrap {
         # we currently pin dotnet-cli version, and will
         # update it when more stable version comes out.
         [string]$Version = $dotnetCLIRequiredVersion,
-        [switch]$Package,
         [switch]$NoSudo,
         [switch]$BuildLinuxArm,
-        [switch]$Force
+        [switch]$Force,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Package", "DotNet", "Both")]
+        [string]$Scenario = "Package"
     )
 
     Write-Log -message "Installing PowerShell build dependencies"
@@ -2262,7 +2264,7 @@ function Start-PSBootstrap {
                 elseif ($environment.IsUbuntu18) { $Deps += "libicu60"}
 
                 # Packaging tools
-                if ($Package) { $Deps += "ruby-dev", "groff", "libffi-dev", "rpm", "g++", "make" }
+                if ($Scenario -eq 'Both' -or $Scenario -eq 'Package') { $Deps += "ruby-dev", "groff", "libffi-dev", "rpm", "g++", "make" }
 
                 # Install dependencies
                 # change the fontend from apt-get to noninteractive
@@ -2286,7 +2288,7 @@ function Start-PSBootstrap {
                 $Deps += "libicu", "openssl-libs"
 
                 # Packaging tools
-                if ($Package) { $Deps += "ruby-devel", "rpm-build", "groff", 'libffi-devel', "gcc-c++" }
+                if ($Scenario -eq 'Both' -or $Scenario -eq 'Package') { $Deps += "ruby-devel", "rpm-build", "groff", 'libffi-devel', "gcc-c++" }
 
                 $PackageManager = Get-RedHatPackageManager
 
@@ -2307,7 +2309,7 @@ function Start-PSBootstrap {
                 $Deps += "wget"
 
                 # Packaging tools
-                if ($Package) { $Deps += "ruby-devel", "rpmbuild", "groff", 'libffi-devel', "gcc" }
+                if ($Scenario -eq 'Both' -or $Scenario -eq 'Package') { $Deps += "ruby-devel", "rpmbuild", "groff", 'libffi-devel', "gcc" }
 
                 $PackageManager = "zypper --non-interactive install"
                 $baseCommand = "$sudo $PackageManager"
@@ -2347,7 +2349,7 @@ function Start-PSBootstrap {
             }
 
             # Install [fpm](https://github.com/jordansissel/fpm)
-            if ($Package) {
+            if ($Scenario -eq 'Both' -or $Scenario -eq 'Package') {
                 Install-GlobalGem -Sudo $sudo -GemName "dotenv" -GemVersion "2.8.1"
                 Install-GlobalGem -Sudo $sudo -GemName "ffi" -GemVersion "1.16.3"
                 Install-GlobalGem -Sudo $sudo -GemName "fpm" -GemVersion "1.15.1"
@@ -2355,42 +2357,45 @@ function Start-PSBootstrap {
             }
         }
 
-        Write-Verbose -Verbose "Calling Find-Dotnet from Start-PSBootstrap"
+        if ($Scenario -eq 'DotNet' -or $Scenario -eq 'Both') {
 
-        # Try to locate dotnet-SDK before installing it
-        Find-Dotnet
+            Write-Verbose -Verbose "Calling Find-Dotnet from Start-PSBootstrap"
 
-        Write-Verbose -Verbose "Back from calling Find-Dotnet from Start-PSBootstrap"
+            # Try to locate dotnet-SDK before installing it
+            Find-Dotnet
 
-        # Install dotnet-SDK
-        $dotNetExists = precheck 'dotnet' $null
-        $dotNetVersion = [string]::Empty
-        if($dotNetExists) {
-            $dotNetVersion = Find-RequiredSDK $dotnetCLIRequiredVersion
-        }
+            Write-Verbose -Verbose "Back from calling Find-Dotnet from Start-PSBootstrap"
 
-        if(!$dotNetExists -or $dotNetVersion -ne $dotnetCLIRequiredVersion -or $Force.IsPresent) {
-            if($Force.IsPresent) {
-                Write-Log -message "Installing dotnet due to -Force."
+            # Install dotnet-SDK
+            $dotNetExists = precheck 'dotnet' $null
+            $dotNetVersion = [string]::Empty
+            if($dotNetExists) {
+                $dotNetVersion = Find-RequiredSDK $dotnetCLIRequiredVersion
             }
-            elseif(!$dotNetExists) {
-                Write-Log -message "dotnet not present.  Installing dotnet."
+
+            if(!$dotNetExists -or $dotNetVersion -ne $dotnetCLIRequiredVersion -or $Force.IsPresent) {
+                if($Force.IsPresent) {
+                    Write-Log -message "Installing dotnet due to -Force."
+                }
+                elseif(!$dotNetExists) {
+                    Write-Log -message "dotnet not present.  Installing dotnet."
+                }
+                else {
+                    Write-Log -message "dotnet out of date ($dotNetVersion).  Updating dotnet."
+                }
+
+                $DotnetArguments = @{ Channel=$Channel; Version=$Version; NoSudo=$NoSudo }
+
+                if ($dotnetAzureFeed) {
+                    $null = $DotnetArguments.Add("AzureFeed", $dotnetAzureFeed)
+                    $null = $DotnetArguments.Add("FeedCredential", $dotnetAzureFeedSecret)
+                }
+
+                Install-Dotnet @DotnetArguments
             }
             else {
-                Write-Log -message "dotnet out of date ($dotNetVersion).  Updating dotnet."
+                Write-Log -message "dotnet is already installed.  Skipping installation."
             }
-
-            $DotnetArguments = @{ Channel=$Channel; Version=$Version; NoSudo=$NoSudo }
-
-            if ($dotnetAzureFeed) {
-                $null = $DotnetArguments.Add("AzureFeed", $dotnetAzureFeed)
-                $null = $DotnetArguments.Add("FeedCredential", $dotnetAzureFeedSecret)
-            }
-
-            Install-Dotnet @DotnetArguments
-        }
-        else {
-            Write-Log -message "dotnet is already installed.  Skipping installation."
         }
 
         # Install Windows dependencies if `-Package` or `-BuildWindowsNative` is specified
@@ -2402,7 +2407,7 @@ function Start-PSBootstrap {
                 $psInstallFile = [System.IO.Path]::Combine($PSScriptRoot, "tools", "install-powershell.ps1")
                 & $psInstallFile -AddToPath
             }
-            if ($Package) {
+            if ($Scenario -eq 'Both' -or $Scenario -eq 'Package') {
                 Import-Module "$PSScriptRoot\tools\wix\wix.psm1"
                 $isArm64 = "$env:RUNTIME" -eq 'arm64'
                 Install-Wix -arm64:$isArm64

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -188,8 +188,6 @@ function Invoke-CIInstall
     }
 
     Set-BuildVariable -Name TestPassed -Value False
-    Write-Verbose -Verbose -Message "Calling Start-PSBootstrap from Invoke-CIInstall"
-    Start-PSBootstrap
 }
 
 function Invoke-CIxUnit
@@ -402,8 +400,6 @@ function New-CodeCoverageAndTestPackage
 
     if (Test-DailyBuild)
     {
-        Start-PSBootstrap -Verbose
-
         Start-PSBuild -Configuration 'CodeCoverage' -Clean
 
         $codeCoverageOutput = Split-Path -Parent (Get-PSOutput)
@@ -691,7 +687,7 @@ function Invoke-BootstrapStage
     Write-Log -Message "Executing ci.psm1 Bootstrap Stage"
     # Make sure we have all the tags
     Sync-PSTags -AddRemoteIfMissing
-    Start-PSBootstrap -Package:$createPackages
+    Start-PSBootstrap -Scenario Package:$createPackages
 }
 
 # Run pester tests for Linux and macOS

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1637,7 +1637,7 @@ function Get-PackageDependencies
 function Test-Dependencies
 {
     foreach ($Dependency in "fpm") {
-        if (!(precheck $Dependency "Package dependency '$Dependency' not found. Run Start-PSBootstrap -Package")) {
+        if (!(precheck $Dependency "Package dependency '$Dependency' not found. Run Start-PSBootstrap -Scenario Package")) {
             # These tools are not added to the path automatically on OpenSUSE 13.2
             # try adding them to the path and re-tesing first
             [string] $gemsPath = $null
@@ -1647,7 +1647,7 @@ function Test-Dependencies
                 $depenencyPath  = Get-ChildItem -Path (Join-Path -Path $gemsPath -ChildPath "gems" -AdditionalChildPath $Dependency) -Recurse | Sort-Object -Property LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty DirectoryName
                 $originalPath = $env:PATH
                 $env:PATH = $ENV:PATH +":" + $depenencyPath
-                if ((precheck $Dependency "Package dependency '$Dependency' not found. Run Start-PSBootstrap -Package")) {
+                if ((precheck $Dependency "Package dependency '$Dependency' not found. Run Start-PSBootstrap -Scenario Package")) {
                     continue
                 }
                 else {


### PR DESCRIPTION
Backport #24905

This pull request includes changes to streamline the bootstrap process and ensure consistency across various CI/CD workflows by replacing `Start-PSBootstrap` with `Start-PSBootstrap -Scenario Package` and adding the `UseDotNet@2` task to set up the .NET Core SDK. Below are the most important changes:

### Consistency in Bootstrap Command:
* Updated all instances of `Start-PSBootstrap` to `Start-PSBootstrap -Scenario Package` to ensure a consistent bootstrap process across different platforms and workflows. [[1]](diffhunk://#diff-563b328e4298c6de2609ba9cc8bdc3106451999c98c0ac0e6c61b0e18a8f702bL30-R30) [[2]](diffhunk://#diff-e7ed668ef29b90f676cc62f5d952da5d8c56b6902771b617172359859bb63e9aL177-R177) [[3]](diffhunk://#diff-c4deeac235a73bb18401801ffa4dbcba3977cfb09599cd432e2a5940de12734eL106-R106) [[4]](diffhunk://#diff-88d2abacc35dc8631d9c0e94c7e5d1ccdffc9426d13a16183b3c45f7841688b5L113-R113) [[5]](diffhunk://#diff-75adb3400c53c5cbe183c86d9d543a4cda81cd7664b45c4bf3ce77478e8ff098L89-R96) [[6]](diffhunk://#diff-8cd51058f435650a9337e54ab692f1abfa790bf021af6efc7f0a13a15ce5a16eL36-R42)

### .NET Core SDK Setup:
* Added `UseDotNet@2` task to various CI/CD templates to ensure the .NET Core SDK is set up using the `global.json` file. This change was applied to Linux, Windows, and macOS workflows. [[1]](diffhunk://#diff-956e26a1ef540e674ee9ef2e42c3423127167b56ef282ba5073fa8304d94dfadR34-R37) [[2]](diffhunk://#diff-9a8a3273e0db8ac68a2678dbb9daa2570f98e94773070e4cc4c4a89b081e5d9fR191-R194) [[3]](diffhunk://#diff-d57c933d863854f9d912e16e721ee4f97370454f265d73be75d62448be712056R65-R71) [[4]](diffhunk://#diff-36df43c9f4f3a05ba28d68446fe703429dd357f723690b0e1f9e47e50ff4ecdcR42-R51) [[5]](diffhunk://#diff-75adb3400c53c5cbe183c86d9d543a4cda81cd7664b45c4bf3ce77478e8ff098R66-R72)

### Removal of Redundant Bootstrap Commands:
* Removed redundant `Start-PSBootstrap` commands from several CI/CD templates to streamline the build process and avoid unnecessary steps. [[1]](diffhunk://#diff-956e26a1ef540e674ee9ef2e42c3423127167b56ef282ba5073fa8304d94dfadL53) [[2]](diffhunk://#diff-d57c933d863854f9d912e16e721ee4f97370454f265d73be75d62448be712056L78) [[3]](diffhunk://#diff-75adb3400c53c5cbe183c86d9d543a4cda81cd7664b45c4bf3ce77478e8ff098L138) [[4]](diffhunk://#diff-259a54dd3016b0c16ea3d2ec2874af152d3b4fd53414507fa4da8e9a6e3d1c11L64-R69) [[5]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL111-L112)

These changes help in maintaining a more consistent and efficient build process across different environments.