### PR TITLE
Revert "Never load a module targeting the PSReadLine module's `SessionState`"

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -136,12 +136,17 @@ namespace Microsoft.PowerShell.Commands
 
         internal SessionState TargetSessionState
         {
-            // Module loading could happen during tab completion triggered by PSReadLine,
-            // but that doesn't mean the module should be loaded targeting the PSReadLine
-            // module's session state. In that case, use Global session state instead.
-            get => BaseGlobal || Context.EngineSessionState.Module?.Name is "PSReadLine"
-                ? Context.TopLevelSessionState.PublicSessionState
-                : Context.SessionState;
+            get
+            {
+                if (BaseGlobal)
+                {
+                    return this.Context.TopLevelSessionState.PublicSessionState;
+                }
+                else
+                {
+                    return this.Context.SessionState;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Reverts PowerShell/PowerShell#24909

The change causes nested modules of PSReadLine to be loaded to global session state as well.

It's possible to check if we are currently importing the PSReadLine module but the check would depend on the current design of the PSReadLine module, such as how many nested modules it has, its module type, and etc., which is fragile. It's safer to just revert the change.