### PR TITLE
Ensure PowerShell-related files end with one newline

### DIFF
--- a/.github/actions/infrastructure/markdownlinks/Verify-MarkdownLinks.ps1
+++ b/.github/actions/infrastructure/markdownlinks/Verify-MarkdownLinks.ps1
@@ -314,4 +314,3 @@ if ($env:GITHUB_STEP_SUMMARY) {
     $summaryContent | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
     Write-Verbose -Verbose "Summary written to GitHub Actions step summary"
 }
-

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -229,4 +229,3 @@ Install-PluginEndpoint -Force $Force -VersionIndependent
 
 Write-Host "Restarting WinRM to ensure that the plugin configuration change takes effect.`nThis is required for WinRM running on Windows SKUs prior to Windows 10." -ForegroundColor Magenta
 Restart-Service winrm
-

--- a/test/infrastructure/ciModule.Tests.ps1
+++ b/test/infrastructure/ciModule.Tests.ps1
@@ -243,4 +243,3 @@ Describe "Install-CIPester" {
         }
     }
 }
-

--- a/test/powershell/Language/Classes/ProtectedAccess.Tests.ps1
+++ b/test/powershell/Language/Classes/ProtectedAccess.Tests.ps1
@@ -187,4 +187,3 @@ Describe "Protected Member Access - members not visible outside class" -Tags "CI
     It "Invalid protected constructor Access" { { [Base]::new() } | Should -Throw -ErrorId "MethodCountCouldNotFindBest" }
     It "Invalid protected method Access" { { $derived1.Method() } | Should -Throw -ErrorId "MethodNotFound" }
 }
-

--- a/test/powershell/Language/CompletionTestSupport.psm1
+++ b/test/powershell/Language/CompletionTestSupport.psm1
@@ -141,4 +141,3 @@ function Test-Completions
         }
     }
 }
-

--- a/test/powershell/Language/Parser/BNotOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/BNotOperator.Tests.ps1
@@ -138,4 +138,3 @@ Describe "bnot on integral types" -Tags "CI" {
         }
     }
 }
-

--- a/test/powershell/Language/Scripting/CmdletDeclaration.Tests.ps1
+++ b/test/powershell/Language/Scripting/CmdletDeclaration.Tests.ps1
@@ -119,4 +119,3 @@ Describe "Cmdlet declaration statement" -Tags "CI" {
             $syntaxerrors.Count | Should -Be 0
         }
 }
-

--- a/test/powershell/Language/Scripting/Generics.Tests.ps1
+++ b/test/powershell/Language/Scripting/Generics.Tests.ps1
@@ -91,4 +91,3 @@ Describe "Generics support" -Tags "CI" {
         $x.scriptText | Should -BeExactly "1...4"
    }
 }
-

--- a/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
+++ b/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
@@ -391,4 +391,3 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
         $script:bar_err | Should -BeExactly @("bar-error", "foo-error", "foo-error")
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -846,4 +846,3 @@ finally
     Pop-DefaultParameterValueStack
     $WarningPreference = $originalWarningPreference
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -922,4 +922,3 @@ try {
 finally {
     $global:PSDefaultParameterValues = $originalDefaultParameterValues
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -171,4 +171,3 @@ while true; do sleep 1; done
         }
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/scriptdsc/scriptdsc.psd1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/scriptdsc/scriptdsc.psd1
@@ -93,4 +93,3 @@ AliasesToExport = '*'
 # DefaultCommandPrefix = ''
 
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
@@ -60,4 +60,3 @@ Describe "Debug-Runspace" -Tag "CI" {
         $debugTarget.Runspace.IsRemoteDebuggerAttached | Should -BeFalse
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSBreakpoint.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-PSBreakpoint.Tests.ps1
@@ -32,4 +32,3 @@ Describe "Get-PSBreakpoint" -Tags "CI" {
 
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -49,4 +49,3 @@ Describe "New-Guid" -Tags "CI" {
         $guid1.ToString() | Should -Not -Be $guid2.ToString()
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -143,4 +143,3 @@ Describe "Out-File" -Tags "CI" {
         { Out-File -Path $testfile } | Should -Not -Throw
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/localized.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/localized.ps1
@@ -24,4 +24,3 @@ $a = $Day.d0, $Day.d1, $Day.d2, $Day.d3, $Day.d4, $Day.d5, $Day.d6
         # Use string formatting to build a sentence.
 
         "{0} {1}" -f $Day.messageDate, $a[(Get-Date -UFormat %u)] | Out-Host
-

--- a/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
+++ b/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
@@ -15,4 +15,3 @@ Describe "ProviderIntrinsics Tests" -tags "CI" {
             Should -Throw -ErrorId 'ItemNotFoundException'
     }
 }
-

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -248,4 +248,3 @@ Describe "Runspace Debugging API tests" -Tag CI {
 
     }
 }
-

--- a/test/powershell/engine/Module/assets/testmodulerunspace/ModuleWithDependencies2/2.0/ModuleWithDependencies2.psd1
+++ b/test/powershell/engine/Module/assets/testmodulerunspace/ModuleWithDependencies2/2.0/ModuleWithDependencies2.psd1
@@ -62,4 +62,3 @@ PrivateData = @{
 } # End of PrivateData hashtable
 
 }
-

--- a/test/powershell/engine/Module/assets/testmodulerunspace/NestedRequiredModule1/2.5/NestedRequiredModule1.psd1
+++ b/test/powershell/engine/Module/assets/testmodulerunspace/NestedRequiredModule1/2.5/NestedRequiredModule1.psd1
@@ -59,4 +59,3 @@ PrivateData = @{
 } # End of PrivateData hashtable
 
 }
-

--- a/test/shebang/script.ps1
+++ b/test/shebang/script.ps1
@@ -2,4 +2,3 @@
 
 Get-Process
 Get-Module
-

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -621,4 +621,3 @@ function Get-HelpNetworkTestCases
 
     return $cases | Sort-Object -Property ExpectedError, Command -Unique
 }
-

--- a/test/tools/OpenCover/OpenCover.psd1
+++ b/test/tools/OpenCover/OpenCover.psd1
@@ -14,4 +14,3 @@ CmdletsToExport = @()
 VariablesToExport = @()
 AliasesToExport = @()
 }
-

--- a/tools/ResxGen/ResxGen.ps1
+++ b/tools/ResxGen/ResxGen.ps1
@@ -58,4 +58,3 @@ finally
 {
     Remove-Module ResxGen -Force -ErrorAction Ignore
 }
-


### PR DESCRIPTION
Ensure all PowerShell-related files end with a single newline character.

### Affected file types

* `.ps1`
* `.psm1`
* `.psd1`
* `.ps1xml`

### Justification

Ensuring that each file ends with exactly one newline follows POSIX conventions (where a line is defined as ending with a newline) and improves consistency across editors and tools. It also prevents unnecessary diffs caused by extra blank lines, keeping version history cleaner and easier to review.

### Notes

A [Python script](https://gist.github.com/xtqqczze/91a99b7bb113b7ee9ba3442616bdddd8) was used to apply these changes.
