### PR TITLE
Build: Add -TestName Parameter to Start-PSPester

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1364,6 +1364,7 @@ function Start-PSPester {
         [string]$OutputFile = "pester-tests.xml",
         [string[]]$ExcludeTag = 'Slow',
         [string[]]$Tag = @("CI","Feature"),
+        [string[]]$TestName,
         [switch]$ThrowOnFailure,
         [string]$BinDir = (Split-Path (Get-PSOptions -DefaultToNew).Output),
         [string]$powershell = (Join-Path $BinDir 'pwsh'),
@@ -1447,7 +1448,7 @@ function Start-PSPester {
         }
     }
 
-    Write-Verbose "Running pester tests at '$path' with tag '$($Tag -join ''', ''')' and ExcludeTag '$($ExcludeTag -join ''', ''')'" -Verbose
+    Write-Verbose "Running pester tests at '$path' with tag '$($Tag -join ''', ''')' and ExcludeTag '$($ExcludeTag -join ''', ''')' and TestName '$($TestName -join ''', ''')'" -Verbose
     if(!$SkipTestToolBuild.IsPresent)
     {
         $publishArgs = @{ }
@@ -1496,6 +1497,9 @@ function Start-PSPester {
     $command += "Invoke-Pester "
 
     $command += "-OutputFormat ${OutputFormat} -OutputFile ${OutputFile} "
+    if ($TestName) {
+        $command += "-TestName @('" + (${TestName} -join "','") + "') "
+    }
     if ($ExcludeTag -and ($ExcludeTag -ne "")) {
         $command += "-ExcludeTag @('" + (${ExcludeTag} -join "','") + "') "
     }


### PR DESCRIPTION
Adds the `-TestName` parameter to `Start-PSPester`. This passes through to the `-TestName` parameter in Pester that allows filtering to specific `Describe` sections in Pester 4 (and eventually specific `It` sections in Pester 5) to allow to narrow to specific tests for faster inner dev loop development.