### PR TITLE
Enable nullable in `TestExe` project

### DIFF
--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -142,7 +142,7 @@ namespace TestExe
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 nint cmdLinePtr = Interop.GetCommandLineW();
-                rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr);
+                rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr)!;
             }
 
             Console.WriteLine(rawCmdLine);
@@ -198,15 +198,21 @@ Other options are for specific tests only. Read source code for details.
             if (target.HasFlag(EnvTarget.User))
             {
                 // Append to the User Path.
-                using RegistryKey reg = Registry.CurrentUser.OpenSubKey(UserEnvRegPath, writable: true);
-                UpdateEnvPathImpl(reg, append: true, @"X:\not-exist-user-path");
+                using RegistryKey? reg = Registry.CurrentUser.OpenSubKey(UserEnvRegPath, writable: true);
+                if (reg is not null)
+                {
+                    UpdateEnvPathImpl(reg, append: true, @"X:\not-exist-user-path");
+                }
             }
 
             if (target.HasFlag(EnvTarget.System))
             {
                 // Prepend to the System Path.
-                using RegistryKey reg = Registry.LocalMachine.OpenSubKey(SysEnvRegPath, writable: true);
-                UpdateEnvPathImpl(reg, append: false, @"X:\not-exist-sys-path");
+                using RegistryKey? reg = Registry.LocalMachine.OpenSubKey(SysEnvRegPath, writable: true);
+                if (reg is not null)
+                {
+                    UpdateEnvPathImpl(reg, append: false, @"X:\not-exist-sys-path");
+                }
             }
 
             static void UpdateEnvPathImpl(RegistryKey regKey, bool append, string newPathItem)

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -138,14 +138,15 @@ namespace TestExe
         // </Summary>
         private static void EchoCmdLine()
         {
-            string rawCmdLine = "N/A";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                nint cmdLinePtr = Interop.GetCommandLineW();
-                rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr)!;
+                ReadOnlySpan<char> rawCmdLine = Interop.GetCommandLine();
+                Console.WriteLine(rawCmdLine);
             }
-
-            Console.WriteLine(rawCmdLine);
+            else
+            {
+                Console.WriteLine("N/A");
+            }
         }
 
         // <Summary>
@@ -245,10 +246,19 @@ Other options are for specific tests only. Read source code for details.
             }
         }
     }
+}
 
-    internal static partial class Interop
+internal static partial class Interop
+{
+    internal static ReadOnlySpan<char> GetCommandLine()
     {
-        [LibraryImport("Kernel32.dll")]
-        internal static partial nint GetCommandLineW();
+        unsafe
+        {
+            char* cmdLinePtr = GetCommandLineW();
+            return MemoryMarshal.CreateReadOnlySpanFromNullTerminated(cmdLinePtr);
+        }
     }
+
+    [LibraryImport("Kernel32.dll")]
+    private static unsafe partial char* GetCommandLineW();
 }

--- a/test/tools/TestExe/TestExe.csproj
+++ b/test/tools/TestExe/TestExe.csproj
@@ -9,6 +9,7 @@
     <TieredCompilation>true</TieredCompilation>
     <TieredCompilationQuickJit>true</TieredCompilationQuickJit>
     <RuntimeIdentifiers>win-x86;win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR introduces nullable reference types (`#nullable enable`) within the `TestExe` project, along with associated null-safety enhancements.

Contributes to: https://github.com/PowerShell/PowerShell/issues/12631.

