### PR TITLE
Publish `.msixbundle` package as a VPack

### DIFF
--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -99,7 +99,6 @@ extends:
           - template: .pipelines/templates/SetVersionVariables.yml@self
             parameters:
               ReleaseTagVar: $(ReleaseTagVar)
-              CreateJson: yes
               UseJson: no
 
           - pwsh: |

--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -114,11 +114,24 @@ extends:
             displayName: Download package
 
           - pwsh: |
-              Get-ChildItem '$(Pipeline.Workspace)\PSPackagesOfficial' -Recurse | Out-String -Width 150
+              $payloadDir = '$(Pipeline.Workspace)\PSPackagesOfficial\drop_msixbundle_CreateMSIXBundle'
+              Get-ChildItem $payloadDir -Recurse | Out-String -Width 150
+              $vstsCommandString = "vso[task.setvariable variable=PayloadDir]$payloadDir"
+              Write-Host "sending " + $vstsCommandString
+              Write-Host "##$vstsCommandString"
             displayName: 'Capture Artifact Listing'
 
           - pwsh: |
-              $bundlePackage = Get-ChildItem '$(Pipeline.Workspace)\PSPackagesOfficial\*.msixbundle'
+              $bundlePackage = Get-ChildItem '$(PayloadDir)\*.msixbundle'
+              Write-Verbose -Verbose ("MSIX bundle package: " + $bundlePackage.FullName -join ', ')
+              if ($bundlePackage.Count -ne 1) {
+                  throw "Expected to find 1 MSIX bundle package, but found $($bundlePackage.Count)"
+              }
+
+              if (-not (Test-Path '$(ob_outputDirectory)' -PathType Container)) {
+                  $null = New-Item '$(ob_outputDirectory)' -ItemType Directory -ErrorAction Stop
+              }
+
               $targetPath = Join-Path '$(ob_outputDirectory)' 'Microsoft.PowerShell_8wekyb3d8bbwe.msixbundle'
               Copy-Item -Verbose -Path $bundlePackage.FullName -Destination $targetPath
             displayName: 'Stage msixbundle for vpack'

--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -91,6 +91,7 @@ extends:
           ob_createvpack_targetDestinationDirectory: '$(Destination)'
           ob_createvpack_propsFile: false
           ob_createvpack_provData: true
+          ob_createvpack_metadata: '$(Build.SourceVersion)'
           ob_createvpack_versionAs: string
           ob_createvpack_version: '$(version)'
           ob_createvpack_verbose: true

