### PR TITLE
Build: Resolve -Output path to allow for relative paths

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -434,9 +434,14 @@ Fix steps:
         return
     }
 
+    # resolve the output path to an absolute path. We cannot use Resolve-Path here because it will error if the path does not exist.
+    if ($Output) {
+        $OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Output)
+    }
+
     # set output options
     $OptionsArguments = @{
-        Output=$Output
+        Output=$OutputPath
         Runtime=$Runtime
         Configuration=$Configuration
         Verbose=$true
@@ -456,7 +461,7 @@ Fix steps:
     # removing --no-restore due to .NET SDK issue: https://github.com/dotnet/sdk/issues/18999
     # $Arguments = @("publish","--no-restore","/property:GenerateFullPaths=true", "/property:ErrorOnDuplicatePublishOutputFiles=false")
     $Arguments = @("publish","/property:GenerateFullPaths=true", "/property:ErrorOnDuplicatePublishOutputFiles=false")
-    if ($Output -or $SMAOnly) {
+    if ($Options.Output -or $SMAOnly) {
         $Arguments += "--output", (Split-Path $Options.Output)
     }
 


### PR DESCRIPTION
If you do `Start-PSBuild -Output output` it will fail as relative paths do not resolve correctly and are incorrectly resolved relative to the primary project root.

This PR performes a PowerShell path resolution on output so that relative paths, including PSProvider paths such as TEMP:/debug can be used.