### PR TITLE
Remove obsolete `CA2104` rule suppression

### DIFF
--- a/src/System.Management.Automation/engine/interpreter/InstructionFactory.cs
+++ b/src/System.Management.Automation/engine/interpreter/InstructionFactory.cs
@@ -69,7 +69,6 @@ namespace System.Management.Automation.Interpreter
 
     internal sealed class InstructionFactory<T> : InstructionFactory
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         public static readonly InstructionFactory Factory = new InstructionFactory<T>();
 
         private Instruction _getArrayItem;

--- a/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
+++ b/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
@@ -251,8 +251,6 @@ namespace System.Management.Automation.Interpreter
     {
         public readonly string MethodName;
 
-        // TODO:
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         public readonly DebugInfo DebugInfo;
 
         public InterpretedFrameInfo(string methodName, DebugInfo info)

--- a/src/System.Management.Automation/namespaces/TransactedRegistry.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistry.cs
@@ -42,8 +42,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        // The TransactedRegistryKey's members cannot be changed.
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey CurrentUser = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_CURRENT_USER);
 
         /**
@@ -60,8 +58,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        // The TransactedRegistryKey's members cannot be changed.
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey LocalMachine = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_LOCAL_MACHINE);
 
         /**
@@ -78,8 +74,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        // The TransactedRegistryKey's members cannot be changed.
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey ClassesRoot = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_CLASSES_ROOT);
 
         /**
@@ -96,8 +90,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        // The TransactedRegistryKey's members cannot be changed.
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey Users = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_USERS);
 
         /**
@@ -114,8 +106,6 @@ namespace Microsoft.PowerShell.Commands.Internal
         /// subkeys, there must be a Transaction.Current and the resulting TransactedRegistryKey from those operations ARE associated with
         /// the transaction.</para>
         /// </summary>
-        // The TransactedRegistryKey's members cannot be changed.
-        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         internal static readonly TransactedRegistryKey CurrentConfig = TransactedRegistryKey.GetBaseKey(BaseRegistryKeys.HKEY_CURRENT_CONFIG);
     }
 }


### PR DESCRIPTION
The FxCop [`CA2104:DoNotDeclareReadOnlyMutableReferenceTypes`](https://learn.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ms182302(v=vs.100)) rule was [not ported to roslyn](https://github.com/dotnet/roslyn-analyzers/issues/716).

Contributes to: https://github.com/PowerShell/PowerShell/issues/25936.