### PR TITLE
Improve verbose and debug logging level messaging in web cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal static string GetFriendlyContentLength(long? length) =>
             length.HasValue
-            ? $"{length.Value.Bytes().Humanize()} ({length.Value.ToString("#,0").Replace(",", " ")} bytes)"
+            ? $"{length.Value.Bytes().Humanize()} ({length.Value:#,0} bytes)"
             : "unknown size";
 
         internal static StringBuilder GetRawContentHeader(HttpResponseMessage response)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -9,7 +9,7 @@ using System.Management.Automation;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
-
+using Humanizer;
 using Microsoft.Win32;
 
 namespace Microsoft.PowerShell.Commands
@@ -21,7 +21,14 @@ namespace Microsoft.PowerShell.Commands
         // ContentType may not exist in response header.  Return null if not.
         internal static string? GetContentType(HttpResponseMessage response) => response.Content.Headers.ContentType?.MediaType;
 
+        internal static string? GetContentType(HttpRequestMessage request) => request.Content?.Headers.ContentType?.MediaType;
+
         internal static Encoding GetDefaultEncoding() => Encoding.UTF8;
+
+        internal static string GetFriendlyContentLength(long? length) =>
+            length.HasValue
+            ? $"{length.Value.Bytes().Humanize()} ({length.Value.ToString("#,0").Replace(",", " ")} bytes)"
+            : "unknown size";
 
         internal static StringBuilder GetRawContentHeader(HttpResponseMessage response)
         {
@@ -133,9 +140,12 @@ namespace Microsoft.PowerShell.Commands
                        || contentType.Equals("application/xml-external-parsed-entity", StringComparison.OrdinalIgnoreCase)
                        || contentType.Equals("application/xml-dtd", StringComparison.OrdinalIgnoreCase)
                        || contentType.EndsWith("+xml", StringComparison.OrdinalIgnoreCase);
-            
+
             return isXml;
         }
+
+        internal static bool IsTextBasedContentType([NotNullWhen(true)] string? contentType)
+            => IsText(contentType) || IsJson(contentType) || IsXml(contentType);
 
         #endregion Internal Methods
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -99,8 +99,8 @@ namespace Microsoft.PowerShell.Commands
                     string? characterSet = WebResponseHelper.GetCharacterSet(response);
                     string str = StreamHelper.DecodeStream(responseStream, characterSet, out Encoding encoding, perReadTimeout, _cancelToken.Token);
 
-                    string encodingName = string.Empty;
-                    string encodingHeaderName = string.Empty;
+                    string encodingName = "unknown";
+                    string encodingHeaderName = "unknown";
                     string encodingPage = encoding.CodePage == -1 ? "unknown" : encoding.CodePage.ToString();
                     try
                     {
@@ -114,10 +114,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     // NOTE: Tests use this debug output to verify the encoding.
-                    if (encodingHeaderName != string.Empty && encodingName != string.Empty)
-                    {
-                        WriteDebug($"WebResponse content encoding: {encodingHeaderName} ({encodingName}) CodePage: {encodingPage}");
-                    }
+                    WriteDebug($"WebResponse content encoding: {encodingHeaderName} ({encodingName}) CodePage: {encodingPage}");
 
                     // Determine the response type
                     RestReturnType returnType = CheckReturnType(response);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -99,18 +99,20 @@ namespace Microsoft.PowerShell.Commands
                     string? characterSet = WebResponseHelper.GetCharacterSet(response);
                     string str = StreamHelper.DecodeStream(responseStream, characterSet, out Encoding encoding, perReadTimeout, _cancelToken.Token);
 
-                    string encodingVerboseName;
+                    string encodingName;
                     try
                     {
-                        encodingVerboseName = encoding.HeaderName;
+                        // NOTE: This is a getter method that may possibly throw a NotSupportedException exception,
+                        // hence the try/catch
+                        encodingName = encoding.HeaderName;
                     }
                     catch
                     {
-                        encodingVerboseName = string.Empty;
+                        encodingName = string.Empty;
                     }
 
-                    // NOTE: Tests use this verbose output to verify the encoding.
-                    WriteVerbose($"Content encoding: {encodingVerboseName}");
+                    // NOTE: Tests use this debug output to verify the encoding.
+                    WriteDebug($"WebResponse content encoding: {encodingName}");
 
                     // Determine the response type
                     RestReturnType returnType = CheckReturnType(response);
@@ -140,7 +142,7 @@ namespace Microsoft.PowerShell.Commands
 
                 responseStream.Position = 0;
             }
