### PR TITLE
Populate ErrorRecord.InvocationInfo BoundParameters and UnboundArguments properties

### DIFF
--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -1571,6 +1571,18 @@ namespace System.Management.Automation
 
                 _pipelineIterationInfo = new ReadOnlyCollection<int>(snapshot);
             }
+
+            //
+            // Add BoundParameters and UnboundArguments to this ErrorRecord's InvocationInfo
+            //
+            if (invocationInfo != null && invocationInfo.BoundParameters != null)
+            {
+                _invocationInfo.BoundParameters = invocationInfo.BoundParameters;
+            }
+            if (invocationInfo != null && invocationInfo.UnboundArguments != null)
+            {
+                _invocationInfo.UnboundArguments = invocationInfo.UnboundArguments;
+            }
         }
 
         // 2005/07/14-913791 "write-error output is confusing and misleading"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When an `ErrorRecord` is created and propagated, currently the properties `BoundParameters` and `UnboundArguments` are not being populated in the `InvocationInfo` property. This PR makes both properties available for faster diagnostics in cases like complex scripts or modules, where you would generally want to isolate the function creating the error as much as possible.

This PR fixes #25307 in the cases of both `Write-Error` and `$PSCmdlet.ThrowTerminatingError()`. It does not address exceptions produced by the keyword `throw`.

## PR Context

Input parameters, e.g., `BoundParameters`, being made available in the error object provides a diagnostic shortcut straight to the function causing the error. If all the input parameters to a function are known, it often becomes trivial to track the few lines of code inside the function and reproduce the error. This can save time and energy scanning code prior to the function call.

Unlike a breakpoint and debugger, this approach should also be convenient with long-running processes, when working remotely, or inside a container. 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
