### PR TITLE
Remove AsyncSDL from Pipelines Toggle Official/NonOfficial Runs

### DIFF
--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -71,8 +71,6 @@ extends:
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false
-      asyncSDL:
-        enabled: false
       tsaOptionsFile: .config/tsaoptions.json
 
     stages:

--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -68,6 +68,7 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)\.config\suppress.json
       binskim:
         enabled: false
+        exactToolVersion: 4.4.2
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -30,13 +30,9 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
-  - name: Officialness
-    displayName: Officialness of the Pipeline
-    type: string
-    values:
-     - "Official"
-     - "Nonofficial"
-    default: "Official"
+  - name: OfficialBuild
+    type: boolean
+    default: false
 
 
 resources:
@@ -95,10 +91,12 @@ variables:
       value: true
     ${{ else }}:
       value: false
-
+  - name: templateFile
+    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
+  
 
 extends:
-  template: v2/OneBranch.${{ parameters.Officialness }}.CrossPlat.yml@onebranchTemplates
+  template: ${{ variables.templateFile }}
   parameters:
     customTags: 'ES365AIMigrationTooling'
     featureFlags:

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -125,6 +125,9 @@ extends:
         ignoreDirectories: '.devcontainer,demos,docker,docs,src,test,tools/packaging'
       binskim:
         enabled: false
+        # Fix for ICU package error in Linux containers - enable globalization invariant mode for BinSkim
+        environment:
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: true
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -93,6 +93,9 @@ variables:
       value: false
   - name: templateFile
     value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
+  # Fix for BinSkim ICU package error in Linux containers
+  - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
+    value: true
   
 
 extends:

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -96,6 +96,9 @@ variables:
   # Fix for BinSkim ICU package error in Linux containers
   - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
     value: true
+  # Disable BinSkim at job level to override NonOfficial template defaults
+  - name: ob_sdl_binskim_enabled
+    value: false
   
 
 extends:
@@ -128,9 +131,7 @@ extends:
         ignoreDirectories: '.devcontainer,demos,docker,docs,src,test,tools/packaging'
       binskim:
         enabled: false
-        # Fix for ICU package error in Linux containers - enable globalization invariant mode for BinSkim
-        environment:
-          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: true
+        exactToolVersion: 4.4.2
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -30,6 +30,14 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
+  - name: Officialness
+    displayName: Officialness of the Pipeline
+    type: string
+    values:
+     - "Official"
+     - "Nonofficial"
+    default: "Official"
+
 
 resources:
   repositories:
@@ -90,7 +98,7 @@ variables:
 
 
 extends:
-  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
+  template: v2/OneBranch.${{ parameters.Officialness }}.CrossPlat.yml@onebranchTemplates
   parameters:
     customTags: 'ES365AIMigrationTooling'
     featureFlags:
@@ -98,6 +106,7 @@ extends:
           Network: KS3
       WindowsHostVersion:
           Network: KS3
+      incrementalSDLBinaryAnalysis: true
     globalSdl:
       disableLegacyManifest: true
       # disabled Armorty as we dont have any ARM templates to scan. It fails on some sample ARM templates.
@@ -116,19 +125,12 @@ extends:
       cg:
         enabled: true
         ignoreDirectories: '.devcontainer,demos,docker,docs,src,test,tools/packaging'
-      asyncSdl:
-        enabled: true
-        forStages: [prep, macos, linux, windows, test_and_release_artifacts]
-        credscan:
-          enabled: true
-          scanFolder:  $(Build.SourcesDirectory)
-          suppressionsFile: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
-        binskim:
-          enabled: false
-        # APIScan requires a non-Ready-To-Run build
-        apiscan:
-          enabled: false
-        tsaOptionsFile: .config\tsaoptions.json
+      binskim:
+        enabled: false
+      # APIScan requires a non-Ready-To-Run build
+      apiscan:
+        enabled: false
+      tsaOptionsFile: .config\tsaoptions.json
 
     stages:
     - stage: prep

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -113,6 +113,9 @@ extends:
         ignoreDirectories: '.devcontainer,demos,docker,docs,src,test,tools/packaging'
       binskim:
         enabled: false
+        # Fix for ICU package error in Linux containers - enable globalization invariant mode for BinSkim
+        environment:
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: true
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -24,13 +24,9 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: Officialness
-    displayName: Officialness of the Pipeline
-    type: string
-    values:
-     - "Official"
-     - "Nonofficial"
-    default: "Official"
+  - name: OfficialBuild
+    type: boolean
+    default: false
 
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 
@@ -68,6 +64,9 @@ variables:
   - name: branchCounter
     value: $[counter(variables['branchCounterKey'], 1)]
   - group: MSIXSigningProfile
+  - name: templateFile
+    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
+  
 
 resources:
   pipelines:
