### PR TITLE
Remove eager initialization of `_startupScripts` to enable lazy thread-safe initialization

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -2124,7 +2124,7 @@ namespace System.Management.Automation.Runspaces
             }
         }
 
-        private HashSet<string> _startupScripts = new HashSet<string>();
+        private HashSet<string> _startupScripts;
 
         private readonly object _syncObject = new object();
 


### PR DESCRIPTION
The field `_startupScripts` was being initialized at declaration, which prevented the
`Interlocked.CompareExchange` logic in the `StartupScripts` property from ever executing.

This change removes the eager initialization to allow proper lazy and thread-safe setup
of the `HashSet` when the property is first accessed.
