### PR TITLE
WIP [release/v7.5] rebuild based on packages

### DIFF
--- a/.github/actions/build/ci/action.yml
+++ b/.github/actions/build/ci/action.yml
@@ -1,5 +1,12 @@
 name: CI Build
 description: 'Builds PowerShell'
+inputs:
+  ExtraBuildParams:
+    description: 'Extra Build Params'
+    default: ''
+  SkipXUnitTests:
+    description: 'Skip xUnit Tests'
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -29,8 +36,9 @@ runs:
     run: |-
       Write-Verbose -Verbose "Running Build..."
       Import-Module .\tools\ci.psm1
-      Invoke-CIBuild
+      Invoke-CIBuild -ExtraBuildParams '${{ inputs.ExtraBuildParams }}'
     shell: pwsh
+
   - name: xUnit Tests
     if: success()
     continue-on-error: true
@@ -42,6 +50,7 @@ runs:
     shell: pwsh
   - name: Upload build artifact
     uses: actions/upload-artifact@v4
+    if: eq('${{ inputs.SkipXUnitTests }}', 'true')
     with:
       name: build
       path: ${{ runner.workspace }}/build
@@ -50,3 +59,4 @@ runs:
     with:
       name: testResults-xunit
       path: ${{ runner.workspace }}/xunit
+    if: eq('${{ inputs.SkipXUnitTests }}', 'true')

