### PR TITLE
PathInfo: Add new 'DisplayPath' property, use it in prompts

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4874,12 +4874,13 @@ end {
             }
         }
 
-        internal const string DefaultPromptFunctionText = @"
-""PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "";
-# .Link
-# https://go.microsoft.com/fwlink/?LinkID=225750
-# .ExternalHelp System.Management.Automation.dll-help.xml
-";
+        internal const string DefaultPromptFunctionText =
+                """
+                "PS $($ExecutionContext.SessionState.Path.CurrentLocation.DisplayPath)$('>' * ($nestedPromptLevel + 1)) ";
+                # .Link
+                # https://go.microsoft.com/fwlink/?LinkID=225750
+                # .ExternalHelp System.Management.Automation.dll-help.xml
+                """;
 
         internal const string DefaultSetDriveFunctionText = "Set-Location $MyInvocation.MyCommand.Name";
 

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4510,7 +4510,7 @@ namespace System.Management.Automation
                 DebuggerStrings.NestedRunspaceDebuggerPromptProcessName,
                 @"$($PID)",
                 @"""");
-            const string locationPart = @"""PS $($executionContext.SessionState.Path.CurrentLocation)> """;
+            const string locationPart = @"""PS $($ExecutionContext.SessionState.Path.CurrentLocation.DisplayPath)> """;
             string promptScript = "'[DBG]: '" + " + " + processPart + " + " + "' [" + CodeGeneration.EscapeSingleQuotedStringContent(_runspace.Name) + "]: '" + " + " + locationPart;
 
             // Get the command prompt from the wrapped debugger.

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -1433,8 +1433,9 @@ namespace System.Management.Automation.PSTasks
         {
             // Nested debugged runspace prompt should look like:
             // [DBG]: [JobName]: PS C:\>>
-            string promptScript = "'[DBG]: '" + " + " + "'[" + CodeGeneration.EscapeSingleQuotedStringContent(_jobName) + "]: '" + " + " + @"""PS $($executionContext.SessionState.Path.CurrentLocation)>> """;
-            PSCommand promptCommand = new PSCommand();
+            string promptScript = $"'[DBG]: [{CodeGeneration.EscapeSingleQuotedStringContent(_jobName)}]: ' + "
+                                  + @"""PS $($ExecutionContext.SessionState.Path.CurrentLocation.DisplayPath)>> """;
+            var promptCommand = new PSCommand();
             promptCommand.AddScript(promptScript);
             _wrappedDebugger.ProcessCommand(promptCommand, output);
 

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -4135,8 +4135,9 @@ namespace System.Management.Automation
         {
             // Nested debugged runspace prompt should look like:
             // [DBG]: [JobName]: PS C:\>>
-            string promptScript = "'[DBG]: '" + " + " + "'[" + CodeGeneration.EscapeSingleQuotedStringContent(_jobName) + "]: '" + " + " + @"""PS $($executionContext.SessionState.Path.CurrentLocation)>> """;
-            PSCommand promptCommand = new PSCommand();
+            string promptScript = $"'[DBG]: [{CodeGeneration.EscapeSingleQuotedStringContent(_jobName)}]: ' + "
+                                  + @"""PS $($ExecutionContext.SessionState.Path.CurrentLocation.DisplayPath)>> """;
+            var promptCommand = new PSCommand();
             promptCommand.AddScript(promptScript);
             _wrappedDebugger.ProcessCommand(promptCommand, output);
 

--- a/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
@@ -294,7 +294,7 @@ namespace Microsoft.PowerShell.Commands
             string promptFn = StringUtil.Format(RemotingErrorIdStrings.EnterPSHostProcessPrompt,
                 @"function global:prompt { """,
                 @"$($PID)",
-                @"PS $($executionContext.SessionState.Path.CurrentLocation)> "" }"
+                @"PS $($ExecutionContext.SessionState.Path.CurrentLocation.DisplayPath)> "" }"
             );
 
             // Set prompt in pushed named pipe runspace.

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1178,7 +1178,7 @@ namespace Microsoft.PowerShell.Commands
                 string promptFn = StringUtil.Format(RemotingErrorIdStrings.EnterVMSessionPrompt,
                     @"function global:prompt { """,
                     targetName,
-                    @"PS $($executionContext.SessionState.Path.CurrentLocation)> "" }");
+                    @"PS $($executionContext.SessionState.Path.CurrentLocation.DisplayPath)> "" }");
 
                 // Set prompt in pushed named pipe runspace.
                 using (System.Management.Automation.PowerShell ps = System.Management.Automation.PowerShell.Create())

--- a/src/System.Management.Automation/namespaces/PathInfo.cs
+++ b/src/System.Management.Automation/namespaces/PathInfo.cs
@@ -58,6 +58,23 @@ public sealed class PathInfo
             : LocationGlobber.GetDriveQualifiedPath(_path, Drive);
 
     /// <summary>
