### PR TITLE
Use `[bool]` type accelerator

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -3547,7 +3547,7 @@ function New-PSOptionsObject
         $Configuration,
 
         [Parameter(Mandatory)]
-        [Bool]
+        [bool]
         $PSModuleRestore,
 
         [Parameter(Mandatory)]
@@ -3559,7 +3559,7 @@ function New-PSOptionsObject
         $Output,
 
         [Parameter(Mandatory)]
-        [Bool]
+        [bool]
         $ForMinimalSize
     )
 

--- a/build.psm1
+++ b/build.psm1
@@ -4303,7 +4303,7 @@ function New-PSOptionsObject
         $Configuration,
 
         [Parameter(Mandatory)]
-        [Bool]
+        [bool]
         $PSModuleRestore,
 
         [Parameter(Mandatory)]
@@ -4315,7 +4315,7 @@ function New-PSOptionsObject
         $Output,
 
         [Parameter(Mandatory)]
-        [Bool]
+        [bool]
         $ForMinimalSize
     )
 

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -6661,7 +6661,7 @@ namespace System.Management.Automation.Language
             //              $ConfigurationData, # a collection of property bags describe the configuration environment
             //          [string]
             //              $InstanceName = ""  # THe name of the configuration instance being created.
-            //          [boolean]
+            //          [bool]
             //               $IsMetaConfig = $false # the configuration to generated is a meta configuration
             //      )
             //   }

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -302,7 +302,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
         function get-foo
         {
             param([Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)] $a,
-                  [System.Boolean] $b)
+                  [bool] $b)
             $a
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -161,8 +161,8 @@ try
                     param (
                         [string] $SessionConfigName,
                         [string] $ConfigFilePath,
-                        [Bool] $InitialSessionStateEnabled,
-                        [Bool] $FinalSessionStateEnabled,
+                        [bool] $InitialSessionStateEnabled,
+                        [bool] $FinalSessionStateEnabled,
                         [string] $TestDescription,
                         [bool] $EnablePSSessionConfig)
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -528,7 +528,7 @@ Describe "Json Tests" -Tags "Feature" {
 			$result."guid" | Should -BeOfType [String]
 			$result."index" | Should -BeOfType [Int64]
 			$result."isActive"| Should -Be False
-			$result."isActive" | Should -BeOfType [Boolean]
+			$result."isActive" | Should -BeOfType [bool]
 			$result."latitude"| Should -Be 51.890798
 			$result."latitude" | Should -BeOfType [Double]
 			$result."longitude"| Should -Be -47.522764


### PR DESCRIPTION
Use the `[bool]` type accelerator to simplify references to the `System.Boolean` class.

This also aligns with the canonical lowercase capitalization used for the type accelerator:

https://github.com/PowerShell/PowerShell/blob/b664c2e026d1610e9b5a6cc5b14d3c86aae9ab81/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1#L42-L43

Contributes to https://github.com/PowerShell/PowerShell/issues/25952.

