### PR TITLE
Fix memory leak in `GetFileShares`

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5199,38 +5199,48 @@ namespace System.Management.Automation
             uint numEntries = 0;
             uint totalEntries;
             uint resumeHandle = 0;
-            int result = Interop.Windows.NetShareEnum(
-                machine,
-                level: 1,
-                out shBuf,
-                Interop.Windows.MAX_PREFERRED_LENGTH,
-                out numEntries,
-                out totalEntries,
-                ref resumeHandle);
-
-            var shares = new List<string>();
-            if (result == Interop.Windows.ERROR_SUCCESS || result == Interop.Windows.ERROR_MORE_DATA)
+            try
             {
-                for (int i = 0; i < numEntries; ++i)
+                int result = Interop.Windows.NetShareEnum(
+                    machine,
+                    level: 1,
+                    out shBuf,
+                    Interop.Windows.MAX_PREFERRED_LENGTH,
+                    out numEntries,
+                    out totalEntries,
+                    ref resumeHandle);
+
+                var shares = new List<string>();
+                if (result == Interop.Windows.ERROR_SUCCESS || result == Interop.Windows.ERROR_MORE_DATA)
                 {
-                    nint curInfoPtr = shBuf + (Marshal.SizeOf<SHARE_INFO_1>() * i);
-                    SHARE_INFO_1 shareInfo = Marshal.PtrToStructure<SHARE_INFO_1>(curInfoPtr);
-
-                    if ((shareInfo.type & Interop.Windows.STYPE_MASK) != Interop.Windows.STYPE_DISKTREE)
+                    for (int i = 0; i < numEntries; ++i)
                     {
-                        continue;
-                    }
+                        nint curInfoPtr = shBuf + (Marshal.SizeOf<SHARE_INFO_1>() * i);
+                        SHARE_INFO_1 shareInfo = Marshal.PtrToStructure<SHARE_INFO_1>(curInfoPtr);
 
-                    if (ignoreHidden && shareInfo.netname.EndsWith('$'))
-                    {
-                        continue;
-                    }
+                        if ((shareInfo.type & Interop.Windows.STYPE_MASK) != Interop.Windows.STYPE_DISKTREE)
+                        {
+                            continue;
+                        }
 
-                    shares.Add(shareInfo.netname);
+                        if (ignoreHidden && shareInfo.netname.EndsWith('$'))
+                        {
+                            continue;
+                        }
+
+                        shares.Add(shareInfo.netname);
+                    }
+                }
+
+                return shares;
+            }
+            finally
+            {
+                if (shBuf != nint.Zero)
+                {
+                    Interop.Windows.NetApiBufferFree(shBuf);
                 }
             }
-
-            return shares;
 #endif
         }
 

--- a/src/System.Management.Automation/engine/Interop/Windows/NetApiBufferFree.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/NetApiBufferFree.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static unsafe partial class Windows
+    {
+
+        [LibraryImport("Netapi32.dll")]
+        internal static partial int NetApiBufferFree(nint Buffer);
+    }
+}

--- a/src/System.Management.Automation/engine/Interop/Windows/NetApiBufferFree.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/NetApiBufferFree.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     {
 
         [LibraryImport("Netapi32.dll")]
-        internal static partial int NetApiBufferFree(nint Buffer);
+        internal static partial uint NetApiBufferFree(IntPtr Buffer);
     }
 }

--- a/src/System.Management.Automation/engine/Interop/Windows/NetApiBufferFree.cs
+++ b/src/System.Management.Automation/engine/Interop/Windows/NetApiBufferFree.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     {
 
         [LibraryImport("Netapi32.dll")]
-        internal static partial uint NetApiBufferFree(IntPtr Buffer);
+        internal static partial uint NetApiBufferFree(nint Buffer);
     }
 }


### PR DESCRIPTION
Documentation for `NetShareEnum` states: "This buffer is allocated by the system and must be freed using the `NetApiBufferFree` function."

References: [NetShareEnum function](https://learn.microsoft.com/windows/win32/api/lmshare/nf-lmshare-netshareenum)

Fix https://github.com/PowerShell/PowerShell/issues/26137
