### PR TITLE
Add more tests for `PSForEach` and `PSWhere` methods

### DIFF
--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -204,6 +204,12 @@ Describe "Adapter Tests" -tags "CI" {
         It "Can use PSForEach as an alias for the Foreach magic method" {
             $x = 5
             $x.PSForEach({$_}) | Should -Be 5
+
+            $p = $null.PSForEach{"I didn't run"}
+            $p.GetType().Name | Should -BeExactly 'Collection`1'
+            $p.Count | Should -BeExactly 0
+
+            ([pscustomobject]@{ Name = 'bar' }).PSForEach({$_.Name}) | Should -BeExactly 'bar'
         }
     }
 
@@ -249,6 +255,12 @@ Describe "Adapter Tests" -tags "CI" {
         It "Can use PSWhere as an alias for the Where magic method" {
             $x = 5
             $x.PSWhere{$true} | Should -Be 5
+
+            $p = $null.PSWhere{"I didn't run"}
+            $p.GetType().Name | Should -BeExactly 'Collection`1'
+            $p.Count | Should -BeExactly 0
+
+            ([pscustomobject]@{ Name = 'bar' }).PSWhere({$_.Name}) | ForEach-Object Name | Should -BeExactly 'bar'
         }
     }
 }


### PR DESCRIPTION
### Summary

This is a follow-up of the PR #25511 to add more tests for `PSForEach` and `PSWhere` methods.
The intrinsic methods are handled in 3 places in the binder to cover 3 scenarios. A few more tests are added to cover all those scenarios.