### PR TITLE
Use a dedicated configuration directory path for all-users profiles on non-windows systems.

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -233,16 +233,27 @@ namespace System.Management.Automation
         /// <returns>The base path for all users profiles.</returns>
         private static string GetAllUsersFolderPath(string shellId)
         {
-            string folderPath = string.Empty;
-            try
+            string folderPath = Environment.GetEnvironmentVariable("POWERSHELL_COMMON_APPLICATION_DATA");
+            if (!string.IsNullOrEmpty(folderPath)) return folderPath;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                folderPath = Utils.GetApplicationBase(shellId);
-            }
-            catch (System.Security.SecurityException)
-            {
+                try
+                {
+                    return Utils.GetApplicationBase(shellId);
+                }
+                catch (System.Security.SecurityException)
+                {
+                    return string.Empty;
+                }
             }
 
-            return folderPath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "/Library/Application Support/PowerShell";
+            }
+
+            return "/etc/opt/powershell";
         }
         #endregion GetProfileCommands
 

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -17,15 +17,23 @@ Describe "Configuration file locations" -tags "CI","Slow" {
                 {
                     $ProductName =  "PowerShell"
                 }
-                $expectedCache    = [IO.Path]::Combine($env:LOCALAPPDATA, "Microsoft", "Windows", "PowerShell", "StartupProfileData-NonInteractive")
-                $expectedModule   = [IO.Path]::Combine($env:USERPROFILE, "Documents", $ProductName, "Modules")
-                $expectedProfile  = [IO.Path]::Combine($env:USERPROFILE, "Documents", $ProductName, $profileName)
-                $expectedReadline = [IO.Path]::Combine($env:AppData, "Microsoft", "Windows", "PowerShell", "PSReadline", "ConsoleHost_history.txt")
+                $expectedCache              = [IO.Path]::Combine($env:LOCALAPPDATA, "Microsoft", "Windows", "PowerShell", "StartupProfileData-NonInteractive")
+                $expectedModule             = [IO.Path]::Combine($env:USERPROFILE, "Documents", $ProductName, "Modules")
+                $expectedAllUsersProfile    = [IO.Path]::Combine($PSHOME, $profileName)
+                $expectedCurrentUserProfile = [IO.Path]::Combine($env:USERPROFILE, "Documents", $ProductName, $profileName)
+                $expectedReadline           = [IO.Path]::Combine($env:AppData, "Microsoft", "Windows", "PowerShell", "PSReadline", "ConsoleHost_history.txt")
             } else {
-                $expectedCache    = [IO.Path]::Combine($env:HOME, ".cache", "powershell", "StartupProfileData-NonInteractive")
-                $expectedModule   = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "Modules")
-                $expectedProfile  = [IO.Path]::Combine($env:HOME,".config","powershell",$profileName)
-                $expectedReadline = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "PSReadLine", "ConsoleHost_history.txt")
+                if ($IsMacOS) {
+                    $PowershellConfigRoot = "/Library/Application Support/PowerShell"
+                } else {
+                    $PowershellConfigRoot = "/etc/opt/powershell"
+                }
+
+                $expectedCache              = [IO.Path]::Combine($env:HOME, ".cache", "powershell", "StartupProfileData-NonInteractive")
+                $expectedModule             = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "Modules")
+                $expectedAllUsersProfile    = [IO.Path]::Combine($PowershellConfigRoot, $profileName)
+                $expectedCurrentUserProfile = [IO.Path]::Combine($env:HOME,".config","powershell", $profileName)
+                $expectedReadline           = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "PSReadLine", "ConsoleHost_history.txt")
             }
 
             $ItArgs = @{}
@@ -39,8 +47,17 @@ Describe "Configuration file locations" -tags "CI","Slow" {
             $env:PSModulePath = $original_PSModulePath
         }
 
