### PR TITLE
Remove redundant `System.Security` attributes

### DIFF
--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
@@ -72,7 +72,6 @@ namespace System.Diagnostics.Eventing
         /// <param name="providerGuid">
         /// Unique GUID among all trace sources running on a system
         /// </param>
-        [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "guid")]
         public EventProvider(Guid providerGuid)
         {
@@ -116,7 +115,6 @@ namespace System.Diagnostics.Eventing
             GC.SuppressFinalize(this);
         }
 
-        [System.Security.SecuritySafeCritical]
         protected virtual void Dispose(bool disposing)
         {
             //

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
@@ -12,7 +12,6 @@ namespace System.Diagnostics.Eventing
 {
     public class EventProvider : IDisposable
     {
-        [SecurityCritical]
         private UnsafeNativeMethods.EtwEnableCallback _etwCallback;  // Trace Callback function
 
         private long _regHandle;                       // Trace Registration Handle
@@ -92,7 +91,6 @@ namespace System.Diagnostics.Eventing
         /// If for some reason the ETW EtwRegister call failed
         /// a NotSupported exception will be thrown.
         /// </summary>
-        [System.Security.SecurityCritical]
         private unsafe void EtwRegister()
         {
             uint status;
@@ -167,7 +165,6 @@ namespace System.Diagnostics.Eventing
         /// <summary>
         /// This method un-registers from ETW.
         /// </summary>
-        [System.Security.SecurityCritical]
         private unsafe void Deregister()
         {
             //
@@ -182,7 +179,6 @@ namespace System.Diagnostics.Eventing
             }
         }
 
-        [System.Security.SecurityCritical]
         private unsafe void EtwEnableCallBack(
                         [In] ref System.Guid sourceId,
                         [In] int isEnabled,
@@ -269,7 +265,6 @@ namespace System.Diagnostics.Eventing
             }
         }
 
-        [System.Security.SecurityCritical]
         private static unsafe string EncodeObject(ref object data, EventData* dataDescriptor, byte* dataBuffer)
         /*++
 
@@ -434,7 +429,6 @@ namespace System.Diagnostics.Eventing
         /// <param name="eventKeywords">
         /// Keyword to test
         /// </param>
-        [System.Security.SecurityCritical]
         public bool WriteMessageEvent(string eventMessage, byte eventLevel, long eventKeywords)
         {
             int status = 0;
@@ -501,7 +495,6 @@ namespace System.Diagnostics.Eventing
         /// <param name="data">
         /// string to log.
         /// </param>
-        [System.Security.SecurityCritical]
         [SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly")]
         public bool WriteEvent(in EventDescriptor eventDescriptor, string data)
         {
@@ -560,7 +553,6 @@ namespace System.Diagnostics.Eventing
         /// <param name="data">
         /// pointer do the event data
         /// </param>
-        [System.Security.SecurityCritical]
         protected bool WriteEvent(in EventDescriptor eventDescriptor, int dataCount, IntPtr data)
         {
             uint status = 0;
@@ -597,7 +589,6 @@ namespace System.Diagnostics.Eventing
         /// </param>
         /// <param name="eventPayload">
         /// </param>
-        [System.Security.SecurityCritical]
         public bool WriteTransferEvent(in EventDescriptor eventDescriptor, Guid relatedActivityId, params object[] eventPayload)
         {
             uint status = 0;
@@ -732,7 +723,6 @@ namespace System.Diagnostics.Eventing
             return true;
         }
 
-        [System.Security.SecurityCritical]
         protected bool WriteTransferEvent(in EventDescriptor eventDescriptor, Guid relatedActivityId, int dataCount, IntPtr data)
         {
             uint status = 0;
@@ -759,20 +749,17 @@ namespace System.Diagnostics.Eventing
             return true;
         }
 
-        [System.Security.SecurityCritical]
         private static Guid GetActivityId()
         {
             return t_activityId;
         }
 
-        [System.Security.SecurityCritical]
         public static void SetActivityId(ref Guid id)
         {
             t_activityId = id;
             UnsafeNativeMethods.EventActivityIdControl((int)ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID, ref id);
         }
 
-        [System.Security.SecurityCritical]
         public static Guid CreateActivityId()
         {
             Guid newId = new();

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/CoTaskMemSafeHandle.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/CoTaskMemSafeHandle.cs
@@ -14,11 +14,6 @@ using System.Runtime.InteropServices;
 
 namespace System.Diagnostics.Eventing.Reader
 {
-    //
-    // Marked as SecurityCritical due to link demands from inherited
-    // SafeHandle members.
-    //
-    [System.Security.SecurityCritical]
     internal sealed class CoTaskMemSafeHandle : SafeHandle
     {
         internal CoTaskMemSafeHandle()

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/CoTaskMemUnicodeSafeHandle.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/CoTaskMemUnicodeSafeHandle.cs
@@ -14,11 +14,6 @@ using System.Runtime.InteropServices;
 
 namespace System.Diagnostics.Eventing.Reader
 {
-    //
-    // Marked as SecurityCritical due to link demands from inherited
-    // SafeHandle members.
-    //
-    [System.Security.SecurityCritical]
     internal sealed class CoTaskMemUnicodeSafeHandle : SafeHandle
     {
         internal CoTaskMemUnicodeSafeHandle()

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/EventLogHandle.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/EventLogHandle.cs
@@ -14,15 +14,6 @@ using System.Runtime.InteropServices;
 
 namespace System.Diagnostics.Eventing.Reader
 {
-    //
-    // Marked as SecurityCritical due to link demands from inherited
-    // SafeHandle members.
-    //
-
-    // marked as Safe since the only real operation that is performed
-    // by this class is NativeWrapper.EvtClose and that is protected
-    // by a full Demand() before doing any work.
-    [System.Security.SecuritySafeCritical]
     internal sealed class EventLogHandle : SafeHandle
     {
         // Called by P/Invoke when returning SafeHandles

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
@@ -131,7 +131,6 @@ namespace System.Diagnostics.Eventing.Reader
             return win32Error == 0;
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void EvtCancel(EventLogHandle handle)
         {
             if (!UnsafeNativeMethods.EvtCancel(handle))
@@ -232,7 +231,6 @@ namespace System.Diagnostics.Eventing.Reader
             return handle;
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void EvtSaveChannelConfig(EventLogHandle channelConfig, int flags)
         {
             bool status = UnsafeNativeMethods.EvtSaveChannelConfig(channelConfig, flags);
@@ -250,7 +248,6 @@ namespace System.Diagnostics.Eventing.Reader
             return logHandle;
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void EvtExportLog(
                             EventLogHandle session,
                             string channelPath,
@@ -265,7 +262,6 @@ namespace System.Diagnostics.Eventing.Reader
                 ThrowEventLogException(win32Error);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void EvtArchiveExportedLog(
                             EventLogHandle session,
                             string logFilePath,
@@ -279,7 +275,6 @@ namespace System.Diagnostics.Eventing.Reader
                 ThrowEventLogException(win32Error);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void EvtClearLog(
                             EventLogHandle session,
                             string channelPath,
@@ -359,7 +354,6 @@ namespace System.Diagnostics.Eventing.Reader
                 ThrowEventLogException(win32Error);
         }
 
-        [System.Security.SecuritySafeCritical]
         public static object EvtGetEventInfo(EventLogHandle handle, UnsafeNativeMethods.EvtEventPropertyId enumType)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -422,7 +416,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public static object EvtGetPublisherMetadataProperty(EventLogHandle pmHandle, UnsafeNativeMethods.EvtPublisherMetadataPropertyId thePropertyId)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -608,7 +601,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public static object EvtGetChannelConfigProperty(EventLogHandle handle, UnsafeNativeMethods.EvtChannelConfigPropertyId enumType)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -647,7 +639,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void EvtSetChannelConfigProperty(EventLogHandle handle, UnsafeNativeMethods.EvtChannelConfigPropertyId enumType, object val)
         {
             UnsafeNativeMethods.EvtVariant varVal = new();
@@ -824,7 +815,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public static void EvtRenderBufferWithContextSystem(EventLogHandle contextHandle, EventLogHandle eventHandle, UnsafeNativeMethods.EvtRenderFlags flag, SystemProperties systemProperties, int SYSTEM_PROPERTY_COUNT)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -926,7 +916,6 @@ namespace System.Diagnostics.Eventing.Reader
 
         // EvtRenderContextFlags can be both: EvtRenderContextFlags.EvtRenderContextUser and EvtRenderContextFlags.EvtRenderContextValues
         // Render with Context = ContextUser or ContextValues (with user defined Xpath query strings)
-        [System.Security.SecuritySafeCritical]
         public static IList<object> EvtRenderBufferWithContextUserOrValues(EventLogHandle contextHandle, EventLogHandle eventHandle)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -972,7 +961,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecuritySafeCritical]
         public static string EvtFormatMessageRenderName(EventLogHandle pmHandle, EventLogHandle eventHandle, UnsafeNativeMethods.EvtFormatMessageFlags flag)
         {
             int bufferNeeded;
@@ -1026,7 +1014,6 @@ namespace System.Diagnostics.Eventing.Reader
         }
 
         // The EvtFormatMessage used for the obtaining of the Keywords names.
-        [System.Security.SecuritySafeCritical]
         public static IEnumerable<string> EvtFormatMessageRenderKeywords(EventLogHandle pmHandle, EventLogHandle eventHandle, UnsafeNativeMethods.EvtFormatMessageFlags flag)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -1126,7 +1113,6 @@ namespace System.Diagnostics.Eventing.Reader
         }
 
         // Get the formatted description, using the msgId for FormatDescription(string [])
-        [System.Security.SecuritySafeCritical]
         public static string EvtFormatMessageFormatDescription(EventLogHandle handle, EventLogHandle eventHandle, string[] values)
         {
             int bufferNeeded;

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
@@ -90,7 +90,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtQuery(
                             EventLogHandle session,
                             string path,
@@ -104,7 +103,6 @@ namespace System.Diagnostics.Eventing.Reader
             return handle;
         }
 
-        [System.Security.SecurityCritical]
         public static void EvtSeek(
                             EventLogHandle resultSet,
                             long position,
@@ -118,7 +116,6 @@ namespace System.Diagnostics.Eventing.Reader
                 ThrowEventLogException(win32Error);
         }
 
-        [System.Security.SecurityCritical]
         public static bool EvtNext(
                             EventLogHandle queryHandle,
                             int eventSize,
@@ -144,7 +141,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static void EvtClose(IntPtr handle)
         {
             //
@@ -154,7 +150,6 @@ namespace System.Diagnostics.Eventing.Reader
             UnsafeNativeMethods.EvtClose(handle);
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtOpenProviderMetadata(
                             EventLogHandle session,
                             string ProviderId,
@@ -175,7 +170,6 @@ namespace System.Diagnostics.Eventing.Reader
             return handle;
         }
 
-        [System.Security.SecurityCritical]
         public static int EvtGetObjectArraySize(EventLogHandle objectArray)
         {
             int arraySize;
@@ -186,7 +180,6 @@ namespace System.Diagnostics.Eventing.Reader
             return arraySize;
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtOpenEventMetadataEnum(EventLogHandle ProviderMetadata, int flags)
         {
             EventLogHandle emEnumHandle = UnsafeNativeMethods.EvtOpenEventMetadataEnum(ProviderMetadata, flags);
@@ -197,7 +190,6 @@ namespace System.Diagnostics.Eventing.Reader
         }
 
         // returns null if EOF
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtNextEventMetadata(EventLogHandle eventMetadataEnum, int flags)
         {
             EventLogHandle emHandle = UnsafeNativeMethods.EvtNextEventMetadata(eventMetadataEnum, flags);
@@ -213,7 +205,6 @@ namespace System.Diagnostics.Eventing.Reader
             return emHandle;
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtOpenChannelEnum(EventLogHandle session, int flags)
         {
             EventLogHandle channelEnum = UnsafeNativeMethods.EvtOpenChannelEnum(session, flags);
@@ -223,7 +214,6 @@ namespace System.Diagnostics.Eventing.Reader
             return channelEnum;
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtOpenProviderEnum(EventLogHandle session, int flags)
         {
             EventLogHandle pubEnum = UnsafeNativeMethods.EvtOpenPublisherEnum(session, flags);
@@ -233,7 +223,6 @@ namespace System.Diagnostics.Eventing.Reader
             return pubEnum;
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtOpenChannelConfig(EventLogHandle session, string channelPath, int flags)
         {
             EventLogHandle handle = UnsafeNativeMethods.EvtOpenChannelConfig(session, channelPath, flags);
@@ -252,7 +241,6 @@ namespace System.Diagnostics.Eventing.Reader
                 ThrowEventLogException(win32Error);
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtOpenLog(EventLogHandle session, string path, PathType flags)
         {
             EventLogHandle logHandle = UnsafeNativeMethods.EvtOpenLog(session, path, flags);
@@ -305,7 +293,6 @@ namespace System.Diagnostics.Eventing.Reader
                 ThrowEventLogException(win32Error);
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtCreateRenderContext(
                             int valuePathsCount,
                             string[] valuePaths,
@@ -318,7 +305,6 @@ namespace System.Diagnostics.Eventing.Reader
             return renderContextHandleValues;
         }
 
-        [System.Security.SecurityCritical]
         public static void EvtRender(
                             EventLogHandle context,
                             EventLogHandle eventHandle,
@@ -347,7 +333,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtOpenSession(UnsafeNativeMethods.EvtLoginClass loginClass, ref UnsafeNativeMethods.EvtRpcLogin login, int timeout, int flags)
         {
             EventLogHandle handle = UnsafeNativeMethods.EvtOpenSession(loginClass, ref login, timeout, flags);
@@ -357,7 +342,6 @@ namespace System.Diagnostics.Eventing.Reader
             return handle;
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle EvtCreateBookmark(string bookmarkXml)
         {
             EventLogHandle handle = UnsafeNativeMethods.EvtCreateBookmark(bookmarkXml);
@@ -367,7 +351,6 @@ namespace System.Diagnostics.Eventing.Reader
             return handle;
         }
 
-        [System.Security.SecurityCritical]
         public static void EvtUpdateBookmark(EventLogHandle bookmark, EventLogHandle eventHandle)
         {
             bool status = UnsafeNativeMethods.EvtUpdateBookmark(bookmark, eventHandle);
@@ -410,7 +393,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static object EvtGetQueryInfo(EventLogHandle handle, UnsafeNativeMethods.EvtQueryPropertyId enumType)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -471,7 +453,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         internal static EventLogHandle EvtGetPublisherMetadataPropertyHandle(EventLogHandle pmHandle, UnsafeNativeMethods.EvtPublisherMetadataPropertyId thePropertyId)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -509,7 +490,6 @@ namespace System.Diagnostics.Eventing.Reader
         }
 
         // implies UnsafeNativeMethods.EvtFormatMessageFlags.EvtFormatMessageId flag.
-        [System.Security.SecurityCritical]
         public static string EvtFormatMessage(EventLogHandle handle, uint msgId)
         {
             int bufferNeeded;
@@ -566,7 +546,6 @@ namespace System.Diagnostics.Eventing.Reader
             return sb.ToString();
         }
 
-        [System.Security.SecurityCritical]
         public static object EvtGetObjectArrayProperty(EventLogHandle objArrayHandle, int index, int thePropertyId)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -598,7 +577,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static object EvtGetEventMetadataProperty(EventLogHandle handle, UnsafeNativeMethods.EvtEventMetadataPropertyId enumType)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -759,7 +737,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static string EvtNextChannelPath(EventLogHandle handle, ref bool finish)
         {
             StringBuilder sb = new(null);
@@ -788,7 +765,6 @@ namespace System.Diagnostics.Eventing.Reader
             return sb.ToString();
         }
 
-        [System.Security.SecurityCritical]
         public static string EvtNextPublisherId(EventLogHandle handle, ref bool finish)
         {
             StringBuilder sb = new(null);
@@ -817,7 +793,6 @@ namespace System.Diagnostics.Eventing.Reader
             return sb.ToString();
         }
 
-        [System.Security.SecurityCritical]
         public static object EvtGetLogInfo(EventLogHandle handle, UnsafeNativeMethods.EvtLogPropertyId enumType)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -1118,7 +1093,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static string EvtRenderBookmark(EventLogHandle eventHandle)
         {
             IntPtr buffer = IntPtr.Zero;
@@ -1212,7 +1186,6 @@ namespace System.Diagnostics.Eventing.Reader
             return sb.ToString();
         }
 
-        [System.Security.SecurityCritical]
         private static object ConvertToObject(UnsafeNativeMethods.EvtVariant val)
         {
             switch (val.Type)
@@ -1324,7 +1297,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static object ConvertToObject(UnsafeNativeMethods.EvtVariant val, UnsafeNativeMethods.EvtVariantType desiredType)
         {
             if (val.Type == (int)UnsafeNativeMethods.EvtVariantType.EvtVarTypeNull) return null;
@@ -1334,7 +1306,6 @@ namespace System.Diagnostics.Eventing.Reader
             return ConvertToObject(val);
         }
 
-        [System.Security.SecurityCritical]
         public static string ConvertToString(UnsafeNativeMethods.EvtVariant val)
         {
             if (val.StringVal == IntPtr.Zero)
@@ -1343,7 +1314,6 @@ namespace System.Diagnostics.Eventing.Reader
                 return Marshal.PtrToStringUni(val.StringVal);
         }
 
-        [System.Security.SecurityCritical]
         public static string ConvertToAnsiString(UnsafeNativeMethods.EvtVariant val)
         {
             if (val.AnsiString == IntPtr.Zero)
@@ -1352,7 +1322,6 @@ namespace System.Diagnostics.Eventing.Reader
                 return Marshal.PtrToStringAnsi(val.AnsiString);
         }
 
-        [System.Security.SecurityCritical]
         public static EventLogHandle ConvertToSafeHandle(UnsafeNativeMethods.EvtVariant val)
         {
             if (val.Handle == IntPtr.Zero)
@@ -1361,7 +1330,6 @@ namespace System.Diagnostics.Eventing.Reader
                 return new EventLogHandle(val.Handle, true);
         }
 
-        [System.Security.SecurityCritical]
         public static Array ConvertToArray<T>(UnsafeNativeMethods.EvtVariant val, int size) where T : struct
         {
             IntPtr ptr = val.Reference;
@@ -1382,7 +1350,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static Array ConvertToBoolArray(UnsafeNativeMethods.EvtVariant val)
         {
             // NOTE: booleans are padded to 4 bytes in ETW
@@ -1405,7 +1372,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static Array ConvertToFileTimeArray(UnsafeNativeMethods.EvtVariant val)
         {
             IntPtr ptr = val.Reference;
@@ -1426,7 +1392,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static Array ConvertToSysTimeArray(UnsafeNativeMethods.EvtVariant val)
         {
             IntPtr ptr = val.Reference;
@@ -1448,7 +1413,6 @@ namespace System.Diagnostics.Eventing.Reader
             }
         }
 
-        [System.Security.SecurityCritical]
         public static string[] ConvertToStringArray(UnsafeNativeMethods.EvtVariant val, bool ansi)
         {
             if (val.Reference == IntPtr.Zero)

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/UnsafeNativeMethods.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/UnsafeNativeMethods.cs
@@ -75,13 +75,11 @@ namespace System.Diagnostics.Eventing
         private const int FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;
 
         [DllImport(FormatMessageDllName, CharSet = CharSet.Unicode, BestFitMapping = false)]
-        [SecurityCritical]
         internal static extern int FormatMessage(int dwFlags, IntPtr lpSource,
             int dwMessageId, int dwLanguageId, StringBuilder lpBuffer,
             int nSize, IntPtr va_list_arguments);
 
         // Gets an error message for a Win32 error code.
-        [SecurityCritical]
         internal static string GetMessage(int errorCode)
         {
             StringBuilder sb = new(512);
@@ -104,7 +102,6 @@ namespace System.Diagnostics.Eventing
 
         // ETW Methods
         // Callback
-        [SecurityCritical]
         internal unsafe delegate void EtwEnableCallback(
             [In] ref Guid sourceId,
             [In] int isEnabled,
@@ -117,7 +114,6 @@ namespace System.Diagnostics.Eventing
 
         // Registration APIs
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventRegister", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern unsafe uint EventRegister(
                     [In] in Guid providerId,
                     [In] EtwEnableCallback enableCallback,
@@ -126,21 +122,17 @@ namespace System.Diagnostics.Eventing
                     );
 
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventUnregister", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern int EventUnregister([In] long registrationHandle);
 
         // Control (Is Enabled) APIs
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventEnabled", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern int EventEnabled([In] long registrationHandle, [In] in System.Diagnostics.Eventing.EventDescriptor eventDescriptor);
 
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventProviderEnabled", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern int EventProviderEnabled([In] long registrationHandle, [In] byte level, [In] long keywords);
 
         // Writing (Publishing/Logging) APIs
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventWrite", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern unsafe uint EventWrite(
                 [In] long registrationHandle,
                 [In] in EventDescriptor eventDescriptor,
@@ -150,7 +142,6 @@ namespace System.Diagnostics.Eventing
 
         // Writing (Publishing/Logging) APIs
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventWrite", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern unsafe uint EventWrite(
                 [In] long registrationHandle,
                 [In] EventDescriptor* eventDescriptor,
@@ -159,7 +150,6 @@ namespace System.Diagnostics.Eventing
                 );
 
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventWriteTransfer", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern unsafe uint EventWriteTransfer(
                 [In] long registrationHandle,
                 [In] in EventDescriptor eventDescriptor,
@@ -170,7 +160,6 @@ namespace System.Diagnostics.Eventing
                 );
 
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventWriteString", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern unsafe uint EventWriteString(
                 [In] long registrationHandle,
                 [In] byte level,
@@ -180,7 +169,6 @@ namespace System.Diagnostics.Eventing
 
         // ActivityId Control APIs
         [DllImport(EventProviderDllName, ExactSpelling = true, EntryPoint = "EventActivityIdControl", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
-        [SecurityCritical]
         internal static extern unsafe uint EventActivityIdControl([In] int ControlCode, [In][Out] ref Guid ActivityId);
 
         // EventLog
@@ -264,7 +252,6 @@ namespace System.Diagnostics.Eventing
         }
 
         [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
-        [SecurityCritical]
         internal struct EvtVariant
         {
             [FieldOffset(0)]
@@ -531,7 +518,6 @@ namespace System.Diagnostics.Eventing
             [MarshalAs(UnmanagedType.LPWStr)]
             public string Domain;
 
-            [SecurityCritical]
             public CoTaskMemUnicodeSafeHandle Password;
 
             public int Flags;
@@ -550,7 +536,6 @@ namespace System.Diagnostics.Eventing
         }
 
         [DllImport(WEVTAPI, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtQuery(
                             EventLogHandle session,
                             [MarshalAs(UnmanagedType.LPWStr)] string path,
@@ -559,7 +544,6 @@ namespace System.Diagnostics.Eventing
 
         // SEEK
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtSeek(
                             EventLogHandle resultSet,
@@ -570,7 +554,6 @@ namespace System.Diagnostics.Eventing
                                         );
 
         [DllImport(WEVTAPI, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtNext(
                             EventLogHandle queryHandle,
@@ -581,12 +564,10 @@ namespace System.Diagnostics.Eventing
                             ref int returned);
 
         [DllImport(WEVTAPI, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtCancel(EventLogHandle handle);
 
         [DllImport(WEVTAPI)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtClose(IntPtr handle);
 
@@ -598,7 +579,6 @@ namespace System.Diagnostics.Eventing
          */
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetEventInfo(
                             EventLogHandle eventHandle,
@@ -610,7 +590,6 @@ namespace System.Diagnostics.Eventing
                                             );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetQueryInfo(
                             EventLogHandle queryHandle,
@@ -622,7 +601,6 @@ namespace System.Diagnostics.Eventing
 
         // PUBLISHER METADATA
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtOpenPublisherMetadata(
                             EventLogHandle session,
                             [MarshalAs(UnmanagedType.LPWStr)] string publisherId,
@@ -632,7 +610,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetPublisherMetadataProperty(
                             EventLogHandle publisherMetadataHandle,
@@ -645,7 +622,6 @@ namespace System.Diagnostics.Eventing
 
         // NEW
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetObjectArraySize(
                             EventLogHandle objectArray,
@@ -653,7 +629,6 @@ namespace System.Diagnostics.Eventing
                                         );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetObjectArrayProperty(
                             EventLogHandle objectArray,
@@ -667,14 +642,12 @@ namespace System.Diagnostics.Eventing
 
         // NEW 2
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtOpenEventMetadataEnum(
                             EventLogHandle publisherMetadata,
                             int flags
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         // public static extern IntPtr EvtNextEventMetadata(
         internal static extern EventLogHandle EvtNextEventMetadata(
                             EventLogHandle eventMetadataEnum,
@@ -682,7 +655,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetEventMetadataProperty(
                             EventLogHandle eventMetadata,
@@ -695,14 +667,12 @@ namespace System.Diagnostics.Eventing
 
         // Channel Configuration Native Api
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtOpenChannelEnum(
                             EventLogHandle session,
                             int flags
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtNextChannelPath(
                             EventLogHandle channelEnum,
@@ -713,14 +683,12 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtOpenPublisherEnum(
                             EventLogHandle session,
                             int flags
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtNextPublisherId(
                             EventLogHandle publisherEnum,
@@ -730,7 +698,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtOpenChannelConfig(
                             EventLogHandle session,
                             [MarshalAs(UnmanagedType.LPWStr)] string channelPath,
@@ -738,7 +705,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtSaveChannelConfig(
                             EventLogHandle channelConfig,
@@ -746,7 +712,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtSetChannelConfigProperty(
                             EventLogHandle channelConfig,
@@ -756,7 +721,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetChannelConfigProperty(
                             EventLogHandle channelConfig,
@@ -769,7 +733,6 @@ namespace System.Diagnostics.Eventing
 
         // Log Information Native API
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtOpenLog(
                             EventLogHandle session,
                             [MarshalAs(UnmanagedType.LPWStr)] string path,
@@ -777,7 +740,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtGetLogInfo(
                             EventLogHandle log,
@@ -789,7 +751,6 @@ namespace System.Diagnostics.Eventing
 
         // LOG MANIPULATION
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtExportLog(
                             EventLogHandle session,
@@ -800,7 +761,6 @@ namespace System.Diagnostics.Eventing
                                         );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtArchiveExportedLog(
                             EventLogHandle session,
@@ -810,7 +770,6 @@ namespace System.Diagnostics.Eventing
                                         );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtClearLog(
                             EventLogHandle session,
@@ -821,7 +780,6 @@ namespace System.Diagnostics.Eventing
 
         // RENDERING
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtCreateRenderContext(
                             int valuePathsCount,
                             [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)]
@@ -830,7 +788,6 @@ namespace System.Diagnostics.Eventing
                                     );
 
         [DllImport(WEVTAPI, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtRender(
                             EventLogHandle context,
@@ -843,7 +800,6 @@ namespace System.Diagnostics.Eventing
                                         );
 
         [DllImport(WEVTAPI, EntryPoint = "EvtRender", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtRender(
                             EventLogHandle context,
@@ -869,7 +825,6 @@ namespace System.Diagnostics.Eventing
         }
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtFormatMessage(
                              EventLogHandle publisherMetadataHandle,
@@ -884,7 +839,6 @@ namespace System.Diagnostics.Eventing
                                         );
 
         [DllImport(WEVTAPI, EntryPoint = "EvtFormatMessage", CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtFormatMessageBuffer(
                              EventLogHandle publisherMetadataHandle,
@@ -900,7 +854,6 @@ namespace System.Diagnostics.Eventing
 
         // SESSION
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtOpenSession(
                             [MarshalAs(UnmanagedType.I4)] EvtLoginClass loginClass,
                             ref EvtRpcLogin login,
@@ -910,13 +863,11 @@ namespace System.Diagnostics.Eventing
 
         // BOOKMARK
         [DllImport(WEVTAPI, EntryPoint = "EvtCreateBookmark", CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         internal static extern EventLogHandle EvtCreateBookmark(
                             [MarshalAs(UnmanagedType.LPWStr)] string bookmarkXml
                                         );
 
         [DllImport(WEVTAPI, CharSet = CharSet.Unicode, SetLastError = true)]
-        [SecurityCritical]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvtUpdateBookmark(
                             EventLogHandle bookmark,

--- a/src/System.Management.Automation/namespaces/Win32Native.cs
+++ b/src/System.Management.Automation/namespaces/Win32Native.cs
@@ -24,10 +24,6 @@ namespace Microsoft.PowerShell.Commands.Internal
     /**
      * Win32 encapsulation for MSCORLIB.
      */
-    // Remove the default demands for all N/Direct methods with this
-    // global declaration on the class.
-    //
-    [SuppressUnmanagedCodeSecurity]
     internal static class Win32Native
     {
         #region Integer Const


### PR DESCRIPTION
Contributes to: https://github.com/PowerShell/PowerShell/issues/25937

### Summary

These attributes are not applicable in .NET Core and can be safely removed:

* [`System.Security.SecurityCriticalAttribute`](https://learn.microsoft.com/dotnet/api/system.security.securitycriticalattribute)
* [`System.Security.SecuritySafeCriticalAttribute`](https://learn.microsoft.com/dotnet/api/system.security.securitysafecriticalattribute)
* [`System.Security.SuppressUnmanagedCodeSecurityAttribute`](https://learn.microsoft.com/dotnet/api/system.security.suppressunmanagedcodesecurityattribute)

### References
 
- https://github.com/dotnet/runtime/issues/18938
- https://github.com/dotnet/corefx/commit/bf1997a6265aa56326ad389bd1b19584d6d9bf61