### PR TITLE
Remove obsolete `CA1703` rule suppression

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -24,9 +24,6 @@ using Microsoft.Management.Infrastructure.Options;
 using Microsoft.Win32;
 using Dbg = System.Management.Automation;
 
-// FxCop suppressions for resource strings:
-[module: SuppressMessage("Microsoft.Naming", "CA1703:ResourceStringsShouldBeSpelledCorrectly", Scope = "resource", Target = "ComputerResources.resources", MessageId = "unjoined")]
-
 namespace Microsoft.PowerShell.Commands
 {
     #region Restart-Computer

--- a/src/System.Management.Automation/engine/Credential.cs
+++ b/src/System.Management.Automation/engine/Credential.cs
@@ -10,9 +10,6 @@ using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using Microsoft.PowerShell;
 
-// FxCop suppressions for resource strings:
-[module: SuppressMessage("Microsoft.Naming", "CA1703:ResourceStringsShouldBeSpelledCorrectly", Scope = "resource", Target = "Credential.resources", MessageId = "Cred")]
-
 namespace System.Management.Automation
 {
     /// <summary>


### PR DESCRIPTION
The FxCop [`CA1703:ResourceStringsShouldBeSpelledCorrectly`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/bb264483(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/442).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.