### PR TITLE
Use `[string]` type accelerator

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -3535,15 +3535,15 @@ function New-PSOptionsObject
         $RootInfo,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Top,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Runtime,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Configuration,
 
         [Parameter(Mandatory)]
@@ -3551,11 +3551,11 @@ function New-PSOptionsObject
         $PSModuleRestore,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Framework,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Output,
 
         [Parameter(Mandatory)]
@@ -3810,7 +3810,7 @@ function New-NugetPackageSource {
     return [NugetPackageSource] @{Url = $Url; Name = $Name }
 }
 
-$script:NuGetEndpointCredentials = [System.Collections.Generic.Dictionary[String,System.Object]]::new()
+$script:NuGetEndpointCredentials = [System.Collections.Generic.Dictionary[string,System.Object]]::new()
 function New-NugetConfigFile {
     param(
         [Parameter(Mandatory = $true, ParameterSetName ='user')]

--- a/build.psm1
+++ b/build.psm1
@@ -4274,15 +4274,15 @@ function New-PSOptionsObject
         $RootInfo,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Top,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Runtime,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Configuration,
 
         [Parameter(Mandatory)]
@@ -4290,11 +4290,11 @@ function New-PSOptionsObject
         $PSModuleRestore,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Framework,
 
         [Parameter(Mandatory)]
-        [String]
+        [string]
         $Output,
 
         [Parameter(Mandatory)]
@@ -4582,7 +4582,7 @@ function New-NugetPackageSource {
     return [NugetPackageSource] @{Url = $Url; Name = $Name }
 }
 
-$script:NuGetEndpointCredentials = [System.Collections.Generic.Dictionary[String,System.Object]]::new()
+$script:NuGetEndpointCredentials = [System.Collections.Generic.Dictionary[string,System.Object]]::new()
 function New-NugetConfigFile {
     <#
     .SYNOPSIS

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -937,7 +937,7 @@ namespace System.Management.Automation.Runspaces
                                         }
                                         # if the object implements IEnumerable and not a string, we try to show each object
                                         # We ignore the `Data` property as it can contain lots of type information by the interpreter that isn't useful here
-                                        elseif (!($prop.Value -is [System.String]) -and $prop.Value.GetType().GetInterface('IEnumerable') -ne $null -and $prop.Name -ne 'Data') {
+                                        elseif (!($prop.Value -is [string]) -and $prop.Value.GetType().GetInterface('IEnumerable') -ne $null -and $prop.Name -ne 'Data') {
 
                                             if ($depth -ge $maxDepth) {
                                                 $null = $output.Append($ellipsis)
@@ -1379,7 +1379,7 @@ namespace System.Management.Automation.Runspaces
 
                                     if ($ErrorView -eq 'ConciseView') {
                                         $recommendedAction = $_.ErrorDetails.RecommendedAction
-                                        if (-not [String]::IsNullOrWhiteSpace($recommendedAction)) {
+                                        if (-not [string]::IsNullOrWhiteSpace($recommendedAction)) {
                                             $recommendedAction = $newline +
                                                 ${errorColor} +
                                                 '  Recommendation: ' +

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -577,7 +577,7 @@ namespace System.Management.Automation
                 {
                     if (pattern.IsMatch(parameterName) && !parameterNames.Contains(parameterName, StringComparer.OrdinalIgnoreCase))
                     {
-                        string tooltip = "[String] " + parameterName;
+                        string tooltip = "[string] " + parameterName;
                         result.Add(new CompletionResult("-" + parameterName, parameterName, CompletionResultType.ParameterName, tooltip));
                     }
                 }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4413,13 +4413,13 @@ param(
 param(
     [Parameter(ParameterSetName='nameSet', Position=0, ValueFromPipelineByPropertyName=$true)]
     [Parameter(ParameterSetName='pathSet', Mandatory=$true, Position=0, ValueFromPipelineByPropertyName=$true)]
-    [System.String[]]
+    [string[]]
     ${Path},
 
     [Parameter(ParameterSetName='nameSet', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
     [AllowNull()]
     [AllowEmptyString()]
-    [System.String]
+    [string]
     ${Name},
 
     [Parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]

--- a/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
@@ -9069,12 +9069,12 @@ namespace System.Management.Automation.Runspaces
                     @"ToString",
                     GetScriptBlock(@"
           $suffix = """"
-          if (![String]::IsNullOrEmpty($this.PSSemVerPreReleaseLabel))
+          if (![string]::IsNullOrEmpty($this.PSSemVerPreReleaseLabel))
           {
               $suffix = ""-""+$this.PSSemVerPreReleaseLabel
           }
 
-          if (![String]::IsNullOrEmpty($this.PSSemVerBuildLabel))
+          if (![string]::IsNullOrEmpty($this.PSSemVerBuildLabel))
           {
               $suffix += ""+""+$this.PSSemVerBuildLabel
           }

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -4042,7 +4042,7 @@ function Enable-PSSessionConfiguration
 [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact=""Medium"")]
 param(
     [Parameter(Position=0, ValueFromPipeline=$true)]
-    [System.String]
+    [string]
     $Name,
 
     [Parameter()]
@@ -4429,7 +4429,7 @@ function Disable-PSSessionConfiguration
 [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact=""Low"")]
 param(
     [Parameter(Position=0, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-    [System.String]
+    [string]
     $Name,
 
     [Parameter()]

--- a/src/System.Management.Automation/resources/TabCompletionStrings.resx
+++ b/src/System.Management.Automation/resources/TabCompletionStrings.resx
@@ -368,17 +368,17 @@ Specifies the order of sorting for one or more properties.</value>
 Specifies the order of sorting for one or more properties.</value>
   </data>
   <data name="LogNameHashtableKeyDescription" xml:space="preserve">
-    <value>[String[]]
+    <value>[string[]]
 Specifies the log names to get events from.
 Supports wildcards.</value>
   </data>
   <data name="ProviderNameHashtableKeyDescription" xml:space="preserve">
-    <value>[String[]]
+    <value>[string[]]
 Specifies the event log providers to get events from.
 Supports wildcards.</value>
   </data>
   <data name="PathHashtableKeyDescription" xml:space="preserve">
-    <value>[String[]]
+    <value>[string[]]
 Specifies file paths to log files to get events from.
 Valid file formats are: .etl, .evt, and .evtx</value>
   </data>

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -124,7 +124,7 @@ function Install-PluginEndpoint {
     #                    #
     ######################
 
-    if (-not [String]::IsNullOrEmpty($PowerShellHome))
+    if (-not [string]::IsNullOrEmpty($PowerShellHome))
     {
         $targetPsHome = $PowerShellHome
         $targetPsVersion = & "$targetPsHome\pwsh" -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'

--- a/test/packaging/windows/exe.tests.ps1
+++ b/test/packaging/windows/exe.tests.ps1
@@ -24,7 +24,7 @@ Describe -Name "Windows EXE" -Fixture {
 
                 [Parameter(Mandatory)]
                 [ValidateScript({Test-Path -Path $_})]
-                [String]$ExePath
+                [string]$ExePath
             )
             $action = "$($PSCmdlet.ParameterSetName)ing"
             if ($Install) {

--- a/test/packaging/windows/msi.tests.ps1
+++ b/test/packaging/windows/msi.tests.ps1
@@ -81,7 +81,7 @@ Describe -Name "Windows MSI" -Fixture {
 
                 [Parameter(Mandatory)]
                 [ValidateScript({Test-Path -Path $_})]
-                [String]$MsiPath,
+                [string]$MsiPath,
 
                 [Parameter(ParameterSetName = 'Install')]
                 [HashTable] $Properties

--- a/test/perf/benchmarks/assets/compiler.test.ps1
+++ b/test/perf/benchmarks/assets/compiler.test.ps1
@@ -1308,7 +1308,7 @@ function Start-CrossGen {
     param(
         [Parameter(Mandatory= $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [string]
         $PublishPath,
 
         [Parameter(Mandatory=$true)]
@@ -1330,12 +1330,12 @@ function Start-CrossGen {
         param (
             [Parameter(Mandatory = $true)]
             [ValidateNotNullOrEmpty()]
-            [String[]]
+            [string[]]
             $AssemblyPath,
 
             [Parameter(Mandatory = $true)]
             [ValidateNotNullOrEmpty()]
-            [String]
+            [string]
             $CrossgenPath,
 
             [Parameter(Mandatory = $true)]

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -762,7 +762,7 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
             param($testArg, $expectedMatches)
             $output = & $powershell $testArg -File foo 2>&1
             $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
-            $outString = [String]::Join(",", $output)
+            $outString = [string]::Join(",", $output)
             foreach ($expectedMatch in $expectedMatches)
             {
                 $outString | Should -Match $expectedMatch

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -57,20 +57,20 @@ Describe "PSVersionTable" -Tags "CI" {
     }
 
     It "Should have the correct platform info" {
-       $platform = [String][System.Environment]::OSVersion.Platform
-       [String]$PSVersionTable["Platform"] | Should -Be $platform
+       $platform = [string][System.Environment]::OSVersion.Platform
+       [string]$PSVersionTable["Platform"] | Should -Be $platform
     }
 
     It "Should have the correct OS info" {
        if ($IsCoreCLR)
        {
-           $OSDescription = [String][System.Runtime.InteropServices.RuntimeInformation]::OSDescription
-           [String]$PSVersionTable["OS"] | Should -Be $OSDescription
+           $OSDescription = [string][System.Runtime.InteropServices.RuntimeInformation]::OSDescription
+           [string]$PSVersionTable["OS"] | Should -Be $OSDescription
        }
        else
        {
-           $OSDescription = [String][System.Environment]::OSVersion
-           [String]$PSVersionTable["OS"] | Should -Be $OSDescription
+           $OSDescription = [string][System.Environment]::OSVersion
+           [string]$PSVersionTable["OS"] | Should -Be $OSDescription
        }
     }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -2815,7 +2815,7 @@ param ($Param1)
             $scriptBl = {
                 function Test-Completion {
                     param (
-                        [String]$TestVal
+                        [string]$TestVal
                     )
                 }
                 [scriptblock]$completer = {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -2899,7 +2899,7 @@ param ($Param1)
             $scriptBl = {
                 function Test-Completion {
                     param (
-                        [String]$TestVal
+                        [string]$TestVal
                     )
                 }
                 [scriptblock]$completer = {

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -279,14 +279,14 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
 
         BeforeAll {
             class GenValuesForParam : System.Management.Automation.IValidateSetValuesGenerator {
-                [String[]] GetValidValues() {
+                [string[]] GetValidValues() {
 
                     return [string[]]("Test1","TestString1","Test2")
                 }
             }
 
             class GenValuesForParamNull : System.Management.Automation.IValidateSetValuesGenerator {
-                [String[]] GetValidValues() {
+                [string[]] GetValidValues() {
 
                     return [string[]]$null
                 }
@@ -294,7 +294,7 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
 
             # Return '$testValues2' and after 2 seconds after first use return another array '$testValues1'.
             class GenValuesForParamCache1 : System.Management.Automation.IValidateSetValuesGenerator {
-                [String[]] GetValidValues() {
+                [string[]] GetValidValues() {
 
                     $testValues1 = "Test11","TestString11","Test22"
                     $testValues2 = "Test11","TestString22","Test22"
@@ -413,7 +413,7 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
                 GenValuesForParam() : base(300) {
                 }
 
-                [String[]] GenerateValidValues() {
+                [string[]] GenerateValidValues() {
 
                     return [string[]]("Test1","TestString1","Test2")
                 }
@@ -425,7 +425,7 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
 
                 Static [bool] $temp = $true;
 
-                [String[]] GenerateValidValues() {
+                [string[]] GenerateValidValues() {
 
                     if ([GenValuesWithExpiration]::temp) {
                         [GenValuesWithExpiration]::temp = $false

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -134,7 +134,7 @@ class ClassWithStaticAbstractInterface : IInterfaceWithStaticAbstractProperty {
         BeforeAll {
             class TestHost : System.Management.Automation.Host.PSHost
             {
-                [String]$myName = "MyHost"
+                [string]$myName = "MyHost"
                 [Version]$myVersion = [Version]"1.0.0.0"
                 [Guid]$myInstanceId = [guid]::NewGuid()
                 [System.Globalization.CultureInfo]$myCurrentCulture = "en-us"

--- a/test/powershell/Language/Scripting/CheckRestrictedlanguage.Tests.ps1
+++ b/test/powershell/Language/Scripting/CheckRestrictedlanguage.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Test restricted language check method on scriptblocks" -Tags "CI" {
             Set-StrictMode -v 2
             function list {
 
-            $l = [System.Collections.Generic.List[String]]::new()
+            $l = [System.Collections.Generic.List[string]]::new()
             $args | ForEach-Object {$l.Add($_)}
             , $l
             }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -283,7 +283,7 @@ Categories=Application;
             $beforeCount = [int]('tell application "TextEdit" to count of windows' | osascript)
             & $TestFile
             $startTime = Get-Date
-            $title = [String]::Empty
+            $title = [string]::Empty
             while (((Get-Date) - $startTime).TotalSeconds -lt 30 -and ($title -ne $expectedTitle)) {
                 Start-Sleep -Milliseconds 100
                 $title = 'tell application "TextEdit" to get name of front window' | osascript

--- a/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
+++ b/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
@@ -559,7 +559,7 @@ Describe 'get-help other tests' -Tags "CI" {
     Context 'get-help helpFunc12' {
         # Test case w/ cmdlet binding, but no parameter sets.
         function helpFunc12 {
-            Param ([Parameter(Mandatory=$true)][String]$Name,
+            Param ([Parameter(Mandatory=$true)][string]$Name,
                    [string]$Extension = "txt",
                    $NoType,
                    [switch]$ASwitch,

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -155,7 +155,7 @@ function RemoveMachineName
     param (
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [string]
         $path
     )
 
@@ -185,7 +185,7 @@ function TranslateCounterName
     param (
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [string]
         $counterName
     )
 
@@ -205,7 +205,7 @@ function TranslateCounterPath
     param (
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [string]
         $path
     )
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -772,8 +772,8 @@ try {
 
         BeforeEach {
             if ($IsNotSkipped) {
-                $group1SID = [String](New-LocalGroup -Name TestGroupRemove1 -Description "Test Group Remove 1 Description" 2>&1).SID
-                $group2SID = [String](New-LocalGroup -Name TestGroupRemove2 -Description "Test Group Remove 2 Description" 2>&1).SID
+                $group1SID = [string](New-LocalGroup -Name TestGroupRemove1 -Description "Test Group Remove 1 Description" 2>&1).SID
+                $group2SID = [string](New-LocalGroup -Name TestGroupRemove2 -Description "Test Group Remove 2 Description" 2>&1).SID
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -76,8 +76,8 @@ try {
 
         BeforeEach {
             if ($IsNotSkipped) {
-                $user1sid = [String](New-LocalUser TestUser1 -NoPassword).SID
-                $group1sid = [String](New-LocalGroup TestGroup1).SID
+                $user1sid = [string](New-LocalUser TestUser1 -NoPassword).SID
+                $group1sid = [string](New-LocalGroup TestGroup1).SID
             }
         }
 
@@ -105,10 +105,10 @@ try {
 
         BeforeEach {
             if ($IsNotSkipped) {
-                $user1sid = [String](New-LocalUser TestUser1 -NoPassword).SID
-                $user2sid = [String](New-LocalUser TestUser2 -NoPassword).SID
-                $group1sid = [String](New-LocalGroup TestGroup1).SID
-                $group2sid = [String](New-LocalGroup TestGroup2).SID
+                $user1sid = [string](New-LocalUser TestUser1 -NoPassword).SID
+                $user2sid = [string](New-LocalUser TestUser2 -NoPassword).SID
+                $group1sid = [string](New-LocalGroup TestGroup1).SID
+                $group2sid = [string](New-LocalGroup TestGroup2).SID
             }
         }
 
@@ -252,8 +252,8 @@ try {
                 $user1 = New-LocalUser TestUserGet1 -NoPassword
                 $group1 = New-LocalGroup TestGroupGet1
                 Add-LocalGroupMember TestGroupGet1 -Member TestUserGet1
-                $user1sid = [String]($user1.SID)
-                $group1sid = [String]($group1.SID)
+                $user1sid = [string]($user1.SID)
+                $group1sid = [string]($group1.SID)
             }
         }
 
@@ -291,10 +291,10 @@ try {
                 $group2 = New-LocalGroup TestGroupGet2
                 Add-LocalGroupMember TestGroupGet1 -Member TestUserGet1
                 Add-LocalGroupMember TestGroupGet1 -Member TestUserGet2
-                $user1sid = [String]($user1.SID)
-                $user2sid = [String]($user2.SID)
-                $group1sid = [String]($group1.SID)
-                $group2sid = [String]($group2.SID)
+                $user1sid = [string]($user1.SID)
+                $user2sid = [string]($user2.SID)
+                $group1sid = [string]($group1.SID)
+                $group2sid = [string]($group2.SID)
             }
         }
 
@@ -418,8 +418,8 @@ try {
                 $user1 = New-LocalUser TestUserRemove1 -NoPassword
                 $group1 = New-LocalGroup TestGroupRemove1
                 Add-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1
-                $user1sid = [String]($user1.SID)
-                $group1sid = [String]($group1.SID)
+                $user1sid = [string]($user1.SID)
+                $group1sid = [string]($group1.SID)
             }
         }
 
@@ -448,10 +448,10 @@ try {
                 $group2 = New-LocalGroup TestGroupRemove2
                 Add-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1
                 Add-LocalGroupMember TestGroupRemove1 -Member TestUserRemove2
-                $user1sid = [String]($user1.SID)
-                $user2sid = [String]($user2.SID)
-                $group1sid = [String]($group1.SID)
-                $group2sid = [String]($group2.SID)
+                $user1sid = [string]($user1.SID)
+                $user2sid = [string]($user2.SID)
+                $group1sid = [string]($group1.SID)
+                $group2sid = [string]($group2.SID)
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -583,7 +583,7 @@ try {
         BeforeEach {
             if ($IsNotSkipped) {
                 New-LocalUser -Name TestUserSet1 -NoPassword -Description "Test User Set 1 Description" | Out-Null
-                $user1SID = [String](Get-LocalUser -Name TestUserSet1).SID
+                $user1SID = [string](Get-LocalUser -Name TestUserSet1).SID
             }
         }
 
@@ -613,7 +613,7 @@ try {
         BeforeEach {
             if ($IsNotSkipped) {
                 New-LocalUser -Name TestUserSet1 -NoPassword -Description "Test User Set 1 Description" | Out-Null
-                $user1SID = [String](Get-LocalUser -Name TestUserSet1).SID
+                $user1SID = [string](Get-LocalUser -Name TestUserSet1).SID
             }
         }
 
@@ -835,7 +835,7 @@ try {
         BeforeEach {
             if ($IsNotSkipped) {
                 New-LocalUser -Name TestUserRename1 -NoPassword -Description "Test User Rename 1 Description" | Out-Null
-                $user1SID = [String](Get-LocalUser -Name TestUserRename1).SID
+                $user1SID = [string](Get-LocalUser -Name TestUserRename1).SID
             }
         }
 
@@ -865,7 +865,7 @@ try {
         BeforeEach {
             if ($IsNotSkipped) {
                 New-LocalUser -Name TestUserRename1 -NoPassword -Description "Test User Rename 1 Description" | Out-Null
-                $user1SID = [String](Get-LocalUser -Name TestUserRename1).SID
+                $user1SID = [string](Get-LocalUser -Name TestUserRename1).SID
             }
         }
 
@@ -1016,7 +1016,7 @@ try {
         BeforeEach {
             if ($IsNotSkipped) {
                 New-LocalUser -Name TestUserRemove1 -NoPassword -Description "Test User Remove 1 Description" | Out-Null
-                $user1SID = [String](Get-LocalUser -Name TestUserRemove1).SID
+                $user1SID = [string](Get-LocalUser -Name TestUserRemove1).SID
             }
         }
 
@@ -1096,8 +1096,8 @@ try {
 
         BeforeEach {
             if ($IsNotSkipped) {
-                $user1SID = [String](New-LocalUser -Name TestUserRemove1 -NoPassword -Description "Test User Remove 1 Description").SID
-                $user2SID = [String](New-LocalUser -Name TestUserRemove2 -NoPassword -Description "Test User Remove 2 Description").SID
+                $user1SID = [string](New-LocalUser -Name TestUserRemove1 -NoPassword -Description "Test User Remove 1 Description").SID
+                $user2SID = [string](New-LocalUser -Name TestUserRemove2 -NoPassword -Description "Test User Remove 2 Description").SID
             }
         }
 
@@ -1229,7 +1229,7 @@ try {
         BeforeEach {
             if ($IsNotSkipped) {
                 New-LocalUser -Name TestUserDisabled1 -NoPassword -Disabled -Description "Test User Disabled 1 Description" | Out-Null
-                $disabledUser1SID = [String](Get-LocalUser -Name TestUserDisabled1).SID
+                $disabledUser1SID = [string](Get-LocalUser -Name TestUserDisabled1).SID
             }
         }
 
@@ -1261,10 +1261,10 @@ try {
 
         BeforeEach {
             if ($IsNotSkipped) {
-                $enabledUser1SID = [String](New-LocalUser -Name TestUserEnabled1 -NoPassword -Description "Test User Enabled 1 Description").SID
-                $enabledUser2SID = [String](New-LocalUser -Name TestUserEnabled2 -NoPassword -Description "Test User Enabled 2 Description").SID
-                $disabledUser1SID = [String](New-LocalUser -Name TestUserDisabled1 -NoPassword -Description "Test User Disabled 1 Description" -Disabled).SID
-                $disabledUser2SID = [String](New-LocalUser -Name TestUserDisabled2 -NoPassword -Description "Test User Disabled 2 Description" -Disabled).SID
+                $enabledUser1SID = [string](New-LocalUser -Name TestUserEnabled1 -NoPassword -Description "Test User Enabled 1 Description").SID
+                $enabledUser2SID = [string](New-LocalUser -Name TestUserEnabled2 -NoPassword -Description "Test User Enabled 2 Description").SID
+                $disabledUser1SID = [string](New-LocalUser -Name TestUserDisabled1 -NoPassword -Description "Test User Disabled 1 Description" -Disabled).SID
+                $disabledUser2SID = [string](New-LocalUser -Name TestUserDisabled2 -NoPassword -Description "Test User Disabled 2 Description" -Disabled).SID
             }
         }
 
@@ -1400,7 +1400,7 @@ try {
         BeforeEach {
             if ($IsNotSkipped) {
                 New-LocalUser -Name TestUserEnabled1 -NoPassword -Disabled -Description "Test User Enabled 1 Description" | Out-Null
-                $enabledUser1SID = [String](Get-LocalUser -Name TestUserEnabled1).SID
+                $enabledUser1SID = [string](Get-LocalUser -Name TestUserEnabled1).SID
             }
         }
 
@@ -1432,10 +1432,10 @@ try {
 
         BeforeEach {
             if ($IsNotSkipped) {
-                $enabledUser1SID = [String](New-LocalUser -Name TestUserEnabled1 -NoPassword -Description "Test User Enabled 1 Description").SID
-                $enabledUser2SID = [String](New-LocalUser -Name TestUserEnabled2 -NoPassword -Description "Test User Enabled 2 Description").SID
-                $disabledUser1SID = [String](New-LocalUser -Name TestUserDisabled1 -NoPassword -Description "Test User Disabled 1 Description" -Disabled).SID
-                $disabledUser2SID = [String](New-LocalUser -Name TestUserDisabled2 -NoPassword -Description "Test User Disabled 2 Description" -Disabled).SID
+                $enabledUser1SID = [string](New-LocalUser -Name TestUserEnabled1 -NoPassword -Description "Test User Enabled 1 Description").SID
+                $enabledUser2SID = [string](New-LocalUser -Name TestUserEnabled2 -NoPassword -Description "Test User Enabled 2 Description").SID
+                $disabledUser1SID = [string](New-LocalUser -Name TestUserDisabled1 -NoPassword -Description "Test User Disabled 1 Description" -Disabled).SID
+                $disabledUser2SID = [string](New-LocalUser -Name TestUserDisabled2 -NoPassword -Description "Test User Disabled 2 Description" -Disabled).SID
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
 
   $testCases =
     @{ data = $null          ; value = 'null' },
-    @{ data = [String]::Empty; value = 'empty string' }
+    @{ data = [string]::Empty; value = 'empty string' }
 
   Context 'Check null or empty value to the -Name parameter' {
     It 'Should throw if <value> is passed to -Name parameter' -TestCases $testCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage2.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage2.Tests.ps1
@@ -7,7 +7,7 @@ using namespace System.Security.Cryptography
 function New-CmsRecipient {
     [CmdletBinding(SupportsShouldProcess = $true)]
     [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]
-    param([String]$Name, [Switch]$Invalid, [String]$OutPfxFile)
+    param([string]$Name, [Switch]$Invalid, [string]$OutPfxFile)
     $hash = [HashAlgorithmName]::SHA256
     $pad = [RSASignaturePadding]::Pkcs1
     $oids = [OidCollection]::new()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -213,7 +213,7 @@ Describe "Get-Alias null tests" -Tags "CI" {
 
   $testCases =
     @{ data = $null; value = 'null' },
-    @{ data = [String]::Empty; value = 'empty string' }
+    @{ data = [string]::Empty; value = 'empty string' }
 
   Context 'Check null or empty value to the -Name parameter' {
     It 'Should throw if <value> is passed to -Name parameter' -TestCases $testCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -121,14 +121,14 @@ Describe "Get-Command" -Tag CI {
         It "Should return a string object when -Name is an alias and -Syntax is specified" {
             $Result = Get-Command -Name del -Syntax
 
-            $Result | Should -BeOfType [String]
+            $Result | Should -BeOfType [string]
             $Result | Should -Match 'del \[-Path\]'
         }
 
         It "Should replace commands with aliases in matching commands when using a wildcard search" {
             $Result = Get-Command -Name sp* -Syntax
 
-            $Result | Should -BeOfType [String]
+            $Result | Should -BeOfType [string]
             $Result -join '' | Should -Match 'sp \(alias\) -> Set-ItemProperty'
             $Result -join '' | Should -Match 'sp \[-Path\]'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -357,7 +357,7 @@ Describe "Get-Date -UFormat tests" -Tags "CI" {
 
         $amUpper1 = [System.Globalization.CultureInfo]::CurrentCulture.DateTimeFormat.AMDesignator
         $amLower1 = [System.Globalization.CultureInfo]::CurrentCulture.DateTimeFormat.AMDesignator.ToLower()
-        $timeZone1 = [String]::Format("{0:+00;-00}", [Timezone]::CurrentTimeZone.GetUtcOffset( $date1 ).Hours)
+        $timeZone1 = [string]::Format("{0:+00;-00}", [Timezone]::CurrentTimeZone.GetUtcOffset( $date1 ).Hours)
     }
 
     It "Get-Date -UFormat <format> (<result>)" -TestCases @(

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -112,7 +112,7 @@ Describe "Invoke-Item basic tests" -Tags "Feature" {
             $beforeCount = Get-WindowCountMacOS -Name TextEdit
             Invoke-Item -Path $TestFile
             $startTime = Get-Date
-            $title = [String]::Empty
+            $title = [string]::Empty
             while (((Get-Date) - $startTime).TotalSeconds -lt 30 -and ($title -ne $expectedTitle))
             {
                 Start-Sleep -Milliseconds 100
@@ -249,7 +249,7 @@ Categories=Application;
                 Invoke-Item -Path $PSHOME
                 $startTime = Get-Date
                 $expectedTitle = Split-Path $PSHOME -Leaf
-                $title = [String]::Empty
+                $title = [string]::Empty
                 while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and ($title -ne $expectedTitle))
                 {
                     Start-Sleep -Milliseconds 100

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -424,35 +424,35 @@ Describe "Json Tests" -Tags "Feature" {
 				$result."date-upperO-should-parse-as-datetime" | Should -BeOfType [DateTime]
 
 				$result."date-o-should-parse-as-string" | Should -Be "2019-12-17T06:14:06 +06:00"
-				$result."date-o-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-o-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-f-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01 PM"
-				$result."date-f-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-f-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-g-should-parse-as-string" | Should -Be "9/22/2008 2:01 PM"
-				$result."date-g-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-g-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-m-should-parse-as-string" | Should -Be "September 22"
-				$result."date-m-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-m-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperM-should-parse-as-string" | Should -Be "September 22"
-				$result."date-upperM-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperM-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-t-should-parse-as-string" | Should -Be "2:01 PM"
-				$result."date-t-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-t-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-u-should-parse-as-string" | Should -Be "2008-09-22 14:01:54Z"
-				$result."date-u-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-u-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperD-should-parse-as-string" | Should -Be "Monday, September 22, 2008"
-				$result."date-upperD-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperD-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperF-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01:54 PM"
-				$result."date-upperF-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperF-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperG-should-parse-as-string" | Should -Be "9/22/2008 2:01:54 PM"
-				$result."date-upperG-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperG-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperR-should-parse-as-string" | Should -Be "Mon, 22 Sep 2008 14:01:54 GMT"
-				$result."date-upperR-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperR-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperT-should-parse-as-string" | Should -Be "2:01:54 PM"
-				$result."date-upperT-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperT-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperU-should-parse-as-string" | Should -Be "Monday, September 22, 2008 2:01:54 PM"
-				$result."date-upperU-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperU-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-upperY-should-parse-as-string" | Should -Be "September 2008"
-				$result."date-upperY-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-upperY-should-parse-as-string" | Should -BeOfType [string]
 				$result."date-y-should-parse-as-string" | Should -Be "September 2008"
-				$result."date-y-should-parse-as-string" | Should -BeOfType [String]
+				$result."date-y-should-parse-as-string" | Should -BeOfType [string]
 			}
 		}
 
@@ -506,26 +506,26 @@ Describe "Json Tests" -Tags "Feature" {
 "@
 			$result = ConvertFrom-Json $Json
 			$result."about"| Should -BeExactly "Ipsum pariatur nisi eiusmod aliquip in cupidatat. Deserunt non sit anim consectetur consectetur incididunt elit qui id proident nostrud. Consectetur pariatur et adipisicing aliquip fugiat fugiat Lorem reprehenderit laboris magna. Duis veniam irure amet ex minim eiusmod et laborum non elit. Dolor enim Lorem occaecat nisi consectetur mollit laborum anim velit et. Irure aliquip eiusmod anim proident ex ea duis deserunt aute amet adipisicing nisi nostrud. Minim ipsum fugiat consequat mollit fugiat tempor fugiat."
-			$result."about" | Should -BeOfType [String]
+			$result."about" | Should -BeOfType [string]
 			$result."address"| Should -BeExactly "931 Kings Place, Hartsville/Hartley, Federated States Of Micronesia, 9344"
-			$result."address" | Should -BeOfType [String]
+			$result."address" | Should -BeOfType [string]
 			$result."age" | Should -BeOfType [Int64]
 			$result."balance"| Should -BeExactly ",039.72"
-			$result."balance" | Should -BeOfType [String]
+			$result."balance" | Should -BeOfType [string]
 			$result."company"| Should -BeExactly "INSECTUS"
-			$result."company" | Should -BeOfType [String]
+			$result."company" | Should -BeOfType [string]
 			$result."email"| Should -BeExactly "rhodesroberson@insectus.com"
-			$result."email" | Should -BeOfType [String]
+			$result."email" | Should -BeOfType [string]
 			$result."eyeColor"| Should -BeExactly "green"
-			$result."eyeColor" | Should -BeOfType [String]
+			$result."eyeColor" | Should -BeOfType [string]
 			$result."favoriteFruit"| Should -BeExactly "banana"
-			$result."favoriteFruit" | Should -BeOfType [String]
+			$result."favoriteFruit" | Should -BeOfType [string]
 			$result."gender"| Should -BeExactly "male"
-			$result."gender" | Should -BeOfType [String]
+			$result."gender" | Should -BeOfType [string]
 			$result."greeting"| Should -BeExactly "Hello, Rhodes Roberson! You have 9 unread messages."
-			$result."greeting" | Should -BeOfType [String]
+			$result."greeting" | Should -BeOfType [string]
 			$result."guid"| Should -BeExactly "429b96a7-24e3-47de-a93b-f44a346c5ac9"
-			$result."guid" | Should -BeOfType [String]
+			$result."guid" | Should -BeOfType [string]
 			$result."index" | Should -BeOfType [Int64]
 			$result."isActive"| Should -Be False
 			$result."isActive" | Should -BeOfType [Boolean]
@@ -534,15 +534,15 @@ Describe "Json Tests" -Tags "Feature" {
 			$result."longitude"| Should -Be -47.522764
 			$result."longitude" | Should -BeOfType [Double]
 			$result."name"| Should -BeExactly "Rhodes Roberson"
-			$result."name" | Should -BeOfType [String]
+			$result."name" | Should -BeOfType [string]
 			$result."phone"| Should -BeExactly "+1 (883) 561-3999"
-			$result."phone" | Should -BeOfType [String]
+			$result."phone" | Should -BeOfType [string]
 			$result."picture"| Should -BeExactly "http://placehold.it/32x32"
-			$result."picture" | Should -BeOfType [String]
+			$result."picture" | Should -BeOfType [string]
 			$result."registered"| Should -BeExactly "2019-12-17T06:14:06 +06:00"
-			$result."registered" | Should -BeOfType [String]
+			$result."registered" | Should -BeOfType [string]
 			$result."_id"| Should -BeExactly "60dd3ea9253016932039a0a2"
-			$result."_id" | Should -BeOfType [String]
+			$result."_id" | Should -BeOfType [string]
 
 			$result.Tags | Should -BeOfType [string]
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
@@ -88,12 +88,12 @@ set-psbreakpoint -command foo
 
     It "Should throw Exception when missing mandatory parameter -line" -Pending {
          $output = & $ps -noninteractive -command "sbp -column 1 -script $scriptFileName"
-         [system.string]::Join(" ", $output) | Should -Match "MissingMandatoryParameter,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
+         [string]::Join(" ", $output) | Should -Match "MissingMandatoryParameter,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
     }
 
     It "Should throw Exception when missing mandatory parameter" -Pending {
          $output = & $ps -noprofile -noninteractive -command "sbp -line 1"
-         [system.string]::Join(" ", $output) | Should -Match "MissingMandatoryParameter,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
+         [string]::Join(" ", $output) | Should -Match "MissingMandatoryParameter,Microsoft.PowerShell.Commands.SetPSBreakpointCommand"
     }
 
     It "Should be able to set psbreakpoints for -command" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -92,7 +92,7 @@ function ExecuteRequestWithHeaders {
 function GetTestData {
     param (
         [ValidateSet("text/plain", "application/xml", "application/json")]
-        [String]
+        [string]
         $contentType
     )
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Write-Output DRT Unit Tests" -Tags "CI" {
         $results[2] -is [System.Array] | Should -BeTrue
 
         $results[3] | Should -Be $objectWritten[3]
-        $results[3] -is [System.String] | Should -BeTrue
+        $results[3] -is [string] | Should -BeTrue
     }
 
     It "Works with NoEnumerate switch" {

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -176,7 +176,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should record Write-Information output when InformationAction is set to Continue" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Information -Message $message -InformationAction Continue
@@ -191,7 +191,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should not record Write-Information output when InformationAction is set to SilentlyContinue" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $traceData = Join-Path $TESTDRIVE tracedata.txt
         $script = {
             Start-Transcript -Path $transcriptFilePath
@@ -207,7 +207,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should not record Write-Information output when InformationAction is set to Ignore" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Information -Message $message -InformationAction Ignore
@@ -222,7 +222,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should record Write-Information output in correct order when InformationAction is set to Inquire" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $newLine = [System.Environment]::NewLine
         $expectedContent = "$message$($newLine)Confirm$($newLine)Continue with this operation?"
         $script = {
@@ -240,7 +240,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should record Write-Host output when InformationAction is set to Continue" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Host -Message $message -InformationAction Continue
@@ -254,7 +254,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should record Write-Host output when InformationAction is set to SilentlyContinue" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Host -Message $message -InformationAction SilentlyContinue
@@ -268,7 +268,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should not record Write-Host output when InformationAction is set to Ignore" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Host -Message $message -InformationAction Ignore
@@ -282,7 +282,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should record Write-Host output in correct order when InformationAction is set to Inquire" {
-        [String]$message = New-Guid
+        [string]$message = New-Guid
         $newLine = [System.Environment]::NewLine
         $expectedContent = "$message$($newLine)Confirm$($newLine)Continue with this operation?"
         $script = {

--- a/test/powershell/Provider/AutomountSubstDrive.ps1
+++ b/test/powershell/Provider/AutomountSubstDrive.ps1
@@ -11,7 +11,7 @@ if ($useModule)
     $m = New-Module {
         function Test-DrivePresenceFromModule
         {
-            param ([String]$Path)
+            param ([string]$Path)
 
             & $global:CoreScriptPath -Path $Path
         }

--- a/test/powershell/Provider/AutomountSubstDriveCore.ps1
+++ b/test/powershell/Provider/AutomountSubstDriveCore.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-param ([String]$Path)
+param ([string]$Path)
 
 try
 {
@@ -14,7 +14,7 @@ try
     $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) { Write-Error "Creating drive with subst.exe failed with exit code $exitCode" }
 
-    $root = [String]::Format('{0}:\', $driveLetter)
+    $root = [string]::Format('{0}:\', $driveLetter)
     $pathToCheck = Join-Path -Path $root -ChildPath $dir.Name
 
     if (Test-Path $pathToCheck)

--- a/test/powershell/Provider/AutomountVHDDrive.ps1
+++ b/test/powershell/Provider/AutomountVHDDrive.ps1
@@ -24,7 +24,7 @@ if ($useModule)
     $m = New-Module {
         function Test-DrivePresenceFromModule
         {
-            param ([String]$Path)
+            param ([string]$Path)
 
             if (Test-Path $Path)
             {

--- a/test/powershell/engine/Basic/Attributes.Tests.ps1
+++ b/test/powershell/engine/Basic/Attributes.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Attribute tests" -Tags "CI" {
 [CmdletBinding()]
 Param (
 [Parameter($attribute="")]
-[String]`$Parameter1
+[string]`$Parameter1
 )
 Write-Output "Hello"
 "@

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -150,7 +150,7 @@ Describe "Command Discovery tests" -Tags "CI" {
         }
 
         It "Invoking <name> should return '<expectedResult>'" -TestCases $executionWithWildcardCases {
-            param($command, $expectedResult, [String]$Pending)
+            param($command, $expectedResult, [string]$Pending)
 
             if($Pending)
             {

--- a/test/powershell/engine/Formatting/BugFix.Tests.ps1
+++ b/test/powershell/engine/Formatting/BugFix.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
 
     It "Formatting for an object with no property/field should use 'ToString'" {
         class Empty {
-            [String]ToString() { return 'MyString' }
+            [string]ToString() { return 'MyString' }
         }
 
         $outstring = [Empty]::new() | Out-String
@@ -32,7 +32,7 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
     It "Formatting for an object with only hidden property should use 'ToString'" {
         class Hidden {
             hidden $Param = 'Foo'
-            [String]ToString() { return 'MyString' }
+            [string]ToString() { return 'MyString' }
         }
 
         $outstring = [Hidden]::new() | Out-String
@@ -49,7 +49,7 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
     It 'Formatting for an object with no-hidden property should use the default view' {
         class Params {
             $Param = 'Foo'
-            [String]ToString() { return 'MyString' }
+            [string]ToString() { return 'MyString' }
         }
 
         $outstring = [Params]::new() | Out-String

--- a/test/tools/Modules/HelpersRemoting/HelpersRemoting.psm1
+++ b/test/tools/Modules/HelpersRemoting/HelpersRemoting.psm1
@@ -138,7 +138,7 @@ function CreateParameters
     if ($Name) {
         if($CimSession.IsPresent)
         {
-            $parameters["Name"] = [String] $Name
+            $parameters["Name"] = [string] $Name
         }
         else
         {

--- a/test/tools/Modules/PSSysLog/PSSysLog.psm1
+++ b/test/tools/Modules/PSSysLog/PSSysLog.psm1
@@ -182,7 +182,7 @@ class PSLogItem
     [string] $EventId = [string]::Empty
     [string] $Message = [string]::Empty
     [int] $Count = 1
-    [System.Collections.Generic.List[String]]$ParseErrors = [System.Collections.Generic.List[string]]::new()
+    [System.Collections.Generic.List[string]]$ParseErrors = [System.Collections.Generic.List[string]]::new()
 
     hidden static $monthNames = @('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun','Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec')
 

--- a/test/tools/Modules/UnixSocket/UnixSocket.psm1
+++ b/test/tools/Modules/UnixSocket/UnixSocket.psm1
@@ -7,7 +7,7 @@ Class UnixSocket
 
     UnixSocket () { }
 
-    [String] GetStatus()
+    [string] GetStatus()
     {
         return $this.Job.JobStateInfo.State
     }

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -15,7 +15,7 @@ Class WebListener
 
     WebListener () { }
 
-    [String] GetStatus()
+    [string] GetStatus()
     {
         return $this.Job.JobStateInfo.State
     }
@@ -245,9 +245,9 @@ function Get-WebListenerUrl {
             'StallDeflate',
             '/'
         )]
-        [String]$Test,
+        [string]$Test,
 
-        [String]$TestValue,
+        [string]$TestValue,
 
         [System.Collections.IDictionary]$Query
     )

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -494,7 +494,7 @@ function Compare-CodeCoverage
         [Parameter(Mandatory=$true,Position=1,ParameterSetName="file")][string]$RunFile2,
         [Parameter(Mandatory=$true,Position=0,ParameterSetName="coverage")][Object]$Run1,
         [Parameter(Mandatory=$true,Position=1,ParameterSetName="coverage")][Object]$Run2,
-        [Parameter()][String[]]$ClassName,
+        [Parameter()][string[]]$ClassName,
         [Parameter()][switch]$Summary
         )
 

--- a/tools/findMissingNotices.ps1
+++ b/tools/findMissingNotices.ps1
@@ -39,7 +39,7 @@ Class Registration {
 
 Class Component {
     [ValidateSet("nuget")]
-    [String] $Type
+    [string] $Type
     [Nuget]$Nuget
 
     [string]ToString() {
@@ -92,7 +92,7 @@ if (!$IsWindows) {
 
 function ConvertTo-SemVer {
     param(
-        [String] $Version
+        [string] $Version
     )
 
     [System.Management.Automation.SemanticVersion]$desiredVersion = [System.Management.Automation.SemanticVersion]::Empty

--- a/tools/findMissingNotices.ps1
+++ b/tools/findMissingNotices.ps1
@@ -80,7 +80,7 @@ Class Registration {
 
 Class Component {
     [ValidateSet("nuget")]
-    [String] $Type
+    [string] $Type
     [Nuget]$Nuget
 
     [string]ToString() {
@@ -133,7 +133,7 @@ if (!$IsWindows) {
 
 function ConvertTo-SemVer {
     param(
-        [String] $Version
+        [string] $Version
     )
 
     [System.Management.Automation.SemanticVersion]$desiredVersion = [System.Management.Automation.SemanticVersion]::Empty

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1587,42 +1587,42 @@ function New-RpmSpec
 {
     param(
         [Parameter(Mandatory,HelpMessage='Package Name')]
-        [String]$Name,
+        [string]$Name,
 
         [Parameter(Mandatory,HelpMessage='Package Version')]
-        [String]$Version,
+        [string]$Version,
 
         [Parameter(Mandatory)]
-        [String]$Iteration,
+        [string]$Iteration,
 
         [Parameter(Mandatory,HelpMessage='Package description')]
-        [String]$Description,
+        [string]$Description,
 
         [Parameter(Mandatory,HelpMessage='Staging folder for installation files')]
-        [String]$Staging,
+        [string]$Staging,
 
         [Parameter(Mandatory,HelpMessage='Install path on target machine')]
-        [String]$Destination,
+        [string]$Destination,
 
         [Parameter(Mandatory,HelpMessage='The built and gzipped man file.')]
-        [String]$ManGzipFile,
+        [string]$ManGzipFile,
 
         [Parameter(Mandatory,HelpMessage='The destination of the man file')]
-        [String]$ManDestination,
+        [string]$ManDestination,
 
         [Parameter(Mandatory,HelpMessage='Symlink to powershell executable')]
         [LinkInfo[]]$LinkInfo,
 
         [Parameter(Mandatory,HelpMessage='Packages required to install this package')]
-        [String[]]$Dependencies,
+        [string[]]$Dependencies,
 
         [Parameter(Mandatory,HelpMessage='Script to run after the package installation.')]
-        [String]$AfterInstallScript,
+        [string]$AfterInstallScript,
 
         [Parameter(Mandatory,HelpMessage='Script to run after the package removal.')]
-        [String]$AfterRemoveScript,
+        [string]$AfterRemoveScript,
 
-        [String]$Distribution = 'rhel.7',
+        [string]$Distribution = 'rhel.7',
         [string]$HostArchitecture
     )
 
@@ -1746,40 +1746,40 @@ function New-NativeDeb
 {
     param(
         [Parameter(Mandatory, HelpMessage='Package Name')]
-        [String]$Name,
+        [string]$Name,
 
         [Parameter(Mandatory, HelpMessage='Package Version')]
-        [String]$Version,
+        [string]$Version,
 
         [Parameter(Mandatory)]
-        [String]$Iteration,
+        [string]$Iteration,
 
         [Parameter(Mandatory, HelpMessage='Package description')]
-        [String]$Description,
+        [string]$Description,
 
         [Parameter(Mandatory, HelpMessage='Staging folder for installation files')]
-        [String]$Staging,
+        [string]$Staging,
 
         [Parameter(Mandatory, HelpMessage='Install path on target machine')]
-        [String]$Destination,
+        [string]$Destination,
 
         [Parameter(Mandatory, HelpMessage='The built and gzipped man file.')]
-        [String]$ManGzipFile,
+        [string]$ManGzipFile,
 
         [Parameter(Mandatory, HelpMessage='The destination of the man file')]
-        [String]$ManDestination,
+        [string]$ManDestination,
 
         [Parameter(Mandatory, HelpMessage='Symlink to powershell executable')]
         [LinkInfo[]]$LinkInfo,
 
         [Parameter(HelpMessage='Packages required to install this package.')]
-        [String[]]$Dependencies,
+        [string[]]$Dependencies,
 
         [Parameter(HelpMessage='Script to run after the package installation.')]
-        [String]$AfterInstallScript,
+        [string]$AfterInstallScript,
 
         [Parameter(HelpMessage='Script to run after the package removal.')]
-        [String]$AfterRemoveScript,
+        [string]$AfterRemoveScript,
 
         [string]$HostArchitecture,
 
@@ -2348,7 +2348,7 @@ function New-MacOSLauncher
 {
     param(
         [Parameter(Mandatory)]
-        [String]$Version,
+        [string]$Version,
 
         [switch]$LTS
     )
@@ -3626,7 +3626,7 @@ function New-SubFolder
         [string]
         $Path,
 
-        [String]
+        [string]
         $ChildPath,
 
         [switch]
@@ -5008,7 +5008,7 @@ function Invoke-AzDevOpsLinuxPackageCreation {
 
         [Parameter(Mandatory)]
         [ValidateSet('fxdependent', 'alpine', 'deb', 'rpm')]
-        [String]$BuildType
+        [string]$BuildType
     )
 
     if (!${env:SYSTEM_ARTIFACTSDIRECTORY}) {
@@ -5124,7 +5124,7 @@ function Invoke-AzDevOpsLinuxPackageBuild {
 
         [Parameter(Mandatory)]
         [ValidateSet('fxdependent', 'alpine', 'deb', 'rpm')]
-        [String]$BuildType
+        [string]$BuildType
     )
 
     if (!${env:SYSTEM_ARTIFACTSDIRECTORY}) {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1520,42 +1520,42 @@ function New-RpmSpec
 {
     param(
         [Parameter(Mandatory,HelpMessage='Package Name')]
-        [String]$Name,
+        [string]$Name,
 
         [Parameter(Mandatory,HelpMessage='Package Version')]
-        [String]$Version,
+        [string]$Version,
 
         [Parameter(Mandatory)]
-        [String]$Iteration,
+        [string]$Iteration,
 
         [Parameter(Mandatory,HelpMessage='Package description')]
-        [String]$Description,
+        [string]$Description,
 
         [Parameter(Mandatory,HelpMessage='Staging folder for installation files')]
-        [String]$Staging,
+        [string]$Staging,
 
         [Parameter(Mandatory,HelpMessage='Install path on target machine')]
-        [String]$Destination,
+        [string]$Destination,
 
         [Parameter(Mandatory,HelpMessage='The built and gzipped man file.')]
-        [String]$ManGzipFile,
+        [string]$ManGzipFile,
 
         [Parameter(Mandatory,HelpMessage='The destination of the man file')]
-        [String]$ManDestination,
+        [string]$ManDestination,
 
         [Parameter(Mandatory,HelpMessage='Symlink to powershell executable')]
         [LinkInfo[]]$LinkInfo,
 
         [Parameter(Mandatory,HelpMessage='Packages required to install this package')]
-        [String[]]$Dependencies,
+        [string[]]$Dependencies,
 
         [Parameter(Mandatory,HelpMessage='Script to run after the package installation.')]
-        [String]$AfterInstallScript,
+        [string]$AfterInstallScript,
 
         [Parameter(Mandatory,HelpMessage='Script to run after the package removal.')]
-        [String]$AfterRemoveScript,
+        [string]$AfterRemoveScript,
 
-        [String]$Distribution = 'rhel.7',
+        [string]$Distribution = 'rhel.7',
         [string]$HostArchitecture
     )
 
@@ -1679,40 +1679,40 @@ function New-NativeDeb
 {
     param(
         [Parameter(Mandatory, HelpMessage='Package Name')]
-        [String]$Name,
+        [string]$Name,
 
         [Parameter(Mandatory, HelpMessage='Package Version')]
-        [String]$Version,
+        [string]$Version,
 
         [Parameter(Mandatory)]
-        [String]$Iteration,
+        [string]$Iteration,
 
         [Parameter(Mandatory, HelpMessage='Package description')]
-        [String]$Description,
+        [string]$Description,
 
         [Parameter(Mandatory, HelpMessage='Staging folder for installation files')]
-        [String]$Staging,
+        [string]$Staging,
 
         [Parameter(Mandatory, HelpMessage='Install path on target machine')]
-        [String]$Destination,
+        [string]$Destination,
 
         [Parameter(Mandatory, HelpMessage='The built and gzipped man file.')]
-        [String]$ManGzipFile,
+        [string]$ManGzipFile,
 
         [Parameter(Mandatory, HelpMessage='The destination of the man file')]
-        [String]$ManDestination,
+        [string]$ManDestination,
 
         [Parameter(Mandatory, HelpMessage='Symlink to powershell executable')]
         [LinkInfo[]]$LinkInfo,
 
         [Parameter(HelpMessage='Packages required to install this package.')]
-        [String[]]$Dependencies,
+        [string[]]$Dependencies,
 
         [Parameter(HelpMessage='Script to run after the package installation.')]
-        [String]$AfterInstallScript,
+        [string]$AfterInstallScript,
 
         [Parameter(HelpMessage='Script to run after the package removal.')]
-        [String]$AfterRemoveScript,
+        [string]$AfterRemoveScript,
 
         [string]$HostArchitecture,
 
@@ -2287,7 +2287,7 @@ function New-MacOSLauncher
 {
     param(
         [Parameter(Mandatory)]
-        [String]$Version,
+        [string]$Version,
 
         [switch]$LTS
     )
@@ -3299,7 +3299,7 @@ function New-SubFolder
         [string]
         $Path,
 
-        [String]
+        [string]
         $ChildPath,
 
         [switch]

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -509,7 +509,7 @@ function Get-ChangeLogMessage
 function Get-NewOfficalPackage
 {
     param(
-        [String]
+        [string]
         $Path = (Join-Path -Path $PSScriptRoot -ChildPath '..\src'),
         [Switch]
         $IncludeAll
@@ -691,15 +691,15 @@ function Update-PsVersionInCode
     param(
         [Parameter(Mandatory)]
         [ValidatePattern("^v\d+\.\d+\.\d+(-\w+(\.\d{1,2})?)?$")]
-        [String]
+        [string]
         $NewReleaseTag,
 
         [Parameter(Mandatory)]
         [ValidatePattern("^v\d+\.\d+\.\d+(-\w+(\.\d{1,2})?)?$")]
-        [String]
+        [string]
         $NextReleaseTag,
 
-        [String]
+        [string]
         $Path = (Join-Path -Path $PSScriptRoot -ChildPath '..')
     )
 
@@ -777,7 +777,7 @@ function Test-GitHubCliVersion {
 function Get-PRBackportReport {
     param(
         [ValidateSet('Consider', 'Approved', 'Done')]
-        [String] $TriageState = 'Approved',
+        [string] $TriageState = 'Approved',
         [ValidatePattern('^\d+\.\d+$')]
         [string] $Version,
         [switch] $Web


### PR DESCRIPTION
Use the `[string]` type accelerator to simplify references to the `System.String` class.

This also aligns with the canonical lowercase capitalization used for the type accelerator:

https://github.com/PowerShell/PowerShell/blob/b664c2e026d1610e9b5a6cc5b14d3c86aae9ab81/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1#L210-L211

Contributes to https://github.com/PowerShell/PowerShell/issues/25952.
