### PR TITLE
Remove obsolete `CA2006` rule suppression

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -3424,7 +3424,6 @@ namespace Microsoft.PowerShell.Commands
             return IntPtr.Zero;
         }
 #else
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private static IntPtr hWnd = IntPtr.Zero;
         private static bool firstRun = true;
 

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -304,7 +304,6 @@ namespace System.Management.Automation.Remoting.Client
                 /// <summary>
                 /// Making password secure.
                 /// </summary>
-                [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
                 internal IntPtr password;
             }
 
@@ -626,7 +625,6 @@ namespace System.Management.Automation.Remoting.Client
         {
             internal int bufferLength;
 
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr data;
         }
 
@@ -637,10 +635,8 @@ namespace System.Management.Automation.Remoting.Client
         {
             private readonly WSManDataStruct _internalData;
 
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             private IntPtr _marshalledObject = IntPtr.Zero;
 
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             private IntPtr _marshalledBuffer = IntPtr.Zero;
 
             /// <summary>
@@ -933,7 +929,6 @@ namespace System.Management.Automation.Remoting.Client
         {
             internal int streamIDsCount;
 
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr streamIDs;
         }
 
@@ -1085,7 +1080,6 @@ namespace System.Management.Automation.Remoting.Client
             /// <summary>
             /// Pointer to an array of WSManOption objects.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr options;
 
             internal bool optionsMustUnderstand;
@@ -1223,13 +1217,11 @@ namespace System.Management.Automation.Remoting.Client
             {
                 internal int argsCount;
 
-                [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
                 internal IntPtr args;
             }
 
             private WSManCommandArgSetInternal _internalData;
 
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             private MarshalledObject _data;
 
             #region Managed to Unmanaged
@@ -1733,7 +1725,6 @@ namespace System.Management.Automation.Remoting.Client
             // GC handle which prevents garbage collector from collecting this delegate.
             private GCHandle _gcHandle;
 
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             private readonly IntPtr _asyncCallback;
 
             internal WSManShellAsyncCallback(WSManShellCompletionFunction callback)

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
@@ -343,61 +343,51 @@ namespace System.Management.Automation.Remoting
             /// <summary>
             /// WsManPluginShutdownPluginCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginShutdownPluginCallbackNative;
 
             /// <summary>
             /// WSManPluginShellCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginShellCallbackNative;
 
             /// <summary>
             /// WSManPluginReleaseShellContextCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginReleaseShellContextCallbackNative;
 
             /// <summary>
             /// WSManPluginCommandCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginCommandCallbackNative;
 
             /// <summary>
             /// WSManPluginReleaseCommandContextCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginReleaseCommandContextCallbackNative;
 
             /// <summary>
             /// WSManPluginSendCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginSendCallbackNative;
 
             /// <summary>
             /// WSManPluginReceiveCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginReceiveCallbackNative;
 
             /// <summary>
             /// WSManPluginSignalCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginSignalCallbackNative;
 
             /// <summary>
             /// WSManPluginConnectCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginConnectCallbackNative;
 
             /// <summary>
             /// WSManPluginCommandCallbackNative.
             /// </summary>
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             internal IntPtr wsManPluginShutdownCallbackNative;
         }
     }

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -317,18 +317,13 @@ namespace System.Management.Automation.Remoting.Client
         #endregion
 
         #region Private Data
+
         // operation handles are owned by WSMan
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _wsManSessionHandle;
-
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _wsManShellOperationHandle;
-
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _wsManReceiveOperationHandle;
-
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _wsManSendOperationHandle;
+
         // this is used with WSMan callbacks to represent a session transport manager.
         private long _sessionContextID;
 
@@ -2643,7 +2638,6 @@ namespace System.Management.Automation.Remoting.Client
         /// </summary>
         internal class WSManAPIDataCommon : IDisposable
         {
-            [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
             private IntPtr _handle;
             // if any
             private WSManNativeApi.WSManStreamIDSet_ManToUn _inputStreamSet;
@@ -2791,18 +2785,11 @@ namespace System.Management.Automation.Remoting.Client
 
         // operation handles
         private readonly IntPtr _wsManShellOperationHandle;
-
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _wsManCmdOperationHandle;
-
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _cmdSignalOperationHandle;
-
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _wsManReceiveOperationHandle;
-
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _wsManSendOperationHandle;
+
         // this is used with WSMan callbacks to represent a command transport manager.
         private long _cmdContextId;
 

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -1607,10 +1607,8 @@ namespace System.Management.Automation
             }
         }
 
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private static IntPtr s_amsiContext = IntPtr.Zero;
 
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private static IntPtr s_amsiSession = IntPtr.Zero;
 
         private static readonly bool s_amsiInitFailed = false;


### PR DESCRIPTION
The FxCop [`CA2006:UseSafeHandleToEncapsulateNativeResources`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182294(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/480).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.