### PR TITLE
Use `DateTimeOffset.FromUnixTimeSeconds`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -1141,32 +1141,6 @@ namespace Microsoft.PowerShell.Commands
 
             return culture?.Name;
         }
-
-        /// <summary>
-        /// Convert a Unix time, expressed in seconds, to a <see cref="DateTime"/>.
-        /// </summary>
-        /// <param name="seconds">Number of seconds since the Unix epoch.</param>
-        /// <returns>
-        /// A DateTime object representing the date and time represented by the
-        /// <paramref name="seconds"/> parameter.
-        /// </returns>
-        internal static DateTime UnixSecondsToDateTime(long seconds)
-        {
-#if false   // requires .NET 4.6 or higher
-            return DateTimeOffset.FromUnixTimeSeconds(seconds).DateTime;
-#else
-            const int DaysPerYear = 365;
-            const int DaysPer4Years = DaysPerYear * 4 + 1;
-            const int DaysPer100Years = DaysPer4Years * 25 - 1;
-            const int DaysPer400Years = DaysPer100Years * 4 + 1;
-            const int DaysTo1970 = DaysPer400Years * 4 + DaysPer100Years * 3 + DaysPer4Years * 17 + DaysPerYear;
-            const long UnixEpochTicks = TimeSpan.TicksPerDay * DaysTo1970;
-
-            long ticks = seconds * TimeSpan.TicksPerSecond + UnixEpochTicks;
-
-            return new DateTimeOffset(ticks, TimeSpan.Zero).DateTime;
-#endif
-        }
     }
 
     /// <summary>
@@ -1272,16 +1246,14 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (key != null)
                 {
-                    object temp = key.GetValue("InstallDate");
-
                     return new RegWinNtCurrentVersion()
                     {
                         BuildLabEx = (string)key.GetValue("BuildLabEx"),
                         CurrentVersion = (string)key.GetValue("CurrentVersion"),
                         EditionId = (string)key.GetValue("EditionID"),
                         InstallationType = (string)key.GetValue("InstallationType"),
-                        InstallDate = temp == null ? (DateTime?)null
-                                                                : Conversion.UnixSecondsToDateTime((long)(int)temp),
+                        InstallDate = key.GetValue("InstallDate") is int seconds
+                            ? DateTimeOffset.FromUnixTimeSeconds(seconds).DateTime : null,
                         ProductId = (string)key.GetValue("ProductId"),
                         ProductName = (string)key.GetValue("ProductName"),
                         RegisteredOrganization = (string)key.GetValue("RegisteredOrganization"),

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -753,14 +753,6 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
         return [string[]]$osPagingFiles
     }
 
-    function Get-UnixSecondsToDateTime
-    {
-        param([string]$seconds)
-
-        $origin = New-Object -Type DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0
-        $origin.AddSeconds($seconds)
-    }
-
     function Get-WinNtCurrentVersion
     {
         # This method was translated/converted from cmdlet impl method = RegistryInfo.GetWinNtCurrentVersion();
@@ -769,20 +761,17 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
         $key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\'
         $regValue = (Get-ItemProperty -Path $key -Name $propertyName -ErrorAction SilentlyContinue).$propertyName
 
-        if ($propertyName -eq "InstallDate")
+        if ($null -eq $regValue)
         {
-            # more complicated case: InstallDate
-            if ($regValue)
-            {
-                return Get-UnixSecondsToDateTime $regValue
-            }
-        }
-        else
-        {
-            return $regValue
+            return $null
         }
 
-        return $null
+        if ($propertyName -eq "InstallDate")
+        {
+            return [DateTimeOffset]::FromUnixTimeSeconds($regValue).DateTime
+        }
+
+        return $regValue
     }
 
     function Get-ExpectedComputerInfoValue

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -753,6 +753,14 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
         return [string[]]$osPagingFiles
     }
 
+    function Get-UnixSecondsToDateTime
+    {
+        param([string]$seconds)
+
+        $origin = New-Object -Type DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0
+        $origin.AddSeconds($seconds)
+    }
+
     function Get-WinNtCurrentVersion
     {
         # This method was translated/converted from cmdlet impl method = RegistryInfo.GetWinNtCurrentVersion();
@@ -761,17 +769,20 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
         $key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\'
         $regValue = (Get-ItemProperty -Path $key -Name $propertyName -ErrorAction SilentlyContinue).$propertyName
 
-        if ($null -eq $regValue)
-        {
-            return $null
-        }
-
         if ($propertyName -eq "InstallDate")
         {
-            return [DateTimeOffset]::FromUnixTimeSeconds($regValue).DateTime
+            # more complicated case: InstallDate
+            if ($regValue)
+            {
+                return Get-UnixSecondsToDateTime $regValue
+            }
+        }
+        else
+        {
+            return $regValue
         }
 
-        return $regValue
+        return $null
     }
 
     function Get-ExpectedComputerInfoValue


### PR DESCRIPTION
This PR uses the [`DateTimeOffset.FromUnixTimeSeconds(Int64)`](https://learn.microsoft.com/dotnet/api/system.datetimeoffset.fromunixtimeseconds) method in place of previous custom implementations of timestamp conversion.

Fix correctness issue with null check where `($regValue)` evaluates to `false` when the value is `0`.