### PR TITLE
Fix `IDE0049` for `object` in `System.Management.Automation`. Part 1

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -87,7 +87,7 @@ namespace System.Management.Automation
     /// <see cref="ValidateArgumentsAttribute"/> validates the argument as a whole. If the argument value may
     /// be an enumerable, you can derive from <see cref="ValidateEnumeratedArgumentsAttribute"/>
     /// which will take care of unrolling the enumerable and validate each element individually.
-    /// It is also recommended to override <see cref="System.Object.ToString"/> to return a readable string
+    /// It is also recommended to override <see cref="object.ToString"/> to return a readable string
     /// similar to the attribute declaration, for example "[ValidateRangeAttribute(5,10)]".
     /// If this attribute is applied to a string parameter, the string command argument will be validated.
     /// If this attribute is applied to a string[] parameter, the string[] command argument will be validated.
@@ -154,7 +154,7 @@ namespace System.Management.Automation
     /// <seealso cref="ValidateEnumeratedArgumentsAttribute"/> and override the
     /// <seealso cref="ValidateEnumeratedArgumentsAttribute.ValidateElement"/>
     /// abstract method, after which they can apply the attribute to their parameters.
-    /// It is also recommended to override <see cref="System.Object.ToString"/> to return a readable string
+    /// It is also recommended to override <see cref="object.ToString"/> to return a readable string
     /// similar to the attribute declaration, for example "[ValidateRangeAttribute(5,10)]".
     /// If this attribute is applied to a string parameter, the string command argument will be validated.
     /// If this attribute is applied to a string[] parameter, each string command argument will be validated.
@@ -2292,7 +2292,7 @@ namespace System.Management.Automation
     /// <see cref="ArgumentTransformationAttribute"/> and override the
     /// <see cref="ArgumentTransformationAttribute.Transform"/> abstract method, after which they
     /// can apply the attribute to their parameters.
-    /// It is also recommended to override <see cref="System.Object.ToString"/> to return a readable
+    /// It is also recommended to override <see cref="object.ToString"/> to return a readable
     /// string similar to the attribute declaration, for example "[ValidateRangeAttribute(5,10)]".
     /// If multiple transformations are defined on a parameter, they will be invoked in series,
     /// each getting the output of the previous transformation.

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -796,7 +796,7 @@ namespace System.Management.Automation
 
         #region ToString
         /// <summary>
-        /// As <see cref="System.Object.ToString()"/>
+        /// As <see cref="object.ToString()"/>
         /// </summary>
         /// <returns>Developer-readable identifier.</returns>
         public override string ToString()
@@ -1677,7 +1677,7 @@ namespace System.Management.Automation
 
         #region ToString
         /// <summary>
-        /// As <see cref="System.Object.ToString()"/>
+        /// As <see cref="object.ToString()"/>
         /// </summary>
         /// <returns>Developer-readable identifier.</returns>
         public override string ToString()

--- a/src/System.Management.Automation/engine/ProgressRecord.cs
+++ b/src/System.Management.Automation/engine/ProgressRecord.cs
@@ -293,7 +293,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.ToString"/>
+        /// Overrides <see cref="object.ToString"/>
         /// </summary>
         /// <returns>
         /// "parent = a id = b act = c stat = d cur = e pct = f sec = g type = h" where

--- a/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
@@ -62,7 +62,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.ToString"/>
+        /// Overrides <see cref="object.ToString"/>
         /// </summary>
         /// <returns>
         /// "a,b" where a and b are the values of the X and Y properties.
@@ -75,7 +75,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.Equals(object)"/>
+        /// Overrides <see cref="object.Equals(object)"/>
         /// </summary>
         /// <param name="obj">
         /// object to be compared for equality.
@@ -99,7 +99,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.GetHashCode"/>
+        /// Overrides <see cref="object.GetHashCode"/>
         /// </summary>
         /// <returns>
         /// Hash code for this instance.
@@ -248,7 +248,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overloads <see cref="System.Object.ToString"/>
+        /// Overloads <see cref="object.ToString"/>
         /// </summary>
         /// <returns>
         /// "a,b" where a and b are the values of the Width and Height properties.
@@ -261,7 +261,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.Equals(object)"/>
+        /// Overrides <see cref="object.Equals(object)"/>
         /// </summary>
         /// <param name="obj">
         /// object to be compared for equality.
