### PR TITLE
Add `SuppressNETCoreSdkPreviewMessage` in test projects

### DIFF
--- a/test/Test.Common.props
+++ b/test/Test.Common.props
@@ -7,6 +7,7 @@
     <Copyright>(c) Microsoft Corporation.</Copyright>
 
     <TargetFramework>net11.0</TargetFramework>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <LangVersion>preview</LangVersion>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Suppress `NETSDK1057: You are using a preview version of .NET. See https://aka.ms/dotnet-support-policy`.

This helps remove clutter from build logs.
