### PR TITLE
Remove obsolete `CA1701` rule suppression

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -26,7 +26,6 @@ using Dbg = System.Management.Automation;
 
 // FxCop suppressions for resource strings:
 [module: SuppressMessage("Microsoft.Naming", "CA1703:ResourceStringsShouldBeSpelledCorrectly", Scope = "resource", Target = "ComputerResources.resources", MessageId = "unjoined")]
-[module: SuppressMessage("Microsoft.Naming", "CA1701:ResourceStringCompoundWordsShouldBeCasedCorrectly", Scope = "resource", Target = "ComputerResources.resources", MessageId = "UpTime")]
 
 namespace Microsoft.PowerShell.Commands
 {


### PR DESCRIPTION
The FxCop [`CA1701:ResourceStringCompoundWordsShouldBeCasedCorrectly`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/bb264481(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/441).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.