### PR TITLE
Use `[datetime]` type accelerator

### DIFF
--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -114,7 +114,7 @@ jobs:
 
         $dateYear = & $toolPath -c '(Get-Date).Year'
 
-        if ( $dateYear -ne [DateTime]::Now.Year)
+        if ( $dateYear -ne [datetime]::Now.Year)
         {
             throw "Get-Date returned incorrect year: $dateYear"
         }

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -147,7 +147,7 @@ jobs:
 
         $dateYear = & $toolPath -c '(Get-Date).Year'
 
-        if ( $dateYear -ne [DateTime]::Now.Year)
+        if ( $dateYear -ne [datetime]::Now.Year)
         {
             throw "Get-Date returned incorrect year: $dateYear"
         }

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -2083,7 +2083,7 @@ namespace System.Management.Automation
                         //       [CmdletBinding()]
                         //       param(
                         //          [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-                        //          [System.DateTime]
+                        //          [datetime]
                         //          $Date,
                         //          [Parameter(ParameterSetName="computer")]
                         //          [Parameter(ParameterSetName="session")]
@@ -2111,7 +2111,7 @@ namespace System.Management.Automation
                         //          [Parameter(ParameterSetName="new")]
                         //          $NewName,
                         //          [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-                        //          [System.DateTime]
+                        //          [datetime]
                         //          $Date,
                         //          [Parameter(ParameterSetName="computer")]
                         //          [Parameter(ParameterSetName="session")]
@@ -2149,7 +2149,7 @@ namespace System.Management.Automation
                         //           $DisableComputer,
                         //
                         //           [Parameter(ParameterSetName="session", ValueFromPipeline=$true)]
-                        //           [DateTime]
+                        //           [datetime]
                         //           $Date
                         //        )
                         //
@@ -2186,7 +2186,7 @@ namespace System.Management.Automation
                         //          $Param,
                         //
                         //          [Parameter(ValueFromPipeline=$true)]
-                        //          [DateTime]
+                        //          [datetime]
                         //          $Date
                         //       )
 

--- a/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
@@ -3218,7 +3218,7 @@ namespace System.Management.Automation.Runspaces
           # WMI team fixed the formatting issue related to InstalledOn
           # property in Windows7 (to return string)..so returning the WMI's
           # version directly
-           [DateTime]::Parse($this.psBase.properties[""InstalledOn""].Value, [System.Globalization.DateTimeFormatInfo]::new())
+           [datetime]::Parse($this.psBase.properties[""InstalledOn""].Value, [System.Globalization.DateTimeFormatInfo]::new())
           }
           else
           {
@@ -8011,7 +8011,7 @@ namespace System.Management.Automation.Runspaces
           # WMI team fixed the formatting issue related to InstalledOn
           # property in Windows7 (to return string)..so returning the WMI's
           # version directly
-          [DateTime]::Parse($this.psBase.CimInstanceProperties[""InstalledOn""].Value, [System.Globalization.DateTimeFormatInfo]::new())
+          [datetime]::Parse($this.psBase.CimInstanceProperties[""InstalledOn""].Value, [System.Globalization.DateTimeFormatInfo]::new())
           }
           else
           {

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -9820,7 +9820,7 @@ namespace System.Management.Automation.Language
 
     /// <summary>
     /// The ast that represents a double quoted string (here string or normal string) and can have nested variable
-    /// references or sub-expressions, e.g. <c>"Name: $name`nAge: $([DateTime]::Now.Year - $dob.Year)"</c>.
+    /// references or sub-expressions, e.g. <c>"Name: $name`nAge: $([datetime]::Now.Year - $dob.Year)"</c>.
     /// </summary>
     public class ExpandableStringExpressionAst : ExpressionAst
     {

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -1453,7 +1453,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// This collection holds any tokens from variable references and sub-expressions within the string.
         /// For example:
-        ///     "In $([DateTime]::Now.Year - $age), $name was born"
+        ///     "In $([datetime]::Now.Year - $age), $name was born"
         /// has a nested expression with a sequence of tokens, plus the variable reference $name.
         /// </summary>
         public ReadOnlyCollection<Token> NestedTokens

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -327,7 +327,7 @@ Path:.*
 
             [string] $contentFile = Join-Path -Path $workingDirectory -ChildPath ('pwsh.log.txt')
             # get log items after current time.
-            [DateTime] $after = [DateTime]::Now
+            [datetime] $after = [datetime]::Now
         }
     }
 
