### PR TITLE
Replace stackallocs with collection expressions

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -578,7 +578,7 @@ namespace Microsoft.PowerShell
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteToConsole(char c, bool transcribeResult)
         {
-            ReadOnlySpan<char> value = stackalloc char[1] { c };
+            ReadOnlySpan<char> value = [c];
             WriteToConsole(value, transcribeResult);
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleTextWriter.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleTextWriter.cs
@@ -76,8 +76,8 @@ namespace Microsoft.PowerShell
         void
         Write(char c)
         {
-            ReadOnlySpan<char> c1 = stackalloc char[1] { c };
-            _ui.WriteToConsole(c1, transcribeResult: true);
+            ReadOnlySpan<char> value = [c];
+            _ui.WriteToConsole(value, transcribeResult: true);
         }
 
         public override

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -637,25 +637,29 @@ namespace System.Management.Automation
                         return DirectoryOwnerFullGroupReadExecOtherReadExec;
                     }
 
-                    Span<char> modeCharacters = stackalloc char[10];
-                    modeCharacters[0] = itemTypeTable[ItemType];
-                    bool isExecutable;
-
                     UnixFileMode modeInfo = (UnixFileMode)Mode;
-                    modeCharacters[1] = modeInfo.HasFlag(UnixFileMode.UserRead) ? CanRead : NoPerm;
-                    modeCharacters[2] = modeInfo.HasFlag(UnixFileMode.UserWrite) ? CanWrite : NoPerm;
-                    isExecutable = modeInfo.HasFlag(UnixFileMode.UserExecute);
-                    modeCharacters[3] = modeInfo.HasFlag(UnixFileMode.SetUser) ? (isExecutable ? SetAndExec : SetAndNotExec) : (isExecutable ? CanExecute : NoPerm);
 
-                    modeCharacters[4] = modeInfo.HasFlag(UnixFileMode.GroupRead) ? CanRead : NoPerm;
-                    modeCharacters[5] = modeInfo.HasFlag(UnixFileMode.GroupWrite) ? CanWrite : NoPerm;
-                    isExecutable = modeInfo.HasFlag(UnixFileMode.GroupExecute);
-                    modeCharacters[6] = modeInfo.HasFlag(UnixFileMode.SetGroup) ? (isExecutable ? SetAndExec : SetAndNotExec) : (isExecutable ? CanExecute : NoPerm);
+                    Span<char> modeCharacters = [
+                        itemTypeTable[ItemType],
 
-                    modeCharacters[7] = modeInfo.HasFlag(UnixFileMode.OtherRead) ? CanRead : NoPerm;
-                    modeCharacters[8] = modeInfo.HasFlag(UnixFileMode.OtherWrite) ? CanWrite : NoPerm;
-                    isExecutable = modeInfo.HasFlag(UnixFileMode.OtherExecute);
-                    modeCharacters[9] = modeInfo.HasFlag(UnixFileMode.StickyBit) ? (isExecutable ? StickyAndExec : StickyAndNotExec) : (isExecutable ? CanExecute : NoPerm);
+                        modeInfo.HasFlag(UnixFileMode.UserRead) ? CanRead : NoPerm,
+                        modeInfo.HasFlag(UnixFileMode.UserWrite) ? CanWrite : NoPerm,
+                        modeInfo.HasFlag(UnixFileMode.SetUser) ?
+                            (modeInfo.HasFlag(UnixFileMode.UserExecute) ? SetAndExec : SetAndNotExec) :
+                            (modeInfo.HasFlag(UnixFileMode.UserExecute) ? CanExecute : NoPerm),
+
+                        modeInfo.HasFlag(UnixFileMode.GroupRead) ? CanRead : NoPerm,
+                        modeInfo.HasFlag(UnixFileMode.GroupWrite) ? CanWrite : NoPerm,
+                        modeInfo.HasFlag(UnixFileMode.SetGroup) ?
+                            (modeInfo.HasFlag(UnixFileMode.GroupExecute) ? SetAndExec : SetAndNotExec) :
+                            (modeInfo.HasFlag(UnixFileMode.GroupExecute) ? CanExecute : NoPerm),
+
+                        modeInfo.HasFlag(UnixFileMode.OtherRead) ? CanRead : NoPerm,
+                        modeInfo.HasFlag(UnixFileMode.OtherWrite) ? CanWrite : NoPerm,
+                        modeInfo.HasFlag(UnixFileMode.StickyBit) ?
+                            (modeInfo.HasFlag(UnixFileMode.OtherExecute) ? StickyAndExec : StickyAndNotExec) :
+                            (modeInfo.HasFlag(UnixFileMode.OtherExecute) ? CanExecute : NoPerm),
+                    ];
 
                     return new string(modeCharacters);
                 }

--- a/src/System.Management.Automation/engine/Interop/Windows/QueryDosDevice.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/QueryDosDevice.cs
@@ -28,7 +28,7 @@ internal static partial class Interop
 #endif
 
             Span<char> buffer = stackalloc char[StartLength + 1];
