### PR TITLE
Properly Expand Aliases to their actual ResolvedCommand 

### DIFF
--- a/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
@@ -565,9 +565,7 @@ namespace System.Management.Automation.Runspaces
                 typeName,
                 new PSScriptProperty(
                     @"DisplayName",
-                    GetScriptBlock(@"if ($this.Name.IndexOf('-') -lt 0)
-          {
-          if ($null -ne $this.ResolvedCommand)
+                    GetScriptBlock(@"if ($null -ne $this.ResolvedCommand)
           {
           $this.Name + "" -> "" + $this.ResolvedCommand.Name
           }
@@ -575,11 +573,7 @@ namespace System.Management.Automation.Runspaces
           {
           $this.Name + "" -> "" + $this.Definition
           }
-          }
-          else
-          {
-          $this.Name
-          }"),
+          "),
                     setterScript: null,
                     shouldCloneOnAccess: true),
                 typeMembers,

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -156,28 +156,18 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
         }
     }
 
-    # Below test was suggested by GitHub Copilot to aid with fixing issue #25616
     It "Get-Alias DisplayName should always show AliasName -> ReferencedCommand for all aliases" {
-    # Address comments in PR by @iSazonov
-    ('Test-MyAlias', 'tma').foreach{Remove-Item Alias:$_ -ErrorAction SilentlyContinue}
-
-    Set-Alias -Name Test-MyAlias -Value Get-Command
-    Set-Alias -Name tma -Value Test-MyAlias
-
-    $aliases = Get-Alias Test-MyAlias, tma
-    $aliases | ForEach-Object {
-        # The DisplayName property should always be in the format: Name -> [Definition or ReferencedCommand]
-        $_.DisplayName | Should -Be "$($_.Name) -> Get-Command"
+        Set-Alias -Name Test-MyAlias -Value Get-Command -Force
+        Set-Alias -Name tma -Value Test-MyAlias -force
+        $aliases = Get-Alias Test-MyAlias, tma
+        $aliases | ForEach-Object {
+            $_.DisplayName | Should -Be "$($_.Name) -> Get-Command"
+        }
+        $aliases.Name.foreach{Remove-Item Alias:$_ -ErrorAction SilentlyContinue}
     }
-
-    # Clean up
-    Remove-Item Alias:Test-MyAlias
-    Remove-Item Alias:tma
-    ('Test-MyAlias', 'tma').foreach{Remove-Item Alias:$_ -ErrorAction SilentlyContinue}
 }
 
 Describe "Get-Alias" -Tags "CI" {
-    }
     It "Should have a return type of System.Array when gal returns more than one object" {
         $val1=(Get-Alias a*)
         $val2=(Get-Alias c*)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -156,7 +156,7 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
         }
     }
 
-    It "Get-Alias DisplayName should always show AliasName -> ReferencedCommand for all aliases" {
+    It "Get-Alias DisplayName should always show AliasName -> ResolvedCommand for all aliases" {
         Set-Alias -Name Test-MyAlias -Value Get-Command -Force
         Set-Alias -Name tma -Value Test-MyAlias -force
         $aliases = Get-Alias Test-MyAlias, tma

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -155,6 +155,29 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
             $returnObject[$i].Definition | Should -Be 'Get-Command'
         }
     }
+
+    # Below test was suggested by GitHub Copilot to aid with fixing issue #25616
+    It "Get-Alias DisplayName should always show AliasName -> ReferencedCommand for all aliases" {
+    # Clean up any existing aliases
+    if (Get-Alias -Name Test-MyAlias -ErrorAction SilentlyContinue) { Remove-Item Alias:Test-MyAlias }
+    if (Get-Alias -Name tma -ErrorAction SilentlyContinue) { Remove-Item Alias:tma }
+
+    # Create a Verb-Noun style alias "Test-MyAlias" pointing to Get-Command
+    Set-Alias -Name Test-MyAlias -Value Get-Command
+    # Create a short alias for the above "tma" -> "Test-MyAlias"
+    Set-Alias -Name tma -Value Test-MyAlias
+
+    $aliases = Get-Alias Test-MyAlias, tma
+
+    $aliases | ForEach-Object {
+        # The DisplayName property should always be in the format: Name -> [Definition or ReferencedCommand]
+        $_.DisplayName | Should -Be "$($_.Name) -> Get-Command"
+    }
+
+    # Clean up
+    Remove-Item Alias:Test-MyAlias
+    Remove-Item Alias:tma
+}
 }
 
 Describe "Get-Alias" -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -158,17 +158,13 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
 
     # Below test was suggested by GitHub Copilot to aid with fixing issue #25616
     It "Get-Alias DisplayName should always show AliasName -> ReferencedCommand for all aliases" {
-    # Clean up any existing aliases
-    if (Get-Alias -Name Test-MyAlias -ErrorAction SilentlyContinue) { Remove-Item Alias:Test-MyAlias }
-    if (Get-Alias -Name tma -ErrorAction SilentlyContinue) { Remove-Item Alias:tma }
+    # Address comments in PR by @iSazonov
+    ('Test-MyAlias', 'tma').foreach{Remove-Item Alias:$_ -ErrorAction SilentlyContinue}
 
-    # Create a Verb-Noun style alias "Test-MyAlias" pointing to Get-Command
     Set-Alias -Name Test-MyAlias -Value Get-Command
-    # Create a short alias for the above "tma" -> "Test-MyAlias"
     Set-Alias -Name tma -Value Test-MyAlias
 
     $aliases = Get-Alias Test-MyAlias, tma
-
     $aliases | ForEach-Object {
         # The DisplayName property should always be in the format: Name -> [Definition or ReferencedCommand]
         $_.DisplayName | Should -Be "$($_.Name) -> Get-Command"
@@ -177,10 +173,11 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
     # Clean up
     Remove-Item Alias:Test-MyAlias
     Remove-Item Alias:tma
-}
+    ('Test-MyAlias', 'tma').foreach{Remove-Item Alias:$_ -ErrorAction SilentlyContinue}
 }
 
 Describe "Get-Alias" -Tags "CI" {
+    }
     It "Should have a return type of System.Array when gal returns more than one object" {
         $val1=(Get-Alias a*)
         $val2=(Get-Alias c*)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #25616

This fixes a long standing "quirk" in how aliased commands would show & fixes #25616 as suggested.

There are no changes to the Get-Alias Cmdlet itself, however does update logic used by this command via the `System.Management.Automation.AliasInfo` object and the `DisplayName` ScriptProperty.

## PR Context

This improves the user experience in understanding which alias maps to the resolved command to improve discoverability.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/12424
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
