### PR TITLE
Use `[initialsessionstate]` type accelerator

### DIFF
--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -833,7 +833,7 @@ class Derived : Base
 [Derived]::new().foo()
 '@)
 
-        $iss = [System.Management.Automation.Runspaces.initialsessionstate]::CreateDefault2()
+        $iss = [initialsessionstate]::CreateDefault2()
         $iss.Commands.Add($ssfe)
 
         $ps = [powershell]::Create($iss)
@@ -929,7 +929,7 @@ class A : Foo.Bar
 return [A]::new()
 '@)
 
-        $iss = [System.Management.Automation.Runspaces.initialsessionstate]::CreateDefault()
+        $iss = [initialsessionstate]::CreateDefault()
         $iss.Commands.Add($ssfe)
 
         $ps = [powershell]::Create($iss)

--- a/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
@@ -417,7 +417,7 @@ function foo()
 '@
             # resolve name to absolute path
             $scriptToProcessPath = (Get-ChildItem $scriptToProcessPath).FullName
-            $iss = [System.Management.Automation.Runspaces.initialsessionstate]::CreateDefault()
+            $iss = [initialsessionstate]::CreateDefault()
             $iss.StartupScripts.Add($scriptToProcessPath)
 
             $ps = [powershell]::Create($iss)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-FormatData.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Export-FormatData" -Tags "CI" {
         {
             $fd | Export-FormatData -Path $TESTDRIVE\allformat.ps1xml -IncludeScriptBlock
 
-            $sessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
+            $sessionState = [initialsessionstate]::CreateDefault()
             $sessionState.Formats.Clear()
             $sessionState.Types.Clear()
 
@@ -135,7 +135,7 @@ Describe "Export-FormatData" -Tags "CI" {
             $testfile = Join-Path -Path $TestDrive -ChildPath "$testfilename.ps1xml"
             Set-Content -Path $testfile -Value $xmlContent
 
-            $sessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
+            $sessionState = [initialsessionstate]::CreateDefault()
             $sessionState.Formats.Clear()
             $sessionState.Types.Clear()
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -1901,7 +1901,7 @@ try
                 Export-PSSession -Session $session -OutputModule $tempdir\Diag -CommandName New-Guid -AllowClobber > $null
 
                 # Only the snapin Microsoft.PowerShell.Core is loaded
-                $iss = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault2()
+                $iss = [initialsessionstate]::CreateDefault2()
                 $ps = [PowerShell]::Create($iss)
                 $result = $ps.AddScript(" & $tempdir\TestBug450687.ps1").Invoke()
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-TypeData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-TypeData.Tests.ps1
@@ -36,7 +36,7 @@ Describe "Remove-TypeData DRT Unit Tests" -Tags "CI" {
 
     BeforeEach {
         $ps = [powershell]::Create()
-        $iss = [system.management.automation.runspaces.initialsessionstate]::CreateDefault2()
+        $iss = [initialsessionstate]::CreateDefault2()
         $rs = [system.management.automation.runspaces.runspacefactory]::CreateRunspace($iss)
         $rs.Open()
         $ps.Runspace = $rs

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
@@ -110,7 +110,7 @@ Describe "Update-FormatData with resources in CustomControls" -Tags "CI" {
         $templatePath = Join-Path $PSScriptRoot (Join-Path 'assets' 'UpdateFormatDataTests.format.ps1xml')
         $formatFilePath = Join-Path $TestDrive 'UpdateFormatDataTests.format.ps1xml'
         $ps = [powershell]::Create()
-        $iss = [system.management.automation.runspaces.initialsessionstate]::CreateDefault2()
+        $iss = [initialsessionstate]::CreateDefault2()
         $rs = [system.management.automation.runspaces.runspacefactory]::CreateRunspace($iss)
         $rs.Open()
         $ps.Runspace = $rs

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-TypeData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-TypeData.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Update-TypeData basic functionality" -Tags "CI" {
 
     BeforeEach {
         $ps = [powershell]::Create()
-        $iss = [system.management.automation.runspaces.initialsessionstate]::CreateDefault2()
+        $iss = [initialsessionstate]::CreateDefault2()
         $rs = [system.management.automation.runspaces.runspacefactory]::CreateRunspace($iss)
         $rs.Open()
         $ps.Runspace = $rs


### PR DESCRIPTION
Use `[initialsessionstate]` type accelerator, simplifying references to the `System.Management.Automation.Runspaces.InitialSessionState` class.

Contributes to: https://github.com/PowerShell/PowerShell/issues/25952.
