### PR TITLE
Remove obsolete `CA1059` rule suppression

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -225,10 +225,6 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = false,
                 ParameterSetName = "XmlQuerySet",
                 HelpMessageBaseName = "GetEventResources")]
-        [SuppressMessage("Microsoft.Design", "CA1059:MembersShouldNotExposeCertainConcreteTypes",
-                            Scope = "member",
-                            Target = "Microsoft.PowerShell.Commands.GetEvent.FilterXml",
-                            Justification = "An XmlDocument is required here because that is the type Powershell supports")]
         public XmlDocument FilterXml { get; set; }
 
         /// <summary>


### PR DESCRIPTION
The FxCop [`CA1059:MembersShouldNotExposeCertainConcreteTypes`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182160(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/402).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.