### PR TITLE
Seal internal types in `Microsoft.PowerShell.Commands.Utility`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
@@ -321,7 +321,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// This allows for @{e='foo';label='bar';alignment='center';width='20'}.
         /// </summary>
-        internal class ConvertHTMLExpressionParameterDefinition : CommandParameterDefinition
+        internal sealed class ConvertHTMLExpressionParameterDefinition : CommandParameterDefinition
         {
             protected override void SetEntries()
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Csv.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Csv.cs
@@ -8,7 +8,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// This class is used to parse CSV text.
     /// </summary>
-    internal class CSVHelper
+    internal sealed class CSVHelper
     {
         internal CSVHelper(char delimiter)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -885,7 +885,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Helper class for Export-Csv and ConvertTo-Csv.
     /// </summary>
-    internal class ExportCsvHelper : IDisposable
+    internal sealed class ExportCsvHelper : IDisposable
     {
         private readonly char _delimiter;
         private readonly BaseCsvWritingCommand.QuoteKind _quoteKind;
@@ -1224,7 +1224,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Helper class to import single CSV file.
     /// </summary>
-    internal class ImportCsvHelper
+    internal sealed class ImportCsvHelper
     {
         #region constructor
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -14,7 +14,7 @@ namespace System.Management.Automation
     /// <summary>
     /// This class provides functionality for serializing a PSObject.
     /// </summary>
-    internal class CustomSerialization
+    internal sealed class CustomSerialization
     {
         #region constructor
         /// <summary>
@@ -179,8 +179,7 @@ namespace System.Management.Automation
     /// <summary>
     /// This internal helper class provides methods for serializing mshObject.
     /// </summary>
-    internal class
-    CustomInternalSerializer
+    internal sealed class CustomInternalSerializer
     {
         #region constructor
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/ExpressionColumnInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/ExpressionColumnInfo.cs
@@ -6,7 +6,7 @@ using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class ExpressionColumnInfo : ColumnInfo
+    internal sealed class ExpressionColumnInfo : ColumnInfo
     {
         private readonly PSPropertyExpression _expression;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/HeaderInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/HeaderInfo.cs
@@ -7,7 +7,7 @@ using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class HeaderInfo
+    internal sealed class HeaderInfo
     {
         private readonly List<ColumnInfo> _columns = new();
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OriginalColumnInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OriginalColumnInfo.cs
@@ -9,7 +9,7 @@ using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class OriginalColumnInfo : ColumnInfo
+    internal sealed class OriginalColumnInfo : ColumnInfo
     {
         private readonly string _liveObjectPropertyName;
         private readonly OutGridViewCommand _parentCmdlet;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -323,7 +323,7 @@ namespace Microsoft.PowerShell.Commands
             internal abstract void ProcessInputObject(PSObject input);
         }
 
-        internal class ScalarTypeHeader : GridHeader
+        internal sealed class ScalarTypeHeader : GridHeader
         {
             private readonly Type _originalScalarType;
 
@@ -349,7 +349,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        internal class NonscalarTypeHeader : GridHeader
+        internal sealed class NonscalarTypeHeader : GridHeader
         {
             private readonly AppliesTo _appliesTo = null;
 
@@ -453,7 +453,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        internal class HeteroTypeHeader : GridHeader
+        internal sealed class HeteroTypeHeader : GridHeader
         {
             internal HeteroTypeHeader(OutGridViewCommand parentCmd, PSObject input) : base(parentCmd)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
@@ -13,7 +13,7 @@ using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class OutWindowProxy : IDisposable
+    internal sealed class OutWindowProxy : IDisposable
     {
         private const string OutGridViewWindowClassName = "Microsoft.Management.UI.Internal.OutGridViewWindow";
         private const string OriginalTypePropertyName = "OriginalType";

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/ScalarTypeColumnInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/ScalarTypeColumnInfo.cs
@@ -6,7 +6,7 @@ using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class ScalarTypeColumnInfo : ColumnInfo
+    internal sealed class ScalarTypeColumnInfo : ColumnInfo
     {
         private readonly Type _type;
 
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
-    internal class TypeNameColumnInfo : ColumnInfo
+    internal sealed class TypeNameColumnInfo : ColumnInfo
     {
         internal TypeNameColumnInfo(string staleObjectPropertyName, string displayName)
             : base(staleObjectPropertyName, displayName)
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
-    internal class ToStringColumnInfo : ColumnInfo
+    internal sealed class ToStringColumnInfo : ColumnInfo
     {
         private readonly OutGridViewCommand _parentCmdlet;
 
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
-    internal class IndexColumnInfo : ColumnInfo
+    internal sealed class IndexColumnInfo : ColumnInfo
     {
         private int _index = 0;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
@@ -12,7 +12,7 @@ using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class TableView
+    internal sealed class TableView
     {
         private PSPropertyExpressionFactory _expressionFactory;
         private TypeInfoDataBase _typeInfoDatabase;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommandBase.cs
@@ -561,7 +561,7 @@ namespace Microsoft.PowerShell.Commands
     /// methods using the NextBytes() primitive based on the CLR implementation:
     ///     https://referencesource.microsoft.com/#mscorlib/system/random.cs.
     /// </summary>
-    internal class PolymorphicRandomNumberGenerator
+    internal sealed class PolymorphicRandomNumberGenerator
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicRandomNumberGenerator"/> class.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -1916,7 +1916,7 @@ namespace Microsoft.PowerShell.Commands
         #endregion
     }
 
-    internal class ImplicitRemotingCodeGenerator
+    internal sealed class ImplicitRemotingCodeGenerator
     {
         internal static readonly Version VersionOfScriptWriter = new(1, 0);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/JsonSchemaReferenceResolutionException.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/JsonSchemaReferenceResolutionException.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerShell.Commands;
 /// Thrown during evaluation of <see cref="TestJsonCommand"/> when an attempt
 /// to resolve a <code>$ref</code> or <code>$dynamicRef</code> fails.
 /// </summary>
-internal class JsonSchemaReferenceResolutionException : Exception
+internal sealed class JsonSchemaReferenceResolutionException : Exception
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonSchemaReferenceResolutionException"/> class.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands
     /// isExistingProperty is needed to distinguish whether a property exists and its value is null or
     /// the property does not exist at all.
     /// </summary>
-    internal class ObjectCommandPropertyValue
+    internal sealed class ObjectCommandPropertyValue
     {
         private ObjectCommandPropertyValue() { }
 
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// ObjectCommandComparer class.
     /// </summary>
-    internal class ObjectCommandComparer : IComparer
+    internal sealed class ObjectCommandComparer : IComparer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectCommandComparer"/> class.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.Commands
 
     /// <summary>
     /// </summary>
-    internal class SortObjectExpressionParameterDefinition : CommandParameterDefinition
+    internal sealed class SortObjectExpressionParameterDefinition : CommandParameterDefinition
     {
         protected override void SetEntries()
         {
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.Commands
 
     /// <summary>
     /// </summary>
-    internal class GroupObjectExpressionParameterDefinition : CommandParameterDefinition
+    internal sealed class GroupObjectExpressionParameterDefinition : CommandParameterDefinition
     {
         protected override void SetEntries()
         {
@@ -630,7 +630,7 @@ namespace Microsoft.PowerShell.Commands
         internal bool comparable = false;
     }
 
-    internal class OrderByPropertyComparer : IComparer<OrderByPropertyEntry>
+    internal sealed class OrderByPropertyComparer : IComparer<OrderByPropertyEntry>
     {
         internal OrderByPropertyComparer(bool[] ascending, CultureInfo cultureInfo, bool caseSensitive)
         {
@@ -699,7 +699,7 @@ namespace Microsoft.PowerShell.Commands
         private readonly ObjectCommandComparer[] _propertyComparers = null;
     }
 
-    internal class IndexedOrderByPropertyComparer : IComparer<OrderByPropertyEntry>
+    internal sealed class IndexedOrderByPropertyComparer : IComparer<OrderByPropertyEntry>
     {
         internal IndexedOrderByPropertyComparer(OrderByPropertyComparer orderByPropertyComparer)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.Commands
         private readonly WildcardPattern[] _wildcardPatterns;
     }
 
-    internal class SelectObjectExpressionParameterDefinition : CommandParameterDefinition
+    internal sealed class SelectObjectExpressionParameterDefinition : CommandParameterDefinition
     {
         protected override void SetEntries()
         {
@@ -866,7 +866,7 @@ namespace Microsoft.PowerShell.Commands
     [SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable", Justification = "This exception is internal and never thrown by any public API")]
     [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors", Justification = "This exception is internal and never thrown by any public API")]
     [SuppressMessage("Microsoft.Design", "CA1064:ExceptionsShouldBePublic", Justification = "This exception is internal and never thrown by any public API")]
-    internal class SelectObjectException : SystemException
+    internal sealed class SelectObjectException : SystemException
     {
         internal ErrorRecord ErrorRecord { get; }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommandProxy.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Commands
     /// Help show-command create WPF object and invoke WPF windows with the
     /// Microsoft.PowerShell.Commands.ShowCommandInternal.ShowCommandHelperhelp type defined in Microsoft.PowerShell.GraphicalHost.dll.
     /// </summary>
-    internal class ShowCommandProxy
+    internal sealed class ShowCommandProxy
     {
         private const string ShowCommandHelperName = "Microsoft.PowerShell.Commands.ShowCommandInternal.ShowCommandHelper";
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -354,7 +354,7 @@ namespace Microsoft.PowerShell.Commands
             Xml,
         }
 
-        internal class BufferingStreamReader : Stream
+        internal sealed class BufferingStreamReader : Stream
         {
             internal BufferingStreamReader(Stream baseStream, TimeSpan perReadTimeout, CancellationToken cancellationToken)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebProxy.cs
@@ -8,7 +8,7 @@ using System.Net;
 
 namespace Microsoft.PowerShell.Commands
 {
-    internal class WebProxy : IWebProxy, IEquatable<WebProxy>
+    internal sealed class WebProxy : IWebProxy, IEquatable<WebProxy>
     {
         private ICredentials? _credentials;
         private readonly Uri _proxyAddress;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands
     /// this class as a wrapper to MemoryStream to lazily initialize. Otherwise, the
     /// content will unnecessarily be read even if there are no consumers for it.
     /// </summary>
-    internal class WebResponseContentMemoryStream : MemoryStream
+    internal sealed class WebResponseContentMemoryStream : MemoryStream
     {
         #region Data
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -715,7 +715,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Helper class to import single XML file.
     /// </summary>
-    internal class ImportXmlHelper : IDisposable
+    internal sealed class ImportXmlHelper : IDisposable
     {
         #region constructor
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/MshHostTraceListener.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/MshHostTraceListener.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.Commands
     /// This trace listener cannot be specified in the app.config file.
     /// It must be added through the add-tracelistener cmdlet.
     /// </remarks>
-    internal class PSHostTraceListener
+    internal sealed class PSHostTraceListener
         : System.Diagnostics.TraceListener
     {
         #region TraceListener constructors and disposer

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
@@ -323,7 +323,7 @@ namespace Microsoft.PowerShell.Commands
     /// cmdlet.  It gets attached to the sub-pipelines success or error pipeline and redirects
     /// all objects written to these pipelines to trace-command pipeline.
     /// </summary>
-    internal class TracePipelineWriter : PipelineWriter
+    internal sealed class TracePipelineWriter : PipelineWriter
     {
         internal TracePipelineWriter(
             TraceListenerCommandBase cmdlet,


### PR DESCRIPTION
Add sealed modifier to internal types without subtypes in `Microsoft.PowerShell.Commands.Utility`.

Contributes to https://github.com/PowerShell/PowerShell/issues/24094.

cc: @iSazonov