@@ -86,7 +85,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: v2/OneBranch.${{ parameters.Officialness }}.CrossPlat.yml@templates
+  template: ${{ variables.templateFile }}
   parameters:
     cloudvault:
       enabled: false

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -24,7 +24,14 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-    
+  - name: Officialness
+    displayName: Officialness of the Pipeline
+    type: string
+    values:
+     - "Official"
+     - "Nonofficial"
+    default: "Official"
+
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 
 variables:
@@ -79,7 +86,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  template: v2/OneBranch.${{ parameters.Officialness }}.CrossPlat.yml@templates
   parameters:
     cloudvault:
       enabled: false
@@ -88,6 +95,7 @@ extends:
         Version: 2022
         Network: KS3
       linuxEsrpSigning: true
+      incrementalSDLBinaryAnalysis: true
     globalSdl:
       disableLegacyManifest: true
       # disabled Armorty as we dont have any ARM templates to scan. It fails on some sample ARM templates.
@@ -104,19 +112,12 @@ extends:
       cg:
         enabled: true
         ignoreDirectories: '.devcontainer,demos,docker,docs,src,test,tools/packaging'
-      asyncSdl:
-        enabled: true
-        forStages: ['build']
-        credscan:
-          enabled: true
-          scanFolder:  $(Build.SourcesDirectory)
-          suppressionsFile: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
-        binskim:
-          enabled: false
-        # APIScan requires a non-Ready-To-Run build
-        apiscan:
-          enabled: false
-        tsaOptionsFile: .config\tsaoptions.json
+      binskim:
+        enabled: false
+      # APIScan requires a non-Ready-To-Run build
+      apiscan:
+        enabled: false
+      tsaOptionsFile: .config\tsaoptions.json
     stages:
     - stage: prep
       jobs:

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -113,9 +113,7 @@ extends:
         ignoreDirectories: '.devcontainer,demos,docker,docs,src,test,tools/packaging'
       binskim:
         enabled: false
-        # Fix for ICU package error in Linux containers - enable globalization invariant mode for BinSkim
-        environment:
-          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: true
+        exactToolVersion: 4.4.2
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -13,6 +13,14 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
+  - name: Officialness
+    displayName: Officialness of the Pipeline
+    type: string
+    values:
+     - "Official"
+     - "Nonofficial"
+    default: "Official"
+
 
 name: ev2-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 
@@ -74,6 +82,7 @@ extends:
         Version: 2022
         Network: Netlock
       linuxEsrpSigning: true
+      incrementalSDLBinaryAnalysis: true
     cloudvault:
       enabled: false
     globalSdl:
@@ -81,9 +90,6 @@ extends:
       # disabled Armory as we dont have any ARM templates to scan. It fails on some sample ARM templates.
       armory:
         enabled: false
-      asyncSdl:
-        enabled: true
-        tsaOptionsFile: .config/tsaoptions.json
       tsa:
         enabled: true
       credscan:

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -13,14 +13,9 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: Officialness
-    displayName: Officialness of the Pipeline
-    type: string
-    values:
-     - "Official"
-     - "Nonofficial"
-    default: "Official"
-
+  - name: OfficialBuild
+    type: boolean
+    default: false
 
 name: ev2-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 
@@ -54,6 +49,9 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/cbl-mariner/build:2.0
   - group: PoolNames
+  - name: templateFile
+    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
+  
 
 resources:
   repositories:
