### PR TITLE
WIP: Changes to address aspects of issue #6291 for native applications parameter binding

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -71,8 +71,9 @@ namespace System.Management.Automation
         {
             bool sawVerbatimArgumentMarker = false;
             bool first = true;
-            foreach (CommandParameterInternal parameter in parameters)
+            for (int i = 0; i < parameters.Count; i++)
             {
+                var parameter = parameters[i];
                 if (!first)
                 {
                     _arguments.Append(' ');
@@ -83,6 +84,16 @@ namespace System.Management.Automation
                 if (parameter.ParameterNameSpecified)
                 {
                     Diagnostics.Assert(!parameter.ParameterText.Contains(' '), "Parameters cannot have whitespace");
+                    // We may need to cook up a new parameter in some cases
+                    // e.g., in the case of -foo=bar.baz the PS parser sees this as multiple tokens (and others - see the tests), which requires special handling.
+                    int combinedParameterCount = CombineNativeParameters(parameters, i, out CommandParameterInternal combinedParameter);
+
+                    if (combinedParameterCount > 0)
+                    {
+                        parameter = combinedParameter;
+                        i += combinedParameterCount;
+                    }
+
                     PossiblyGlobArg(parameter.ParameterText, parameter, usedQuotes: false);
 
                     if (parameter.SpaceAfterParameter)
@@ -508,6 +519,80 @@ namespace System.Management.Automation
             }
 
             return " , ";
+        }
+
+        /// <summary>
+        /// Combine multiple parameters into a single parameter.
+        /// The the parser will find something that looks like this:
+        ///   -parameterName=text.part1.part2
+        /// and turn it into multiple parameters.
+        /// We need to look for those tokens which are not separated by spaces and recombine them to be sure the
+        /// native executable gets an arguably more reasonable parameter.
+        /// Note:
+        /// The complexity of properly resolving variables is non-trivial, so we create a non-expandable string representation of the string provided
+        /// on the command line. This means that parameters which contain variable references will not have those variables resolved, so executions like:
+        /// nativeapp -p1=$a.$b.$c
+        /// will now be treated as an non-expandable string.
+        /// If variables are desired in a parameter to a native app when '=' is used, they should be provided as explicit expandable strings:
+        /// nativeapp -p1="$a.$b.$c"
+        /// </summary>
+        /// <param name="parameters">The parameters for the current command.</param>
+        /// <param name="currentOffset">The current offset within the parameters array.</param>
+        /// <param name="combinedParameter">The combined parameter.</param>
+        /// <returns>an int representing the number of combined parameters</returns>
+        private static int CombineNativeParameters(IList<CommandParameterInternal> parameters, int currentOffset, out CommandParameterInternal combinedParameter)
+        {
+            combinedParameter = null;
+            var parameter = currentOffset >= parameters.Count ? null : parameters[currentOffset];
+            var nextParameter = currentOffset + 1 >= parameters.Count ? null : parameters[currentOffset + 1];
+
+            // don't combine if one of the parameters is null, or if the next parameter actually has a parameterAst
+            // which indicates that it is a separate parameter (i.e., it has a prepended '-')
+            if (parameter == null || nextParameter == null || nextParameter.ParameterAst != null)
+            {
+                return 0;
+            }
+
+            if (parameter.ParameterAst.Extent.EndScriptPosition.Offset != nextParameter.ArgumentAst.Extent.StartScriptPosition.Offset)
+            {
+                return 0;
+            }
+
+            StringBuilder paramText = new StringBuilder();
+            paramText.Append(parameter.ParameterText);
+            if (parameter.ArgumentAst is not null)
+            {
+                paramText.Append(parameter.ArgumentAst.Extent.Text);
+            }
+
+            // combine the parameters that should be combined
+            int parameterCombineCount = 0;
+            var startOffset = parameter.ParameterAst.Extent.EndScriptPosition.Offset;
+            var endOffset = nextParameter.ArgumentAst.Extent.StartScriptPosition.Offset;
+
+            // loop through the parameters where there is no separating space
+            while (startOffset == endOffset)
+            {
+                parameterCombineCount++;
+                // stitch the next segment from the next parameter argumentAst text to the parameter
+                paramText.Append(nextParameter.ArgumentAst.Extent.Text);
+
+                var parameterOffset = currentOffset + parameterCombineCount;
+
+                parameter = nextParameter;
+                nextParameter = parameterOffset + 1 < parameters.Count ? parameters[parameterOffset + 1] : null;
+
+                if (nextParameter is null || nextParameter.ArgumentAst is null)
+                {
+                    break;
+                }
+
+                startOffset = parameter.ArgumentAst.Extent.EndScriptPosition.Offset;
+                endOffset = nextParameter.ArgumentAst.Extent.StartScriptPosition.Offset;
+            }
+
+            combinedParameter = CommandParameterInternal.CreateParameter(paramText.ToString(), paramText.ToString());
+            return parameterCombineCount;
         }
 
         /// <summary>

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -7,9 +7,11 @@ Describe "Behavior is specific for each platform" -tags "CI" {
     It "PSNativeCommandArgumentPassing is set to 'Windows' on Windows systems" -skip:(-not $IsWindows) {
         $PSNativeCommandArgumentPassing | Should -BeExactly "Windows"
     }
+
     It "PSNativeCommandArgumentPassing is set to 'Standard' on non-Windows systems" -skip:($IsWindows) {
         $PSNativeCommandArgumentPassing | Should -Be "Standard"
     }
+
     It "Has proper behavior on Windows" -skip:(-not $IsWindows) {
         "@echo off`nSET V1=1" > "$TESTDRIVE\script 1.cmd"
         "@echo off`nSET V2=a`necho %V1%" > "$TESTDRIVE\script 2.cmd"
@@ -20,7 +22,6 @@ Describe "Behavior is specific for each platform" -tags "CI" {
         $result[1] | Should -Be 1
         $result[2] | Should Be "a"
     }
-
 }
 
 Describe "tests for multiple languages and extensions" -tags "CI" {
@@ -170,9 +171,11 @@ Describe "find.exe uses legacy behavior on Windows" -Tag 'CI' {
             @{ pattern = "blat" },
             @{ pattern = "bl at" }
     }
+
     AfterAll {
         $PSNativeCommandArgumentPassing = $currentSetting
     }
+
     It "The pattern '<pattern>' is used properly by find.exe" -skip:(! $IsWindows) -testCases $testCases {
         param ($pattern)
         $expr = "'foo' | find.exe --% /v ""$pattern"""
@@ -308,6 +311,29 @@ foreach ( $argumentListValue in "Standard","Legacy","Windows" ) {
             $lines = testexe -echoargs temp:/foo
             $lines.Count | Should -Be 1
             $lines | Should -BeExactly 'Arg 0 is <temp:/foo>'
+        }
+    }
+
+    Describe "Should handle native parameters which use '=' in combination with dots in the argument" -tags "CI" {
+        BeforeAll {
+            $testCases = @(
+                @{arguments = "-foo=bar.baz"; expected = @("Arg 0 is <-foo=bar.baz>")},
+                @{arguments = "-foo=bar.baz -baz=qux.quux"; expected = @("Arg 0 is <-foo=bar.baz>", "Arg 1 is <-baz=qux.quux>")}
+                @{arguments = "--foo=bar.baz -baz=qux.quux"; expected = @("Arg 0 is <--foo=bar.baz>", "Arg 1 is <-baz=qux.quux>")}
+                @{arguments = '-foo=bar.baz -baz=qux.$PID'; expected = @("Arg 0 is <-foo=bar.baz>", 'Arg 1 is <-baz=qux.$PID>')}
+                @{arguments = '-foo=bar.baz -baz=qux.$PWD.length'; expected = @("Arg 0 is <-foo=bar.baz>", 'Arg 1 is <-baz=qux.$PWD.length>')}
+            )
+        }
+
+        It "Should handle '<arguments>' in argument values" -TestCases $testCases {
+            param ($arguments, $expected)
+            $sb = [scriptblock]::Create("testexe -echoargs $arguments")
+            $lines = & $sb
+            if ($lines.count -ne $expected.count) {
+                wait-debugger
+            }
+            $lines.Count | Should -Be $expected.count
+            $lines | Should -BeExactly $expected
         }
     }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -329,9 +329,6 @@ foreach ( $argumentListValue in "Standard","Legacy","Windows" ) {
             param ($arguments, $expected)
             $sb = [scriptblock]::Create("testexe -echoargs $arguments")
             $lines = & $sb
-            if ($lines.count -ne $expected.count) {
-                wait-debugger
-            }
             $lines.Count | Should -Be $expected.count
             $lines | Should -BeExactly $expected
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Address aspects of issue #6291

<!-- Summarize your PR between here and the checklist. -->

## PR Context

Our native command parameter binder has a number of issues, this PR attempts to address some of them.

here's our current behavior (echoit is my tools for `testexe -echoargs`):

```powershell
#1
PS> echoit -bar $PWD.Length
Argument 1 <-bar>
Argument 2 <22>

#2
PS> echoit -bar:$PWD.Length
Argument 1 <-bar:22>

#3
PS> echoit -bar:foo.$PWD.Length
Argument 1 <-bar:foo./Users/james/Downloads.Length>

#4(?)
PS> echoit -bar=$PWD.Length
Argument 1 <-bar=$PWD>
Argument 2 <.Length>

#5(??)
PS> echoit -bar=foo.$PWD.Length
Argument 1 <-bar=foo>
Argument 2 <.>
Argument 3 <22>
```

Especially egregious is #5 where we are very excited to tokenize as much as we can.

Perhaps unsurprisingly, our handling of  parameters separated with ':' is less problematic, as we support that natively.
We can break that up into parameter name and argument value nicely as shown in the following:

```powershell
PS> { echoit -bar:$PWD.Length }.Ast.Findall({$true}, $false).Where({$_.gettype().Name -eq "CommandParameterAst"})

ParameterName : bar
Argument      : $PWD.Length
ErrorPosition : -bar:
Extent        : -bar:$PWD.Length
Parent        : echoit -bar:$PWD.Length
```

however, PowerShell doesn't recognize '=' as a parameter terminator, so we don't handle this as adeptly.

```powershell
PS> { echoit -bar=$PWD.Length }.Ast.Findall({$true}, $false).Where({$_.gettype().Name -eq "CommandParameterAst"})

ParameterName : bar=$PWD
Argument      :
ErrorPosition : -bar=$PWD
Extent        : -bar=$PWD
Parent        : echoit -bar=$PWD.Length
```

you can see that the ".Length" is is missing, it's a separate token and looks like an additional positional parameter.
We see the '.' and that's a token separator, so we've split up a single token into 2 

```powershell
PS> { echoit -bar=$PWD.Length }.Ast.Findall({$true}, $false)|ft {$_.gettype()},extent

$_.gettype()                                                      Extent
------------                                                      ------
System.Management.Automation.Language.ScriptBlockAst              {  echoit -bar=$PWD.Length }
System.Management.Automation.Language.NamedBlockAst               echoit -bar=$PWD.Length
System.Management.Automation.Language.PipelineAst                 echoit -bar=$PWD.Length
System.Management.Automation.Language.CommandAst                  echoit -bar=$PWD.Length
System.Management.Automation.Language.StringConstantExpressionAst echoit
System.Management.Automation.Language.CommandParameterAst         -bar=$PWD
System.Management.Automation.Language.StringConstantExpressionAst .Length
```

This PR essentially combines those tokens which don't have a separating
_space_ and treats the resultant string as non-expandable.

This PR behaves like this:

```powershell
PS> echoit -bar $PWD.Length   
Argument 1 <-bar>
Argument 2 <55>

PS>  echoit -bar:$PWD.Length
Argument 1 <-bar:55>

PS> echoit -bar:foo.$PWD.Length
Argument 1 <-bar:foo./Users/james/src/github/forks/jameswtruher/PowerShell-1.Length>

PS>  echoit -bar=$PWD.Length
Argument 1 <-bar=$PWD.Length>

PS> echoit -bar=foo.$PWD.Length
Argument 1 <-bar=foo.$PWD.Length>
```

Parenthetically, this PS> echoit -bar:foo.$PWD.Length which renders
Argument 1 <-bar:foo./Users/james/Downloads.Length>
is still probably not what the user is looking for, but that's also how we behave natively within PS.

Technically, this is a breaking change, but the current behavior has a number of issues. It should be noted that this will not affect anyone who as worked around the problem by using expandable strings:

```powershell
PS> echoit "-foo=bar.$PWD.Length"
Argument 1 <-bar=foo./Users/james/src/github/forks/jameswtruher/PowerShell-1.Length>
```

---

_Possibly_, the right thing to do is to change the parser/tokenizer to also accept '=' as a parameter
"terminator". This would mean changes to ParameterToken as well a number of other changes in the parser which would be a very risky thing for unintended consequences. (I took a run at this before my retirement, and it was pretty hairy).
This change, at least, will be more consistent and explainable than what we have now.

Please let me know if you want this protected in an experimental feature.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