-            Span<char> fullDeviceName = stackalloc char[3] { deviceName, ':', '\0' };
+            Span<char> fullDeviceName = [deviceName, ':', '\0'];
             char[]? rentedArray = null;
 
             try

--- a/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/WNetGetConnection.cs
@@ -25,7 +25,7 @@ internal static partial class Interop
                 return ERROR_NOT_SUPPORTED;
             }
 
-            ReadOnlySpan<char> driveName = stackalloc char[] { drive, ':', '\0' };
+            ReadOnlySpan<char> driveName = [drive, ':', '\0'];
             int bufferSize = MAX_PATH;
             Span<char> uncBuffer = stackalloc char[MAX_PATH];
             if (InternalTestHooks.WNetGetConnectionBufferSize > 0 && InternalTestHooks.WNetGetConnectionBufferSize <= MAX_PATH)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1902,15 +1902,16 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                bool isDirectory = fileAttributes.HasFlag(FileAttributes.Directory);
-                ReadOnlySpan<char> mode = stackalloc char[]
-                {
-                    isLink ? 'l' : isDirectory ? 'd' : '-',
+                ReadOnlySpan<char> mode =
+                [
+                    isLink ?
+                        'l' :
+                        fileAttributes.HasFlag(FileAttributes.Directory) ? 'd' : '-',
                     fileAttributes.HasFlag(FileAttributes.Archive) ? 'a' : '-',
                     fileAttributes.HasFlag(FileAttributes.ReadOnly) ? 'r' : '-',
                     fileAttributes.HasFlag(FileAttributes.Hidden) ? 'h' : '-',
                     fileAttributes.HasFlag(FileAttributes.System) ? 's' : '-',
-                };
+                ];
                 return new string(mode);
             }
 

--- a/src/powershell/Program.cs
+++ b/src/powershell/Program.cs
@@ -129,10 +129,7 @@ namespace Microsoft.PowerShell
             // At this point, we are on macOS
 
             // Set up the mib array and the query for process maximum args size
-            Span<int> mib = stackalloc int[3];
-            int mibLength = 2;
-            mib[0] = MACOS_CTL_KERN;
-            mib[1] = MACOS_KERN_ARGMAX;
+            Span<int> mib = [MACOS_CTL_KERN, MACOS_KERN_ARGMAX];
             int size = IntPtr.Size / 2;
             int argmax = 0;
 
@@ -141,7 +138,7 @@ namespace Microsoft.PowerShell
             {
                 fixed (int *mibptr = mib)
                 {
-                    ThrowOnFailure(nameof(argmax), SysCtl(mibptr, mibLength, &argmax, &size, IntPtr.Zero, 0));
+                    ThrowOnFailure(nameof(argmax), SysCtl(mibptr, mib.Length, &argmax, &size, IntPtr.Zero, 0));
                 }
             }
 
@@ -155,16 +152,13 @@ namespace Microsoft.PowerShell
             IntPtr executablePathPtr = IntPtr.Zero;
             try
             {
-                mib[0] = MACOS_CTL_KERN;
-                mib[1] = MACOS_KERN_PROCARGS2;
-                mib[2] = pid;
-                mibLength = 3;
+                mib = [MACOS_CTL_KERN, MACOS_KERN_PROCARGS2, pid];
 
                 unsafe
                 {
                     fixed (int *mibptr = mib)
                     {
-                        ThrowOnFailure(nameof(procargs), SysCtl(mibptr, mibLength, procargs.ToPointer(), &argmax, IntPtr.Zero, 0));
+                        ThrowOnFailure(nameof(procargs), SysCtl(mibptr, mib.Length, procargs.ToPointer(), &argmax, IntPtr.Zero, 0));
                     }
 
                     // The memory block we're reading is a series of null-terminated strings

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -86,9 +86,9 @@ namespace TestExe
         private static void ReadBytes()
         {
             using Stream stdin = Console.OpenStandardInput();
-            Span<byte> buffer = [0x200];
+            Span<byte> buffer = stackalloc byte[0x200];
             Unsafe.InitBlock(ref MemoryMarshal.GetReference(buffer), 0, 0x200);
-            Span<char> hex = ['\0', '\0'];
+            Span<char> hex = stackalloc char[] { '\0', '\0' };
             while (true)
             {
                 int received = stdin.Read(buffer);

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -86,9 +86,9 @@ namespace TestExe
         private static void ReadBytes()
         {
             using Stream stdin = Console.OpenStandardInput();
-            Span<byte> buffer = stackalloc byte[0x200];
+            Span<byte> buffer = [0x200];
             Unsafe.InitBlock(ref MemoryMarshal.GetReference(buffer), 0, 0x200);
-            Span<char> hex = stackalloc char[] { '\0', '\0' };
+            Span<char> hex = ['\0', '\0'];
             while (true)
             {
                 int received = stdin.Read(buffer);


### PR DESCRIPTION
This is the same thing that was done in https://github.com/dotnet/runtime/pull/105143.

These will result in using an `InlineArray` rather than a `localloc`.