--- a/.github/workflows/windows-ci-rebuild.yml
+++ b/.github/workflows/windows-ci-rebuild.yml
@@ -1,0 +1,170 @@
+name: Windows-CI-BuildFromPackages
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release/**
+      - github-mirror
+    paths:
+      - "**"
+      - "!.vsts-ci/misc-analysis.yml"
+      - "!.github/ISSUE_TEMPLATE/**"
+      - "!.dependabot/config.yml"
+      - "!test/perf/**"
+      - "!.pipelines/**"
+  pull_request:
+    branches:
+      - release/**
+      - github-mirror
+
+# Path filters for PRs need to go into the changes job
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ contains(github.ref, 'merge')}}
+
+permissions:
+  contents: read
+
+run-name: "${{ github.ref_name }} - ${{ github.run_number }}"
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  GIT_CONFIG_PARAMETERS: "'core.autocrlf=false'"
+  NugetSecurityAnalysisWarningLevel: none
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+  __SuppressAnsiEscapeSequences: 1
+  nugetMultiFeedWarnLevel: none
+jobs:
+  changes:
+    name: Change Detection
+    runs-on: ubuntu-latest
+    if: startsWith(github.repository_owner, 'azure') || github.repository_owner == 'PowerShell'
+    # Required permissions
+    permissions:
+      pull-requests: read
+      contents: read
+
+    # Set job outputs to values from filter step
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Change Detection
+        id: filter
+        uses: "./.github/actions/infrastructure/path-filters"
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ci_build:
+    name: Build PowerShell
+    needs: changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1000
+      - name: Build
+        uses: "./.github/actions/build/ci"
+        with:
+          ExtraBuildParams: BuildFromPackages
+          SkipXUnitTests: true
+  windows_test_unelevated_ci:
+    name: Windows Unelevated CI
+    needs:
+      - ci_build
+      - changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1000
+      - name: Windows Unelevated CI
+        uses: "./.github/actions/test/windows"
+        with:
+          purpose: UnelevatedPesterTests
+          tagSet: CI
+  windows_test_elevated_ci:
+    name: Windows Elevated CI
+    needs:
+      - ci_build
+      - changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1000
+      - name: Windows Elevated CI
+        uses: "./.github/actions/test/windows"
+        with:
+          purpose: ElevatedPesterTests
+          tagSet: CI
+  windows_test_unelevated_others:
+    name: Windows Unelevated Others
+    needs:
+      - ci_build
+      - changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1000
+      - name: Windows Unelevated Others
+        uses: "./.github/actions/test/windows"
+        with:
+          purpose: UnelevatedPesterTests
+          tagSet: Others
+  windows_test_elevated_others:
+    name: Windows Elevated Others
+    needs:
+      - ci_build
+      - changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 1000
+      - name: Windows Elevated Others
+        uses: "./.github/actions/test/windows"
+        with:
+          purpose: ElevatedPesterTests
+          tagSet: Others
+  # verify_xunit:
+  #   name: Verify xUnit test results
+  #   needs:
+  #     - ci_build
+  #     - changes
+  #   if: ${{ needs.changes.outputs.source == 'true' }}
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v4.1.0
+  #       with:
+  #         fetch-depth: 1000
+  #     - name: Verify xUnit test results
+  #       uses: "./.github/actions/test/verify_xunit"
+  ready_to_merge:
+    name: windows ready to merge
+    needs:
+      # - verify_xunit
+      - windows_test_elevated_ci
+      - windows_test_elevated_others
+      - windows_test_unelevated_ci
+      - windows_test_unelevated_others
+    if: always()
+    uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@v1.0.0
+    with:
+      needs_context: ${{ toJson(needs) }}

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -37,9 +37,12 @@
         For RCs, we will increment the iteration from 100.
 
         Examples
-        7.2.0 becomes 7.2.0
-        7.2.0-preview.1 becomes 7.2.0.1
-        7.2.0-rc.1 becomes 7.2.0.101
+        7.2.0 becomes 7.2.0.500
+        7.2.1 becomes 7.2.0.500
+        7.2.0-preview.1 becomes 7.2.0.4
+        7.2.0-preview.2 becomes 7.2.0.4
+        7.2.0-rc.1 becomes 7.2.0.100
+        7.2.0-rc.2 becomes 7.2.0.100
       -->
 
       <!-- parse the release tag into the parts we need -->
@@ -47,11 +50,14 @@
       <ReleaseTagVersionPart>$([System.Text.RegularExpressions.Regex]::Match($(ReleaseTag), $(RegexReleaseTag)).Groups[1].Value)</ReleaseTagVersionPart>
       <ReleaseTagSemVersionPart>$([System.Text.RegularExpressions.Regex]::Match($(ReleaseTag), $(RegexReleaseTag)).Groups[8].Value)</ReleaseTagSemVersionPart>
       <ReleaseTagSemVersionPrereleaseNamePart>$([System.Text.RegularExpressions.Regex]::Match($(ReleaseTag), $(RegexReleaseTag)).Groups[6].Value)</ReleaseTagSemVersionPrereleaseNamePart>
+      <!-- Increment revision 4 for preview releases -->
+      <PreviewSemVerPartValue>4</PreviewSemVerPartValue>
       <!-- Increment revision 100 for rc releases -->
       <RCIncrementValue>100</RCIncrementValue>
       <!-- Increment revision 500 for GA releases -->
       <GAIncrementValue>500</GAIncrementValue>
-      <ReleaseTagSemVersionPart Condition = "'$(ReleaseTagSemVersionPrereleaseNamePart)' == 'rc'">$([MSBuild]::Add($(ReleaseTagSemVersionPart), $(RCIncrementValue)))</ReleaseTagSemVersionPart>
+      <ReleaseTagSemVersionPart Condition = "'$(ReleaseTagSemVersionPrereleaseNamePart)' != 'rc'">$(PreviewSemVerPartValue)</ReleaseTagSemVersionPart>
+      <ReleaseTagSemVersionPart Condition = "'$(ReleaseTagSemVersionPrereleaseNamePart)' == 'rc'">$(RCIncrementValue)</ReleaseTagSemVersionPart>
       <!-- Create the internal version -->
       <PSCoreBuildVersion>$(ReleaseTag)</PSCoreBuildVersion>
       <!-- Create the version if we have a pre-release -->

--- a/build.psm1
+++ b/build.psm1
@@ -300,6 +300,7 @@ function Start-PSBuild {
         [switch]$NoPSModuleRestore,
         [switch]$CI,
         [switch]$ForMinimalSize,
+        [switch]$BuildFromPackages,
 
         # Skips the step where the pwsh that's been built is used to create a configuration
         # Useful when changing parsing/compilation, since bugs there can mean we can't get past this step
@@ -469,6 +470,10 @@ Fix steps:
     }
     else {
         $Arguments += "--self-contained"
+    }
+
+    if($BuildFromPackages) {
+        $Arguments += "/property:Rebuild=true"
     }
 
     if ($Options.Runtime -like 'win*') {

--- a/src/Microsoft.Management.UI.Internal/Microsoft.PowerShell.GraphicalHost.csproj
+++ b/src/Microsoft.Management.UI.Internal/Microsoft.PowerShell.GraphicalHost.csproj
@@ -31,7 +31,11 @@
     <Resource Include="resources\Graphics\SpyGlass16.png" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(Rebuild)' == 'true'">
+    <PackageReference Include="System.Management.Automation" Version="7.5.2" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Utility" Version="7.5.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Rebuild)' != 'true'">
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Utility\Microsoft.PowerShell.Commands.Utility.csproj" />
   </ItemGroup>

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\PowerShell.Common.props" />
+  <Import Project="..\Module.Common.props" />
   <PropertyGroup>
     <Description>PowerShell's Microsoft.PowerShell.Commands.Management project</Description>
     <NoWarn>$(NoWarn);CS1570;CA1416</NoWarn>
@@ -49,6 +50,8 @@
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.6" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.6" />
+    <PackageReference Include="System.Management" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\PowerShell.Common.props" />
+  <Import Project="..\Module.Common.props" />
   <PropertyGroup>
     <Description>PowerShell's Microsoft.PowerShell.Commands.Utility project</Description>
     <NoWarn>$(NoWarn);CS1570;CA1416</NoWarn>
@@ -11,14 +12,16 @@
     <PackageReference Include="JsonPointer.Net" Version="5.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+      </PackageReference>
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="9.0.6" />
     <PackageReference Include="System.Reflection.Metadata" Version="8.0.1" />
-    <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
     <PackageReference Include="Markdig.Signed" Version="0.38.0" />
     <PackageReference Include="Microsoft.PowerShell.MarkdownRender" Version="7.2.1" />
+    <!-- the following package(s) are from https://github.com/JamesNK/Newtonsoft.Json -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.DirectoryServices" Version="9.0.6" />
   </ItemGroup>
+
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -6,12 +6,14 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(Rebuild)' != 'true'">
+    <ProjectReference Include="..\Microsoft.PowerShell.ConsoleHost\Microsoft.PowerShell.ConsoleHost.csproj" />
+    <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Management\Microsoft.PowerShell.Commands.Management.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Utility\Microsoft.PowerShell.Commands.Utility.csproj" />
-    <ProjectReference Include="..\Microsoft.PowerShell.ConsoleHost\Microsoft.PowerShell.ConsoleHost.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.csproj" />
-    <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
+++ b/src/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
@@ -6,11 +6,10 @@
     <AssemblyName>Microsoft.PowerShell.Security</AssemblyName>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
-  </ItemGroup>
+  <Import Project="..\Module.Common.props" />
 
   <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.6" />
     <Compile Remove="singleshell\installer\MshSecurityMshSnapin.cs" />
     <Compile Remove="gen\SecurityMshSnapinResources.cs" />
 

--- a/src/Module.Common.props
+++ b/src/Module.Common.props
@@ -1,0 +1,20 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(Rebuild)' == 'true' and '$(IsWindows)' =='true'">
+    <PackageReference Include="System.Management.Automation" Version="7.5.2">
+      <ExcludeAssets>compile</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <Reference Include="System.Management.Automation">
+
+      <HintPath>$(NuGetPackageRoot)System.Management.Automation\7.5.2\runtimes\win\lib\net9.0\System.Management.Automation.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Rebuild)' == 'true' and '$(IsWindows)' !='true'">
+    <PackageReference Include="System.Management.Automation" Version="7.5.2">
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Rebuild)' != 'true'">
+    <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -45,11 +45,21 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(Rebuild)' == 'true'">
+    <ProjectReference Include="..\Microsoft.PowerShell.SDK\Microsoft.PowerShell.SDK.csproj" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.2" />
+    <PackageReference Include="Microsoft.PowerShell.ConsoleHost" Version="7.5.2" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.5.2" />
+    <PackageReference Include="Microsoft.Management.Infrastructure.CimCmdlets" Version="7.5.2" />
+    <PackageReference Include="Microsoft.WSMan.Management" Version="7.5.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Rebuild)' != 'true'">
     <ProjectReference Include="..\Microsoft.PowerShell.SDK\Microsoft.PowerShell.SDK.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Diagnostics\Microsoft.PowerShell.Commands.Diagnostics.csproj" />
     <ProjectReference Include="..\Microsoft.Management.Infrastructure.CimCmdlets\Microsoft.Management.Infrastructure.CimCmdlets.csproj" />
     <ProjectReference Include="..\Microsoft.WSMan.Management\Microsoft.WSMan.Management.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Management.UI.Internal\Microsoft.PowerShell.GraphicalHost.csproj" Condition="'$(SDKToUse)' == 'Microsoft.NET.Sdk.WindowsDesktop' "/>
   </ItemGroup>
 

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -98,6 +98,11 @@ function Invoke-CIFull
 # Implements the CI 'build_script' step
 function Invoke-CIBuild
 {
+    param(
+        [string]
+        $ExtraBuildParams
+    )
+
     $releaseTag = Get-ReleaseTag
     # check to be sure our test tags are correct
     $result = Get-PesterTag
@@ -112,7 +117,17 @@ function Invoke-CIBuild
         Start-PSBuild -Configuration 'CodeCoverage' -PSModuleRestore -CI -ReleaseTag $releaseTag
     }
 
-    Start-PSBuild -PSModuleRestore -Configuration 'Release' -CI -ReleaseTag $releaseTag -UseNuGetOrg
+    $buildParams = @()
+    foreach($switch in $ExtraBuildParams.Split(' '))
+    {
+        if($switch -and $switch.Trim().Length -gt 0)
+        {
+            Write-Verbose "Adding extra build param: $switch" -Verbose
+            $buildParams += $switch
+        }
+    }
+
+    Start-PSBuild -PSModuleRestore -Configuration 'Release' -CI -ReleaseTag $releaseTag -UseNuGetOrg $buildParams
     Save-PSOptions
 
     $options = (Get-PSOptions)


### PR DESCRIPTION
This pull request introduces a new build mode that allows building PowerShell modules and SDKs from pre-built packages instead of project references, controlled by a new `BuildFromPackages` switch and the `Rebuild` MSBuild property. This change streamlines the build process, especially for scenarios where consuming official package releases is preferred over local source builds. The implementation involves conditional logic in the build scripts and project files to switch between package references and project references based on the build mode.

**Build system enhancements:**

* Added a `BuildFromPackages` switch to the `Start-PSBuild` function in `build.psm1`, which sets the `/property:Rebuild=true` MSBuild property to control package-based builds. [[1]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR303) [[2]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aR475-R478)
* Introduced a shared `Module.Common.props` file that conditionally includes either `PackageReference` or `ProjectReference` for `System.Management.Automation` depending on the `Rebuild` property and platform, centralizing this logic for multiple projects.

**Project file conditional references:**

* Updated multiple `.csproj` files (such as `Microsoft.PowerShell.Commands.Management`, `Microsoft.PowerShell.Commands.Utility`, `Microsoft.PowerShell.Security`, and `Microsoft.PowerShell.SDK`) to import `Module.Common.props` and/or conditionally switch between package and project references based on the `Rebuild` property. This includes adding or moving relevant `PackageReference` and `ProjectReference` entries. [[1]](diffhunk://#diff-c685efeb82dd23385566a8241eb3db56068963c14299d2054fc57ceaefb4bdc2R3) [[2]](diffhunk://#diff-c685efeb82dd23385566a8241eb3db56068963c14299d2054fc57ceaefb4bdc2R53-R54) [[3]](diffhunk://#diff-1d477db337d41a086f43d0d9351448c5781d5818a906fb88b55d5e08cf755509R3) [[4]](diffhunk://#diff-1d477db337d41a086f43d0d9351448c5781d5818a906fb88b55d5e08cf755509L14-R25) [[5]](diffhunk://#diff-13293ca2d3c23f49a3a189ec60e6065154719cad161cbdf7a56c70f690de1b0eL9-R12) [[6]](diffhunk://#diff-9b88575be5ea8ea6e9597c67f8c284e5bc75529b70c7c61e9762f02022eb78dfR9-L14)

**Windows-specific build logic:**

* In `Module.Common.props`, added special handling for Windows builds by including a direct assembly reference to `System.Management.Automation.dll` from the NuGet package when rebuilding on Windows.

**SDK and host packaging:**

* Modified `powershell-win-core.csproj` to use package references for SDK and related modules when in rebuild mode, and project references otherwise, aligning the packaging with the new build strategy.

**Graphical host build adjustments:**

* Updated `Microsoft.PowerShell.GraphicalHost.csproj` to use package references for dependencies when rebuilding, and project references otherwise, supporting the new build mode.

These changes collectively enable a more flexible build process, allowing developers and CI systems to choose between source-based and package-based builds as needed.