### PR TITLE
Remove redundant `System.Runtime.Versioning` attributes

### DIFF
--- a/src/System.Management.Automation/namespaces/TransactedRegistry.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistry.cs
@@ -42,7 +42,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        [ResourceExposure(ResourceScope.Machine)]
         // The TransactedRegistryKey's members cannot be changed.
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey CurrentUser = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_CURRENT_USER);
@@ -61,7 +60,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        [ResourceExposure(ResourceScope.Machine)]
         // The TransactedRegistryKey's members cannot be changed.
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey LocalMachine = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_LOCAL_MACHINE);
@@ -80,7 +78,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        [ResourceExposure(ResourceScope.Machine)]
         // The TransactedRegistryKey's members cannot be changed.
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey ClassesRoot = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_CLASSES_ROOT);
@@ -99,7 +96,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        [ResourceExposure(ResourceScope.Machine)]
         // The TransactedRegistryKey's members cannot be changed.
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey Users = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_USERS);
@@ -118,7 +114,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        [ResourceExposure(ResourceScope.Machine)]
         // The TransactedRegistryKey's members cannot be changed.
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey CurrentConfig = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_CURRENT_CONFIG);

--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -805,6 +805,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         {
             return InternalOpenSubKey(name, permissionCheck, (int)rights);
         }
+
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         private TransactedRegistryKey InternalOpenSubKey(string name, RegistryKeyPermissionCheck permissionCheck, int rights)

--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -346,7 +346,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// otherwise an ArgumentException is thrown.</param>
         /// <returns>A TransactedRegistryKey object for the subkey, which is associated with Transaction.Current.
         /// returns null if the operation failed.</returns>
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey CreateSubKey(string subkey)
@@ -365,7 +364,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name='permissionCheck'>One of the Microsoft.Win32.RegistryKeyPermissionCheck values that
         /// specifies whether the key is opened for read or read/write access.</param>
         [ComVisible(false)]
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey CreateSubKey(string subkey, RegistryKeyPermissionCheck permissionCheck)
@@ -385,7 +383,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// specifies whether the key is opened for read or read/write access.</param>
         /// <param name='registrySecurity'>A TransactedRegistrySecurity object that specifies the access control security for the new key.</param>
         [ComVisible(false)]
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public unsafe TransactedRegistryKey CreateSubKey(string subkey, RegistryKeyPermissionCheck permissionCheck, TransactedRegistrySecurity registrySecurity)
@@ -394,7 +391,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         }
 
         [ComVisible(false)]
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         private unsafe TransactedRegistryKey CreateSubKeyInternal(string subkey, RegistryKeyPermissionCheck permissionCheck, object registrySecurityObj)
@@ -485,7 +481,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <exception cref="InvalidOperationException">Thrown if the subkey as child subkeys.</exception>
         /// </summary>
         /// <param name='subkey'>The subkey to delete.</param>
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public void DeleteSubKey(string subkey)
@@ -505,7 +500,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name='throwOnMissingSubKey'>Specify true if an ArgumentException should be thrown if
         /// the specified subkey does not exist. If false is specified, a missing subkey does not throw
         /// an exception.</param>
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public void DeleteSubKey(string subkey, bool throwOnMissingSubKey)
@@ -563,7 +557,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// Utilizes Transaction.Current for its transaction.</para>
         /// </summary>
         /// <param name="subkey">The subkey to delete.</param>
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public void DeleteSubKeyTree(string subkey)
@@ -619,7 +612,6 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         // An internal version which does no security checks or argument checking.  Skipping the
         // security checks should give us a slight perf gain on large trees.
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         private void DeleteSubKeyTreeInternal(string subkey)
@@ -664,7 +656,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// Utilizes Transaction.Current for its transaction.</para>
         /// </summary>
         /// <param name="name">Name of the value to delete.</param>
-        [ResourceExposure(ResourceScope.None)]
         public void DeleteValue(string name)
         {
             DeleteValue(name, true);
@@ -678,7 +669,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="throwOnMissingValue">Specify true if an ArgumentException should be thrown if
         /// the specified value does not exist. If false is specified, a missing value does not throw
         /// an exception.</param>
-        [ResourceExposure(ResourceScope.None)]
         public void DeleteValue(string name, bool throwOnMissingValue)
         {
             EnsureWriteable();
@@ -748,7 +738,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <returns>The subkey requested or null if the operation failed.</returns>
         /// <param name="name">Name or path of the subkey to open.</param>
         /// <param name="writable">Set to true of you only need readonly access.</param>
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name, bool writable)
@@ -792,7 +781,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="permissionCheck">One of the Microsoft.Win32.RegistryKeyPermissionCheck values that specifies
         /// whether the key is opened for read or read/write access.</param>
         [ComVisible(false)]
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name, RegistryKeyPermissionCheck permissionCheck)
@@ -811,15 +799,12 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// whether the key is opened for read or read/write access.</param>
         /// <param name="rights">A bitwise combination of Microsoft.Win32.RegistryRights values that specifies the desired security access.</param>
         [ComVisible(false)]
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name, RegistryKeyPermissionCheck permissionCheck, RegistryRights rights)
         {
             return InternalOpenSubKey(name, permissionCheck, (int)rights);
         }
-
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         private TransactedRegistryKey InternalOpenSubKey(string name, RegistryKeyPermissionCheck permissionCheck, int rights)
@@ -860,7 +845,6 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         // This required no security checks. This is to get around the Deleting SubKeys which only require
         // write permission. They call OpenSubKey which required read. Now instead call this function w/o security checks
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         internal TransactedRegistryKey InternalOpenSubKey(string name, bool writable)
@@ -891,7 +875,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// </summary>
         /// <returns>The subkey requested or null if the operation failed.</returns>
         /// <param name="name">Name or path of the subkey to open.</param>
