### PR TITLE
Use PSCustomObject instead of PSObject for synthetic types.

### DIFF
--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -905,7 +905,7 @@ namespace System.Management.Automation
     }
 
     /// <summary>
-    /// Represents dynamic types such as <see cref="System.Management.Automation.PSObject"/>,
+    /// Represents dynamic types such as <see cref="System.Management.Automation.PSCustomObject"/>,
     /// but can be used where a real type might not be available, in which case the name of the type can be used.
     /// The type encodes the members of dynamic objects in the type name.
     /// </summary>
@@ -928,7 +928,7 @@ namespace System.Management.Automation
         : base(typeName, type)
         {
             Members = membersTypes;
-            if (type != typeof(PSObject))
+            if (type != typeof(PSCustomObject))
             {
                 return;
             }
@@ -948,7 +948,7 @@ namespace System.Management.Automation
 
         private static string GetMemberTypeProjection(string typename, IList<PSMemberNameAndType> members)
         {
-            if (typename == typeof(PSObject).FullName)
+            if (typename == typeof(PSCustomObject).FullName)
             {
                 foreach (var mem in members)
                 {

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -478,7 +478,7 @@ namespace System.Management.Automation
                             psobjectPropertyList.Add(new PSMemberNameAndType(property.Name, propertyTypeName, property.Value));
                         }
 
-                        type = PSSyntheticTypeName.Create(typeObject, psobjectPropertyList);
+                        type = PSSyntheticTypeName.Create(typeof(PSCustomObject), psobjectPropertyList);
                     }
                     else
                     {
@@ -915,7 +915,10 @@ namespace System.Management.Automation
             {
                 if (InferTypes(hashtableAst).FirstOrDefault() is PSSyntheticTypeName syntheticTypeName)
                 {
-                    return new[] { PSSyntheticTypeName.Create(type, syntheticTypeName.Members) };
+                    var baseSyntheticType = convertExpressionAst.Type.TypeName.FullName.EqualsOrdinalIgnoreCase("PSCustomObject")
+                        ? typeof(PSCustomObject)
+                        : typeof(Hashtable);
+                    return new[] { PSSyntheticTypeName.Create(baseSyntheticType, syntheticTypeName.Members) };
                 }
             }
 
@@ -1780,7 +1783,7 @@ namespace System.Management.Automation
                     foreach (var t in InferTypes(previousPipelineElementAst))
                     {
                         var list = GetMemberNameAndTypeFromProperties(t, IsInPropertyArgument);
-                        inferredTypes.Add(PSSyntheticTypeName.Create(typeof(PSObject), list));
+                        inferredTypes.Add(PSSyntheticTypeName.Create(typeof(PSCustomObject), list));
                     }
                 }
             }
@@ -1944,7 +1947,7 @@ namespace System.Management.Automation
             var memberNameList = new List<string> { memberAsStringConst.Value };
             foreach (var type in exprType)
             {
-                if (type.Type == typeof(PSObject) && type is not PSSyntheticTypeName)
+                if (type.Type == typeof(PSObject))
                 {
                     continue;
                 }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -915,7 +915,7 @@ namespace System.Management.Automation
             {
                 if (InferTypes(hashtableAst).FirstOrDefault() is PSSyntheticTypeName syntheticTypeName)
                 {
-                    var baseSyntheticType = convertExpressionAst.Type.TypeName.FullName.EqualsOrdinalIgnoreCase("PSCustomObject")
+                    var baseSyntheticType = convertExpressionAst.Type.TypeName.FullName.EqualsOrdinalIgnoreCase(nameof(PSCustomObject))
                         ? typeof(PSCustomObject)
                         : typeof(Hashtable);
                     return new[] { PSSyntheticTypeName.Create(baseSyntheticType, syntheticTypeName.Members) };

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -293,6 +293,19 @@ namespace BugRepro
         }
     }
 
+    it 'should only complete selected properties' -Test {
+        $res = TabExpansion2 -inputScript 'Get-ChildItem | Select Name, FullName | Select '
+        $res.CompletionMatches.Count | Should -Be 2
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly FullName
+        $res.CompletionMatches[1].CompletionText | Should -BeExactly Name
+    }
+
+    it 'should hashtable properties for psobject wrapped hashtable' -Test {
+        $res = TabExpansion2 -inputScript '([psobject]@{Test = New-Guid}).Key'
+        $res.CompletionMatches.Count | Should -Be 1
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly Keys
+    }
+
     It 'should complete index expression for <Intent>' -TestCases @(
         @{
             Intent = 'Hashtable with no user input'

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -518,7 +518,7 @@ Describe "Type inference Tests" -tags "CI" {
                 }}.Ast)
         $res.Count | Should -Be 1
         $res[0].GetType().Name | Should -Be "PSSyntheticTypeName"
-        $res[0].Name | Should -Be "System.Management.Automation.PSObject#A:B"
+        $res[0].Name | Should -Be "System.Management.Automation.PSCustomObject#A:B"
         $res[0].Members[0].Name | Should -Be "A"
         $res[0].Members[0].PSTypeName | Should -Be "System.Int32"
         $res[0].Members[1].Name | Should -Be "B"
@@ -544,7 +544,7 @@ Describe "Type inference Tests" -tags "CI" {
         $res = [AstTypeInference]::InferTypeOf( { [io.fileinfo]::new("file") | Select-Object -Property Directory }.Ast)
         $res.Count | Should -Be 1
         $res[0].GetType().Name | Should -Be "PSSyntheticTypeName"
-        $res[0].Name | Should -Be "System.Management.Automation.PSObject#Directory"
+        $res[0].Name | Should -Be "System.Management.Automation.PSCustomObject#Directory"
         $res[0].Members[0].Name | Should -Be "Directory"
         $res[0].Members[0].PSTypeName | Should -Be "System.IO.DirectoryInfo"
     }
@@ -552,7 +552,7 @@ Describe "Type inference Tests" -tags "CI" {
     It "Infers typeof Select-Object when PSObject and Parameter is Property" {
         $res = [AstTypeInference]::InferTypeOf( { [PSCustomObject] @{A = 1; B = "2"} | Select-Object -Property A}.Ast)
         $res.Count | Should -Be 1
-        $res[0].Name | Should -Be "System.Management.Automation.PSObject#A"
+        $res[0].Name | Should -Be "System.Management.Automation.PSCustomObject#A"
         $res[0].Members[0].Name | Should -Be "A"
         $res[0].Members[0].PSTypeName | Should -Be "System.Int32"
     }
@@ -560,7 +560,7 @@ Describe "Type inference Tests" -tags "CI" {
     It "Infers typeof Select-Object when Parameter is Properties" {
         $res = [AstTypeInference]::InferTypeOf( {  [io.fileinfo]::new("file")  | Select-Object -Property Director*, Name }.Ast)
         $res.Count | Should -Be 1
-        $res[0].Name | Should -Be "System.Management.Automation.PSObject#Directory:DirectoryName:Name"
+        $res[0].Name | Should -Be "System.Management.Automation.PSCustomObject#Directory:DirectoryName:Name"
         $res[0].Members[0].Name | Should -Be "Directory"
         $res[0].Members[0].PSTypeName | Should -Be "System.IO.DirectoryInfo"
         $res[0].Members[1].Name | Should -Be "DirectoryName"
@@ -570,7 +570,7 @@ Describe "Type inference Tests" -tags "CI" {
     It "Infers typeof Select-Object when Parameter is ExcludeProperty" {
         $res = [AstTypeInference]::InferTypeOf( {  [io.fileinfo]::new("file")  |  Select-Object -ExcludeProperty *Time*, E* }.Ast)
         $res.Count | Should -Be 1
-        $res[0].Name | Should -BeExactly "System.Management.Automation.PSObject#Attributes:BaseName:Directory:DirectoryName:FullName:IsReadOnly:Length:LengthString:LinkTarget:LinkType:Mode:ModeWithoutHardLink:Name:NameString:ResolvedTarget:Target:UnixFileMode:VersionInfo"
+        $res[0].Name | Should -BeExactly "System.Management.Automation.PSCustomObject#Attributes:BaseName:Directory:DirectoryName:FullName:IsReadOnly:Length:LengthString:LinkTarget:LinkType:Mode:ModeWithoutHardLink:Name:NameString:ResolvedTarget:Target:UnixFileMode:VersionInfo"
         $names = $res[0].Members.Name
         $names -contains "BaseName" | Should -BeTrue
         $names -contains "Name" | Should -BeTrue


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR updates the synthetic types used for tab completion and type inference to use PSCustomObject instead of PSObject as the default type name. This will remove the irrelevant and unusable PSObject members like `BaseObject` and `ImmediateBaseObject` from the tab completion when working with synthetic types, like: `$Data = ls | select Name,Length; $Data.<Tab>` and when dealing with custom objects in general: `$Var1 = [pscustomobject]@{Test = ls}; $Var1.<Tab>`.
This also fixes a minor issue where attempting to wrap a hashtable in a PSObject would remove the hashtable members: `$Var1 = [psobject]@{Test = ls}; $Var1.<Tab>` so you didn't see members like "keys" and "Count".
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