+    /// Gets the PowerShell path that this object represents, in a format suitable for display to the user.
+    /// For scripting, prefer to use the other properties of PathInfo, do not rely on the exact format of this property.
+    /// </summary>
+    public string DisplayPath
+    {
+        // for real filesystem paths, always return the provider path, since the provider-qualified paths can be a bit
+        // unwieldy (e.g., after `Get-Item D:\dir | cd`, `Path` will be `Microsoft.PowerShell.Core\FileSystem::D:\dir`)
+        //
+        // for other providers (such as Registry), the provider-qualified path has the same issue, but the solution is
+        // less clear-cut, since the provider path may not have a drive (Registry), or it may be empty (Env), or it may
+        // not match the semantic location (virtual drive from New-PSDrive); return the fully-qualified path for now
+        get => Drive == null && Provider.ImplementingType == typeof(FileSystemProvider)
+                ? ProviderPath
+                : Path;
+    }
+
+    /// <summary>
     /// Gets a string representing the PowerShell path.
     /// </summary>
     /// <returns>

--- a/src/System.Management.Automation/namespaces/PathInfo.cs
+++ b/src/System.Management.Automation/namespaces/PathInfo.cs
@@ -1,165 +1,94 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace System.Management.Automation
+using Microsoft.PowerShell.Commands;
+
+namespace System.Management.Automation;
+
+/// <summary>
+/// An object that represents a path.
+/// </summary>
+public sealed class PathInfo
 {
+    private string _providerPath = null;
+    private readonly SessionState _sessionState;
+    private readonly PSDriveInfo _drive;
+    private readonly ProviderInfo _provider;
+    private readonly string _path;
+
     /// <summary>
-    /// An object that represents a path.
+    /// Gets the drive that contains the path.
     /// </summary>
-    public sealed class PathInfo
+    public PSDriveInfo Drive => _drive == null || _drive.Hidden ? null : _drive;
+
+    /// <summary>
+    /// Gets the provider that contains the path.
+    /// </summary>
+    public ProviderInfo Provider => _provider;
+
+    /// <summary>
+    /// This is the internal mechanism to get the hidden drive.
+    /// </summary>
+    /// <returns>
+    /// The drive associated with this PathInfo.
+    /// </returns>
+    internal PSDriveInfo GetDrive() => _drive;
+
+    /// <summary>
+    /// Gets the provider internal path for the PSPath that this PathInfo represents.
+    /// </summary>
+    /// <exception cref="ProviderInvocationException">
+    /// The provider encountered an error when resolving the path.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The path was a home relative path but the home path was not
+    /// set for the provider.
+    /// </exception>
+    public string ProviderPath
     {
-        /// <summary>
-        /// Gets the drive that contains the path.
-        /// </summary>
-        public PSDriveInfo Drive
-        {
-            get
-            {
-                PSDriveInfo result = null;
+        // Construct the providerPath
+        get => _providerPath ??= _sessionState.Internal.ExecutionContext.LocationGlobber.GetProviderPath(Path);
+    }
 
-                if (_drive != null &&
-                    !_drive.Hidden)
-                {
-                    result = _drive;
-                }
+    /// <summary>
+    /// Gets the PowerShell path that this object represents.
+    /// </summary>
+    public string Path => Drive == null
+            ? LocationGlobber.GetProviderQualifiedPath(_path, Provider)
+            : LocationGlobber.GetDriveQualifiedPath(_path, Drive);
 
-                return result;
-            }
-        }
+    /// <summary>
+    /// Gets a string representing the PowerShell path.
+    /// </summary>
+    /// <returns>
+    /// A string representing the PowerShell path.
+    /// </returns>
+    public override string ToString() => Path;
 
-        /// <summary>
-        /// Gets the provider that contains the path.
-        /// </summary>
-        public ProviderInfo Provider
-        {
-            get
-            {
-                return _provider;
-            }
-        }
-
-        /// <summary>
-        /// This is the internal mechanism to get the hidden drive.
-        /// </summary>
-        /// <returns>
-        /// The drive associated with this PathInfo.
-        /// </returns>
-        internal PSDriveInfo GetDrive()
-        {
-            return _drive;
-        }
-
-        /// <summary>
-        /// Gets the provider internal path for the PSPath that this PathInfo represents.
-        /// </summary>
-        /// <exception cref="ProviderInvocationException">
-        /// The provider encountered an error when resolving the path.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">
-        /// The path was a home relative path but the home path was not
-        /// set for the provider.
-        /// </exception>
-        public string ProviderPath
-        {
-            get
-            {
-                if (_providerPath == null)
-                {
-                    // Construct the providerPath
-
-                    LocationGlobber pathGlobber = _sessionState.Internal.ExecutionContext.LocationGlobber;
-                    _providerPath = pathGlobber.GetProviderPath(Path);
-                }
-
-                return _providerPath;
-            }
-        }
-
-        private string _providerPath;
-        private readonly SessionState _sessionState;
-
-        /// <summary>
-        /// Gets the PowerShell path that this object represents.
-        /// </summary>
-        public string Path
-        {
-            get
-            {
-                return this.ToString();
-            }
-        }
-
-        private readonly PSDriveInfo _drive;
-        private readonly ProviderInfo _provider;
-        private readonly string _path = string.Empty;
-
-        /// <summary>
-        /// Gets a string representing the PowerShell path.
-        /// </summary>
-        /// <returns>
-        /// A string representing the PowerShell path.
-        /// </returns>
-        public override string ToString()
-        {
-            string result = _path;
-
-            if (_drive == null ||
-                _drive.Hidden)
-            {
-                // For hidden drives just return the current location
-                result =
-                    LocationGlobber.GetProviderQualifiedPath(
-                        _path,
-                        _provider);
-            }
-            else
-            {
-                result = LocationGlobber.GetDriveQualifiedPath(_path, _drive);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// The constructor of the PathInfo object.
-        /// </summary>
-        /// <param name="drive">
-        /// The drive that contains the path
-        /// </param>
-        /// <param name="provider">
-        /// The provider that contains the path.
-        /// </param>
-        /// <param name="path">
-        /// The path this object represents.
-        /// </param>
-        /// <param name="sessionState">
-        /// The session state associated with the drive, provider, and path information.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// If <paramref name="drive"/>, <paramref name="provider"/>,
-        /// <paramref name="path"/>, or <paramref name="sessionState"/> is null.
-        /// </exception>
-        internal PathInfo(PSDriveInfo drive, ProviderInfo provider, string path, SessionState sessionState)
-        {
-            if (provider == null)
-            {
-                throw PSTraceSource.NewArgumentNullException(nameof(provider));
-            }
-
-            if (path == null)
-            {
-                throw PSTraceSource.NewArgumentNullException(nameof(path));
-            }
-
-            if (sessionState == null)
-            {
-                throw PSTraceSource.NewArgumentNullException(nameof(sessionState));
-            }
-
-            _drive = drive;
-            _provider = provider;
-            _path = path;
-            _sessionState = sessionState;
-        }
+    /// <summary>
+    /// The constructor of the PathInfo object.
+    /// </summary>
+    /// <param name="drive">
+    /// The drive that contains the path
+    /// </param>
+    /// <param name="provider">
+    /// The provider that contains the path.
+    /// </param>
+    /// <param name="path">
+    /// The path this object represents.
+    /// </param>
+    /// <param name="sessionState">
+    /// The session state associated with the drive, provider, and path information.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="drive"/>, <paramref name="provider"/>,
+    /// <paramref name="path"/>, or <paramref name="sessionState"/> is null.
+    /// </exception>
+    internal PathInfo(PSDriveInfo drive, ProviderInfo provider, string path, SessionState sessionState)
+    {
+        _drive = drive;
+        _provider = provider ?? throw PSTraceSource.NewArgumentNullException(nameof(provider));
+        _path = path ?? throw PSTraceSource.NewArgumentNullException(nameof(path));
+        _sessionState = sessionState ?? throw PSTraceSource.NewArgumentNullException(nameof(sessionState));
     }
 }


### PR DESCRIPTION
# PR Summary

Fixes #12544 and cleans up `PathInfo`.

## PR Context

While most paths explicitly entered by the user are drive-qualified (and resolved as such), most cmdlets return provider-qualified paths in the `PSPath` property. As a result, invoking something like `Get-Item ... | cd` results in prompt showing the provider-qualified path, which is quite unwieldy:

```pwsh
PS D:\programming\_cloned\PowerShell> Get-Item . | cd
PS Microsoft.PowerShell.Core\FileSystem::D:\programming\_cloned\PowerShell>
```

In general, there seems to be a bit of a conflict between getting a universal resolved path format (provider-qualified), which is "correct" but not nice for presentation to the user, and drive-qualified paths, which are not available in some situations, but are more readable.

To resolve both of those issues, this PR adds a `.DisplayPath` property to `PathInfo`, which explicitly does not guarantee the representation, just says that the returned path is intended for displaying to the user. For filesystem paths without an explicit `.Drive`, it uses `.ProviderPath`, otherwise returns `.Path`. All prompt functions (apparently there's 6 of them) are updated to use this property.

I'd recommend reviewing the two commits separately, first one cleans up `PathInfo` without behavioral changes, second one adds the new Property and updates prompt strings.

---

Question: Should the default formatting for `PathInfo` be updated to show `.DisplayPath` instead of `.Path`? The formatting is intended for the user and not for automated use, so the chance of breaking something by the change is probably quite low, otoh, the ROI is probably not very high.

---

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
