### PR TITLE
Explicitly specify ErrorRecord to use in DetailedView error format script

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1324,7 +1324,7 @@ namespace System.Management.Automation.Runspaces
                                     }
 
                                     if ($ErrorView -eq 'DetailedView') {
-                                        $message = Get-Error | Out-String
+                                        $message = Get-Error $err | Out-String
                                         return "${errorColor}${message}${resetcolor}"
                                     }
 

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -211,5 +211,13 @@ Describe 'Tests for $ErrorView' -Tag CI {
 
             $e | Should -BeExactly (Get-Error | Out-String).Trim([Environment]::NewLine.ToCharArray())
         }
+
+        It 'Renders the passed error instead of the last one' {
+            $ErrorView = 'DetailedView'
+            $first = try {throw "first"} catch {$_}
+            try {throw "second"} catch {}
+            # DetailedView internally calls 'Get-Error' to render the output, ensure that it picks up the correct error
+            $first | Out-String | Should -BeLike '*throw "first"*'
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

Previously, formatting for `DetailedView` of error records in `Out-Default` called `Get-Error` without parameters, which picked up the last thrown error instead of the actually passed `ErrorRecord`. This PR explicitly passes the formatted `ErrorRecord` to `Get-Error`.

## PR Context

Currently, if you try to override `Out-Default` and then use `.GetSteppablePipeline()` to call the original `Out-Default`, errors are not printed at all when in `DetailedView`. Not entirely sure why, but this change fixes it, and the current code is pretty obviously incorrect.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