@@ -342,7 +342,7 @@ Path:.*
 
     It 'Verifies basic logging with no customizations' -Skip:(!$IsMacOS) {
         try {
-            $timeString = [DateTime]::Now.ToString('yyyy-MM-dd HH:mm:ss')
+            $timeString = [datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')
             $configFile = WriteLogSettings -LogId $logId
             copy-item $configFile /tmp/pwshtest.config.json
             $testPid = & $powershell -NoProfile -SettingsFile $configFile -Command '$PID'
@@ -480,7 +480,7 @@ Describe 'Basic EventLog tests on Windows' -Tag @('CI','RequireAdminOnWindows') 
             $logName = 'PowerShellCore'
 
             # get log items after current time.
-            [DateTime] $after = [DateTime]::Now
+            [datetime] $after = [datetime]::Now
             Clear-PSEventLog -Name "$logName/Operational"
         }
     }

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -299,8 +299,8 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
                     $testValues1 = "Test11","TestString11","Test22"
                     $testValues2 = "Test11","TestString22","Test22"
 
-                    $currentTime = [DateTime]::Now
-                    if ([DateTime]::Compare([GenValuesForParamCache1]::cacheTime, $currentTime) -le 0)
+                    $currentTime = [datetime]::Now
+                    if ([datetime]::Compare([GenValuesForParamCache1]::cacheTime, $currentTime) -le 0)
                     {
                         $testValues = $testValues1;
                     }
@@ -311,7 +311,7 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
                     return [string[]]$testValues
                 }
 
