### PR TITLE
Allow users to choose JSON date format for Invoke-RestMethod

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateSet("Default", "Local", "Utc", "Offset", "String")]
-        public JsonDateKind DateFormat { get; set; } = "JsonDateKind.Default";
+        public JsonDateKind DateFormat { get; set; } = JsonDateKind.Default;
 
         #endregion Parameters
 
@@ -293,7 +293,7 @@ namespace Microsoft.PowerShell.Commands
             return doc != null;
         }
 
-        private static bool TryConvertToJson(string json, [NotNullWhen(true)] out object? obj, ref Exception? exRef)
+        private static bool TryConvertToJson(string json, JsonDateKind DateFormat, [NotNullWhen(true)] out object? obj, ref Exception? exRef)
         {
             bool converted = false;
             try

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -128,12 +128,12 @@ namespace Microsoft.PowerShell.Commands
 
                     if (returnType == RestReturnType.Json)
                     {
-                        convertSuccess = TryConvertToJson(str, out obj, ref ex) || TryConvertToXml(str, out obj, ref ex);
+                        convertSuccess = TryConvertToJson(str, DateFormat, out obj, ref ex) || TryConvertToXml(str, out obj, ref ex);
                     }
                     // Default to try xml first since it's more common
                     else
                     {
-                        convertSuccess = TryConvertToXml(str, out obj, ref ex) || TryConvertToJson(str, out obj, ref ex);
+                        convertSuccess = TryConvertToXml(str, out obj, ref ex) || TryConvertToJson(str, DateFormat, out obj, ref ex);
                     }
 
                     if (!convertSuccess)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -300,7 +300,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 obj = JsonObject.ConvertFromJson(json, false, 1024, DateFormat, out ErrorRecord error);
 
-
                 if (obj == null)
                 {
                     // This ensures that a null returned by ConvertFromJson() is the actual JSON null literal.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -67,6 +67,13 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public string? StatusCodeVariable { get; set; }
 
+        /// <summary>
+        /// Gets or sets how DateTime values are to be converted.
+        /// </summary>
+        [Parameter]
+        [ValidateSet("Default", "Local", "Utc", "Offset", "String")]
+        public JsonDateKind DateFormat { get; set; } = "JsonDateKind.Default";
+
         #endregion Parameters
 
         #region Virtual Method Overrides
@@ -291,7 +298,8 @@ namespace Microsoft.PowerShell.Commands
             bool converted = false;
             try
             {
-                obj = JsonObject.ConvertFromJson(json, out ErrorRecord error);
+                obj = JsonObject.ConvertFromJson(json, false, 1024, DateFormat, out ErrorRecord error);
+
 
                 if (obj == null)
                 {


### PR DESCRIPTION
# PR Summary

This PR adds the `DateFormat` parameter to the *Invoke-RestMethod* cmdlet, allowing users to control how date strings in JSON responses are parsed. This parameter mirrors the existing functionality already available in the *ConvertFrom-Json* cmdlet which has the same parameter.

The change preserves the exiting behavior, but extends the cmdlet functionnalities.

## PR Context

The `Invoke-RestMethod` cmdlet automatically converts JSON responses using `ConvertFrom-Json`.

When a response contains string values corresponding to a date format, the default and only behavior is to convert the string to something similar to `dd/MM/YYYY HH:mm:ss`.

As a user, I want to preserve the string as it is, or at least convert it directly to UTC.
Example use case :

```powershell
<#
Current host date : May 1st 2025 - 08:30:00

Raw JSON payload retrieved by Invoke-RestMethod -> { "createdDate" : "2025-05-01T12:00:00Z" }
#>

# Before : the date format is converted and if the time format ends with the character "Z" then the displayed time is UTC.

$response = Invoke-RestMethod @params

Write-Host response.createdDate

<# output : jeudi 1 mai 2025 12:00:00 #>

# After

params.Add("DateFormat",  "String")

# The output date string is as in the raw JSON

$response = Invoke-RestMethod @params

Write-Host response.createdDate

<# output : 2025-05-01T12:00:00Z #>

# Other possible use

params.Add("DateFormat",  "Local")

$response = Invoke-RestMethod @params

Write-Host response.createdDate

<# output : jeudi 1 mai 2025 08:30:00 #>

# The output time matches to the computer's timezone
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
