### PR TITLE
Update PSRP protocol to deprecate session key exchange between newer client and server

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1705,7 +1705,7 @@ namespace Microsoft.PowerShell.Commands
         internal List<CommandMetadata> GetRemoteCommandMetadata(out Dictionary<string, string> alias2resolvedCommandName)
         {
             bool isReleaseCandidateBackcompatibilityMode =
-                this.Session.Runspace.GetRemoteProtocolVersion() == RemotingConstants.ProtocolVersionWin7RC;
+                this.Session.Runspace.GetRemoteProtocolVersion() == RemotingConstants.ProtocolVersion_2_0;
 
             alias2resolvedCommandName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if ((this.CommandName == null) || (this.CommandName.Length == 0) ||

--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -662,7 +662,7 @@ namespace System.Management.Automation.Runspaces
             commandAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.MergeUnclaimedPreviousCommandResults, this.MergeUnclaimedPreviousCommandResults));
 
             if (psRPVersion != null &&
-                psRPVersion >= RemotingConstants.ProtocolVersionWin10RTM)
+                psRPVersion >= RemotingConstants.ProtocolVersion_2_3)
             {
                 // V5 merge instructions
                 commandAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.MergeError, MergeInstructions[(int)MergeType.Error]));
@@ -672,7 +672,7 @@ namespace System.Management.Automation.Runspaces
                 commandAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.MergeInformation, MergeInstructions[(int)MergeType.Information]));
             }
             else if (psRPVersion != null &&
-                psRPVersion >= RemotingConstants.ProtocolVersionWin8RTM)
+                psRPVersion >= RemotingConstants.ProtocolVersion_2_2)
             {
                 // V3 merge instructions.
                 commandAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.MergeError, MergeInstructions[(int)MergeType.Error]));

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -5271,7 +5271,7 @@ namespace System.Management.Automation
             if (_runspace != null)
             {
                 return _runspace.RunspaceStateInfo.State != RunspaceState.BeforeOpen &&
-                       _runspace.GetRemoteProtocolVersion() >= RemotingConstants.ProtocolVersionWin8RTM;
+                       _runspace.GetRemoteProtocolVersion() >= RemotingConstants.ProtocolVersion_2_2;
             }
 
             RemoteRunspacePoolInternal remoteRunspacePoolInternal = null;
@@ -5285,7 +5285,7 @@ namespace System.Management.Automation
             }
 
             return remoteRunspacePoolInternal != null &&
-                   remoteRunspacePoolInternal.PSRemotingProtocolVersion >= RemotingConstants.ProtocolVersionWin8RTM;
+                   remoteRunspacePoolInternal.PSRemotingProtocolVersion >= RemotingConstants.ProtocolVersion_2_2;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
@@ -291,7 +291,7 @@ namespace System.Management.Automation.Runspaces.Internal
             // version 2.3 or greater.
             Version remoteProtocolVersionDeclaredByServer = PSRemotingProtocolVersion;
             if ((remoteProtocolVersionDeclaredByServer == null) ||
-                (remoteProtocolVersionDeclaredByServer < RemotingConstants.ProtocolVersionWin10RTM))
+                (remoteProtocolVersionDeclaredByServer < RemotingConstants.ProtocolVersion_2_3))
             {
                 throw PSTraceSource.NewInvalidOperationException(RunspacePoolStrings.ResetRunspaceStateNotSupportedOnServer);
             }