--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -1,0 +1,134 @@
+trigger: none
+
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'createVPack'
+  displayName: 'Create and Submit VPack'
+  type: boolean
+  default: true
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+- name: 'ReleaseTagVar'
+  type: string
+  displayName: 'Release Tag Var:'
+  default: 'fromBranch'
+
+name: msixbundle_vPack_$(date:yyMM).$(date:dd)$(rev:rrr)
+
+variables:
+  CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]
+  system.debug: ${{ parameters.debug }}
+  BuildSolution: $(Build.SourcesDirectory)\dirs.proj
+  ReleaseTagVar: ${{ parameters.ReleaseTagVar }}
+  BuildConfiguration: Release
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+  Codeql.Enabled: false  #  pipeline is not building artifacts; it repackages existing artifacts into a vpack
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+  pipelines:
+    - pipeline: PSPackagesOfficial
+      source: 'PowerShell-Packages-Official'
+      trigger:
+        branches:
+          include:
+            - master
+            - releases/*
+
+extends:
+  template: v2/Microsoft.Official.yml@templates
+  parameters:
+    platform:
+      name: 'windows_undocked' # windows undocked
+
+    cloudvault:
+      enabled: false
+
+    globalSdl:
+      useCustomPolicy: true # for signing code
+      disableLegacyManifest: true
+      # disabled Armory as we dont have any ARM templates to scan. It fails on some sample ARM templates.
+      armory:
+        enabled: false
+      sbom:
+        enabled: true
+      compiled:
+        enabled: false
+      credscan:
+        enabled: true
+        scanFolder:  $(Build.SourcesDirectory)
+        suppressionsFile: $(Build.SourcesDirectory)\.config\suppress.json
+      binskim:
+        enabled: false
+      # APIScan requires a non-Ready-To-Run build
+      apiscan:
+        enabled: false
+      asyncSDL:
+        enabled: false
+      tsaOptionsFile: .config/tsaoptions.json
+
+    stages:
+    - stage: build
+      jobs:
+      - job: main
+        pool:
+          type: windows
+
+        variables:
+          ob_outputDirectory: '$(BUILD.SOURCESDIRECTORY)\out'
+          ob_createvpack_enabled: ${{ parameters.createVPack }}
+          ob_createvpack_packagename: 'PowerShell.app'
+          ob_createvpack_owneralias: 'dongbow'
+          ob_createvpack_description: 'VPack for the PowerShell Application'
+          ob_createvpack_targetDestinationDirectory: '$(Destination)'
+          ob_createvpack_propsFile: false
+          ob_createvpack_provData: true
+          ob_createvpack_versionAs: string
+          ob_createvpack_version: '$(version)'
+          ob_createvpack_verbose: true
+
+        steps:
+          - template: .pipelines/templates/SetVersionVariables.yml@self
+            parameters:
+              ReleaseTagVar: $(ReleaseTagVar)
+              CreateJson: yes
+              UseJson: no
+
+          - pwsh: |
+              Write-Verbose -Verbose 'PowerShell Version: $(version)'
+              if('$(version)' -match '-') {
+                  throw "Don't release a preview build msixbundle package"
+              }
+            displayName: Stop any preview release
+
+          - download: PSPackagesOfficial
+            artifact: 'drop_msixbundle_CreateMSIXBundle'
+            displayName: Download package
+
+          - pwsh: |
+              Get-ChildItem '$(Pipeline.Workspace)\PSPackagesOfficial' -Recurse | Out-String -Width 150
+            displayName: 'Capture Artifact Listing'
+
+          - pwsh: |
+              $bundlePackage = Get-ChildItem '$(Pipeline.Workspace)\PSPackagesOfficial\*.msixbundle'
+              $targetPath = Join-Path '$(ob_outputDirectory)' 'Microsoft.PowerShell_8wekyb3d8bbwe.msixbundle'
+              Copy-Item -Verbose -Path $bundlePackage.FullName -Destination $targetPath
+            displayName: 'Stage msixbundle for vpack'
+
+          - pwsh: |
+              Write-Verbose "VPack Version: $(ob_createvpack_version)" -Verbose
+              $vpackFiles = Get-ChildItem -Path $(ob_outputDirectory)\* -Recurse
+              if($vpackFiles.Count -eq 0) {
+                  throw "No files found in $(ob_outputDirectory)"
+              }
+              $vpackFiles | Out-String -Width 150
+            displayName: Debug Output Directory and Version
+            condition: succeededOrFailed()

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -368,10 +368,11 @@ extends:
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
         parameters:
-          displayName: Start vPack Release pipeline
+          displayName: Start 2 vPack Release pipelines
           jobName: PublishVPack
           instructions: |
-            Kick off vPack release pipeline
+            1. Kick off PowerShell-vPack-Official pipeline
+            2. Kick off PowerShell-MSIXBundle-VPack pipeline
 
     # Need to verify if the Az PS / CLI team still uses this. Skippinng for this release.
     # - stage: ReleaseDeps

--- a/.pipelines/templates/SetVersionVariables.yml
+++ b/.pipelines/templates/SetVersionVariables.yml
@@ -23,7 +23,7 @@ steps:
     }
     if(Test-Path -Path $path)
     {
-      Write-Verbose "reporoot detect at: ." -Verbose
+      Write-Verbose "reporoot detected at: ." -Verbose
       $repoRoot = '.'
     }
     else{
@@ -51,7 +51,7 @@ steps:
     $REPOROOT = $env:REPOROOT
 
     if (-not (Test-Path $REPOROOT/tools/releaseBuild/setReleaseTag.ps1)) {
-      if ((Test-Path "$REPOROOT/PowerShell/tools/releaseBuild/setReleaseTag.ps1")) {
+      if (Test-Path "$REPOROOT/PowerShell/tools/releaseBuild/setReleaseTag.ps1") {
         $REPOROOT = "$REPOROOT/PowerShell"
       } else {
         throw "Could not find setReleaseTag.ps1 in $REPOROOT/tools/releaseBuild or $REPOROOT/PowerShell/tools/releaseBuild"
@@ -72,7 +72,7 @@ steps:
     ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
 - powershell: |
-    Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
+    Get-ChildItem -Path Env: | Out-String -Width 150
   displayName: Capture environment
   condition: succeededOrFailed()
   env:

--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -48,4 +48,5 @@
     <rescap:Capability Name="packageManagement" />
     <rescap:Capability Name="packageQuery" />
   </Capabilities>
+  <mp:PhoneIdentity PhoneProductId="$PHONEPRODUCTID$" PhonePublisherId="95d94207-0c7c-47ed-82db-d75c81153c35" />
 </Package>

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3707,8 +3707,17 @@ function New-MSIXPackage
 
     $ProductVersion = Get-WindowsVersion -PackageName $packageName
 
+    # Any app that is submitted to the Store must have a PhoneIdentity in its appxmanifest.
+    # If you submit a package without this information to the Store, the Store will silently modify your package to include it.
+    # To find the PhoneProductId value, you need to run a package through the Store certification process,
+    # and use the PhoneProductId value from the Store certified package to update the manifest in your source code.
+    # This is the PhoneProductId for the "Microsoft.PowerShell" package.
+    $PhoneProductId = "5b3ae196-2df7-446e-8060-94b4ad878387"
+
     $isPreview = Test-IsPreview -Version $ProductSemanticVersion
     if ($isPreview) {
+        # This is the PhoneProductId for the "Microsoft.PowerShellPreview" package.
+        $PhoneProductId = "67859fd2-b02a-45be-8fb5-62c569a3e8bf"
         Write-Verbose "Using Preview assets" -Verbose
     }
 
@@ -3718,7 +3727,14 @@ function New-MSIXPackage
     $releasePublisher = 'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'
 
     $appxManifest = Get-Content "$RepoRoot\assets\AppxManifest.xml" -Raw
-    $appxManifest = $appxManifest.Replace('$VERSION$', $ProductVersion).Replace('$ARCH$', $Architecture).Replace('$PRODUCTNAME$', $productName).Replace('$DISPLAYNAME$', $displayName).Replace('$PUBLISHER$', $releasePublisher)
+    $appxManifest = $appxManifest
+        .Replace('$VERSION$', $ProductVersion)
+        .Replace('$ARCH$', $Architecture)
+        .Replace('$PRODUCTNAME$', $productName)
+        .Replace('$DISPLAYNAME$', $displayName)
+        .Replace('$PUBLISHER$', $releasePublisher)
+        .Replace('$PHONEPRODUCTID$', $PhoneProductId)
+
     $xml = [xml]$appxManifest
     if ($isPreview) {
         Write-Verbose -Verbose "Adding pwsh-preview.exe alias"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3727,13 +3727,13 @@ function New-MSIXPackage
     $releasePublisher = 'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'
 
     $appxManifest = Get-Content "$RepoRoot\assets\AppxManifest.xml" -Raw
-    $appxManifest = $appxManifest
-        .Replace('$VERSION$', $ProductVersion)
-        .Replace('$ARCH$', $Architecture)
-        .Replace('$PRODUCTNAME$', $productName)
-        .Replace('$DISPLAYNAME$', $displayName)
-        .Replace('$PUBLISHER$', $releasePublisher)
-        .Replace('$PHONEPRODUCTID$', $PhoneProductId)
+    $appxManifest = $appxManifest.
+        Replace('$VERSION$', $ProductVersion).
+        Replace('$ARCH$', $Architecture).
+        Replace('$PRODUCTNAME$', $productName).
+        Replace('$DISPLAYNAME$', $displayName).
+        Replace('$PUBLISHER$', $releasePublisher).
+        Replace('$PHONEPRODUCTID$', $PhoneProductId)
 
     $xml = [xml]$appxManifest
     if ($isPreview) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

1. Add the pipeline YAML file for publishing `.msixbundle` package as a VPack.
2. Update `AppxManifest.xml` to include the `PhoneIdentity` tag, which is required to be the same between a pre-installed app and its store version. See https://www.osgwiki.com/wiki/Adding_a_Preinstalled_App#PhoneProductID_in_the_manifest_needs_to_match_values_from_the_Store for more information.
3. Update the `packaging.psm1` file to include the `PhoneProductId` for `Microsoft.PowerShell` and `Microsoft.PowerShellPreview` respectively.
4. Minor updates to `SetVersionVariables.yml` to fix typos and make the display of environment variables readable.
5. Minor updates to the release pipeline to include the new msixbundle-vpack pipeline.

- msixbundle-vpack pipeline test run: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=597669&view=results
- PowerShell build pipeline test run: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=597785&view=results
- PowerShell package pipeline test run: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=598140&view=results -- the `windows_package` stage was successful and `.msix` packages were produced with the expected `PhoneProductID`.