@@ -75,7 +73,7 @@ resources:
             - releases/*
 
 extends:
-  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  template: ${{ variables.templateFile }}
   parameters:
     featureFlags:
       WindowsHostVersion:

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -96,6 +96,7 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)\.config\suppress.json
       binskim:
         break: false # always break the build on binskim issues in addition to TSA upload
+        exactToolVersion: 4.4.2
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
       tsaOptionsFile: .config\tsaoptions.json

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -25,6 +25,13 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Copying Archives and Installers to PSInfrastructure Public Location
     type: boolean
     default: false
+  - name: Officialness
+    displayName: Officialness of the Pipeline
+    type: string
+    values:
+     - "Official"
+     - "Nonofficial"
+    default: "Official"
 
 name: release-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 
@@ -83,7 +90,7 @@ resources:
             - releases/*
 
 extends:
-  template: v2/OneBranch.Official.CrossPlat.yml@templates
+  template: v2/OneBranch.${{ parameters.Officialness }}.CrossPlat.yml@templates
   parameters:
     release: 
       category: NonAzure
@@ -91,6 +98,7 @@ extends:
       WindowsHostVersion:
         Version: 2022
         Network: KS3
+      incrementalSDLBinaryAnalysis: true
     cloudvault:
       enabled: false
     globalSdl:
@@ -98,9 +106,6 @@ extends:
       # disabled Armory as we dont have any ARM templates to scan. It fails on some sample ARM templates.
       armory:
         enabled: false
-      asyncSdl:
-        enabled: true
-        tsaOptionsFile: .config/tsaoptions.json
       tsa:
         enabled: true
       credscan:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -65,6 +65,9 @@ variables:
     value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   - name: releaseEnvironment
     value: ${{ iif ( parameters.OfficialBuild, 'Production', 'Test' ) }}
+  # Fix for BinSkim ICU package error in Linux containers
+  - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
+    value: true
 
 resources:
   repositories:
@@ -114,6 +117,9 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)\.config\suppress.json
       binskim:
         break: false # always break the build on binskim issues in addition to TSA upload
+        # Fix for ICU package error in Linux containers - enable globalization invariant mode for BinSkim
+        environment:
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: true
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
       # suppression:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -117,9 +117,7 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)\.config\suppress.json
       binskim:
         break: false # always break the build on binskim issues in addition to TSA upload
-        # Fix for ICU package error in Linux containers - enable globalization invariant mode for BinSkim
-        environment:
-          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: true
+        exactToolVersion: 4.4.2
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
       # suppression:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -25,13 +25,9 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Copying Archives and Installers to PSInfrastructure Public Location
     type: boolean
     default: false
-  - name: Officialness
-    displayName: Officialness of the Pipeline
-    type: string
-    values:
-     - "Official"
-     - "Nonofficial"
-    default: "Official"
+  - name: OfficialBuild
+    type: boolean
+    default: false
 
 name: release-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 
@@ -65,6 +61,10 @@ variables:
   - name: ReleaseTagVar
     value: ${{ parameters.ReleaseTagVar }}
   - group: PoolNames
+  - name: templateFile
+    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
+  - name: releaseEnvironment
+    value: ${{ iif ( parameters.OfficialBuild, 'Production', 'Test' ) }}
 
 resources:
   repositories:
@@ -90,7 +90,7 @@ resources:
             - releases/*
 
 extends:
-  template: v2/OneBranch.${{ parameters.Officialness }}.CrossPlat.yml@templates
+  template: ${{ variables.templateFile }}
   parameters:
     release: 
       category: NonAzure
@@ -284,7 +284,7 @@ extends:
         - setReleaseTagAndChangelog
         - UpdateChangeLog
       variables:
-        ob_release_environment: Production
+        ob_release_environment: ${{ parameters.releaseEnvironment }}
       jobs:
       - template: /.pipelines/templates/release-githubNuget.yml@self
         parameters:

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -96,8 +96,6 @@ extends:
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false
-      asyncSDL:
-        enabled: false
       tsaOptionsFile: .config/tsaoptions.json
     stages:
     - stage: main

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -93,6 +93,7 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)\.config\suppress.json
       binskim:
         enabled: false
+        exactToolVersion: 4.4.2
       # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: false


### PR DESCRIPTION
- **Remove asyncSDL and add officialness parameter to all pipelines**
- **Use boolean for toggling official and toggle release environment**
- **Turn on binskim globalization invariant**
- **Try as a variable**
- **Set binskim exact tool version to 4.4.2**

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates several Azure Pipeline YAML files to improve build configuration flexibility and security scanning consistency. The main changes introduce a new `OfficialBuild` parameter to control template selection and environment variables, standardize the use of BinSkim with a fixed tool version, and clean up legacy or redundant SDL scanning steps.

**Build configuration improvements:**

* Added an `OfficialBuild` boolean parameter to multiple pipeline YAML files to allow conditional selection of official vs. non-official build templates. This enables more flexible build configurations based on the build type. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR33-R36) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R27-R29) [[3]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eR16-R18) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR28-R30)
* Updated template references to use the new `templateFile` variable, which is set based on the `OfficialBuild` parameter, ensuring the correct pipeline template is used for each build. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR94-R113) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R67-R69) [[3]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L82-R88) [[4]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eR52-R54) [[5]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL70-L86) [[6]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR64-R70) [[7]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL86-L103)

**Security scanning adjustments:**

* Set `exactToolVersion: 4.4.2` for BinSkim across all pipelines to standardize the tool version and avoid compatibility issues. [[1]](diffhunk://#diff-29ab9799aa5f68a8bb9675346fe462bea52330484500cbf965dc8953bb1911a9R71-L75) [[2]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL119-R134) [[3]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L107-R116) [[4]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eR99) [[5]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR120) [[6]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4R96-L100)
* Disabled BinSkim at the job level and set related environment variables to fix known issues with ICU packages in Linux containers. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR94-R113) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR64-R70)
* Enabled `incrementalSDLBinaryAnalysis` in feature flags for more efficient and targeted security analysis. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR94-R113) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R97) [[3]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL70-L86) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL86-L103)

**Legacy and redundant step clean-up:**

* Removed legacy or redundant `asyncSDL` and `credscan` steps from several pipeline configurations to simplify and modernize the security scanning process. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL119-R134) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L107-R116) [[3]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL70-L86) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL86-L103)

**Environment variable management:**

* Added logic to set the `releaseEnvironment` variable based on the `OfficialBuild` parameter, ensuring the correct environment context for release pipelines. [[1]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR64-R70) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL282-R291)

These changes collectively improve pipeline maintainability, security scanning reliability, and build environment flexibility.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