@@ -733,7 +733,7 @@ namespace System.Management.Automation.Runspaces.Internal
                 {
                     // Disconnect/Connect support is currently only provided by the WSMan transport
                     // that is running PSRP protocol version 2.2 and greater.
-                    return (remoteProtocolVersionDeclaredByServer >= RemotingConstants.ProtocolVersionWin8RTM &&
+                    return (remoteProtocolVersionDeclaredByServer >= RemotingConstants.ProtocolVersion_2_2 &&
                             DataStructureHandler.EndpointSupportsDisconnect);
                 }
 

--- a/src/System.Management.Automation/engine/remoting/client/RunspaceRef.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RunspaceRef.cs
@@ -326,7 +326,7 @@ namespace System.Management.Automation.Remoting
                     powerShell.AddParameter("Name", new string[] { "Out-Default", "Exit-PSSession" });
                     powerShell.Runspace = _runspaceRef.Value;
 
-                    bool isReleaseCandidateBackcompatibilityMode = _runspaceRef.Value.GetRemoteProtocolVersion() == RemotingConstants.ProtocolVersionWin7RC;
+                    bool isReleaseCandidateBackcompatibilityMode = _runspaceRef.Value.GetRemoteProtocolVersion() == RemotingConstants.ProtocolVersion_2_0;
                     powerShell.IsGetCommandMetadataSpecialPipeline = !isReleaseCandidateBackcompatibilityMode;
                     int expectedNumberOfResults = isReleaseCandidateBackcompatibilityMode ? 2 : 3;
 

--- a/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
@@ -505,20 +505,11 @@ namespace System.Management.Automation.Remoting
             _serverProtocolVersion = serverProtocolVersion;
             Version clientProtocolVersion = Context.ClientCapability.ProtocolVersion;
 
-            if (
-                clientProtocolVersion.Equals(serverProtocolVersion)
-                || (clientProtocolVersion == RemotingConstants.ProtocolVersionWin7RTM &&
-                    serverProtocolVersion == RemotingConstants.ProtocolVersionWin7RC)
-                || (clientProtocolVersion == RemotingConstants.ProtocolVersionWin8RTM &&
-                    (serverProtocolVersion == RemotingConstants.ProtocolVersionWin7RC ||
-                     serverProtocolVersion == RemotingConstants.ProtocolVersionWin7RTM
-                     ))
-                || (clientProtocolVersion == RemotingConstants.ProtocolVersionWin10RTM &&
-                    (serverProtocolVersion == RemotingConstants.ProtocolVersionWin7RC ||
-                     serverProtocolVersion == RemotingConstants.ProtocolVersionWin7RTM ||
-                     serverProtocolVersion == RemotingConstants.ProtocolVersionWin8RTM
-                     ))
-                 )
+            if (clientProtocolVersion == serverProtocolVersion ||
+                serverProtocolVersion == RemotingConstants.ProtocolVersion_2_0 ||
+                serverProtocolVersion == RemotingConstants.ProtocolVersion_2_1 ||
+                serverProtocolVersion == RemotingConstants.ProtocolVersion_2_2 ||
+                serverProtocolVersion == RemotingConstants.ProtocolVersion_2_3)
             {
                 // passed negotiation check
             }

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.PowerShell.Commands
                                 {
                                     // In order to support foreach remoting properly ( icm | % { icm } ), the server must
                                     // be using protocol version 2.2. Otherwise, we skip this and assume the old behavior.
-                                    if (version >= RemotingConstants.ProtocolVersionWin8RTM)
+                                    if (version >= RemotingConstants.ProtocolVersion_2_2)
                                     {
                                         // Suppress collection behavior
                                         _needToCollect = false;

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -454,7 +454,7 @@ namespace System.Management.Automation.Remoting
             SafePipeHandle pipeHandle = NamedPipeNative.CreateNamedPipe(
                 fullPipeName,
                 NamedPipeNative.PIPE_ACCESS_DUPLEX | NamedPipeNative.FILE_FLAG_FIRST_PIPE_INSTANCE | NamedPipeNative.FILE_FLAG_OVERLAPPED,
-                NamedPipeNative.PIPE_TYPE_MESSAGE | NamedPipeNative.PIPE_READMODE_MESSAGE,
+                NamedPipeNative.PIPE_TYPE_MESSAGE | NamedPipeNative.PIPE_READMODE_MESSAGE | NamedPipeNative.PIPE_REJECT_REMOTE_CLIENTS,
                 1,
                 _namedPipeBufferSizeForRemoting,
                 _namedPipeBufferSizeForRemoting,

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -76,10 +76,11 @@ namespace System.Management.Automation
     {
         internal static readonly Version HostVersion = PSVersionInfo.PSVersion;
 
-        internal static readonly Version ProtocolVersionWin7RC = new Version(2, 0);
-        internal static readonly Version ProtocolVersionWin7RTM = new Version(2, 1);
-        internal static readonly Version ProtocolVersionWin8RTM = new Version(2, 2);
-        internal static readonly Version ProtocolVersionWin10RTM = new Version(2, 3);
+        internal static readonly Version ProtocolVersion_2_0 = new(2, 0); // Window 7 RC
+        internal static readonly Version ProtocolVersion_2_1 = new(2, 1); // Window 7 RTM
+        internal static readonly Version ProtocolVersion_2_2 = new(2, 2); // Window 8 RTM
+        internal static readonly Version ProtocolVersion_2_3 = new(2, 3); // Window 10 RTM
+        internal static readonly Version ProtocolVersion_2_4 = new(2, 4); // PowerShell 7.6
 
         // Minor will be incremented for each change in PSRP client/server stack and new versions will be
         // forked on early major release/drop changes history.
@@ -87,7 +88,13 @@ namespace System.Management.Automation
         //      2.102 to 2.103 - Key exchange protocol changes in M3
         //      2.103 to 2.2   - Final ship protocol version value, no change to protocol
         //      2.2 to 2.3     - Enabling informational stream
-        internal static readonly Version ProtocolVersionCurrent = new Version(2, 3);
+        //      2.3 to 2.4     - Obsolete the key exchange. The following messages are deprecated when both server and client are 2.4 or later:
+        //                        - PUBLIC_KEY
+        //                        - PUBLIC_KEY_REQUEST
+        //                        - ENCRYPTED_SESSION_KEY
+        //                       Per the Crypto board's review, we don't need to do extra encryption for SecureString objects.
+        //                       We will just depend on the secure transport layer to encrypt the data.
+        internal static readonly Version ProtocolVersionCurrent = new(2, 4);
         internal static readonly Version ProtocolVersion = ProtocolVersionCurrent;
         // Used by remoting commands to add remoting specific note properties.
         internal static readonly string ComputerNameNoteProperty = "PSComputerName";
@@ -2158,7 +2165,7 @@ namespace System.Management.Automation
                 return false;
             }
 
-            return (runspace.GetRemoteProtocolVersion() >= RemotingConstants.ProtocolVersionWin8RTM);
+            return (runspace.GetRemoteProtocolVersion() >= RemotingConstants.ProtocolVersion_2_2);
         }
     }
 }

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -88,12 +88,14 @@ namespace System.Management.Automation
         //      2.102 to 2.103 - Key exchange protocol changes in M3
         //      2.103 to 2.2   - Final ship protocol version value, no change to protocol
         //      2.2 to 2.3     - Enabling informational stream
-        //      2.3 to 2.4     - Obsolete the key exchange. The following messages are deprecated when both server and client are 2.4 or later:
+        //      2.3 to 2.4     - Deprecate the 'Session_Key' exchange. The following messages are obsolete when both server and client are v2.4+:
         //                        - PUBLIC_KEY
         //                        - PUBLIC_KEY_REQUEST
         //                        - ENCRYPTED_SESSION_KEY
-        //                       Per the Crypto board's review, we don't need to do extra encryption for SecureString objects.
-        //                       We will just depend on the secure transport layer to encrypt the data.
+        //                       The padding algorithm 'RSAEncryptionPadding.Pkcs1' used in the 'Session_Key' exchange is NOT secure, and therefore,
+        //                       PSRP needs to be used on top of a secure transport and the 'Session_Key' doesn't add any extra security.
+        //                       So, we decided to deprecate the 'Session_Key' exchange in PSRP and skip encryption and decryption for 'SecureString'
+        //                       objects. Instead, we require the transport to be secure for secure data transfer between PSRP clients and servers.
         internal static readonly Version ProtocolVersionCurrent = new(2, 4);
         internal static readonly Version ProtocolVersion = ProtocolVersionCurrent;
         // Used by remoting commands to add remoting specific note properties.

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -1258,7 +1258,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <param name="serverProtocolVersion">Server negotiated protocol version.</param>
         internal void AdjustForProtocolVariations(Version serverProtocolVersion)
         {
-            if (serverProtocolVersion <= RemotingConstants.ProtocolVersionWin7RTM)
+            if (serverProtocolVersion <= RemotingConstants.ProtocolVersion_2_1)
             {
                 int maxEnvSize;
                 WSManNativeApi.WSManGetSessionOptionAsDword(_wsManSessionHandle,

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -716,7 +716,7 @@ namespace System.Management.Automation
             bool isNested = false;
 
             // The server would've dropped the protocol version of an older client was connecting
-            if (_serverCapability.ProtocolVersion >= RemotingConstants.ProtocolVersionWin8RTM)
+            if (_serverCapability.ProtocolVersion >= RemotingConstants.ProtocolVersion_2_2)
             {
                 isNested = RemotingDecoder.GetIsNested(data.Data);
             }

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -973,35 +973,21 @@ namespace System.Management.Automation.Remoting
 
             if (onConnect)
             {
-                bool connectSupported = false;
-
-                // Win10 server can support reconstruct/reconnect for all 2.x protocol versions
-                // that support reconstruct/reconnect, Protocol 2.2+
-                // Major protocol version differences (2.x -> 3.x) are not supported.
-                // A reconstruct can only be initiated by a client that understands disconnect (2.2+),
-                // so we only need to check major versions from client and this server for compatibility.
-                if (clientProtocolVersion.Major == RemotingConstants.ProtocolVersion.Major)
+                // PS v7.6 server can support reconstruct/reconnect for all 2.x protocol versions that support reconstruct/reconnect (v2.2+).
+                // Major protocol version differences (2.x -> 3.x) are not supported. A reconstruct can only be initiated by a client that understands disconnect (v2.2+).
+                if (clientProtocolVersion == RemotingConstants.ProtocolVersion_2_2 ||
+                    clientProtocolVersion == RemotingConstants.ProtocolVersion_2_3)
                 {
-                    if (clientProtocolVersion.Minor == RemotingConstants.ProtocolVersionWin8RTM.Minor)
-                    {
-                        // Report that server is Win8 version to the client
-                        // Protocol: 2.2
-                        connectSupported = true;
-                        serverProtocolVersion = RemotingConstants.ProtocolVersionWin8RTM;
-                        Context.ServerCapability.ProtocolVersion = serverProtocolVersion;
-                    }
-                    else if (clientProtocolVersion.Minor > RemotingConstants.ProtocolVersionWin8RTM.Minor)
-                    {
-                        // All other minor versions are supported and the server returns its full capability
-                        // Protocol: 2.3, 2.4, 2.5 ...
-                        connectSupported = true;
-                    }
+                    // Report the server as the same version to the client.
+                    // Client protocol: v2.2, v2.3
+                    serverProtocolVersion = clientProtocolVersion;
+                    Context.ServerCapability.ProtocolVersion = serverProtocolVersion;
                 }
-
-                if (!connectSupported)
+                else if (!(clientProtocolVersion.Major == serverProtocolVersion.Major &&
+                           clientProtocolVersion.Minor >= serverProtocolVersion.Minor))
                 {
                     // Throw for protocol versions 2.x that don't support disconnect/reconnect.
-                    // Protocol: < 2.2
+                    // Client protocol: < 2.2
                     PSRemotingDataStructureException reasonOfFailure =
                         new PSRemotingDataStructureException(RemotingErrorIdStrings.ServerConnectFailedOnNegotiation,
                             RemoteDataNameStrings.PS_STARTUP_PROTOCOL_VERSION_NAME,
@@ -1010,47 +996,23 @@ namespace System.Management.Automation.Remoting
                             RemotingConstants.ProtocolVersion);
                     throw reasonOfFailure;
                 }
+
+                // All other minor versions are supported and the server returns its full capability.
+                // Client protocol: v2.4, v2.5 ...
             }
             else
             {
-                // Win10 server can support Win8 client
-                if (clientProtocolVersion == RemotingConstants.ProtocolVersionWin8RTM &&
-                    (
-                        (serverProtocolVersion == RemotingConstants.ProtocolVersionWin10RTM)
-                    ))
+                if (clientProtocolVersion == RemotingConstants.ProtocolVersion_2_0 ||
+                    clientProtocolVersion == RemotingConstants.ProtocolVersion_2_1 ||
+                    clientProtocolVersion == RemotingConstants.ProtocolVersion_2_2 ||
+                    clientProtocolVersion == RemotingConstants.ProtocolVersion_2_3)
                 {
-                    // - report that server is Win8 version to the client
-                    serverProtocolVersion = RemotingConstants.ProtocolVersionWin8RTM;
+                    // We support the those client versions and report the server as the same version to the client.
+                    serverProtocolVersion = clientProtocolVersion;
                     Context.ServerCapability.ProtocolVersion = serverProtocolVersion;
                 }
-
-                // Win8, Win10 server can support Win7 client
-                if (clientProtocolVersion == RemotingConstants.ProtocolVersionWin7RTM &&
-                    (
-                        (serverProtocolVersion == RemotingConstants.ProtocolVersionWin8RTM) ||
-                        (serverProtocolVersion == RemotingConstants.ProtocolVersionWin10RTM)
-                    ))
-                {
-                    // - report that server is Win7 version to the client
-                    serverProtocolVersion = RemotingConstants.ProtocolVersionWin7RTM;
-                    Context.ServerCapability.ProtocolVersion = serverProtocolVersion;
-                }
-
-                // Win7, Win8, Win10 server can support Win7 RC client
-                if (clientProtocolVersion == RemotingConstants.ProtocolVersionWin7RC &&
-                    (
-                        (serverProtocolVersion == RemotingConstants.ProtocolVersionWin7RTM) ||
-                        (serverProtocolVersion == RemotingConstants.ProtocolVersionWin8RTM) ||
-                        (serverProtocolVersion == RemotingConstants.ProtocolVersionWin10RTM)
-                    ))
-                {
-                    // - report that server is RC version to the client
-                    serverProtocolVersion = RemotingConstants.ProtocolVersionWin7RC;
-                    Context.ServerCapability.ProtocolVersion = serverProtocolVersion;
-                }
-
-                if (!((clientProtocolVersion.Major == serverProtocolVersion.Major) &&
-                      (clientProtocolVersion.Minor >= serverProtocolVersion.Minor)))
+                else if (!(clientProtocolVersion.Major == serverProtocolVersion.Major &&
+                           clientProtocolVersion.Minor >= serverProtocolVersion.Minor))
                 {
                     PSRemotingDataStructureException reasonOfFailure =
                         new PSRemotingDataStructureException(RemotingErrorIdStrings.ServerNegotiationFailed,

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <param name="data">Input data.</param>
         /// <returns>A SecureString .</returns>
-        private static SecureString New(byte[] data)
+        internal static SecureString New(byte[] data)
         {
             if ((data.Length % 2) != 0)
             {

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -433,6 +433,7 @@ namespace System.Management.Automation.Internal
             GenerateSessionKey();
 
             // encrypt it
+            // codeql[cs/cryptography/rsa-unapproved-encryption-padding-scheme] - PowerShell v7.4 and later versions have deprecated the key exchange in the remoting protocol. This code is kept only for backward compatibility reason.
             byte[] encryptedKey = _rsa.Encrypt(_aes.Key, RSAEncryptionPadding.Pkcs1);
 
             // convert the key to capi simpleblob format before exporting
@@ -466,6 +467,7 @@ namespace System.Management.Automation.Internal
             byte[] sessionKeyBlob = Convert.FromBase64String(sessionKey);
             byte[] rsaEncryptedKey = PSCryptoNativeConverter.FromCapiSimpleKeyBlob(sessionKeyBlob);
 
+            // codeql[cs/cryptography/rsa-unapproved-encryption-padding-scheme] - PowerShell v7.4 and later versions have deprecated the key exchange in the remoting protocol. This code is kept only for backward compatibility reason.
             _aes.Key = _rsa.Decrypt(rsaEncryptedKey, RSAEncryptionPadding.Pkcs1);
 
             // now we have imported the key and will be able to


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Today, a `Session_Key` is used to encrypt a `SecureString` before sending it on wire and decrypt it after receiving one. The PowerShell Remoting Protocol (PSRP) does the `Session_Key` exchange between client and server when a `SecureString` object needs to be transferred. It involves the following steps:
1. The client side generates a public key pair and sends the public key to the server.
2. The server generates a session key (symmetric)
3. The server uses the public key to encrypt the session key and then send it to the client.
4. Afterwards, both the client and server will use the session key to encrypt a `SecureString` object before sending it, and decrypt after receiving one.

However, the padding algorithm `RSAEncryptionPadding.Pkcs1` used in the PSRP `Session_Key` exchange is **NOT** secure, and therefore, the PSRP needs to be used on top of a secure transport and the `Session_Key` doesn't add any extra security.

So, we decided to deprecate the `Session_Key` exchange in PSRP, and instead, require secure transportation layer for secure data transfer between PSRP clients and servers.

This PR increments the protocol version to v2.4 with the following changes:
1. The following PSRP messages are deprecated when both client and server are v2.4+
    - PUBLIC_KEY
    - PUBLIC_KEY_REQUEST
    - ENCRYPTED_SESSION_KEY
2. The encryption and decryption steps for `SecureString` are skipped when both client and server are v2.4+
3. **The change is backward compatible.** For old client or server (v2.3 or prior), the key exchange will still be kicked off as needed.
4. Updated the `pipe_option` for creating the named pipe (used for `Enter-PSHostProcess`) in PowerShell to reject remote client.

------------

- PowerShell remoting over WinRM uses HTTP by default. It uses Kerberos or NTLM session key to encrypt at the message level and is considered secure in trusted networks, but **not** in untrusted networks. Need to assess the implications to it.
- PowerShell has built-in support for 3 non-network transports:
   - Standard I/O -- both client and server are local, so we should be good.
   - HyperV direct -- we've confirmed with the HyperV team that the man-in-the-middle attacks are not possible with HyperV sockets.
   - Named pipe -- it's possible for a remote client to connect to named pipe, which 1) may not be intended from the beginning of this feature 2) could be problematic after `SecureString` is no longer encrypted with a session key. So, it's better off to disable remote client (done by the `pipe_option` change above).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