@@ -285,7 +285,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.GetHashCode"/>
+        /// Overrides <see cref="object.GetHashCode"/>
         /// </summary>
         /// <returns>
         /// Hash code for this instance.
@@ -557,7 +557,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overloads <see cref="System.Object.ToString"/>
+        /// Overloads <see cref="object.ToString"/>
         /// </summary>
         /// <returns>
         /// "a,b,c,d" where a, b, c, and d are the values of the VirtualKeyCode, Character, ControlKeyState, and KeyDown properties.
@@ -569,7 +569,7 @@ namespace System.Management.Automation.Host
             return string.Create(CultureInfo.InvariantCulture, $"{VirtualKeyCode},{Character},{ControlKeyState},{KeyDown}");
         }
         /// <summary>
-        /// Overrides <see cref="System.Object.Equals(object)"/>
+        /// Overrides <see cref="object.Equals(object)"/>
         /// </summary>
         /// <param name="obj">
         /// object to be compared for equality.
@@ -593,7 +593,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.GetHashCode"/>
+        /// Overrides <see cref="object.GetHashCode"/>
         /// </summary>
         /// <returns>
         /// Hash code for this instance.
@@ -787,7 +787,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overloads <see cref="System.Object.ToString"/>
+        /// Overloads <see cref="object.ToString"/>
         /// </summary>
         /// <returns>
         /// "a,b ; c,d" where a, b, c, and d are values of the Left, Top, Right, and Bottom properties.
@@ -800,7 +800,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.Equals(object)"/>
+        /// Overrides <see cref="object.Equals(object)"/>
         /// </summary>
         /// <param name="obj">
         /// object to be compared for equality.
@@ -824,7 +824,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.GetHashCode"/>
+        /// Overrides <see cref="object.GetHashCode"/>
         /// </summary>
         /// <returns>
         /// Hash code for this instance.
@@ -1015,7 +1015,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overloads <see cref="System.Object.ToString"/>
+        /// Overloads <see cref="object.ToString"/>
         /// </summary>
         /// <returns>
         /// "'a' b c d" where a, b, c, and d are the values of the Character, ForegroundColor, BackgroundColor, and Type properties.
@@ -1028,7 +1028,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.Equals(object)"/>
+        /// Overrides <see cref="object.Equals(object)"/>
         /// </summary>
         /// <param name="obj">
         /// object to be compared for equality.
@@ -1052,7 +1052,7 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Overrides <see cref="System.Object.GetHashCode"/>
+        /// Overrides <see cref="object.GetHashCode"/>
         /// <!-- consider (ForegroundColor XOR BackgroundColor) the high-order part of a 32-bit int,
         ///      and Character the lower order half.  Then use the int32.GetHashCode.-->
         /// </summary>

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7939,7 +7939,7 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// The static type produced after the cast is normally the type named by <see cref="Type"/>, but in some cases
-        /// it may not be, in which, <see cref="object"/> is assumed.
+        /// it may not be, in which, <see cref="Object"/> is assumed.
         /// </summary>
         public override Type StaticType
         {

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -7939,7 +7939,7 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// The static type produced after the cast is normally the type named by <see cref="Type"/>, but in some cases
-        /// it may not be, in which, <see cref="Object"/> is assumed.
+        /// it may not be, in which, <see cref="object"/> is assumed.
         /// </summary>
         public override Type StaticType
         {

--- a/src/System.Management.Automation/namespaces/ContainerProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ContainerProviderBase.cs
@@ -840,7 +840,7 @@ namespace System.Management.Automation.Provider
         ///
         /// The <paramref name="newItemValue"/> parameter can be any type of object that the provider can use
         /// to create the item. It is recommended that the provider accept at a minimum strings, and an instance
-        /// of the type of object that would be returned from GetItem() for this path. <see cref="LanguagePrimitives.ConvertTo(System.Object, System.Type)"/>
+        /// of the type of object that would be returned from GetItem() for this path. <see cref="LanguagePrimitives.ConvertTo(object, System.Type)"/>
         /// can be used to convert some types to the desired type.
         ///
         /// The default implementation of this method throws an <see cref="System.Management.Automation.PSNotSupportedException"/>.


### PR DESCRIPTION
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049

Contributes to: https://github.com/PowerShell/PowerShell/issues/25922.

This change was isolated from https://github.com/PowerShell/PowerShell/pull/25900 using a filtering script.