### PR TITLE
Simplify `IDisposable` implementation in `Microsoft.Management.UI.Internal`

### DIFF
--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -280,22 +280,14 @@ Function PSGetSerializedShowCommandInfo
 
         #endregion
 
-        #region constructor and destructor
+        #region constructor
         /// <summary>
         /// Prevents a default instance of the ShowCommandHelper class from being created.
         /// </summary>
         private ShowCommandHelper()
         {
         }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="ShowCommandHelper"/> class.
-        /// </summary>
-        ~ShowCommandHelper()
-        {
-            this.Dispose(false);
-        }
-        #endregion constructor and destructor
+        #endregion constructor
 
         #region properties called using reflection
         /// <summary>
@@ -409,12 +401,14 @@ Function PSGetSerializedShowCommandInfo
 
         #region public Dispose
         /// <summary>
-        /// Dispose method in IDisposeable.
+        /// Release all resources.
         /// </summary>
         public void Dispose()
         {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
+            this.windowClosed.Dispose();
+            this.helpNeeded.Dispose();
+            this.windowLoaded.Dispose();
+            this.importModuleNeeded.Dispose();
         }
         #endregion public Dispose
 
@@ -1246,21 +1240,6 @@ Function PSGetSerializedShowCommandInfo
             }
 
             return this.commandViewModel.GetScript();
-        }
-
-        /// <summary>
-        /// Implements IDisposable logic.
-        /// </summary>
-        /// <param name="isDisposing">True if being called from Dispose.</param>
-        private void Dispose(bool isDisposing)
-        {
-            if (isDisposing)
-            {
-                this.windowClosed.Dispose();
-                this.helpNeeded.Dispose();
-                this.windowLoaded.Dispose();
-                this.importModuleNeeded.Dispose();
-            }
         }
         #endregion instance private methods used only on this file
     }

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
     /// <summary>
     /// Implements the WPF window part of the show-command cmdlet.
     /// </summary>
-    internal class ShowCommandHelper : IDisposable
+    internal sealed class ShowCommandHelper : IDisposable
     {
         #region fields
 
@@ -280,22 +280,14 @@ Function PSGetSerializedShowCommandInfo
 
         #endregion
 
-        #region constructor and destructor
+        #region constructor
         /// <summary>
         /// Prevents a default instance of the ShowCommandHelper class from being created.
         /// </summary>
         private ShowCommandHelper()
         {
         }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="ShowCommandHelper"/> class.
-        /// </summary>
-        ~ShowCommandHelper()
-        {
-            this.Dispose(false);
-        }
-        #endregion constructor and destructor
+        #endregion constructor
 
         #region properties called using reflection
         /// <summary>
@@ -409,12 +401,14 @@ Function PSGetSerializedShowCommandInfo
 
         #region public Dispose
         /// <summary>
-        /// Dispose method in IDisposeable.
+        /// Release all resources.
         /// </summary>
         public void Dispose()
         {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
+            this.windowClosed.Dispose();
+            this.helpNeeded.Dispose();
+            this.windowLoaded.Dispose();
+            this.importModuleNeeded.Dispose();
         }
         #endregion public Dispose
 
@@ -1277,21 +1271,6 @@ Function PSGetSerializedShowCommandInfo
             }
 
             return this.commandViewModel.GetScript();
-        }
-
-        /// <summary>
-        /// Implements IDisposable logic.
-        /// </summary>
-        /// <param name="isDisposing">True if being called from Dispose.</param>
-        private void Dispose(bool isDisposing)
-        {
-            if (isDisposing)
-            {
-                this.windowClosed.Dispose();
-                this.helpNeeded.Dispose();
-                this.windowLoaded.Dispose();
-                this.importModuleNeeded.Dispose();
-            }
         }
         #endregion instance private methods used only on this file
     }


### PR DESCRIPTION
Simplify `ShowCommandHelper` by removing the unnecessary finalizer-based disposal pattern. The class does not own unmanaged resources, so it does not need a finalizer or `GC.SuppressFinalize`.

* Seal `Microsoft.Management.UI.Internal.ShowCommandHelper`
* Remove the finalizer
* Remove `GC.SuppressFinalize`
* Remove the `Dispose(Boolean)` methods