### PR TITLE
Fix debug tracing error with magic extents

### DIFF
--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1536,7 +1536,10 @@ namespace System.Management.Automation
 
         internal void OnSequencePointHit(FunctionContext functionContext)
         {
-            if (_context.ShouldTraceStatement && !_callStack.Last().IsFrameHidden && !functionContext._debuggerStepThrough)
+            if (_context.ShouldTraceStatement &&
+                !_callStack.Last().IsFrameHidden &&
+                !functionContext._debuggerStepThrough &&
+                functionContext.CurrentPosition.StartScriptPosition.ColumnNumber > 0)
             {
                 TraceLine(functionContext.CurrentPosition);
             }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1536,6 +1536,10 @@ namespace System.Management.Automation
 
         internal void OnSequencePointHit(FunctionContext functionContext)
         {
+            // TraceLine uses ColumnNumber and expects it to be 1 based. For
+            // extents added by the engine and not user code the value can be
+            // set to 0 causing an exception. This skips those types of extents
+            // as tracing them wouldn't be useful for the end user anyway.
             if (_context.ShouldTraceStatement &&
                 !_callStack.Last().IsFrameHidden &&
                 !functionContext._debuggerStepThrough &&

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1543,7 +1543,9 @@ namespace System.Management.Automation
             if (_context.ShouldTraceStatement &&
                 !_callStack.Last().IsFrameHidden &&
                 !functionContext._debuggerStepThrough &&
-                functionContext.CurrentPosition.StartScriptPosition.ColumnNumber > 0)
+                functionContext.CurrentPosition is not EmptyScriptExtent &&
+                (functionContext.CurrentPosition is InternalScriptExtent ||
+                   functionContext.CurrentPosition.StartColumnNumber > 0))
             {
                 TraceLine(functionContext.CurrentPosition);
             }

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -3645,13 +3645,25 @@ namespace System.Management.Automation.Language
             : base(extent)
         {
             StatementAst statement = null;
+            AttributeAst[] attributes = [];
             if (type == SpecialMemberFunctionType.DefaultConstructor)
             {
                 var invokeMemberAst = new BaseCtorInvokeMemberExpressionAst(extent, extent, Array.Empty<ExpressionAst>());
                 statement = new CommandExpressionAst(extent, invokeMemberAst, null);
+
+                // This stops the tracer from showing an empty body and an
+                // invalid extent and confusing end users who don't expect to
+                // see something they haven't written.
+                attributes = [new AttributeAst(extent, new ReflectionTypeName(typeof(DebuggerHiddenAttribute)), null, null)];
             }
 
-            Body = new ScriptBlockAst(extent, null, new StatementBlockAst(extent, statement == null ? null : new[] { statement }, null), false);
+            Body = new ScriptBlockAst(
+                extent,
+                attributes,
+                paramBlock: null,
+                statements: new StatementBlockAst(extent, statement == null ? null : new[] { statement }, null),
+                isFilter: false,
+                isConfiguration: false);
             this.SetParent(Body);
             definingType.SetParent(this);
             DefiningType = definingType;

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -3645,25 +3645,13 @@ namespace System.Management.Automation.Language
             : base(extent)
         {
             StatementAst statement = null;
-            AttributeAst[] attributes = [];
             if (type == SpecialMemberFunctionType.DefaultConstructor)
             {
                 var invokeMemberAst = new BaseCtorInvokeMemberExpressionAst(extent, extent, Array.Empty<ExpressionAst>());
                 statement = new CommandExpressionAst(extent, invokeMemberAst, null);
-
-                // This stops the tracer from showing an empty body and an
-                // invalid extent and confusing end users who don't expect to
-                // see something they haven't written.
-                attributes = [new AttributeAst(extent, new ReflectionTypeName(typeof(DebuggerHiddenAttribute)), null, null)];
             }
 
-            Body = new ScriptBlockAst(
-                extent,
-                attributes,
-                paramBlock: null,
-                statements: new StatementBlockAst(extent, statement == null ? null : new[] { statement }, null),
-                isFilter: false,
-                isConfiguration: false);
+            Body = new ScriptBlockAst(extent, null, new StatementBlockAst(extent, statement == null ? null : new[] { statement }, null), false);
             this.SetParent(Body);
             definingType.SetParent(this);
             DefiningType = definingType;

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
@@ -15,5 +15,16 @@ Describe "Set-PSDebug" -Tags "CI" {
         It "Should be able to set strict" {
             { Set-PSDebug -Strict } | Should -Not -Throw
         }
+        
+        It "Should skip magic extents created by pwsh" {
+            class ClassWithDefaultCtor {
+                MyMethod() { }
+            }
+            
+            { 
+                Set-PSDebug -Trace 1
+                [ClassWithDefaultCtor]::new()
+            } | Should -Not -Throw
+        }
     }
 }


### PR DESCRIPTION
# PR Summary
Fixes the error when PowerShell attempts to print the debug trace line for functions generated with an invalid extent. For example PowerShell creates an extent with a column and line of 0 for things like the default class constructors. This is an issue as the trace debug line always subtracts by 1 to make the value start at 0 rather than 1.

~~It also adds the DebuggerHidden attribute to the class default constructor to avoid confusing end users from seeing a trace line for something they did not write.~~

Edit: Removed this due to build issues.

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/issues/16874

~~I can remove the added attribute on the scriptblock and the fix will still be present but I thought it best to keep it there anyway. It doesn't hurt to be present and have that particular scenario skip the tracing altogether.~~

Edit: Was removed due to build issues.

Also Pester code coverage and Profiler uses this tracing so it's commonly seen even if people don't enable the tracing themselves.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