-            
+
             if (ShouldSaveToOutFile)
             {
                 string outFilePath = WebResponseHelper.GetOutFilePath(response, _qualifiedOutFile);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -99,20 +99,25 @@ namespace Microsoft.PowerShell.Commands
                     string? characterSet = WebResponseHelper.GetCharacterSet(response);
                     string str = StreamHelper.DecodeStream(responseStream, characterSet, out Encoding encoding, perReadTimeout, _cancelToken.Token);
 
-                    string encodingName;
+                    string encodingName = string.Empty;
+                    string encodingHeaderName = string.Empty;
+                    string encodingPage = encoding.CodePage == -1 ? "unknown" : encoding.CodePage.ToString();
                     try
                     {
-                        // NOTE: This is a getter method that may possibly throw a NotSupportedException exception,
+                        // NOTE: These are getter methods that may possibly throw a NotSupportedException exception,
                         // hence the try/catch
-                        encodingName = encoding.HeaderName;
+                        encodingHeaderName = encoding.HeaderName;
+                        encodingName = encoding.BodyName;
                     }
                     catch
                     {
-                        encodingName = string.Empty;
                     }
 
                     // NOTE: Tests use this debug output to verify the encoding.
-                    WriteDebug($"WebResponse content encoding: {encodingName}");
+                    if (encodingHeaderName != string.Empty && encodingName != string.Empty)
+                    {
+                        WriteDebug($"WebResponse content encoding: {encodingHeaderName} ({encodingName}) CodePage: {encodingPage}");
+                    }
 
                     // Determine the response type
                     RestReturnType returnType = CheckReturnType(response);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -99,22 +99,22 @@ namespace Microsoft.PowerShell.Commands
                     string? characterSet = WebResponseHelper.GetCharacterSet(response);
                     string str = StreamHelper.DecodeStream(responseStream, characterSet, out Encoding encoding, perReadTimeout, _cancelToken.Token);
 
-                    string encodingName = "unknown";
-                    string encodingHeaderName = "unknown";
+                    string friendlyName = "unknown";
+                    string encodingWebName = "unknown";
                     string encodingPage = encoding.CodePage == -1 ? "unknown" : encoding.CodePage.ToString();
                     try
                     {
                         // NOTE: These are getter methods that may possibly throw a NotSupportedException exception,
                         // hence the try/catch
-                        encodingHeaderName = encoding.HeaderName;
-                        encodingName = encoding.BodyName;
+                        encodingWebName = encoding.WebName;
+                        friendlyName = encoding.EncodingName;
                     }
                     catch
                     {
                     }
 
                     // NOTE: Tests use this debug output to verify the encoding.
-                    WriteDebug($"WebResponse content encoding: {encodingHeaderName} ({encodingName}) CodePage: {encodingPage}");
+                    WriteDebug($"WebResponse content encoding: {encodingWebName} ({friendlyName}) CodePage: {encodingPage}");
 
                     // Determine the response type
                     RestReturnType returnType = CheckReturnType(response);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1285,15 +1285,15 @@ namespace Microsoft.PowerShell.Commands
                 _cancelToken = new CancellationTokenSource();
                 try
                 {
-                    if (IsWriteVerboseEnabled())
-                    {
-                        WriteWebRequestVerboseInfo(currentRequest);
-                    }
+                    // if (IsWriteVerboseEnabled())
+                    // {
+                    //     WriteWebRequestVerboseInfo(currentRequest);
+                    // }
 
-                    if (IsWriteDebugEnabled())
-                    {
-                        WriteWebRequestDebugInfo(currentRequest);
-                    }
+                    // if (IsWriteDebugEnabled())
+                    // {
+                    //     WriteWebRequestDebugInfo(currentRequest);
+                    // }
 
                     response = client.SendAsync(currentRequest, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
 
@@ -1417,6 +1417,8 @@ namespace Microsoft.PowerShell.Commands
                     currentRequest = GetRequest(currentUri);
                     FillRequestStream(currentRequest);
                 }
+
+                totalRequests--;
             }
             while (totalRequests > 0 && !response.IsSuccessStatusCode);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1285,15 +1285,15 @@ namespace Microsoft.PowerShell.Commands
                 _cancelToken = new CancellationTokenSource();
                 try
                 {
-                    // if (IsWriteVerboseEnabled())
-                    // {
-                    //     WriteWebRequestVerboseInfo(currentRequest);
-                    // }
+                    if (IsWriteVerboseEnabled())
+                    {
+                        WriteWebRequestVerboseInfo(currentRequest);
+                    }
 
-                    // if (IsWriteDebugEnabled())
-                    // {
-                    //     WriteWebRequestDebugInfo(currentRequest);
-                    // }
+                    if (IsWriteDebugEnabled())
+                    {
+                        WriteWebRequestDebugInfo(currentRequest);
+                    }
 
                     response = client.SendAsync(currentRequest, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1417,9 +1417,6 @@ namespace Microsoft.PowerShell.Commands
                     currentRequest = GetRequest(currentUri);
                     FillRequestStream(currentRequest);
                 }
-
-                // We know the message will usually be at least a certain size, so this reduces allocations.
-                StringBuilder verboseBuilder = new(128);
             }
             while (totalRequests > 0 && !response.IsSuccessStatusCode);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1488,10 +1488,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     debugBuilder.Append(DebugHeaderPrefix).AppendLine("QUERY");
                     string[] queryParams = request.RequestUri.Query.TrimStart('?').Split('&');
-                    foreach (string param in queryParams)
-                    {
-                        debugBuilder.AppendLine(param);
-                    }
+                    debugBuilder.AppendJoin(Environment.NewLine, queryParams);
                 }
 
                 debugBuilder.Append(DebugHeaderPrefix).AppendLine("HEADERS");
