### PR TITLE
Fix `IDE0049` for `string` in `System.Management.Automation`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ComputerUnix.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Run shutdown command.
         /// </summary>
-        protected void RunShutdown(String args)
+        protected void RunShutdown(string args)
         {
             if (shutdownPath is null)
             {

--- a/src/System.Management.Automation/cimSupport/cmdletization/QueryBuilder.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/QueryBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.Cmdletization
         /// <param name="propertyName">Property name to query on.</param>
         /// <param name="allowedPropertyValues">Property values to accept in the query.</param>
         /// <param name="wildcardsEnabled">
-        /// <see langword="true"/> if <paramref name="allowedPropertyValues"/> should be treated as a <see cref="System.String"/> containing a wildcard pattern;
+        /// <see langword="true"/> if <paramref name="allowedPropertyValues"/> should be treated as a <see cref="string"/> containing a wildcard pattern;
         /// <see langword="false"/> otherwise.
         /// </param>
         /// <param name="behaviorOnNoMatch">
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.Cmdletization
         /// <param name="propertyName">Property name to query on.</param>
         /// <param name="excludedPropertyValues">Property values to reject in the query.</param>
         /// <param name="wildcardsEnabled">
-        /// <see langword="true"/> if <paramref name="excludedPropertyValues"/> should be treated as a <see cref="System.String"/> containing a wildcard pattern;
+        /// <see langword="true"/> if <paramref name="excludedPropertyValues"/> should be treated as a <see cref="string"/> containing a wildcard pattern;
         /// <see langword="false"/> otherwise.
         /// </param>
         /// <param name="behaviorOnNoMatch">

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -562,7 +562,7 @@ namespace System.Management.Automation
         /// <see cref="System.Resources.ResourceManager"/>
         /// </param>
         /// <param name="args">
-        /// <see cref="System.String.Format(IFormatProvider,string,object[])"/>
+        /// <see cref="string.Format(IFormatProvider,string,object[])"/>
         /// insertion parameters
         /// </param>
         /// <remarks>
@@ -584,7 +584,7 @@ namespace System.Management.Automation
         /// by overriding virtual method
         /// <see cref="Cmdlet.GetResourceString"/>.
         /// This constructor then inserts the specified args using
-        /// <see cref="System.String.Format(IFormatProvider,string,object[])"/>.
+        /// <see cref="string.Format(IFormatProvider,string,object[])"/>.
         /// </remarks>
         public ErrorDetails(
             Cmdlet cmdlet,
@@ -610,7 +610,7 @@ namespace System.Management.Automation
         /// <see cref="System.Resources.ResourceManager"/>
         /// </param>
         /// <param name="args">
-        /// <see cref="System.String.Format(IFormatProvider,string,object[])"/>
+        /// <see cref="string.Format(IFormatProvider,string,object[])"/>
         /// insertion parameters
         /// </param>
         /// <remarks>
@@ -637,7 +637,7 @@ namespace System.Management.Automation
         /// will implement
         /// <see cref="IResourceSupplier"/>.
         /// The constructor then inserts the specified args using
-        /// <see cref="System.String.Format(IFormatProvider,string,object[])"/>.
+        /// <see cref="string.Format(IFormatProvider,string,object[])"/>.
         /// </remarks>
         public ErrorDetails(
             IResourceSupplier resourceSupplier,
@@ -663,7 +663,7 @@ namespace System.Management.Automation
         /// <see cref="System.Resources.ResourceManager"/>
         /// </param>
         /// <param name="args">
-        /// <see cref="System.String.Format(IFormatProvider,string,object[])"/>
+        /// <see cref="string.Format(IFormatProvider,string,object[])"/>
         /// insertion parameters
         /// </param>
         /// <remarks>
@@ -678,7 +678,7 @@ namespace System.Management.Automation
         /// This constructor first loads a template string from the assembly using
         /// <see cref="System.Resources.ResourceManager.GetString(string)"/>.
         /// The constructor then inserts the specified args using
-        /// <see cref="System.String.Format(IFormatProvider,string,object[])"/>.
+        /// <see cref="string.Format(IFormatProvider,string,object[])"/>.
         /// </remarks>
         public ErrorDetails(
             System.Reflection.Assembly assembly,
@@ -1823,7 +1823,7 @@ namespace System.Management.Automation
         /// if you want more complex behavior.
         ///
         /// Insertions will be inserted into the string with
-        /// <see cref="System.String.Format(IFormatProvider,string,object[])"/>
+        /// <see cref="string.Format(IFormatProvider,string,object[])"/>
         /// to generate the final error message in
         /// <see cref="ErrorDetails.Message"/>.
         /// </remarks>

--- a/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
@@ -89,7 +89,7 @@ namespace System.Management.Automation.Host
         /// </value>
         /// <remarks>
         /// If not already set by a call to <see cref="System.Management.Automation.Host.FieldDescription.SetParameterType"/>,
-        /// <see cref="System.String"/> will be used as the type.
+        /// <see cref="string"/> will be used as the type.
         /// <!--The value of ParameterTypeName is the string value returned.
         /// by System.Type.Name.-->
         /// </remarks>
@@ -115,7 +115,7 @@ namespace System.Management.Automation.Host
         /// </summary>
         /// <remarks>
         /// If not already set by a call to <see cref="System.Management.Automation.Host.FieldDescription.SetParameterType"/>,
-        /// <see cref="System.String"/> will be used as the type.
+        /// <see cref="string"/> will be used as the type.
         /// <!--The value of ParameterTypeName is the string value returned.
         /// by System.Type.Name.-->
         /// </remarks>
@@ -144,7 +144,7 @@ namespace System.Management.Automation.Host
         /// to load the containing assembly to access the type information. AssemblyName is used for this purpose.
         ///
         /// If not already set by a call to <see cref="System.Management.Automation.Host.FieldDescription.SetParameterType"/>,
-        /// <see cref="System.String"/> will be used as the type.
+        /// <see cref="string"/> will be used as the type.
         /// </remarks>
         public
         string

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2504,7 +2504,7 @@ namespace System.Management.Automation.Runspaces
             var argvList = new List<string>();
             argvList.Add(psi.FileName);
 
-            var argsToParse = string.Join(' ', psi.ArgumentList).Trim();
+            var argsToParse = String.Join(' ', psi.ArgumentList).Trim();
             var argsLength = argsToParse.Length;
             for (int i = 0; i < argsLength; )
             {

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2504,7 +2504,7 @@ namespace System.Management.Automation.Runspaces
             var argvList = new List<string>();
             argvList.Add(psi.FileName);
 
-            var argsToParse = String.Join(' ', psi.ArgumentList).Trim();
+            var argsToParse = string.Join(' ', psi.ArgumentList).Trim();
             var argsLength = argsToParse.Length;
             for (int i = 0; i < argsLength; )
             {


### PR DESCRIPTION
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049

Contributes to: https://github.com/PowerShell/PowerShell/issues/25922.

This change was isolated from https://github.com/PowerShell/PowerShell/pull/25900 using a filtering script.
