### PR TITLE
Enable CA1852: Seal internal types

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -510,6 +510,10 @@ dotnet_diagnostic.CA1846.severity = warning
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
 dotnet_diagnostic.CA1847.severity = warning
 
+# CA1852: Seal internal types
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+dotnet_diagnostic.CA1852.severity = warning
+
 # CA1853: Unnecessary call to 'Dictionary.ContainsKey(key)'
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
 dotnet_diagnostic.CA1853.severity = warning

--- a/test/tools/TestAlc/init/Init.cs
+++ b/test/tools/TestAlc/init/Init.cs
@@ -10,7 +10,7 @@ using System.Runtime.Loader;
 
 namespace Test.Isolated.Init
 {
-    internal class CustomLoadContext : AssemblyLoadContext
+    internal sealed class CustomLoadContext : AssemblyLoadContext
     {
         private readonly string _dependencyDirPath;
 

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -20,7 +20,7 @@ namespace TestExe
         System = 2,
     }
 
-    internal class TestExe
+    internal sealed class TestExe
     {
         private static int Main(string[] args)
         {


### PR DESCRIPTION
Add sealed modifier to internal types without subtypes.

https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852

Fix https://github.com/PowerShell/PowerShell/issues/24094.
