### PR TITLE
Remove obsolete `CA2118` rule suppression

### DIFF
--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -141,9 +141,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         // If that call fails with ERROR_INVALID_TRANSACTION, we have possibly run into bug 181242. To workaround
         // this, we open the key without a transaction and then open it again with
         // a transaction and return THAT hkey.
-
-        // Suppressed because there is no way for arbitrary data to be passed.
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         private int RegOpenKeyTransactedWrapper(SafeRegistryHandle hKey, string lpSubKey,
                     int ulOptions, int samDesired, out SafeRegistryHandle hkResult,
                     SafeTransactionHandle hTransaction, IntPtr pExtendedParameter)

--- a/src/System.Management.Automation/namespaces/Win32Native.cs
+++ b/src/System.Management.Automation/namespaces/Win32Native.cs
@@ -106,7 +106,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="peUse"></param>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.LookupAccountSidDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern unsafe bool LookupAccountSid(string lpSystemName,
                                                      IntPtr sid,
@@ -138,7 +137,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         }
 
         [DllImport(PinvokeDllNames.CloseHandleDllName, SetLastError = true)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool CloseHandle(IntPtr handle);
 
@@ -150,7 +148,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="tokenHandle">Process token.</param>
         /// <returns>The current process token.</returns>
         [DllImport(PinvokeDllNames.OpenProcessTokenDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
 
@@ -165,7 +162,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="returnLength"></param>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.GetTokenInformationDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetTokenInformation(IntPtr tokenHandle,
                                                         TOKEN_INFORMATION_CLASS tokenInformationClass,

--- a/src/System.Management.Automation/utils/PlatformInvokes.cs
+++ b/src/System.Management.Automation/utils/PlatformInvokes.cs
@@ -235,7 +235,6 @@ namespace System.Management.Automation
         /// </returns>
         [DllImport(PinvokeDllNames.CloseHandleDllName, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        // [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         internal static extern bool CloseHandle(IntPtr handle);
 
         [DllImport(PinvokeDllNames.DosDateTimeToFileTimeDllName, SetLastError = false)]
@@ -412,7 +411,6 @@ namespace System.Management.Automation
         /// <param name="lpLuid"></param>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.LookupPrivilegeValueDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool LookupPrivilegeValue(string lpSystemName, string lpName, ref LUID lpLuid);
 
@@ -424,7 +422,6 @@ namespace System.Management.Automation
         /// <param name="pfResult"></param>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.PrivilegeCheckDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool PrivilegeCheck(IntPtr tokenHandler, ref PRIVILEGE_SET requiredPrivileges, out bool pfResult);
 
@@ -441,7 +438,6 @@ namespace System.Management.Automation
         /// <param name="returnLength"></param>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.AdjustTokenPrivilegesDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool AdjustTokenPrivileges(IntPtr tokenHandler, bool disableAllPrivilege,
                                                           ref TOKEN_PRIVILEGE newPrivilegeState, int bufferLength,
@@ -482,7 +478,6 @@ namespace System.Management.Automation
         /// </summary>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.GetCurrentProcessDllName)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         internal static extern IntPtr GetCurrentProcess();
 
         /// <summary>
@@ -494,7 +489,6 @@ namespace System.Management.Automation
         /// <param name="tokenHandle">Process token.</param>
         /// <returns>The current process token.</returns>
         [DllImport(PinvokeDllNames.OpenProcessTokenDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
 


### PR DESCRIPTION
The FxCop [`CA2118:ReviewSuppressUnmanagedCodeSecurityUsage`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182311(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/496).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.
