### PR TITLE
Add property and event for debug attach

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
@@ -265,6 +265,15 @@ namespace Microsoft.PowerShell.Commands
                 // Set up host script debugger to debug the runspace.
                 _debugger.DebugRunspace(_runspace, breakAll: BreakAll);
 
+                _runspace.IsRemoteDebuggerAttached = true;
+                _runspace.Events?.GenerateEvent(
+                    PSEngineEvent.OnDebugAttach,
+                    null,
+                    Array.Empty<object>(),
+                    null,
+                    true,
+                    false);
+
                 while (_debugging)
                 {
                     // Wait for running script.
@@ -307,6 +316,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 _runspace.AvailabilityChanged -= HandleRunspaceAvailabilityChanged;
                 _debugger.NestedDebuggingCancelledEvent -= HandleDebuggerNestedDebuggingCancelledEvent;
+                _runspace.IsRemoteDebuggerAttached = false;
                 _debugger.StopDebugRunspace(_runspace);
                 _newRunningScriptEvent.Dispose();
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
@@ -268,11 +268,11 @@ namespace Microsoft.PowerShell.Commands
                 _runspace.IsRemoteDebuggerAttached = true;
                 _runspace.Events?.GenerateEvent(
                     PSEngineEvent.OnDebugAttach,
-                    null,
-                    Array.Empty<object>(),
-                    null,
-                    true,
-                    false);
+                    sender: null,
+                    args: Array.Empty<object>(),
+                    extraData: null,
+                    processInCurrentThread: true,
+                    waitForCompletionInCurrentThread: false);
 
                 while (_debugging)
                 {

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -1831,7 +1831,7 @@ namespace System.Management.Automation
         public const string OnIdle = "PowerShell.OnIdle";
 
         /// <summary>
-        /// Called when Debug-Runspace has attached a debugger to the current runspace.
+        /// Called when <c>Debug-Runspace</c> has attached a debugger to the current runspace.
         /// </summary>
         public const string OnDebugAttach = "PowerShell.OnDebugAttach";
 

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -1831,6 +1831,11 @@ namespace System.Management.Automation
         public const string OnIdle = "PowerShell.OnIdle";
 
         /// <summary>
+        /// Called when Debug-Runspace has attached a debugger to the current runspace.
+        /// </summary>
+        public const string OnDebugAttach = "PowerShell.OnDebugAttach";
+
+        /// <summary>
         /// Called during scriptblock invocation.
         /// </summary>
         internal const string OnScriptBlockInvoke = "PowerShell.OnScriptBlockInvoke";
@@ -1843,7 +1848,7 @@ namespace System.Management.Automation
         /// <summary>
         /// A HashSet that contains all engine event names.
         /// </summary>
-        internal static readonly HashSet<string> EngineEvents = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { Exiting, OnIdle, OnScriptBlockInvoke };
+        internal static readonly HashSet<string> EngineEvents = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { Exiting, OnIdle, OnDebugAttach, OnScriptBlockInvoke };
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -761,6 +761,12 @@ namespace System.Management.Automation.Runspaces
         /// Gets the Runspace Id.
         /// </summary>
         public int Id { get; }
+        
+        /// <summary>
+        /// Gets and sets a boolean indicating whether the runspace has a
+        /// debugger attached with <c>Debug-Runspace</c>.
+        /// </summary>
+        public bool IsRemoteDebuggerAttached { get; internal set; }
 
         /// <summary>
         /// Returns protocol version that the remote server uses for PS remoting.


### PR DESCRIPTION
# PR Summary
Adds the `IsRemoteDebuggerAttached` property to `Runspace` that indicates whether a debugger is attached to the Runspace through the `Debug-Runspace` cmdlet. Also adds a new engine event `PowerShell.OnDebugAttach` that is emitted when the debugger is attached.

## PR Context

Fixes: https://github.com/PowerShell/PowerShell/issues/21392

Also see https://github.com/PowerShell/PowerShellEditorServices/pull/2250 which is the driver behind the new event. Unfortunately the only safe way to notify that code is safe to continue and a debugger is attached is through PowerShell. Sending our own event before calling `Debug-Runspace` won't work because the code could continue before `Debug-Runspace` has set itself up. We cannot send an event after because the runspace will be busy running `Debug-Runspace`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
