### PR TITLE
Use `foreach` instead of `IDictionary.GetEnumerator`

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
@@ -348,13 +348,13 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             }
 
             collection = new CimMethodParametersCollection();
-            IDictionaryEnumerator enumerator = parameters.GetEnumerator();
-            while (enumerator.MoveNext())
+            
+            foreach (DictionaryEntry entry in parameters)
             {
-                string parameterName = enumerator.Key.ToString();
+                string parameterName = entry.Key.ToString();
 
                 const CimFlags parameterFlags = CimFlags.In;
-                object parameterValue = GetBaseObject(enumerator.Value);
+                object parameterValue = GetBaseObject(entry.Value);
 
                 DebugHelper.WriteLog(@"Create parameter name= {0}, value= {1}, flags= {2}.", 4,
                     parameterName,

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimNewCimInstance.cs
@@ -280,17 +280,16 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 }
             }
 
-            IDictionaryEnumerator enumerator = properties.GetEnumerator();
-            while (enumerator.MoveNext())
+            foreach (DictionaryEntry entry in properties)
             {
                 CimFlags flag = CimFlags.None;
-                string propertyName = enumerator.Key.ToString().Trim();
+                string propertyName = entry.Key.ToString().Trim();
                 if (keys.Contains(propertyName, StringComparer.OrdinalIgnoreCase))
                 {
                     flag = CimFlags.Key;
                 }
 
-                object propertyValue = GetBaseObject(enumerator.Value);
+                object propertyValue = GetBaseObject(entry.Value);
 
                 DebugHelper.WriteLog("Create and add new property to ciminstance: name = {0}; value = {1}; flags = {2}", 5, propertyName, propertyValue, flag);
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
@@ -186,11 +186,10 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 return true;
             }
 
-            IDictionaryEnumerator enumerator = properties.GetEnumerator();
-            while (enumerator.MoveNext())
+            foreach (DictionaryEntry entry in properties)
             {
-                object value = GetBaseObject(enumerator.Value);
-                string key = enumerator.Key.ToString();
+                object value = GetBaseObject(entry.Value);
+                string key = entry.Key.ToString();
                 DebugHelper.WriteLog("Input property name '{0}' with value '{1}'", 1, key, value);
 
                 try

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
@@ -246,10 +246,9 @@ namespace Microsoft.PowerShell.Commands
 
                     if (setObject.Arguments != null)
                     {
-                        IDictionaryEnumerator en = setObject.Arguments.GetEnumerator();
-                        while (en.MoveNext())
+                        foreach (DictionaryEntry entry in setObject.Arguments)
                         {
-                            mObj[en.Key as string] = en.Value;
+                            mObj[entry.Key as string] = entry.Value;
                         }
                     }
 
@@ -439,10 +438,9 @@ namespace Microsoft.PowerShell.Commands
 
                     if (setObject.Arguments != null)
                     {
-                        IDictionaryEnumerator en = setObject.Arguments.GetEnumerator();
-                        while (en.MoveNext())
+                        foreach (DictionaryEntry entry in setObject.Arguments)
                         {
-                            mObject[en.Key as string] = en.Value;
+                            mObject[entry.Key as string] = entry.Value;
                         }
                     }
 
@@ -1277,10 +1275,9 @@ namespace Microsoft.PowerShell.Commands
 
                 if (setObject.Arguments != null)
                 {
-                    IDictionaryEnumerator en = setObject.Arguments.GetEnumerator();
-                    while (en.MoveNext())
+                    foreach (DictionaryEntry entry in setObject.Arguments)
                     {
-                        mObject[en.Key as string] = en.Value;
+                        mObject[entry.Key as string] = entry.Value;
                     }
                 }
             }
@@ -1431,10 +1428,9 @@ namespace Microsoft.PowerShell.Commands
 
                     if (wmiInstance.Arguments != null)
                     {
-                        IDictionaryEnumerator en = wmiInstance.Arguments.GetEnumerator();
-                        while (en.MoveNext())
+                        foreach (DictionaryEntry entry in wmiInstance.Arguments)
                         {
-                            mObj[en.Key as string] = en.Value;
+                            mObj[entry.Key as string] = entry.Value;
                         }
                     }
                 }

--- a/src/System.Management.Automation/help/MamlNode.cs
+++ b/src/System.Management.Automation/help/MamlNode.cs
@@ -260,11 +260,9 @@ namespace System.Management.Automation
 
             PSObject mshObject = new PSObject();
 
-            IDictionaryEnumerator enumerator = properties.GetEnumerator();
-
-            while (enumerator.MoveNext())
+            foreach (DictionaryEntry entry in properties)
             {
-                mshObject.Properties.Add(new PSNoteProperty((string)enumerator.Key, enumerator.Value));
+                mshObject.Properties.Add(new PSNoteProperty((string)entry.Key, entry.Value));
             }
 
             return mshObject;
@@ -421,11 +419,10 @@ namespace System.Management.Automation
                 return null;
 
             Hashtable result = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            IDictionaryEnumerator enumerator = properties.GetEnumerator();
 
-            while (enumerator.MoveNext())
+            foreach (DictionaryEntry entry in properties)
             {
-                ArrayList propertyValues = (ArrayList)enumerator.Value;
+                ArrayList propertyValues = (ArrayList)entry.Value;
 
                 if (propertyValues == null || propertyValues.Count == 0)
                     continue;
@@ -439,13 +436,13 @@ namespace System.Management.Automation
                         // Even for strings or other basic types, they need to be contained in PSObject in case
                         // there is attributes for this object.
 
-                        result[enumerator.Key] = mshObject;
+                        result[entry.Key] = mshObject;
 
                         continue;
                     }
                 }
 
-                result[enumerator.Key] = propertyValues.ToArray(typeof(PSObject));
+                result[entry.Key] = propertyValues.ToArray(typeof(PSObject));
             }
 
             return result;


### PR DESCRIPTION
Replace manual use of `IDictionaryEnumerator` and `while` loops with idiomatic `foreach` loops. This improves readability, and also ensures that any enumerators implementing IDisposable are properly disposed, as guaranteed by the compiler-generated try/finally pattern.

Fix https://github.com/PowerShell/PowerShell/issues/19221.