-        [ResourceExposure(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name)

--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -347,7 +347,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <returns>A TransactedRegistryKey object for the subkey, which is associated with Transaction.Current.
         /// returns null if the operation failed.</returns>
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey CreateSubKey(string subkey)
@@ -367,7 +366,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// specifies whether the key is opened for read or read/write access.</param>
         [ComVisible(false)]
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey CreateSubKey(string subkey, RegistryKeyPermissionCheck permissionCheck)
@@ -388,7 +386,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name='registrySecurity'>A TransactedRegistrySecurity object that specifies the access control security for the new key.</param>
         [ComVisible(false)]
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public unsafe TransactedRegistryKey CreateSubKey(string subkey, RegistryKeyPermissionCheck permissionCheck, TransactedRegistrySecurity registrySecurity)
@@ -398,7 +395,6 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         [ComVisible(false)]
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         private unsafe TransactedRegistryKey CreateSubKeyInternal(string subkey, RegistryKeyPermissionCheck permissionCheck, object registrySecurityObj)
@@ -490,7 +486,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// </summary>
         /// <param name='subkey'>The subkey to delete.</param>
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public void DeleteSubKey(string subkey)
@@ -511,7 +506,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// the specified subkey does not exist. If false is specified, a missing subkey does not throw
         /// an exception.</param>
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public void DeleteSubKey(string subkey, bool throwOnMissingSubKey)
@@ -570,7 +564,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// </summary>
         /// <param name="subkey">The subkey to delete.</param>
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public void DeleteSubKeyTree(string subkey)
@@ -627,7 +620,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         // An internal version which does no security checks or argument checking.  Skipping the
         // security checks should give us a slight perf gain on large trees.
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         private void DeleteSubKeyTreeInternal(string subkey)
@@ -673,7 +665,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// </summary>
         /// <param name="name">Name of the value to delete.</param>
         [ResourceExposure(ResourceScope.None)]
-        [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
         public void DeleteValue(string name)
         {
             DeleteValue(name, true);
@@ -688,7 +679,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// the specified value does not exist. If false is specified, a missing value does not throw
         /// an exception.</param>
         [ResourceExposure(ResourceScope.None)]
-        [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
         public void DeleteValue(string name, bool throwOnMissingValue)
         {
             EnsureWriteable();
@@ -759,7 +749,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="name">Name or path of the subkey to open.</param>
         /// <param name="writable">Set to true of you only need readonly access.</param>
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name, bool writable)
@@ -804,7 +793,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// whether the key is opened for read or read/write access.</param>
         [ComVisible(false)]
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name, RegistryKeyPermissionCheck permissionCheck)
@@ -824,7 +812,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="rights">A bitwise combination of Microsoft.Win32.RegistryRights values that specifies the desired security access.</param>
         [ComVisible(false)]
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name, RegistryKeyPermissionCheck permissionCheck, RegistryRights rights)
@@ -833,7 +820,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         }
 
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         private TransactedRegistryKey InternalOpenSubKey(string name, RegistryKeyPermissionCheck permissionCheck, int rights)
@@ -875,7 +861,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         // This required no security checks. This is to get around the Deleting SubKeys which only require
         // write permission. They call OpenSubKey which required read. Now instead call this function w/o security checks
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         internal TransactedRegistryKey InternalOpenSubKey(string name, bool writable)
@@ -907,7 +892,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <returns>The subkey requested or null if the operation failed.</returns>
         /// <param name="name">Name or path of the subkey to open.</param>
         [ResourceExposure(ResourceScope.Machine)]
-        [ResourceConsumption(ResourceScope.Machine)]
         // Suppressed to be consistent with naming in Microsoft.Win32.RegistryKey
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
         public TransactedRegistryKey OpenSubKey(string name)

--- a/src/System.Management.Automation/namespaces/Win32Native.cs
+++ b/src/System.Management.Automation/namespaces/Win32Native.cs
@@ -106,7 +106,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="peUse"></param>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.LookupAccountSidDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [ResourceExposure(ResourceScope.Machine)]
         [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern unsafe bool LookupAccountSid(string lpSystemName,
@@ -139,7 +138,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         }
 
         [DllImport(PinvokeDllNames.CloseHandleDllName, SetLastError = true)]
-        [ResourceExposure(ResourceScope.Machine)]
         [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool CloseHandle(IntPtr handle);
@@ -152,7 +150,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="tokenHandle">Process token.</param>
         /// <returns>The current process token.</returns>
         [DllImport(PinvokeDllNames.OpenProcessTokenDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [ResourceExposure(ResourceScope.Machine)]
         [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
@@ -168,7 +165,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// <param name="returnLength"></param>
         /// <returns></returns>
         [DllImport(PinvokeDllNames.GetTokenInformationDllName, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        [ResourceExposure(ResourceScope.Machine)]
         [SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetTokenInformation(IntPtr tokenHandle,


### PR DESCRIPTION
Remove the obsolete attributes:

* [`System.Runtime.Versioning.ResourceExposureAttribute`](https://learn.microsoft.com/dotnet/api/system.runtime.versioning.resourceexposureattribute)
* [`System.Runtime.Versioning.ResourceConsumptionAttribute`](https://learn.microsoft.com/dotnet/api/system.runtime.versioning.resourceconsumptionattribute)

Contributes to: https://github.com/PowerShell/PowerShell/issues/25937.

References: https://github.com/dotnet/corefx/pull/30863