### PR TITLE
WIP: Implement enhanced splatting options

### DIFF
--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1373,4 +1373,13 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="ConfigurationNotAllowedOnArm64" xml:space="preserve">
     <value>Configuration keyword is not supported on ARM64 processors.</value>
   </data>
+  <data name="MissingSplatValue" xml:space="preserve">
+    <value>Missing value after the splat parameter -@.</value>
+  </data>
+  <data name="SplatValueAfterSplatParameter" xml:space="preserve">
+    <value>Cannot use a @splat expression '{0}' after the splat parameter '-@'. Remove the splat parameter or change the splat to a variable instead.</value>
+  </data>
+  <data name="CommandParameterValueAfterSplatParameter" xml:space="preserve">
+    <value>Cannot use a -Parameter:Value expression '{0}' after the splat parameter '-@'. Remove the splat parameter or specify the parameter value in a hashtable instead.</value>
+  </data>
 </root>


### PR DESCRIPTION
# PR Summary

Adds the ability to do inline splatting through a new `-@` splat parameter. This can be used to splat both variables, literals, and expression results.

## PR Context

Fixes: https://github.com/PowerShell/PowerShell/issues/25721 - This PR is for testing to validate the changes don't break any other test. Will be updating the RFC officially with some of the details here.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
