### PR TITLE
Replace `CA1811` rule suppression with `IDE0051`

### DIFF
--- a/src/Microsoft.Management.UI.Internal/ManagementList/Common/KeyboardHelp.cs
+++ b/src/Microsoft.Management.UI.Internal/ManagementList/Common/KeyboardHelp.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         /// <param name="key">The key pressed.</param>
         /// <returns>True if the key is a navigation key.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051:Remove unused private members")]
         private static bool IsFlowDirectionKey(Key key)
         {
             switch (key)

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/HelpWindowHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/HelpWindowHelper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// </summary>
         /// <param name="helpObj">Object with help information.</param>
         /// <param name="cmdlet">Cmdlet calling this method.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called from methods called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called from methods called using reflection")]
         private static void ShowHelpWindow(PSObject helpObj, PSCmdlet cmdlet)
         {
             Window ownerWindow = ShowCommandHelper.GetHostWindow(cmdlet);

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/OutGridView.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="invocation">Commands of the PowerShell.</param>
         /// <param name="outputModeOptions">Selection mode of the list.</param>
         /// <param name="closedEvent">ClosedEvent.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "The method is called using reflection.")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "The method is called using reflection.")]
         private void StartWindow(string invocation, string outputModeOptions, AutoResetEvent closedEvent)
         {
             this.closedEvent = closedEvent;
@@ -397,7 +397,7 @@ namespace Microsoft.Management.UI.Internal
         /// <param name="propertyNames">An array of property names to add.</param>
         /// <param name="displayNames">An array of display names to add.</param>
         /// <param name="types">An array of types to add.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "The method is called using reflection.")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "The method is called using reflection.")]
         private void AddColumns(string[] propertyNames, string[] displayNames, Type[] types)
         {
             // Wait for the gridViewWindow thread to signal that loading of Window is done
@@ -482,7 +482,7 @@ namespace Microsoft.Management.UI.Internal
         /// Add an item to ObservableCollection.
         /// </summary>
         /// <param name="value">PSObject of comlet data.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "The method is called using reflection.")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "The method is called using reflection.")]
         private void AddItem(PSObject value)
         {
             if (this.GetWindowClosedStatus())
@@ -528,7 +528,7 @@ namespace Microsoft.Management.UI.Internal
         /// Returns the state of GridView Window.
         /// </summary>
         /// <returns>The status of GridView Window close or not.</returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "The method is called using reflection.")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "The method is called using reflection.")]
         private bool GetWindowClosedStatus()
         {
             if (this.closedEvent == null)
@@ -543,7 +543,7 @@ namespace Microsoft.Management.UI.Internal
         /// Returns any exception that has been thrown by previous method calls.
         /// </summary>
         /// <returns>The thrown and caught exception. It returns null if no exceptions were thrown by any previous method calls.</returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "The method is called using reflection.")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "The method is called using reflection.")]
         private Exception GetLastException()
         {
             Exception local = this.exception;

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -301,7 +301,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the Screen Width.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private static double ScreenWidth
         {
             get
@@ -313,7 +313,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the Screen Height.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private static double ScreenHeight
         {
             get
@@ -325,7 +325,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the event set when the show-command window is closed.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private AutoResetEvent WindowClosed
         {
             get
@@ -337,7 +337,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the event set when help is needed for a command.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private AutoResetEvent HelpNeeded
         {
             get
@@ -349,7 +349,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the event set when it is necessary to import a module.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private AutoResetEvent ImportModuleNeeded
         {
             get
@@ -361,7 +361,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the event set when the window is loaded.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private AutoResetEvent WindowLoaded
         {
             get
@@ -373,7 +373,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the command needing help when HelpNeeded is set.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private string CommandNeedingHelp
         {
             get
@@ -385,7 +385,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets the module we want to import.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private string ParentModuleNeedingImportModule
         {
             get
@@ -397,7 +397,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets a value indicating whether there is a host window.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private bool HasHostWindow
         {
             get
@@ -709,7 +709,7 @@ Function PSGetSerializedShowCommandInfo
         /// <returns>
         /// Property value or null if it was not able to retrieve it. This method is not suitable to return a property value that might be null.
         /// </returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called from a method called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called from a method called using reflection")]
         private static object GetPropertyValue(Type type, object obj, string propertyName, BindingFlags bindingFlags)
         {
             PropertyInfo property = type.GetProperty(propertyName, bindingFlags);
@@ -753,7 +753,7 @@ Function PSGetSerializedShowCommandInfo
         /// <param name="value">Value to set the property with.</param>
         /// <param name="bindingFlags">Flags passed to reflection.</param>
         /// <returns>True if it was able to set.</returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called from a method called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called from a method called using reflection")]
         private static bool SetPropertyValue(Type type, object obj, string propertyName, object value, BindingFlags bindingFlags)
         {
             PropertyInfo property = type.GetProperty(propertyName, bindingFlags);
@@ -808,7 +808,7 @@ Function PSGetSerializedShowCommandInfo
         /// <param name="commandName">The particular command we are running show-command on.</param>
         /// <param name="includeAliasAndModules">True if we want to include aliases and retrieve modules.</param>
         /// <returns>The command to be run when calling show-command for a particular command.</returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private static string GetShowCommandCommand(string commandName, bool includeAliasAndModules)
         {
             string quotedCommandName = ShowCommandHelper.SingleQuote(commandName);
@@ -825,7 +825,7 @@ Function PSGetSerializedShowCommandInfo
         /// <param name="importedModules">The loaded modules.</param>
         /// <param name="moduleQualify">True to qualify command with module name in GetScript.</param>
         /// <returns>A CommandViewModel of a CommandInfo.</returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private static object GetCommandViewModel(ShowCommandCommandInfo command, bool noCommonParameter, Dictionary<string, ShowCommandModuleInfo> importedModules, bool moduleQualify)
         {
             CommandViewModel returnValue = CommandViewModel.GetCommandViewModel(new ModuleViewModel(command.ModuleName, importedModules), command, noCommonParameter);
@@ -837,7 +837,7 @@ Function PSGetSerializedShowCommandInfo
         /// Dispatches a message to the window for it to activate.
         /// </summary>
         /// <param name="window">Window to be activated.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called from ActivateWindow() which is called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called from ActivateWindow() which is called using reflection")]
         private static void ActivateWindow(Window window)
         {
             window.Dispatcher.Invoke(
@@ -856,7 +856,7 @@ Function PSGetSerializedShowCommandInfo
         /// <param name="windowWidth">Window width.</param>
         /// <param name="windowHeight">Window height.</param>
         /// <param name="passThrough">True if the GUI should mention ok instead of run.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private void ShowAllModulesWindow(PSCmdlet cmdlet, Dictionary<string, ShowCommandModuleInfo> importedModules, IEnumerable<ShowCommandCommandInfo> commands, bool noCommonParameter, double windowWidth, double windowHeight, bool passThrough)
         {
             this.methodThatReturnsDialog = new DispatcherOperationCallback((object ignored) =>
@@ -888,7 +888,7 @@ Function PSGetSerializedShowCommandInfo
         /// to the hostWindow thread if there is a hostWindow
         /// </summary>
         /// <param name="cmdlet">Cmdlet used to retrieve the host window.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called from a method called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called from a method called using reflection")]
         private void CallShowDialog(PSCmdlet cmdlet)
         {
             this.hostWindow = ShowCommandHelper.GetHostWindow(cmdlet);
@@ -927,7 +927,7 @@ Function PSGetSerializedShowCommandInfo
         /// <param name="windowWidth">Window width.</param>
         /// <param name="windowHeight">Window height.</param>
         /// <param name="passThrough">True if the GUI should mention ok instead of run.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private void ShowCommandWindow(PSCmdlet cmdlet, object commandViewModelObj, double windowWidth, double windowHeight, bool passThrough)
         {
             this.methodThatReturnsDialog = new DispatcherOperationCallback((object ignored) =>
@@ -962,7 +962,7 @@ Function PSGetSerializedShowCommandInfo
         /// </summary>
         /// <param name="importedModules">All modules currently imported.</param>
         /// <param name="commands">Commands to be displayed.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private void ImportModuleDone(Dictionary<string, ShowCommandModuleInfo> importedModules, IEnumerable<ShowCommandCommandInfo> commands)
         {
             this.allModulesViewModel.WaitMessageDisplayed = false;
@@ -989,7 +989,7 @@ Function PSGetSerializedShowCommandInfo
         /// Called when the module importation has failed.
         /// </summary>
         /// <param name="reason">Reason why the module importation failed.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private void ImportModuleFailed(Exception reason)
         {
             this.allModulesViewModel.WaitMessageDisplayed = false;
@@ -1013,7 +1013,7 @@ Function PSGetSerializedShowCommandInfo
         /// Called when the results or get-help are ready in order to display the help window for a command.
         /// </summary>
         /// <param name="getHelpResults">Results of a get-help call.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private void DisplayHelp(Collection<PSObject> getHelpResults)
         {
             if (this.window != null && getHelpResults != null && getHelpResults.Count > 0)
@@ -1033,7 +1033,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Activates this.window.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private void ActivateWindow()
         {
             if (this.window != null)
@@ -1046,7 +1046,7 @@ Function PSGetSerializedShowCommandInfo
         /// Returns the script to execute if dialog has not been canceled.
         /// </summary>
         /// <returns>The script to execute if dialog has not been canceled.</returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called using reflection")]
         private string GetScript()
         {
             if (this.dialogCanceled)
@@ -1063,7 +1063,7 @@ Function PSGetSerializedShowCommandInfo
         /// Sets up window settings common between the two flavors of show-command.
         /// </summary>
         /// <param name="commandWindow">The window being displayed.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called from ShowAllModulesWindow and ShowCommandWindow which are called with reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called from ShowAllModulesWindow and ShowCommandWindow which are called with reflection")]
         private void SetupWindow(Window commandWindow)
         {
             this.window = commandWindow;
@@ -1130,7 +1130,7 @@ Function PSGetSerializedShowCommandInfo
         /// <param name="copy">Button to copy command code.</param>
         /// <param name="cancel">Button to close window.</param>
         /// <param name="passThrough">True to change the text of Run to OK.</param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called from methods called using reflection")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called from methods called using reflection")]
         private void SetupButtonEvents(Button run, Button copy, Button cancel, bool passThrough)
         {
             if (passThrough)

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -2043,7 +2043,7 @@ namespace Microsoft.PowerShell.Commands
         public string HotFixID
         {
             get;
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Class is instantiated directly from a CIM instance")]
+            [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Class is instantiated directly from a CIM instance")]
             internal set;
         }
 
@@ -2053,7 +2053,7 @@ namespace Microsoft.PowerShell.Commands
         public string Description
         {
             get;
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Class is instantiated directly from a CIM instance")]
+            [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Class is instantiated directly from a CIM instance")]
             internal set;
         }
 
@@ -2063,7 +2063,7 @@ namespace Microsoft.PowerShell.Commands
         public string InstalledOn
         {
             get;
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Class is instantiated directly from a CIM instance")]
+            [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Class is instantiated directly from a CIM instance")]
             internal set;
         }
 
@@ -2073,7 +2073,7 @@ namespace Microsoft.PowerShell.Commands
         public string FixComments
         {
             get;
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Class is instantiated directly from a CIM instance")]
+            [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Class is instantiated directly from a CIM instance")]
             internal set;
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
@@ -1601,7 +1601,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Checks the status of remote command execution.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         private void SetStatusMessage()
         {
             _statusMessage = "test";
@@ -1845,7 +1845,7 @@ namespace Microsoft.PowerShell.Commands
         /// running and raise an event indicating to this
         /// parent job that this job is unblocked.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         internal void UnblockJob()
         {
             SetJobState(JobState.Running, null);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -1199,7 +1199,7 @@ namespace Microsoft.PowerShell
         /// <exception cref="HostException">
         /// If there is not enough memory to complete calls to Win32's ReadConsoleOutput
         /// </exception>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called in CHK builds")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called in CHK builds")]
         internal static void CheckWriteEdges(
             ConsoleHandle consoleHandle,
             uint codePage, Coordinates origin,
@@ -1259,7 +1259,7 @@ namespace Microsoft.PowerShell
             }
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Called in CHK builds")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Called in CHK builds")]
         private static void CheckWriteConsoleOutputContents(BufferCell[,] contents, Rectangle contentsRegion)
         {
             for (int r = contentsRegion.Top; r <= contentsRegion.Bottom; r++)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -847,13 +847,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor FormatAccentColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.FormatAccentColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.FormatAccentColor = value;
@@ -862,13 +862,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor ErrorAccentColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.ErrorAccentColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.ErrorAccentColor = value;
@@ -877,13 +877,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor ErrorForegroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.ErrorForegroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.ErrorForegroundColor = value;
@@ -892,13 +892,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor ErrorBackgroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.ErrorBackgroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.ErrorBackgroundColor = value;
@@ -907,13 +907,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor WarningForegroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.WarningForegroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.WarningForegroundColor = value;
@@ -922,13 +922,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor WarningBackgroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.WarningBackgroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.WarningBackgroundColor = value;
@@ -937,13 +937,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor DebugForegroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.DebugForegroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.DebugForegroundColor = value;
@@ -952,13 +952,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor DebugBackgroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.DebugBackgroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.DebugBackgroundColor = value;
@@ -967,13 +967,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor VerboseForegroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.VerboseForegroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.VerboseForegroundColor = value;
@@ -982,13 +982,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor VerboseBackgroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.VerboseBackgroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.VerboseBackgroundColor = value;
@@ -997,13 +997,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor ProgressForegroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.ProgressForegroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.ProgressForegroundColor = value;
@@ -1012,13 +1012,13 @@ namespace Microsoft.PowerShell
 
             public ConsoleColor ProgressBackgroundColor
             {
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 get
                 {
                     return _ui.ProgressBackgroundColor;
                 }
 
-                [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+                [SuppressMessage("Style", "IDE0051:Remove unused private members")]
                 set
                 {
                     _ui.ProgressBackgroundColor = value;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
@@ -416,7 +416,7 @@ namespace Microsoft.PowerShell
             return results;
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Needed by ProfileTests as mentioned in bug 140572")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Needed by ProfileTests as mentioned in bug 140572")]
         internal Collection<PSObject> ExecuteCommand(string command)
         {
             Collection<PSObject> result = null;

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/NtStatus.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/NtStatus.cs
@@ -456,7 +456,7 @@ namespace System.Management.Automation.SecurityAccountsManager.Native
         /// <returns>
         /// True if the NTSTATUS value indicates a warning, false otherwise.
         /// </returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         public static bool IsWarning(UInt32 ntstatus)
         {
             return Severity(ntstatus) == STATUS_SEVERITY_WARNING;
@@ -469,7 +469,7 @@ namespace System.Management.Automation.SecurityAccountsManager.Native
         /// <returns>
         /// True if the NTSTATUS value indicates that it is informational, false otherwise.
         /// </returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         public static bool IsInformational(UInt32 ntstatus)
         {
             return Severity(ntstatus) == STATUS_SEVERITY_INFORMATIONAL;
@@ -495,7 +495,7 @@ namespace System.Management.Automation.SecurityAccountsManager.Native
         /// The value of the Facility portion of an NTSTATUS value.
         /// </returns>
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         public static uint Facility(UInt32 ntstatus)
         {
             return (ntstatus >> 16) & 0x0FFF;
@@ -508,7 +508,7 @@ namespace System.Management.Automation.SecurityAccountsManager.Native
         /// <returns>
         /// The value of the Code portion of an NTSTATUS value.
         /// </returns>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         public static uint Code(UInt32 ntstatus)
         {
             return ntstatus & 0xFFFF;

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
@@ -266,7 +266,7 @@ namespace System.Management.Automation.SecurityAccountsManager
             /// <summary>
             /// Gets a string containing the type of operation under way.
             /// </summary>
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+            [SuppressMessage("Style", "IDE0051:Remove unused private members")]
             public string OperationName
             {
                 get { return operation.ToString(); }
@@ -276,7 +276,7 @@ namespace System.Management.Automation.SecurityAccountsManager
             /// Gets a string containing the type of object ("User" or "Group")
             /// being used.
             /// </summary>
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+            [SuppressMessage("Style", "IDE0051:Remove unused private members")]
             public string TypeNamne
             {
                 get { return type.ToString(); }

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/StringUtil.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/StringUtil.cs
@@ -18,7 +18,7 @@ namespace System.Management.Automation.SecurityAccountsManager
         {
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051:Remove unused private members")]
         internal static string Format(string str)
         {
             return string.Format(CultureInfo.CurrentCulture, str);

--- a/src/ResGen/Program.cs
+++ b/src/ResGen/Program.cs
@@ -137,7 +137,7 @@ using System.Reflection;
     private static global::System.Globalization.CultureInfo resourceCulture;
 
     /// <summary>constructor</summary>
-    [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(""Microsoft.Performance"", ""CA1811:AvoidUncalledPrivateCode"")]
+    [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(""Style"", ""IDE0051:Remove unused private members"")]
     {4} {0}() {{
     }}
 

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1842,7 +1842,7 @@ namespace System.Management.Automation.Language
 
         private bool FoundError
         {
-            [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+            [SuppressMessage("Style", "IDE0051:Remove unused private members")]
             get;
             set;
         }

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -1742,7 +1742,7 @@ namespace System.Management.Automation
         /// job object</param>
         /// <param name="name"> a friendly name for the job object
         /// </param>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         internal PSRemotingJob(string[] computerNames,
                         List<IThrottleOperation> computerNameHelpers, string remoteCommand, string name)
             : this(computerNames, computerNameHelpers, remoteCommand, 0, name)
@@ -2314,7 +2314,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Checks the status of remote command execution.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Style", "IDE0051:Remove unused private members")]
         private void SetStatusMessage()
         {
             _statusMessage = "test";

--- a/src/System.Management.Automation/engine/remoting/common/Indexer.cs
+++ b/src/System.Management.Automation/engine/remoting/common/Indexer.cs
@@ -48,7 +48,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Check lengths non negative.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051:Remove unused private members")]
         private static bool CheckLengthsNonNegative(int[] lengths)
         {
             for (int i = 0; i < lengths.Length; ++i)

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
@@ -605,7 +605,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Array is zero based.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051:Remove unused private members")]
         private static bool ArrayIsZeroBased(Array array)
         {
             int rank = array.Rank;


### PR DESCRIPTION
The FxCop [`CA1811:AvoidUncalledPrivateCode`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182264(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/464).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.