### PR TITLE
Remove obsolete `CA2233` rule suppression

### DIFF
--- a/src/System.Management.Automation/utils/perfCounters/CounterSetInstanceBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetInstanceBase.cs
@@ -74,7 +74,6 @@ namespace System.Management.Automation.PerformanceData
         /// But, if isNumerator is false, then a check is made on the input
         /// counter's type to ensure that denominator is indeed value for such a counter.
         /// </summary>
-        [SuppressMessage("Microsoft.Usage", "CA2233:OperationsShouldNotOverflow", Justification = "countId is validated as known denominator before it is incremented.")]
         protected bool RetrieveTargetCounterIdIfValid(int counterId, bool isNumerator, out int targetCounterId)
         {
             targetCounterId = counterId;


### PR DESCRIPTION
The FxCop [`CA2233:OperationsShouldNotOverflow`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182354(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/546).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.