-                static [DateTime] $cacheTime = [DateTime]::Now.AddSeconds(2);
+                static [datetime] $cacheTime = [datetime]::Now.AddSeconds(2);
             }
 
             function Get-TestValidateSetPS4

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Enter-PSHostProcess.Tests.ps1
@@ -10,7 +10,7 @@ function Wait-JobPid {
 
     # This is to prevent hanging in the test.
     # Some test environments (such as raspberry_pi) require more time for background job to run.
-    $startTime = [DateTime]::Now
+    $startTime = [datetime]::Now
     $TimeoutInMilliseconds = 60000
 
     # This will receive the pid of the Job process and nothing more since that was the only thing written to the pipeline.
@@ -18,7 +18,7 @@ function Wait-JobPid {
         Start-Sleep -Seconds 1
         $pwshId = Receive-Job $Job
 
-        if (([DateTime]::Now - $startTime).TotalMilliseconds -gt $timeoutInMilliseconds) {
+        if (([datetime]::Now - $startTime).TotalMilliseconds -gt $timeoutInMilliseconds) {
             throw "Unable to receive PowerShell process id."
         }
     } while (!$pwshId)

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -237,11 +237,11 @@ function DateTimesAreEqualish
     param (
         [Parameter(Mandatory=$true)]
         [ValidateNotNull()]
-        [DateTime]
+        [datetime]
         $dtA,
         [Parameter(Mandatory)]
         [ValidateNotNull()]
-        [DateTime]
+        [datetime]
         $dtB
     )
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -220,7 +220,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.AccountExpires | Should -Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([datetime]$expiration)
         }
 
         It "Can set AccountExpires to the past" {
@@ -232,7 +232,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.AccountExpires | Should -Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([datetime]$expiration)
         }
 
         It "Errors on AccountExpires being set to invalid date" {
@@ -561,7 +561,7 @@ try {
             $result = New-LocalUser TestUserGet3 -NoPassword -AccountExpires $AccountExpires -Description $Description -Disabled -FullName $FullName -UserMayNotChangePassword
 
             $result.Name | Should -BeExactly $Name
-            $result.AccountExpires | Should -Be ([DateTime]$AccountExpires)
+            $result.AccountExpires | Should -Be ([datetime]$AccountExpires)
             $result.Description | Should -BeExactly $Description
             $result.Enabled | Should -BeFalse
             $result.FullName | Should -BeExactly $FullName
@@ -670,7 +670,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.AccountExpires | Should -Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([datetime]$expiration)
         }
 
         It "Can set AccountExpires to the past" {
@@ -683,7 +683,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -Be User
-            $result.AccountExpires | Should -Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([datetime]$expiration)
         }
 
         It "Errors on AccountExpires being set to invalid date" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -173,7 +173,7 @@ c                              3
         }
         @{
             Value = '"1970-01-01T00:00:00"'
-            Expected = ([DateTime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Unspecified'))
+            Expected = ([datetime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Unspecified'))
         }
         @{
             Value = '"1970-01-01T00:00:00.0000000Z"'
@@ -199,12 +199,12 @@ c                              3
         param ($Value, $Expected)
 
         $json = $Value | ConvertFrom-Json
-        $json | Should -BeOfType ([DateTime])
+        $json | Should -BeOfType ([datetime])
         $json.Kind | Should -Be $Expected.Kind
         $json | Should -Be $Expected
 
         $json = $Value | ConvertFrom-Json -DateKind Default
-        $json | Should -BeOfType ([DateTime])
+        $json | Should -BeOfType ([datetime])
         $json.Kind | Should -Be $Expected.Kind
         $json | Should -Be $Expected
     }
@@ -220,7 +220,7 @@ c                              3
         }
         @{
             Value = '"1970-01-01T00:00:00"'
-            Expected = ([DateTime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Local'))
+            Expected = ([datetime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Local'))
         }
         @{
             Value = '"1970-01-01T00:00:00.0000000Z"'
@@ -246,7 +246,7 @@ c                              3
         param ($Value, $Expected)
 
         $json = $Value | ConvertFrom-Json -DateKind Local
-        $json | Should -BeOfType ([DateTime])
+        $json | Should -BeOfType ([datetime])
         $json.Kind | Should -Be Local
         $json | Should -Be $Expected
     }
@@ -262,7 +262,7 @@ c                              3
         }
         @{
             Value = '"1970-01-01T00:00:00"'
-            Expected = ([DateTime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Utc'))
+            Expected = ([datetime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Utc'))
         }
         @{
             Value = '"1970-01-01T00:00:00.0000000Z"'
@@ -288,7 +288,7 @@ c                              3
         param ($Value, $Expected)
 
         $json = $Value | ConvertFrom-Json -DateKind Utc
-        $json | Should -BeOfType ([DateTime])
+        $json | Should -BeOfType ([datetime])
         $json.Kind | Should -Be Utc
         $json | Should -Be $Expected
     }
@@ -304,7 +304,7 @@ c                              3
         }
         @{
             Value = '"1970-01-01T00:00:00"'
-            Expected = ([DateTimeOffset]::new([DateTime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Local')))
+            Expected = ([DateTimeOffset]::new([datetime]::new(1970, 1, 1, 0, 0, 0, 0, 0, 'Local')))
         }
         @{
             Value = '"1970-01-01T00:00:00.0000000Z"'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -134,7 +134,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
     It 'Should not serialize ETS properties added to DateTime' {
         $date = "2021-06-24T15:54:06.796999-07:00"
-        $d = [DateTime]::Parse($date)
+        $d = [datetime]::Parse($date)
 
         # need to use wildcard here due to some systems may be configured with different culture setting showing time in different format
         $d | ConvertTo-Json -Compress | Should -BeLike '"2021-06-24T*'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -134,7 +134,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
     It 'Should not serialize ETS properties added to DateTime' {
         $date = "2021-06-24T15:54:06.796999-07:00"
-        $d = [DateTime]::Parse($date)
+        $d = [datetime]::Parse($date)
 
         # need to use wildcard here due to some systems may be configured with different culture setting showing time in different format
         $d | ConvertTo-Json -Compress | Should -BeLike '"2021-06-24T*'
@@ -251,7 +251,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
     Context 'DateTime and related types' {
         It 'Should serialize DateTime with UTC kind via Pipeline and InputObject' {
-            $dt = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc)
+            $dt = [datetime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc)
             $jsonPipeline = $dt | ConvertTo-Json -Compress
             $jsonInputObject = ConvertTo-Json -InputObject $dt -Compress
             $jsonPipeline | Should -BeExactly '"2024-06-15T10:30:00Z"'
@@ -259,7 +259,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should serialize DateTime with Local kind' {
-            $dt = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Local)
+            $dt = [datetime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Local)
             $json = $dt | ConvertTo-Json -Compress
             $offset = $dt.ToString('zzz')
             $expected = '"2024-06-15T10:30:00' + $offset + '"'
@@ -267,7 +267,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should serialize DateTime with Unspecified kind via Pipeline and InputObject' {
-            $dt = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Unspecified)
+            $dt = [datetime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Unspecified)
             $jsonPipeline = $dt | ConvertTo-Json -Compress
             $jsonInputObject = ConvertTo-Json -InputObject $dt -Compress
             $jsonPipeline | Should -BeExactly '"2024-06-15T10:30:00"'
@@ -301,7 +301,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should ignore ETS properties on DateTime' {
-            $dt = [DateTime]::new(2024, 6, 15, 0, 0, 0, [DateTimeKind]::Utc)
+            $dt = [datetime]::new(2024, 6, 15, 0, 0, 0, [DateTimeKind]::Utc)
             $dt = Add-Member -InputObject $dt -MemberType NoteProperty -Name MyProp -Value 'test' -PassThru
             $json = $dt | ConvertTo-Json -Compress
             $json | Should -BeExactly '"2024-06-15T00:00:00Z"'
@@ -556,7 +556,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should serialize hashtable with <TypeName> value correctly' -TestCases @(
-            @{ TypeName = 'DateTime'; Value = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc); Expected = '{"val":"2024-06-15T10:30:00Z"}' }
+            @{ TypeName = 'DateTime'; Value = [datetime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc); Expected = '{"val":"2024-06-15T10:30:00Z"}' }
             @{ TypeName = 'Guid'; Value = [Guid]'12345678-1234-1234-1234-123456789abc'; Expected = '{"val":"12345678-1234-1234-1234-123456789abc"}' }
             @{ TypeName = 'Enum'; Value = [DayOfWeek]::Monday; Expected = '{"val":1}' }
             @{ TypeName = 'Uri'; Value = [Uri]'https://example.com'; Expected = '{"val":"https://example.com"}' }
@@ -727,8 +727,8 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should serialize array with DateTime elements correctly via Pipeline and InputObject' {
-            $date1 = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc)
-            $date2 = [DateTime]::new(2024, 12, 25, 0, 0, 0, [DateTimeKind]::Utc)
+            $date1 = [datetime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc)
+            $date2 = [datetime]::new(2024, 12, 25, 0, 0, 0, [DateTimeKind]::Utc)
             $arr = @($date1, $date2)
             $expected = '["2024-06-15T10:30:00Z","2024-12-25T00:00:00Z"]'
             $jsonPipeline = ,$arr | ConvertTo-Json -Compress
@@ -956,7 +956,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
     Context 'Dictionary with complex values' {
         It 'Should serialize hashtable with DateTime value correctly via Pipeline and InputObject' {
-            $hash = @{ date = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc) }
+            $hash = @{ date = [datetime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc) }
             $jsonPipeline = $hash | ConvertTo-Json -Compress
             $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
             $jsonPipeline | Should -BeExactly '{"date":"2024-06-15T10:30:00Z"}'
@@ -1109,7 +1109,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
         It 'Should serialize PSCustomObject with DateTime property via Pipeline and InputObject' {
             $obj = [PSCustomObject]@{
-                Date = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc)
+                Date = [datetime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc)
             }
             $expected = '{"Date":"2024-06-15T10:30:00Z"}'
             $jsonPipeline = $obj | ConvertTo-Json -Compress

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -238,7 +238,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
     It "Get-date works with pipeline input" {
         $x = New-Object System.Management.Automation.PSObject
-        $x | Add-Member NoteProperty Date ([DateTime]::Now)
+        $x | Add-Member NoteProperty Date ([datetime]::Now)
         $y = @($x,$x)
         ($y | Get-Date).Length | Should -Be 2
     }
@@ -315,7 +315,7 @@ Describe "Get-Date" -Tags "CI" {
     }
 
     It "Should check that Get-Date can return the correct datetime from the system time" {
-        $timeDifference = $(Get-Date).Subtract([System.DateTime]::Now)
+        $timeDifference = $(Get-Date).Subtract([datetime]::Now)
 
         $timeDifference.Days         | Should -Be 0
         $timeDifference.Hours        | Should -Be 0
@@ -331,7 +331,7 @@ Describe "Get-Date" -Tags "CI" {
     ) {
         param(
             [long] $UnixTimeSeconds,
-            [DateTime] $Expected
+            [datetime] $Expected
         )
 
         Get-Date -UnixTimeSeconds $UnixTimeSeconds | Should -Be $Expected

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -930,7 +930,7 @@ try
                 Invoke-Command -Session $session -Scriptblock {
                     function foo {
                         param(
-                            [DateTime]
+                            [datetime]
                             [parameter(ValueFromPipeline = $true)]
                             $date,
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -400,7 +400,7 @@ Describe "Json Tests" -Tags "Feature" {
 				$result."date-s-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
 				$result."date-s-should-parse-as-datetime".ToString("Y") | Should -Be "September 2008"
 				$result."date-s-should-parse-as-datetime".ToString("y") | Should -Be "September 2008"
-				$result."date-s-should-parse-as-datetime" | Should -BeOfType [DateTime]
+				$result."date-s-should-parse-as-datetime" | Should -BeOfType [datetime]
 
                 $result."date-upperO-should-parse-as-datetime" = [datetime]::SpecifyKind($result."date-upperO-should-parse-as-datetime", [System.DateTimeKind]::Utc)
 				$result."date-upperO-should-parse-as-datetime".ToString("d") | Should -Be "9/22/2008"
@@ -421,7 +421,7 @@ Describe "Json Tests" -Tags "Feature" {
 				$result."date-upperO-should-parse-as-datetime".ToString("U") | Should -Be "Monday, September 22, 2008 2:01:54 PM"
 				$result."date-upperO-should-parse-as-datetime".ToString("Y") | Should -Be "September 2008"
 				$result."date-upperO-should-parse-as-datetime".ToString("y") | Should -Be "September 2008"
-				$result."date-upperO-should-parse-as-datetime" | Should -BeOfType [DateTime]
+				$result."date-upperO-should-parse-as-datetime" | Should -BeOfType [datetime]
 
 				$result."date-o-should-parse-as-string" | Should -Be "2019-12-17T06:14:06 +06:00"
 				$result."date-o-should-parse-as-string" | Should -BeOfType [String]

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceBreakpointManagement.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/RunspaceBreakpointManagement.Tests.ps1
@@ -143,9 +143,9 @@ Describe 'Runspace Breakpoint Unit Tests - Feature-Enabled' -Tags 'CI' {
         }
 
         It 'Breakpoints are triggered by the remote debugger' {
-            $startTime = [DateTime]::UtcNow
+            $startTime = [datetime]::UtcNow
             $maxTimeToWait = [TimeSpan]'00:00:20'
-            while ($job.State -ne 'AtBreakpoint' -and ([DateTime]::UtcNow - $startTime) -lt $maxTimeToWait) {
+            while ($job.State -ne 'AtBreakpoint' -and ([datetime]::UtcNow - $startTime) -lt $maxTimeToWait) {
                 Start-Sleep -Milliseconds 100 # Give the job a bit of time to hit a breakpoint
             }
             $job.State | Should -Be 'AtBreakpoint'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Sort-Object.Tests.ps1
@@ -89,9 +89,9 @@ Describe "Sort-Object DRT Unit Tests" -Tags "CI" {
 	It "Sort-Object with HistoryInfo object should work"{
 		Add-Type -TypeDefinition "public enum PipelineState{NotStarted,Running,Stopping,Stopped,Completed,Failed,Disconnected}"
 
-		$historyInfo1 = [pscustomobject]@{"PipelineId"=1; "Cmdline"="cmd3"; "Status"=[PipelineState]::Completed; "StartTime" = [DateTime]::Now;"EndTime" = [DateTime]::Now.AddSeconds(5.0);}
-		$historyInfo2 = [pscustomobject]@{"PipelineId"=2; "Cmdline"="cmd1"; "Status"=[PipelineState]::Completed; "StartTime" = [DateTime]::Now;"EndTime" = [DateTime]::Now.AddSeconds(5.0);}
-		$historyInfo3 = [pscustomobject]@{"PipelineId"=3; "Cmdline"="cmd2"; "Status"=[PipelineState]::Completed; "StartTime" = [DateTime]::Now;"EndTime" = [DateTime]::Now.AddSeconds(5.0);}
+		$historyInfo1 = [pscustomobject]@{"PipelineId"=1; "Cmdline"="cmd3"; "Status"=[PipelineState]::Completed; "StartTime" = [datetime]::Now;"EndTime" = [datetime]::Now.AddSeconds(5.0);}
+		$historyInfo2 = [pscustomobject]@{"PipelineId"=2; "Cmdline"="cmd1"; "Status"=[PipelineState]::Completed; "StartTime" = [datetime]::Now;"EndTime" = [datetime]::Now.AddSeconds(5.0);}
+		$historyInfo3 = [pscustomobject]@{"PipelineId"=3; "Cmdline"="cmd2"; "Status"=[PipelineState]::Completed; "StartTime" = [datetime]::Now;"EndTime" = [datetime]::Now.AddSeconds(5.0);}
 
 		$historyInfos = @($historyInfo1,$historyInfo2,$historyInfo3)
 
@@ -296,7 +296,7 @@ Describe 'Sort-Object Stable Unit Tests' -Tags 'CI' {
 			$results[1]  | Should -Be 1
 			$results[2]  | Should -Be 3
 		}
-		
+
 		It "Sort-Object with Unique Stable should return proper records"{
 			$Record1=[PSCustomObject]@{Key="A";Record="A1"}
 			$Record2=[PSCustomObject]@{Key="A";Record="A2"}
@@ -304,7 +304,7 @@ Describe 'Sort-Object Stable Unit Tests' -Tags 'CI' {
 			$Record4=[PSCustomObject]@{Key="B";Record="B2"}
 			$Records = @($Record1,$Record2,$Record3,$Record4)
 			$results = $Records | Sort-Object -Stable -Unique -Property Key
-	
+
 			$results[0] | Should -Be $Records[0]
 			$results[1] | Should -Be $Records[2]
 		}
@@ -496,9 +496,9 @@ Describe 'Sort-Object Top and Bottom Unit Tests' -Tags 'CI' {
 
 		Add-Type -TypeDefinition 'public enum PipelineState{NotStarted,Running,Stopping,Stopped,Completed,Failed,Disconnected}'
 		$unsortedData = @(
-			[pscustomobject]@{PipelineId=1;Cmdline='cmd3';Status=[PipelineState]::Completed;StartTime=[DateTime]::Now;EndTime=[DateTime]::Now.AddSeconds(5.0)}
-			[pscustomobject]@{PipelineId=2;Cmdline='cmd1';Status=[PipelineState]::Completed;StartTime=[DateTime]::Now;EndTime=[DateTime]::Now.AddSeconds(5.0)}
-			[pscustomobject]@{PipelineId=3;Cmdline='cmd2';Status=[PipelineState]::Completed;StartTime=[DateTime]::Now;EndTime=[DateTime]::Now.AddSeconds(5.0)}
+			[pscustomobject]@{PipelineId=1;Cmdline='cmd3';Status=[PipelineState]::Completed;StartTime=[datetime]::Now;EndTime=[datetime]::Now.AddSeconds(5.0)}
+			[pscustomobject]@{PipelineId=2;Cmdline='cmd1';Status=[PipelineState]::Completed;StartTime=[datetime]::Now;EndTime=[datetime]::Now.AddSeconds(5.0)}
+			[pscustomobject]@{PipelineId=3;Cmdline='cmd2';Status=[PipelineState]::Completed;StartTime=[datetime]::Now;EndTime=[datetime]::Now.AddSeconds(5.0)}
 		)
 
 		It 'Return the <nSortType> N sorted in <orderType> order' -TestCases $topBottomAscendingDescending {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Trace-Command" -tags "CI" {
         It "Datetime works" {
             $expectedDate = Trace-Command -Name * -Expression {Get-Date} -ListenerOption DateTime -FilePath $logfile
             $log = Get-Content $logfile | Where-Object {$_ -like "*DateTime=*"}
-            $results = $log | ForEach-Object {[DateTime]::Parse($_.Split("=")[1])}
+            $results = $log | ForEach-Object {[datetime]::Parse($_.Split("=")[1])}
 
             ## allow a gap of 6 seconds. All traces should be finished within 6 seconds.
             $allowedGap = [timespan](60 * 1000 * 1000)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
@@ -33,7 +33,7 @@ Describe "Trace-Command" -tags "Feature" {
         It "Datetime works" {
             $expectedDate = Trace-Command -Name * -Expression {Get-Date} -ListenerOption DateTime -FilePath $logfile
             $log = Get-Content $logfile | Where-Object {$_ -like "*DateTime=*"}
-            $results = $log | ForEach-Object {[DateTime]::Parse($_.Split("=")[1])}
+            $results = $log | ForEach-Object {[datetime]::Parse($_.Split("=")[1])}
 
             ## allow a gap of 6 seconds. All traces should be finished within 6 seconds.
             $allowedGap = [timespan](60 * 1000 * 1000)

--- a/test/powershell/engine/Api/Serialization.Tests.ps1
+++ b/test/powershell/engine/Api/Serialization.Tests.ps1
@@ -36,12 +36,12 @@ Describe "Serialization Tests" -tags "CI" {
     }
 
     It 'Test DateTimeUtc serialize and deserialize work as expected.' {
-        $inputObject = [System.DateTime]::UtcNow;
+        $inputObject = [datetime]::UtcNow;
         SerializeAndDeserialize($inputObject) | Should -Be $inputObject
     }
 
     It 'Test DateTime stamps serialize and deserialize work as expected.' {
-        $objs = [System.DateTime]::MaxValue, [System.DateTime]::MinValue, [System.DateTime]::Today, (New-Object System.DateTime), (New-Object System.DateTime 123456789)
+        $objs = [datetime]::MaxValue, [datetime]::MinValue, [datetime]::Today, (New-Object System.DateTime), (New-Object System.DateTime 123456789)
         foreach($inputObject in $objs)
         {
            SerializeAndDeserialize($inputObject) | Should -Be $inputObject

--- a/test/powershell/engine/Api/TaskBasedAsyncPowerShellAPI.Tests.ps1
+++ b/test/powershell/engine/Api/TaskBasedAsyncPowerShellAPI.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'Task-based PowerShell async APIs' -Tags 'Feature' {
         $sbStub = @'
 .foreach{
     [pscustomobject]@{
-        Time       = [DateTime]::Now.ToString('yyyyMMddTHHmmss.fffffff')
+        Time       = [datetime]::Now.ToString('yyyyMMddTHHmmss.fffffff')
         Value      = $_
         ThreadId   = [System.Threading.Thread]::CurrentThread.ManagedThreadId
         RunspaceId = [runspace]::DefaultRunspace.Id

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -174,7 +174,7 @@ Describe "Type inference Tests" -tags "CI" {
 
     It 'Infers type of Index expression on Dictionary' {
         $ast = {
-            [System.Collections.Generic.Dictionary[int, DateTime]]::new()[1]
+            [System.Collections.Generic.Dictionary[int, datetime]]::new()[1]
         }.ast.EndBlock.Statements[0].PipelineElements[0].Expression
         $res = [AstTypeInference]::InferTypeOf( $ast )
 
@@ -377,7 +377,7 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It "Infers type from static member property" {
-        $res = [AstTypeInference]::InferTypeOf( { [DateTime]::Now }.Ast)
+        $res = [AstTypeInference]::InferTypeOf( { [datetime]::Now }.Ast)
         $res.Count | Should -Be 1
         $res.Name | Should -Be 'System.DateTime'
     }
@@ -1329,7 +1329,7 @@ Describe "Type inference Tests" -tags "CI" {
     It 'Infers type of function member' {
         $res = [AstTypeInference]::InferTypeOf( {
                 class X {
-                    [DateTime] GetDate() { return [datetime]::Now }
+                    [datetime] GetDate() { return [datetime]::Now }
                 }
             }.Ast.Find( {param($ast) $ast -is [System.Management.Automation.Language.FunctionMemberAst]}, $true))
 
@@ -1338,7 +1338,7 @@ Describe "Type inference Tests" -tags "CI" {
 
     It 'Infers type of MemberExpression on class property' {
         class X {
-            [DateTime] $Date
+            [datetime] $Date
         }
         $x = [X]::new()
         $res = [AstTypeInference]::InferTypeOf( {
@@ -1351,7 +1351,7 @@ Describe "Type inference Tests" -tags "CI" {
 
     It 'Infers type of MemberExpression on class Method' {
         class X {
-            [DateTime] GetDate() { return [DateTime]::Now }
+            [datetime] GetDate() { return [datetime]::Now }
         }
         $x = [X]::new()
         $res = [AstTypeInference]::InferTypeOf( {

--- a/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
+++ b/test/powershell/engine/Security/UntrustedDataMode.Tests.ps1
@@ -45,7 +45,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
 
                 [Parameter()]
                 [ValidateTrustedData()]
-                [DateTime] $Date,
+                [datetime] $Date,
 
                 [Parameter()]
                 [ValidateTrustedData()]
@@ -486,7 +486,7 @@ Describe "UntrustedDataMode tests for variable assignments" -Tags 'CI' {
             $result | Should -Be "ParameterArgumentValidationError,Test-OtherParameterType"
         }
 
-        It "test 'ValidateTrustedDataAttribute' with value type param [DateTime]" {
+        It "test 'ValidateTrustedDataAttribute' with value type param [datetime]" {
             ## Run this in the global scope, so value of $globalVar will be marked as untrusted
             $result = Execute-Script -Script @'
             try {

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -9,12 +9,12 @@ function Wait-UntilTrue
         [int]$IntervalInMilliseconds = 1000
         )
     # Get the current time
-    $startTime = [DateTime]::Now
+    $startTime = [datetime]::Now
 
     # Loop until the script block evaluates to true
     while (-not ($sb.Invoke())) {
         # If the timeout period has passed, return false
-        if (([DateTime]::Now - $startTime).TotalMilliseconds -gt $timeoutInMilliseconds) {
+        if (([datetime]::Now - $startTime).TotalMilliseconds -gt $timeoutInMilliseconds) {
             return $false
         }
         # Wait

--- a/test/tools/Modules/PSSysLog/PSSysLog.psm1
+++ b/test/tools/Modules/PSSysLog/PSSysLog.psm1
@@ -173,7 +173,7 @@ Class OsLogIds
 class PSLogItem
 {
     [string] $LogId = [string]::Empty
-    [DateTime] $Timestamp = [DateTime]::Now
+    [datetime] $Timestamp = [datetime]::Now
     [string] $Hostname = [string]::Empty
     [int] $ProcessId = 0
     [int] $ThreadId = 0
@@ -200,7 +200,7 @@ class PSLogItem
         return 1
     }
 
-    static [PSLogItem] ConvertSysLog([string] $content, [string] $id, [Nullable[DateTime]] $after)
+    static [PSLogItem] ConvertSysLog([string] $content, [string] $id, [Nullable[datetime]] $after)
     {
         Set-StrictMode -Version 3.0
         <#
@@ -228,7 +228,7 @@ class PSLogItem
         #>
 
         $firstToken = $content.split()[0]
-        $dt = $firstToken -as [DateTime]
+        $dt = $firstToken -as [datetime]
         if ($dt)
         {
             $replacement = "{0:MMM} {0:dd} {0:hh}:{0:mm}:{0:ss}" -f $dt
@@ -253,18 +253,18 @@ class PSLogItem
             }
         }
 
-        $now = [DateTime]::Now
+        $now = [datetime]::Now
         $month = [PSLogItem]::GetMonth($parts[[SysLogIds]::Month])
         $day = [int]::Parse($parts[[SysLogIds]::Day])
 
         # guess at the year
-        $year = [DateTime]::Now.Year
+        $year = [datetime]::Now.Year
         if (($month -gt $now.Month) -or ($now.Month -eq $month -and $day -gt $now.Day))
         {
             $year--;
         }
-        [DateTime]$time = [DateTime]::Parse($parts[[SysLogIds]::Time], [System.Globalization.CultureInfo]::InvariantCulture)
-        $time = [DateTime]::new($year, $month, $day, $time.Hour, $time.Minute, $time.Second)
+        [datetime]$time = [datetime]::Parse($parts[[SysLogIds]::Time], [System.Globalization.CultureInfo]::InvariantCulture)
+        $time = [datetime]::new($year, $month, $day, $time.Hour, $time.Minute, $time.Second)
 
         if ($after -ne $null -and $time -lt $after)
         {
@@ -352,7 +352,7 @@ class PSLogItem
         return $item
     }
 
-    static [object] ConvertOsLog([string] $content, [string] $id, [Nullable[DateTime]] $after)
+    static [object] ConvertOsLog([string] $content, [string] $id, [Nullable[datetime]] $after)
     {
         Set-StrictMode -Version 3.0
         <#
@@ -390,9 +390,9 @@ class PSLogItem
 
             # look for a date/time stamp prior to the thread.
             # if this succeeds, we'll ignore the values in split.
-            [DateTime] $time = [DateTime]::Now
+            [datetime] $time = [datetime]::Now
             $value = $content.Substring(0, $index).Trim()
-            if ([DateTime]::TryParse($value, [ref] $time) -eq $false)
+            if ([datetime]::TryParse($value, [ref] $time) -eq $false)
             {
                 # no timestamp,
                 # assume text only
@@ -501,7 +501,7 @@ function ConvertFrom-SysLog
 
         [string] $Id,
 
-        [Nullable[DateTime]] $After
+        [Nullable[datetime]] $After
     )
 
     Begin
@@ -577,7 +577,7 @@ function ConvertFrom-SysLog
     Gets up to 200 log entries with the id 'powershell' from /var/log/syslog
 
 .Example
-    PS> $time = [DateTime]::Parse('1/19/2018 1:26:49 PM')
+    PS> $time = [datetime]::Parse('1/19/2018 1:26:49 PM')
     PS> Get-PSSysLog -id 'powershell' -logPath '/var/log/syslog' -After $time
 
     Gets log entries with the id 'powershell' that occurred on or after a specific date/time
@@ -616,7 +616,7 @@ function Get-PSSysLog
 
         [Parameter(ParameterSetName = 'All')]
         [Parameter(ParameterSetName = 'After')]
-        [Nullable[DateTime]] $After
+        [Nullable[datetime]] $After
     )
 
     [int] $maxItems = 0
@@ -726,7 +726,7 @@ function ConvertFrom-OSLog
 
         [string] $Id,
 
-        [Nullable[DateTime]] $After
+        [Nullable[datetime]] $After
     )
 
     Begin
@@ -815,7 +815,7 @@ function Get-PSOsLog
         [ValidateRange(0, [int]::MaxValue)]
         [int] $TotalCount,
 
-        [Nullable[DateTime]] $After
+        [Nullable[datetime]] $After
     )
 
     [int] $maxItems = 0
@@ -847,12 +847,12 @@ function Get-PSOsLog
     Log entries with a timestamp on or after this value will be returned.
 
 .EXAMPLE
-    PS> $timestamp = [DateTime]::Now
+    PS> $timestamp = [datetime]::Now
     PS> # perform some work...
     PS> $content = (Export-PSOsLog -After $timestamp)
 
 .EXAMPLE
-    PS> $timestamp = [DateTime]::Now
+    PS> $timestamp = [datetime]::Now
     PS> # perform some work...
     PS> Export-PSOsLog -After $timestamp | Set-Content -Path "$PSDrive/mytest.txt"
 
@@ -867,7 +867,7 @@ function Export-PSOsLog
     (
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [DateTime] $After,
+        [datetime] $After,
 
         [string] $LogId = "powershell",
 
@@ -942,7 +942,7 @@ function Wait-UntilSuccess
         [int]$IntervalInMilliseconds = 10000
         )
     # Get the current time
-    $startTime = [DateTime]::Now
+    $startTime = [datetime]::Now
 
     # Loop until the script block returns
     while ($true) {
@@ -951,7 +951,7 @@ function Wait-UntilSuccess
         }
         catch{
             # If the timeout period has passed, return false
-            $msPassed = ([DateTime]::Now - $startTime).TotalMilliseconds
+            $msPassed = ([datetime]::Now - $startTime).TotalMilliseconds
             if ($msPassed -gt $timeoutInMilliseconds) {
                 if($LogErrorSb)
                 {
@@ -1091,7 +1091,7 @@ function Wait-PSWinEvent
         $All
     )
 
-    $startTime = [DateTime]::Now
+    $startTime = [datetime]::Now
     $lastFoundCount = 0;
 
     do
@@ -1142,7 +1142,7 @@ function Wait-PSWinEvent
 
             $lastFoundCount = $recordsToReturn.Count
         }
-    } while (([DateTime]::Now - $startTime).TotalSeconds -lt $timeout)
+    } while (([datetime]::Now - $startTime).TotalSeconds -lt $timeout)
 }
 #endregion eventlog support
 

--- a/tools/AttackSurfaceAnalyzer/Summarize-AsaResults.ps1
+++ b/tools/AttackSurfaceAnalyzer/Summarize-AsaResults.ps1
@@ -202,8 +202,8 @@ function Get-AsaSummary {
     # Calculate timespan if we have both run IDs
     if ($summary.Metadata.BaseRunId -and $summary.Metadata.CompareRunId) {
         try {
-            $baseTime = [DateTime]::Parse($summary.Metadata.BaseRunId)
-            $compareTime = [DateTime]::Parse($summary.Metadata.CompareRunId)
+            $baseTime = [datetime]::Parse($summary.Metadata.BaseRunId)
+            $compareTime = [datetime]::Parse($summary.Metadata.CompareRunId)
             $summary.TimeSpan = $compareTime - $baseTime
         }
         catch {
@@ -492,7 +492,7 @@ function Write-ConsoleSummary {
                             $notAfterValue = if ($file -is [hashtable]) { $file['NotAfter'] } else { $file.NotAfter }
                             if ($notAfterValue) {
                                 try {
-                                    $expirationDate = ([DateTime]::Parse($notAfterValue)).ToString('yyyy-MM-dd')
+                                    $expirationDate = ([datetime]::Parse($notAfterValue)).ToString('yyyy-MM-dd')
                                 }
                                 catch {
                                     $expirationDate = 'Unknown'


### PR DESCRIPTION
Use the `[datetime]` type accelerator to simplify references to the `System.DateTime` class.

This also aligns with the canonical lowercase capitalization used for the type accelerator:

https://github.com/PowerShell/PowerShell/blob/b664c2e026d1610e9b5a6cc5b14d3c86aae9ab81/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1#L58-L59

Contributes to https://github.com/PowerShell/PowerShell/issues/25952.
