### PR TITLE
Fix tab completion for env/function variables

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5331,11 +5331,11 @@ namespace System.Management.Automation
                                                                 ToStringCodeMethods.Type(value.GetType(),
                                                                                          dropNamespaces: true), name);
                                 }
-                            }
 
-                            if (!string.IsNullOrEmpty(variable.Description))
-                            {
-                                tooltip += $" - {variable.Description}";
+                                if (!string.IsNullOrEmpty(variable.Description))
+                                {
+                                    tooltip += $" - {variable.Description}";
+                                }
                             }
 
                             var completedName = !tokenAtCursorUsedBraces && !ContainsCharactersRequiringQuotes(name)

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -150,6 +150,46 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].ToolTip | Should -BeExactly $Expected
     }
     
+    It 'Should complete environment variable' {
+        try {
+            $env:PWSH_TEST_1 = 'value 1'
+            $env:PWSH_TEST_2 = 'value 2'
+
+            $res = TabExpansion2 -inputScript '$env:PWSH_TEST_'
+            $res.CompletionMatches.Count | Should -Be 2
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly '$env:PWSH_TEST_1'
+            $res.CompletionMatches[0].ListItemText | Should -BeExactly 'PWSH_TEST_1'
+            $res.CompletionMatches[0].ToolTip | Should -BeExactly 'PWSH_TEST_1'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly '$env:PWSH_TEST_2'
+            $res.CompletionMatches[1].ListItemText | Should -BeExactly 'PWSH_TEST_2'
+            $res.CompletionMatches[1].ToolTip | Should -BeExactly 'PWSH_TEST_2'
+        }
+        finally {
+            $env:PWSH_TEST_1 = $null
+            $env:PWSH_TEST_2 = $null
+        }
+    }
+
+    It 'Should complete function variable' {
+        try {
+            Function Test-PwshTest1 {}
+            Function Test-PwshTest2 {}
+
+            $res = TabExpansion2 -inputScript '${function:Test-PwshTest'
+            $res.CompletionMatches.Count | Should -Be 2
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly '${function:Test-PwshTest1}'
+            $res.CompletionMatches[0].ListItemText | Should -BeExactly 'Test-PwshTest1'
+            $res.CompletionMatches[0].ToolTip | Should -BeExactly 'Test-PwshTest1'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly '${function:Test-PwshTest2}'
+            $res.CompletionMatches[1].ListItemText | Should -BeExactly 'Test-PwshTest2'
+            $res.CompletionMatches[1].ToolTip | Should -BeExactly 'Test-PwshTest2'
+        }
+        finally {
+            Remove-Item function:Test-PwshTest1 -ErrorAction SilentlyContinue
+            Remove-Item function:Test-PwshTest1 -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'Should complete scoped variable with description and value <Value>' -TestCases @(
         @{ Value = 1; Expected = '[int]$VariableWithDescription - Variable description' }
         @{ Value = 'string'; Expected = '[string]$VariableWithDescription - Variable description' }


### PR DESCRIPTION
# PR Summary
Fixes the tab completion logic when attempting to autocomplete a function or env provider item.

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/issues/25299

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
