### PR TITLE
Remove obsolete `CA2105` rule suppression

### DIFF
--- a/src/System.Management.Automation/engine/interpreter/InterpretedFrame.cs
+++ b/src/System.Management.Automation/engine/interpreter/InterpretedFrame.cs
@@ -27,23 +27,19 @@ namespace System.Management.Automation.Interpreter
 {
     internal sealed class InterpretedFrame
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         public static readonly ThreadLocal<InterpretedFrame> CurrentFrame = new ThreadLocal<InterpretedFrame>();
 
         internal readonly Interpreter Interpreter;
         internal InterpretedFrame _parent;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2105:ArrayFieldsShouldNotBeReadOnly")]
         private readonly int[] _continuations;
 
         private int _continuationIndex;
         private int _pendingContinuation;
         private object _pendingValue;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2105:ArrayFieldsShouldNotBeReadOnly")]
         public readonly object[] Data;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2105:ArrayFieldsShouldNotBeReadOnly")]
         public readonly StrongBox<object>[] Closure;
 
         public int StackIndex;


### PR DESCRIPTION
The FxCop [`CA2105:ArrayFieldsShouldNotBeReadOnly`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182299(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/484).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.