### PR TITLE
Remove obsolete `CA1026` rule suppression

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -64,7 +64,6 @@ namespace System.Management.Automation
         /// <param name="moduleName"></param>
         /// <param name="commandTypes"></param>
         /// <returns></returns>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static IEnumerable<CompletionResult> CompleteCommand(string commandName, string moduleName, CommandTypes commandTypes = CommandTypes.All)
         {
             var runspace = Runspace.DefaultRunspace;

--- a/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
@@ -95,7 +95,6 @@ namespace System.Management.Automation.PerformanceData
         /// based on Provider Id, counterSetId, counterSetInstanceType, a collection
         /// with counters information and an optional counterSetName.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         protected CounterSetRegistrarBase(
             Guid providerId,
             Guid counterSetId,
@@ -220,7 +219,6 @@ namespace System.Management.Automation.PerformanceData
         /// <summary>
         /// Constructor that creates an instance of PSCounterSetRegistrar.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public PSCounterSetRegistrar(
             Guid providerId,
             Guid counterSetId,

--- a/src/System.Management.Automation/utils/perfCounters/PSPerfCountersMgr.cs
+++ b/src/System.Management.Automation/utils/perfCounters/PSPerfCountersMgr.cs
@@ -162,7 +162,6 @@ namespace System.Management.Automation.PerformanceData
         /// by 'stepAmount'.
         /// Otherwise, updates the denominator component by 'stepAmount'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool UpdateCounterByValue(
             Guid counterSetId,
             int counterId,
@@ -193,7 +192,6 @@ namespace System.Management.Automation.PerformanceData
         /// by 'stepAmount'.
         /// Otherwise, updates the denominator component by 'stepAmount'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool UpdateCounterByValue(
             Guid counterSetId,
             string counterName,
@@ -224,7 +222,6 @@ namespace System.Management.Automation.PerformanceData
         /// by 'stepAmount'.
         /// Otherwise, updates the denominator component by 'stepAmount'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool UpdateCounterByValue(
             string counterSetName,
             int counterId,
@@ -264,7 +261,6 @@ namespace System.Management.Automation.PerformanceData
         /// by 'stepAmount'.
         /// Otherwise, updates the denominator component by 'stepAmount'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool UpdateCounterByValue(
             string counterSetName,
             string counterName,
@@ -303,7 +299,6 @@ namespace System.Management.Automation.PerformanceData
         /// to 'counterValue'.
         /// Otherwise, updates the denominator component to 'counterValue'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool SetCounterValue(
             Guid counterSetId,
             int counterId,
@@ -334,7 +329,6 @@ namespace System.Management.Automation.PerformanceData
         /// to 'counterValue'.
         /// Otherwise, updates the denominator component to 'counterValue'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool SetCounterValue(
             Guid counterSetId,
             string counterName,
@@ -365,7 +359,6 @@ namespace System.Management.Automation.PerformanceData
         /// to 'counterValue'.
         /// Otherwise, updates the denominator component to 'counterValue'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool SetCounterValue(
             string counterSetName,
             int counterId,
@@ -404,7 +397,6 @@ namespace System.Management.Automation.PerformanceData
         /// to 'counterValue'.
         /// Otherwise, updates the denominator component to 'counterValue'.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public bool SetCounterValue(
             string counterSetName,
             string counterName,


### PR DESCRIPTION
The FxCop [`CA1026:DefaultParametersShouldNotBeUsed`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182135(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/626).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.