-        It @ItArgs "Profile location should be correct" {
-            & $powershell -noprofile -c `$PROFILE | Should -Be $expectedProfile
+        It @ItArgs "Current User Profile location should be correct" {
+            & $powershell -noprofile -c `$PROFILE | Should -Be $expectedCurrentUserProfile
+        }
+
+        It @ItArgs "All Users Profile location should be correct" {
+            & $powershell -noprofile -c `$PROFILE.AllUsersAllHosts | Should -Be $expectedAllUsersProfile
+        }
+
+        It @ItArgs "All Users Profile location should be correct" {
+            $env:POWERSHELL_COMMON_APPLICATION_DATA = Join-Path -Path $PSHOME -ChildPath $profileName
+            & $powershell -noprofile -c `$PROFILE.AllUsersAllHosts | Should -Be $env:POWERSHELL_COMMON_APPLICATION_DATA
         }
 
         It @ItArgs "PSModulePath should contain the correct path" {

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -19,12 +19,12 @@ Describe "Configuration file locations" -tags "CI","Slow" {
                 }
                 $expectedCache    = [IO.Path]::Combine($env:LOCALAPPDATA, "Microsoft", "Windows", "PowerShell", "StartupProfileData-NonInteractive")
                 $expectedModule   = [IO.Path]::Combine($env:USERPROFILE, "Documents", $ProductName, "Modules")
-                $expectedProfile  = [io.path]::Combine($env:USERPROFILE, "Documents", $ProductName, $profileName)
+                $expectedProfile  = [IO.Path]::Combine($env:USERPROFILE, "Documents", $ProductName, $profileName)
                 $expectedReadline = [IO.Path]::Combine($env:AppData, "Microsoft", "Windows", "PowerShell", "PSReadline", "ConsoleHost_history.txt")
             } else {
                 $expectedCache    = [IO.Path]::Combine($env:HOME, ".cache", "powershell", "StartupProfileData-NonInteractive")
                 $expectedModule   = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "Modules")
-                $expectedProfile  = [io.path]::Combine($env:HOME,".config","powershell",$profileName)
+                $expectedProfile  = [IO.Path]::Combine($env:HOME,".config","powershell",$profileName)
                 $expectedReadline = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "PSReadLine", "ConsoleHost_history.txt")
             }
 


### PR DESCRIPTION
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

PowerShell should search in a dedicated directory (other than the installation directory) for the all-users profile to adhere to the [Filesystem Hierarchy Standard (FHS)](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html).

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Currently the all-users profiles are stored in the installation directory. Unix-based systems and derivatives mostly follow recommendations of the FHS. The FHS recommends to place configuration files into the `/etc` directory.

For example, here are the locations of the system wide configuration files of other popular shells:
- [bash(1)](https://manpages.ubuntu.com/manpages/en/man1/bash.1.html): `/etc/bash.bashrc` (Debian/Ubuntu) or `/etc/bashrc` (RedHat/Fedora)
- [zsh(1)](https://manpages.ubuntu.com/manpages/en/man1/zsh.1.html):  `/etc/zshrc`
- [fish(1)](https://manpages.ubuntu.com/manpages/en/man1/fish.1.html): `/etc/fish/config.fish`

I took inspiration from where NuGet is locating its system-wide configuration, see [NuGet config file locations](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#config-file-locations-and-uses):

This commit introduces the environment variable `POWERSHELL_COMMON_APPLICATION_DATA`.
If this variable is neither null nor empty, then this location is used. This allows distros that do not follow the FHS to customize the location.

- On Windows PowerShell keeps using the installation directory.
- On macOS PowerShell uses the `/Library/Application Support/PowerShell` directory. 
- Otherwise PowerShell uses `/etc/opt/powershell`.

This change is also needed to make the all-users profile usable when installing powershell via a snap, see https://github.com/canonical/powershell-snaps/issues/14

Fixes: #20336, #25007

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None (I consider this a bugfix)
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
