### PR TITLE
Add completion for variables assigned in ArrayLiterals and ParenExpressions

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5573,7 +5573,13 @@ namespace System.Management.Automation
                         : AstVisitAction.StopVisit;
                 }
 
-                if (assignmentStatementAst.Left is AttributedExpressionAst attributedExpression)
+                ProcessAssignmentLeftSide(assignmentStatementAst.Left, assignmentStatementAst.Right);
+                return AstVisitAction.Continue;
+            }
+
+            private void ProcessAssignmentLeftSide(ExpressionAst left, StatementAst right)
+            {
+                if (left is AttributedExpressionAst attributedExpression)
                 {
                     var firstConvertExpression = attributedExpression as ConvertExpressionAst;
                     ExpressionAst child = attributedExpression.Child;
@@ -5593,7 +5599,7 @@ namespace System.Management.Automation
                     {
                         if (variableExpression == CompletionVariableAst || s_specialVariablesCache.Value.Contains(variableExpression.VariablePath.UserPath))
                         {
-                            return AstVisitAction.Continue;
+                            return;
                         }
 
                         if (firstConvertExpression is not null)
@@ -5602,22 +5608,22 @@ namespace System.Management.Automation
                         }
                         else
                         {
-                            PSTypeName lastAssignedType = assignmentStatementAst.Right is CommandExpressionAst commandExpression
+                            PSTypeName lastAssignedType = right is CommandExpressionAst commandExpression
                                 ? GetInferredVarTypeFromAst(commandExpression.Expression)
                                 : null;
                             SaveVariableInfo(variableExpression.VariablePath.UnqualifiedPath, lastAssignedType, isConstraint: false);
                         }
                     }
                 }
-                else if (assignmentStatementAst.Left is VariableExpressionAst variableExpression)
+                else if (left is VariableExpressionAst variableExpression)
                 {
                     if (variableExpression == CompletionVariableAst || s_specialVariablesCache.Value.Contains(variableExpression.VariablePath.UserPath))
                     {
-                        return AstVisitAction.Continue;
+                        return;
                     }
 
                     PSTypeName lastAssignedType;
-                    if (assignmentStatementAst.Right is CommandExpressionAst commandExpression)
+                    if (right is CommandExpressionAst commandExpression)
                     {
                         lastAssignedType = GetInferredVarTypeFromAst(commandExpression.Expression);
                     }
@@ -5628,8 +5634,21 @@ namespace System.Management.Automation
 
                     SaveVariableInfo(variableExpression.VariablePath.UnqualifiedPath, lastAssignedType, isConstraint: false);
                 }
-
-                return AstVisitAction.Continue;
+                else if (left is ArrayLiteralAst array)
+                {
+                    foreach (ExpressionAst expression in array.Elements)
+                    {
+                        ProcessAssignmentLeftSide(expression, right);
+                    }
+                }
+                else if (left is ParenExpressionAst parenExpression)
+                {
+                    ExpressionAst pureExpression = parenExpression.Pipeline.GetPureExpression();
+                    if (pureExpression is not null)
+                    {
+                        ProcessAssignmentLeftSide(pureExpression, right);
+                    }
+                }
             }
 
             public override AstVisitAction VisitCommand(CommandAst commandAst)

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1044,6 +1044,17 @@ param([ValidatePattern(
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '$TestVar1'
     }
 
+    It 'Should complete variable assigned in ParenExpression' {
+        $res = TabExpansion2 -inputScript '($ParenVar) = 1; $ParenVa'
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly '$ParenVar'
+    }
+
+    It 'Should complete variable assigned in ArrayLiteral' {
+        $res = TabExpansion2 -inputScript '$DemoVar1, $DemoVar2 = 1..10; $DemoVar'
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly '$DemoVar1'
+        $res.CompletionMatches[1].CompletionText | Should -BeExactly '$DemoVar2'
+    }
+
     Context 'Start-Process -Verb parameter completion' {
         BeforeAll {
             function GetProcessInfoVerbs([string]$path, [switch]$singleQuote, [switch]$doubleQuote) {


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
One can use array literals to deconstruct assignments like this: `$Var1, $Var2 = 1..10` where $Var1 gets the first value and $var2 gets the rest.
One can also assign variables inside ParenExpressions like this: `($Var1) = 1..10` though to my knowledge this serves no practical purpose.
This PR fixes it so variable assignments made like this are included in the completion results.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