@@ -1503,13 +1500,7 @@ namespace Microsoft.PowerShell.Commands
                         continue;
                     }
 
-                    foreach (var header in headerSet)
-                    {
-                        debugBuilder
-                        .Append($"{header.Key}: ")
-                        .AppendJoin(", ", header.Value)
-                        .AppendLine();
-                    }
+                    debugBuilder.AppendLine(headerSet.ToString());
                 }
 
                 if (request.Content is not null)
@@ -1592,7 +1583,7 @@ namespace Microsoft.PowerShell.Commands
                 // 200 OK
                 StringBuilder debugBuilder = new("WebResponse Detail" + Environment.NewLine, 512);
 
-                debugBuilder.AppendLine(DebugHeaderPrefix + "HEADERS");
+                debugBuilder.Append(DebugHeaderPrefix).AppendLine("HEADERS");
 
                 foreach (var headerSet in new HttpHeaders?[] { response.Headers, response.Content?.Headers })
                 {
@@ -1601,15 +1592,12 @@ namespace Microsoft.PowerShell.Commands
                         continue;
                     }
 
-                    foreach (var header in headerSet)
-                    {
-                        debugBuilder.AppendLine($"{header.Key}: {string.Join(", ", header.Value)}");
-                    }
+                    debugBuilder.AppendLine(headerSet.ToString());
                 }
 
                 if (response.Content is not null)
                 {
-                    debugBuilder.AppendLine(DebugHeaderPrefix + "BODY");
+                    debugBuilder.Append(DebugHeaderPrefix).AppendLine("BODY");
 
                     if (ContentHelper.IsTextBasedContentType(ContentHelper.GetContentType(response)))
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1506,7 +1506,7 @@ namespace Microsoft.PowerShell.Commands
                 if (request.Content is not null)
                 {
                     debugBuilder
-                    .AppendLine(DebugHeaderPrefix + "BODY")
+                    .Append(DebugHeaderPrefix).AppendLine("BODY")
                     .AppendLine(request.Content switch
                     {
                         StringContent stringContent => stringContent

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1455,6 +1455,10 @@ namespace Microsoft.PowerShell.Commands
                 {
                     verboseBuilder.Append($" body size {ContentHelper.GetFriendlyContentLength(requestContentLength)}");
                 }
+                if (OutFile is not null)
+                {
+                    verboseBuilder.Append($" output to {QualifyFilePath(OutFile)}");
+                }
 
                 WriteVerbose(verboseBuilder.ToString().Trim());
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1547,7 +1547,7 @@ namespace Microsoft.PowerShell.Commands
         {
             try
             {
-                // Typical basic example: WebResponse: 200 OK with text/plain payload body size (6 B (6 bytes))
+                // Typical basic example: WebResponse: 200 OK with text/plain payload body size 6 B (6 bytes)
                 StringBuilder verboseBuilder = new(128);
                 verboseBuilder.Append($"WebResponse: {(int)response.StatusCode} {response.ReasonPhrase ?? response.StatusCode.ToString()}");
 
@@ -1560,7 +1560,7 @@ namespace Microsoft.PowerShell.Commands
                 long? responseContentLength = response.Content?.Headers?.ContentLength;
                 if (responseContentLength is not null)
                 {
-                    verboseBuilder.Append($" body size ({ContentHelper.GetFriendlyContentLength(responseContentLength)})");
+                    verboseBuilder.Append($" with body size {ContentHelper.GetFriendlyContentLength(responseContentLength)}");
                 }
 
                 WriteVerbose(verboseBuilder.ToString().Trim());

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1459,7 +1459,7 @@ namespace Microsoft.PowerShell.Commands
                 long? requestContentLength = request.Content?.Headers?.ContentLength;
                 if (requestContentLength is not null)
                 {
-                    verboseBuilder.Append($" body size {ContentHelper.GetFriendlyContentLength(requestContentLength)}");
+                    verboseBuilder.Append($" with body size {ContentHelper.GetFriendlyContentLength(requestContentLength)}");
                 }
                 if (OutFile is not null)
                 {
@@ -1491,7 +1491,10 @@ namespace Microsoft.PowerShell.Commands
                 {
                     debugBuilder.Append(DebugHeaderPrefix).AppendLine("QUERY");
                     string[] queryParams = request.RequestUri.Query.TrimStart('?').Split('&');
-                    debugBuilder.AppendJoin(Environment.NewLine, queryParams);
+                    debugBuilder
+                        .AppendJoin(Environment.NewLine, queryParams)
+                        .AppendLine()
+                        .AppendLine();
                 }
 
                 debugBuilder.Append(DebugHeaderPrefix).AppendLine("HEADERS");
@@ -1527,7 +1530,8 @@ namespace Microsoft.PowerShell.Commands
                         StreamContent streamContent =>
                             "[Stream content: " + ContentHelper.GetFriendlyContentLength(streamContent.Headers.ContentLength) + "]",
                         _ => "[Unknown content type]",
-                    });
+                    })
+                    .AppendLine();
                 }
 
                 WriteDebug(debugBuilder.ToString().Trim());

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1277,144 +1277,151 @@ namespace Microsoft.PowerShell.Commands
             HttpRequestMessage currentRequest = request;
             HttpResponseMessage response = null;
 
-            // Track the current URI being used by various requests and re-requests.
-            Uri currentUri = currentRequest.RequestUri;
-
-            _cancelToken = new CancellationTokenSource();
-            try
+            do
             {
-                if (IsWriteVerboseEnabled())
-                {
-                    WriteWebRequestVerboseInfo(currentRequest);
-                }
-
-                if (IsWriteDebugEnabled())
-                {
-                    WriteWebRequestDebugInfo(currentRequest);
-                }
-
-                response = client.SendAsync(currentRequest, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
-
-                if (IsWriteVerboseEnabled())
-                {
-                    WriteWebResponseVerboseInfo(response);
-                }
-
-                if (IsWriteDebugEnabled())
-                {
-                    WriteWebResponseDebugInfo(response);
-                }
-            }
-            catch (TaskCanceledException ex)
-            {
-                if (ex.InnerException is TimeoutException)
-                {
-                    // HTTP Request timed out
-                    ErrorRecord er = new(ex, "ConnectionTimeoutReached", ErrorCategory.OperationTimeout, null);
-                    ThrowTerminatingError(er);
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            if (handleRedirect
-                && _maximumRedirection is not 0
-                && IsRedirectCode(response.StatusCode)
-                && response.Headers.Location is not null)
-            {
-                _cancelToken.Cancel();
-                _cancelToken = null;
-
-                // If explicit count was provided, reduce it for this redirection.
-                if (_maximumRedirection > 0)
-                {
-                    _maximumRedirection--;
-                }
-
-                // For selected redirects, GET must be used with the redirected Location.
-                if (RequestRequiresForceGet(response.StatusCode, currentRequest.Method) && !PreserveHttpMethodOnRedirect)
-                {
-                    Method = WebRequestMethod.Get;
-                    CustomMethod = string.Empty;
-                }
-
-                currentUri = new Uri(request.RequestUri, response.Headers.Location);
-
-                // Continue to handle redirection
-                using HttpRequestMessage redirectRequest = GetRequest(currentUri);
-                response.Dispose();
-                response = GetResponse(client, redirectRequest, handleRedirect);
-            }
-
-            // Request again without the Range header because the server indicated the range was not satisfiable.
-            // This happens when the local file is larger than the remote file.
-            // If the size of the remote file is the same as the local file, there is nothing to resume.
-            if (Resume.IsPresent
-                && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable
-                && (response.Content.Headers.ContentRange.HasLength
-                && response.Content.Headers.ContentRange.Length != _resumeFileSize))
-            {
-                _cancelToken.Cancel();
-
-                WriteVerbose(WebCmdletStrings.WebMethodResumeFailedVerboseMsg);
-
-                // Disable the Resume switch so the subsequent calls to GetResponse() and FillRequestStream()
-                // are treated as a standard -OutFile request. This also disables appending local file.
-                Resume = new SwitchParameter(false);
-
-                using (HttpRequestMessage requestWithoutRange = GetRequest(currentUri))
-                {
-                    FillRequestStream(requestWithoutRange);
-
-                    response.Dispose();
-                    response = GetResponse(client, requestWithoutRange, handleRedirect);
-                }
-            }
-
-            _resumeSuccess = response.StatusCode == HttpStatusCode.PartialContent;
-
-            // When MaximumRetryCount is not specified, the totalRequests is 1.
-            if (totalRequests > 1 && ShouldRetry(response.StatusCode))
-            {
-                int retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
-
-                // If the status code is 429 get the retry interval from the Headers.
-                // Ignore broken header and its value.
-                if (response.StatusCode is HttpStatusCode.TooManyRequests && response.Headers.TryGetValues(HttpKnownHeaderNames.RetryAfter, out IEnumerable<string> retryAfter))
-                {
-                    try
-                    {
-                        IEnumerator<string> enumerator = retryAfter.GetEnumerator();
-                        if (enumerator.MoveNext())
-                        {
-                            retryIntervalInSeconds = Convert.ToInt32(enumerator.Current);
-                        }
-                    }
-                    catch
-                    {
-                        // Ignore broken header.
-                    }
-                }
-
-                string retryMessage = string.Format(
-                    CultureInfo.CurrentCulture,
-                    WebCmdletStrings.RetryVerboseMsg,
-                    retryIntervalInSeconds,
-                    response.StatusCode);
-
-                WriteVerbose(retryMessage);
+                // Track the current URI being used by various requests and re-requests.
+                Uri currentUri = currentRequest.RequestUri;
 
                 _cancelToken = new CancellationTokenSource();
-                Task.Delay(retryIntervalInSeconds * 1000, _cancelToken.Token).GetAwaiter().GetResult();
-                _cancelToken.Cancel();
-                _cancelToken = null;
+                try
+                {
+                    if (IsWriteVerboseEnabled())
+                    {
+                        WriteWebRequestVerboseInfo(currentRequest);
+                    }
 
-                currentRequest.Dispose();
-                currentRequest = GetRequest(currentUri);
-                FillRequestStream(currentRequest);
+                    if (IsWriteDebugEnabled())
+                    {
+                        WriteWebRequestDebugInfo(currentRequest);
+                    }
+
+                    response = client.SendAsync(currentRequest, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
+
+                    if (IsWriteVerboseEnabled())
+                    {
+                        WriteWebResponseVerboseInfo(response);
+                    }
+
+                    if (IsWriteDebugEnabled())
+                    {
+                        WriteWebResponseDebugInfo(response);
+                    }
+                }
+                catch (TaskCanceledException ex)
+                {
+                    if (ex.InnerException is TimeoutException)
+                    {
+                        // HTTP Request timed out
+                        ErrorRecord er = new(ex, "ConnectionTimeoutReached", ErrorCategory.OperationTimeout, null);
+                        ThrowTerminatingError(er);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+
+                }
+                if (handleRedirect
+                    && _maximumRedirection is not 0
+                    && IsRedirectCode(response.StatusCode)
+                    && response.Headers.Location is not null)
+                {
+                    _cancelToken.Cancel();
+                    _cancelToken = null;
+
+                    // If explicit count was provided, reduce it for this redirection.
+                    if (_maximumRedirection > 0)
+                    {
+                        _maximumRedirection--;
+                    }
+
+                    // For selected redirects, GET must be used with the redirected Location.
+                    if (RequestRequiresForceGet(response.StatusCode, currentRequest.Method) && !PreserveHttpMethodOnRedirect)
+                    {
+                        Method = WebRequestMethod.Get;
+                        CustomMethod = string.Empty;
+                    }
+
+                    currentUri = new Uri(request.RequestUri, response.Headers.Location);
+
+                    // Continue to handle redirection
+                    using HttpRequestMessage redirectRequest = GetRequest(currentUri);
+                    response.Dispose();
+                    response = GetResponse(client, redirectRequest, handleRedirect);
+                }
+
+                // Request again without the Range header because the server indicated the range was not satisfiable.
+                // This happens when the local file is larger than the remote file.
+                // If the size of the remote file is the same as the local file, there is nothing to resume.
+                if (Resume.IsPresent
+                    && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable
+                    && (response.Content.Headers.ContentRange.HasLength
+                    && response.Content.Headers.ContentRange.Length != _resumeFileSize))
+                {
+                    _cancelToken.Cancel();
+
+                    WriteVerbose(WebCmdletStrings.WebMethodResumeFailedVerboseMsg);
+
+                    // Disable the Resume switch so the subsequent calls to GetResponse() and FillRequestStream()
+                    // are treated as a standard -OutFile request. This also disables appending local file.
+                    Resume = new SwitchParameter(false);
+
+                    using (HttpRequestMessage requestWithoutRange = GetRequest(currentUri))
+                    {
+                        FillRequestStream(requestWithoutRange);
+
+                        response.Dispose();
+                        response = GetResponse(client, requestWithoutRange, handleRedirect);
+                    }
+                }
+
+                _resumeSuccess = response.StatusCode == HttpStatusCode.PartialContent;
+
+                // When MaximumRetryCount is not specified, the totalRequests is 1.
+                if (totalRequests > 1 && ShouldRetry(response.StatusCode))
+                {
+                    int retryIntervalInSeconds = WebSession.RetryIntervalInSeconds;
+
+                    // If the status code is 429 get the retry interval from the Headers.
+                    // Ignore broken header and its value.
+                    if (response.StatusCode is HttpStatusCode.TooManyRequests && response.Headers.TryGetValues(HttpKnownHeaderNames.RetryAfter, out IEnumerable<string> retryAfter))
+                    {
+                        try
+                        {
+                            IEnumerator<string> enumerator = retryAfter.GetEnumerator();
+                            if (enumerator.MoveNext())
+                            {
+                                retryIntervalInSeconds = Convert.ToInt32(enumerator.Current);
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore broken header.
+                        }
+                    }
+
+                    string retryMessage = string.Format(
+                        CultureInfo.CurrentCulture,
+                        WebCmdletStrings.RetryVerboseMsg,
+                        retryIntervalInSeconds,
+                        response.StatusCode);
+
+                    WriteVerbose(retryMessage);
+
+                    _cancelToken = new CancellationTokenSource();
+                    Task.Delay(retryIntervalInSeconds * 1000, _cancelToken.Token).GetAwaiter().GetResult();
+                    _cancelToken.Cancel();
+                    _cancelToken = null;
+
+                    currentRequest.Dispose();
+                    currentRequest = GetRequest(currentUri);
+                    FillRequestStream(currentRequest);
+                }
+
+                // We know the message will usually be at least a certain size, so this reduces allocations.
+                StringBuilder verboseBuilder = new(128);
             }
+            while (totalRequests > 0 && !response.IsSuccessStatusCode);
 
             return response;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1287,12 +1287,12 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (IsWriteVerboseEnabled())
                     {
-                        WriteWebRequestVerboseInfo(request);
+                        WriteWebRequestVerboseInfo(currentRequest);
                     }
 
                     if (IsWriteDebugEnabled())
                     {
-                        GetWebRequestDebugInfo(request);
+                        GetWebRequestDebugInfo(currentRequest);
                     }
 
                     response = client.SendAsync(currentRequest, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1292,7 +1292,7 @@ namespace Microsoft.PowerShell.Commands
 
                     if (IsWriteDebugEnabled())
                     {
-                        GetWebRequestDebugInfo(currentRequest);
+                        WriteWebRequestDebugInfo(currentRequest);
                     }
 
                     response = client.SendAsync(currentRequest, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
@@ -1472,7 +1472,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private void GetWebRequestDebugInfo(HttpRequestMessage request)
+        private void WriteWebRequestDebugInfo(HttpRequestMessage request)
         {
             try
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -234,20 +234,8 @@
   <data name="FollowingRelLinkVerboseMsg" xml:space="preserve">
     <value>Following rel link {0}</value>
   </data>
-  <data name="WebMethodInvocationVerboseMsg" xml:space="preserve">
-    <value>Requested HTTP/{0} {1} with {2}-byte payload</value>
-  </data>
   <data name="WebMethodResumeFailedVerboseMsg" xml:space="preserve">
     <value>The remote server indicated it could not resume downloading. The local file will be overwritten.</value>
-  </data>
-  <data name="WebResponseVerboseMsg" xml:space="preserve">
-    <value>Received HTTP/{0} {1}-byte response of content type {2}</value>
-  </data>
-  <data name="WebRequestDebugMsg" xml:space="preserve">
-    <value>Request {0}</value>
-  </data>
-  <data name="WebResponseDebugMsg" xml:space="preserve">
-    <value>Response {0}</value>
   </data>
   <data name="WebResponseNoSizeVerboseMsg" xml:space="preserve">
     <value>Received HTTP/{0} response of content type {1} of unknown size</value>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -315,7 +315,7 @@ function ExecuteRestMethod {
                 }
             }
             if ($null -eq $result.Encoding) {
-                throw "Encoding not found in verbose output. Lines: $($result.Debug.Count) Content:$($result.Debug)"
+                throw "Encoding not found in debug output. Lines: $($result.Debug.Count) Content:$($result.Debug)"
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -309,7 +309,7 @@ function ExecuteRestMethod {
             foreach ($item in $result.Debug) {
                 $line = $item.Trim()
                 if ($line.StartsWith($debugEncodingPrefix)) {
-                    $encodingName = $item.SubString($EncodingPrefix.Length).Trim()
+                    $encodingName = $item.SubString($EncodingPrefix.Length).Split('(')[0].Trim()
                     $result.Encoding = [System.Text.Encoding]::GetEncoding($encodingName)
                     break
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -284,7 +284,7 @@ function ExecuteWebRequest {
     return $result
 }
 
-[string] $verboseEncodingPrefix = 'Content encoding: '
+[string] $debugEncodingPrefix = 'WebResponse content encoding: '
 # This function calls Invoke-WebRequest with the given uri and
 # parses the verbose output to determine the encoding used for the content.
 function ExecuteRestMethod {
@@ -297,37 +297,37 @@ function ExecuteRestMethod {
         $UseBasicParsing
     )
     $result = @{Output = $null; Error = $null; Encoding = $null; Content = $null}
-    $verbosePreferenceSave = $VerbosePreference
-    $VerbosePreference = 'Continue'
+    $debugPreferenceSave = $DebugPreference
+    $DebugPreference = 'Continue'
     try {
-        $verboseFile = Join-Path $TestDrive -ChildPath ExecuteRestMethod.verbose.txt
-        $result.Output = Invoke-RestMethod -Uri $Uri -UseBasicParsing:$UseBasicParsing.IsPresent -Verbose 4>$verboseFile
+        $debugFile = Join-Path $TestDrive -ChildPath ExecuteRestMethod.debug.txt
+        $result.Output = Invoke-RestMethod -Uri $Uri -UseBasicParsing:$UseBasicParsing.IsPresent -Debug 5>$debugFile
         $result.Content = $result.Output
 
-        if (Test-Path -Path $verboseFile) {
-            $result.Verbose = Get-Content -Path $verboseFile
-            foreach ($item in $result.Verbose) {
+        if (Test-Path -Path $debugFile) {
+            $result.Debug = Get-Content -Path $debugFile
+            foreach ($item in $result.Debug) {
                 $line = $item.Trim()
-                if ($line.StartsWith($verboseEncodingPrefix)) {
-                    $encodingName = $item.SubString($verboseEncodingPrefix.Length).Trim()
+                if ($line.StartsWith($debugEncodingPrefix)) {
+                    $encodingName = $item.SubString($EncodingPrefix.Length).Trim()
                     $result.Encoding = [System.Text.Encoding]::GetEncoding($encodingName)
                     break
                 }
             }
-            if ($result.Encoding -eq $null) {
-                throw "Encoding not found in verbose output. Lines: $($result.Verbose.Count) Content:$($result.Verbose)"
+            if ($null -eq $result.Encoding) {
+                throw "Encoding not found in verbose output. Lines: $($result.Debug.Count) Content:$($result.Debug)"
             }
         }
 
-        if ($result.Verbose -eq $null) {
-            throw "No verbose output was found"
+        if ($null -eq $result.Debug) {
+            throw "No debug output was found"
         }
     } catch {
         $result.Error = $_ | Select-Object * | Out-String
     } finally {
-        $VerbosePreference = $verbosePreferenceSave
-        if (Test-Path -Path $verboseFile) {
-            Remove-Item -Path $verboseFile -ErrorAction SilentlyContinue
+        $DebugPreference = $debugPreferenceSave
+        if (Test-Path -Path $debugFile) {
+            Remove-Item -Path $debugFile -ErrorAction SilentlyContinue
         }
     }
 


### PR DESCRIPTION
# PR Summary
- Moves debug message processing to separate methods to reduce `GetResponse` cognitive load
- Verbose messages redesigned to a one-line summary suited for watching the HTTP transactional flow of a script/module/etc.
- Debug messages redesigned to show query, header and body content, and intelligently hide binary content to prevent trashing the console/logs
- Messages are now conditionally generated based on Preference setting for performance.
- Humanize the content payload byte length (thanks @kilasuit)
- For Invoke-Restmethod, show the response encoding detail as a debug message

## Example
![image](https://github.com/user-attachments/assets/d0101095-1231-46cc-a0e9-0a8e898ef329)

## WG Review Response
> The Cmdlet WG discussed this. Since the introduction of Windows PowerShell, binary cmdlets emit both the Verbose and the Debug stream when -Debug is used. This introduces some natural redundancy when i.e. the verbose stream summarizes general operations whereas the debug stream provides more detailed info. Since both streams serve different purposes and audiences, neither one should be omitted just because of potential redundancy. As a workaround, either stream can be redirected to $null if not wanted. We continue to agree that the Debugstream is appropriate for technical details and sensitive information, whereas the Verbose stream is best for summary information.

Agreed. I have defined the intent of the messages to be as such:
**Verbose:** One-Liner showing the basics of what is happening, very useful for concisely tracing program flow. Sensitive information has been redacted at this level in general per [Security WG comments](https://github.com/PowerShell/PowerShell/issues/23879#issuecomment-2243692063) but URL is preserved for troubleshooting purposes and basic logging flow if necessary.

**Debug:** Includes all sensitive information including sensitive headers which may include authentication tokens, etc. as the purpose is for debugging, not logging, and specifying DebugPreference or Debug is considered an "opt-in" for this information.

## PR Context
Closes #25492

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
