### PR TITLE
Trim trailing whitespace from `.json` and `.yaml` files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,7 @@ indent_size = 2
 # Data serialization
 [*.{json,yaml,yml}]
 indent_size = 2
+trim_trailing_whitespace = true
 
 # Markdown
 [*.md]

--- a/.github/ISSUE_TEMPLATE/WG_member_request.yaml
+++ b/.github/ISSUE_TEMPLATE/WG_member_request.yaml
@@ -6,10 +6,10 @@ body:
 - type: markdown
   attributes:
     value: |
-      ## Thank you for your interest in joining a PowerShell Working Group. 
+      ## Thank you for your interest in joining a PowerShell Working Group.
 
-      ### Please complete the following public form to request membership to a PowerShell Working Group. 
-      
+      ### Please complete the following public form to request membership to a PowerShell Working Group.
+
       > [!NOTE]
       > Not all Working Groups are accepting new members at this time.
 - type : dropdown
@@ -17,7 +17,7 @@ body:
   validations:
     required: true
   attributes:
-    label: Name of Working Group you are requesting to join? 
+    label: Name of Working Group you are requesting to join?
     description: >-
       Please select the name of the working group you are requesting to join. (Select one)
     options:
@@ -25,21 +25,21 @@ body:
       - "Engine"
       - "Interactive UX"
       - "Remoting"
-- type: dropdown  
+- type: dropdown
   id: time
   validations:
     required: true
   attributes:
     label: Can you provide at least 1 hour per week to the Working Group? Note that time commitments will vary per Working Group and decided by its members.
     description: >-
-      Please select Yes or No.     
+      Please select Yes or No.
     options:
       - "Yes"
       - "No"
-- type: markdown  
+- type: markdown
   attributes:
     value: |
-      ## ⚠️ This form is public. Do not provide any private or proprietary information. ⚠️   
+      ## ⚠️ This form is public. Do not provide any private or proprietary information. ⚠️
 - type: textarea
   attributes:
     label: Why do you want to join this working group?

--- a/.github/policies/IssueManagement.CloseResolutions.yml
+++ b/.github/policies/IssueManagement.CloseResolutions.yml
@@ -1,6 +1,6 @@
 id: CloseResolutionTags
 name: GitOps.PullRequestIssueManagement
-description: Closing issues with Resolution* 
+description: Closing issues with Resolution*
 owner:
 resource: repository
 disabled: false
@@ -23,7 +23,7 @@ configuration:
       - addReply:
           reply: This issue has been marked as declined and has not had any activity for **1 day**. It has been closed for housekeeping purposes.
       - closeIssue
-    
+
     - description: Close if marked as Resolution-By Design after one day of no activity
       frequencies:
       - hourly:
@@ -39,7 +39,7 @@ configuration:
       - addReply:
           reply: This issue has been marked as by-design and has not had any activity for **1 day**. It has been closed for housekeeping purposes.
       - closeIssue
-    
+
     - description: Close if marked as Resolution-Won't Fix after one day of no activity
       frequencies:
       - hourly:
@@ -55,8 +55,8 @@ configuration:
       - addReply:
           reply: This issue has been marked as won't fix and has not had any activity for **1 day**. It has been closed for housekeeping purposes.
       - closeIssue
-    
-    - description: Close if marked as Resolution-No Activity after seven day of no activity, no reply 
+
+    - description: Close if marked as Resolution-No Activity after seven day of no activity, no reply
       frequencies:
       - hourly:
           hour: 12
@@ -69,7 +69,7 @@ configuration:
           days: 7
       actions:
       - closeIssue
-    
+
     - description: Close if marked as Resolution-Duplicate after one day of no activity
       frequencies:
       - hourly:
@@ -85,7 +85,7 @@ configuration:
       - addReply:
           reply: This issue has been marked as duplicate and has not had any activity for **1 day**. It has been closed for housekeeping purposes.
       - closeIssue
-    
+
     - description: Close if marked as Resolution-External after one day of no activity
       frequencies:
       - hourly:
@@ -101,7 +101,7 @@ configuration:
       - addReply:
           reply: This issue has been marked as external and has not had any activity for **1 day**. It has been be closed for housekeeping purposes.
       - closeIssue
-    
+
     - description: Close if marked as Resolution-Answered after one day of no activity
       frequencies:
       - hourly:
@@ -117,7 +117,7 @@ configuration:
       - addReply:
           reply: This issue has been marked as answered and has not had any activity for **1 day**. It has been closed for housekeeping purposes.
       - closeIssue
-    
+
     - description: Close if marked as Resolution-Fixed after one day of no activity
       frequencies:
       - hourly:

--- a/.github/policies/IssueManagement.ResolveStale.yml
+++ b/.github/policies/IssueManagement.ResolveStale.yml
@@ -23,7 +23,7 @@ configuration:
       - addReply:
           reply: This issue has been marked as "Waiting on Author" and has not had any activity for **7 day**. It has been closed for housekeeping purposes.
       - closeIssue
-    
+
     - description: Label as Resolution-No Activity if not labeled with KeepOpen and no activity in 6 months
       frequencies:
       - hourly:
@@ -49,7 +49,7 @@ configuration:
           label: Review - Maintainer
       - isNotLabeledWith:
           label: WG-NeedsReview
-     # Up for grabs labeled issues will get closed after a 6 months of no activity unless KeepOpen label is included
+      # Up for grabs labeled issues will get closed after a 6 months of no activity unless KeepOpen label is included
       - noActivitySince:
           days: 180
       actions:
@@ -67,7 +67,7 @@ configuration:
       then:
       - removeLabel:
           label: Resolution-No Activity
-    
+
     - description: If new issue comment is author then remove waiting on author
       if:
       - payloadType: Issue_Comment
@@ -78,8 +78,8 @@ configuration:
       then:
       - removeLabel:
           label: Waiting on Author
-    
-    - description: Remove Stale label if issue comment 
+
+    - description: Remove Stale label if issue comment
       if:
       - payloadType: Issue_Comment
       - hasLabel:
@@ -87,7 +87,7 @@ configuration:
       then:
       - removeLabel:
           label: Stale
-    
+
     - description: Remove Needs-Triage label if issue is closed
       if:
       - payloadType: Issues
@@ -96,8 +96,8 @@ configuration:
       then:
       - removeLabel:
           label: Needs-Triage
-    
-    - description: Remove Keep Open label if closed by someone 
+
+    - description: Remove Keep Open label if closed by someone
       if:
       - payloadType: Issues
       - isAction:

--- a/.github/policies/PRManagement.yml
+++ b/.github/policies/PRManagement.yml
@@ -42,7 +42,7 @@ configuration:
           label: Stale
       - addReply:
           reply: This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **15 days**. It will be closed if no further activity occurs **within 10 days of this comment**.
-    
+
     - description: Label Review - Needed if PR is opened an no activity in 7 days but no other labels on it
       frequencies:
       - hourly:
@@ -69,7 +69,7 @@ configuration:
             This pull request has been automatically marked as Review Needed because it has been there has not been any activity for **7 days**.
 
             Maintainer, please provide feedback and/or mark it as `Waiting on Author`
-    
+
     - description: Add waiting on Author label if is draft PR, if no activity label
       frequencies:
       - hourly:
@@ -89,7 +89,7 @@ configuration:
       - addLabel:
           label: Waiting on Author
     eventResponderTasks:
-    
+
     - description: If PR has AutoMerge Label then enable Automerge to squash
       if:
       - payloadType: Pull_Request
@@ -98,7 +98,7 @@ configuration:
       then:
       - enableAutoMerge:
           mergeMethod: Squash
-    
+
     - description: If PR has label AutoMerge Removed then disable Automerge
       if:
       - payloadType: Pull_Request
@@ -106,9 +106,9 @@ configuration:
           label: AutoMerge
       then:
       - disableAutoMerge
-    
+
     - description: If PR review requests changes then add label waiting on Author and remove review needed
-      if: 
+      if:
       - payloadType: Pull_Request_Review
       - isAction:
           action: Submitted
@@ -119,7 +119,7 @@ configuration:
           label: Waiting on Author
       - removeLabel:
           label: Review - Needed
-    
+
     - description: Remove Waiting on author if has label and activity from author
       if:
       - payloadType: Pull_Request
@@ -137,7 +137,7 @@ configuration:
       then:
       - removeLabel:
           label: Waiting on Author
-    
+
     - description: remove waiting on author if review by author and has waiting on author
       if:
       - payloadType: Pull_Request_Review
@@ -148,7 +148,7 @@ configuration:
       then:
       - removeLabel:
           label: Waiting on Author
-    
+
     - description: Remove Stale label if PR has activity from author which is not closure
       if:
       - payloadType: Pull_Request
@@ -162,7 +162,7 @@ configuration:
       then:
       - removeLabel:
           label: Stale
-    
+
     - description: Remove Stale label if PR is reviewed
       if:
       - payloadType: Pull_Request_Review
@@ -171,7 +171,7 @@ configuration:
       then:
       - removeLabel:
           label: Stale
-    
+
     - description: Remove Review Needed if PR is created or done any action by Admins and iSazonov
       if:
       - payloadType: Pull_Request
@@ -199,7 +199,7 @@ configuration:
       then:
       - removeLabel:
           label: Review - Needed
-    
+
     - description: Remove Review - Needed if issue comment is by admin or iSazonov
       if:
       - payloadType: Issue_Comment
@@ -214,13 +214,13 @@ configuration:
       then:
       - removeLabel:
           label: Review - Needed
-    
+
     - description: If inPRLabel then label in PR
       if:
       - payloadType: Pull_Request
       then:
       - inPrLabel:
           label: In-PR
-    
+
 onFailure:
 onSuccess:

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -229,16 +229,16 @@ jobs:
         $ltsValue = $IsLTS.ToString().ToLower()
         $stableValue = $IsStable.ToString().ToLower()
         $previewValue = $IsPreview.ToString().ToLower()
-        
+
         Write-Verbose -Verbose "About to set variables:"
         Write-Verbose -Verbose "  LTS=$ltsValue"
         Write-Verbose -Verbose "  STABLE=$stableValue"
         Write-Verbose -Verbose "  PREVIEW=$previewValue"
-        
+
         Write-Host "##vso[task.setvariable variable=LTS]$ltsValue"
         Write-Host "##vso[task.setvariable variable=STABLE]$stableValue"
         Write-Host "##vso[task.setvariable variable=PREVIEW]$previewValue"
-        
+
         Write-Verbose -Verbose "Variables set successfully"
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json

--- a/.pipelines/templates/packaging/windows/sign.yml
+++ b/.pipelines/templates/packaging/windows/sign.yml
@@ -73,7 +73,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
       Write-Verbose -Verbose "Modules imported successfully"
-      
+
       # Install WiX Toolset for EXE package creation
       $isArm64 = '$(Runtime)' -eq 'arm64'
       $env:RUNTIME = '$(Runtime)'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -68,7 +68,7 @@ jobs:
       script: |
         # Convert ADO variables to PowerShell boolean variables
         $IsLTS = '$(LTS)' -eq 'true'
-        $IsStable = '$(STABLE)' -eq 'true' 
+        $IsStable = '$(STABLE)' -eq 'true'
         $IsPreview = '$(PREVIEW)' -eq 'true'
 
         Write-Verbose -Verbose "Channel Selection - LTS: $(LTS), Stable: $(STABLE), Preview: $(PREVIEW)"
@@ -76,7 +76,7 @@ jobs:
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
-          else { 
+          else {
             Write-Error "No valid channel detected"
             exit 1
           }

--- a/.pipelines/templates/release-SetTagAndChangelog.yml
+++ b/.pipelines/templates/release-SetTagAndChangelog.yml
@@ -42,7 +42,7 @@ jobs:
         Write-Error "Changelog file not found: $filePath"
         exit 1
       }
-      
+
       Write-Verbose -Verbose "Creating output directory for CHANGELOG: $(ob_outputDirectory)/CHANGELOG"
       New-Item -Path $(ob_outputDirectory)/CHANGELOG -ItemType Directory -Force
       Copy-Item -Path $filePath -Destination $(ob_outputDirectory)/CHANGELOG

--- a/.pipelines/templates/release-githubNuget.yml
+++ b/.pipelines/templates/release-githubNuget.yml
@@ -49,7 +49,7 @@ jobs:
         $fileContent = Get-Content -Path $OutputPath -Raw | Out-String
         Write-Verbose -Verbose -Message $fileContent
     displayName: Add sha256 hashes
-  
+
   - task: PowerShell@2
     inputs:
       targetType: inline
@@ -66,18 +66,18 @@ jobs:
         Get-Module | Write-Verbose -Verbose
 
         $filePath = Get-ChildItem -Path "$(Pipeline.Workspace)/CHANGELOG" -Filter '*.md' | Select-Object -First 1 -ExpandProperty FullName
-  
+
         if (-not (Test-Path $filePath)) {
           throw "$filePath not found"
         }
-  
+
         $changelog = Get-Content -Path $filePath
-  
+
         $headingPattern = "^## \[\d+\.\d+\.\d+"
         $headingStartLines = $changelog | Select-String -Pattern $headingPattern | Select-Object -ExpandProperty LineNumber
         $startLine = $headingStartLines[0]
         $endLine = $headingStartLines[1] - 1
-  
+
         $clContent = $changelog | Select-Object -Skip ($startLine-1) -First ($endLine - $startLine) | Out-String
 
         $StringBuilder = [System.Text.StringBuilder]::new($clContent, $clContent.Length + 2kb)
@@ -90,14 +90,14 @@ jobs:
         }
 
         $clContent = $StringBuilder.ToString()
-  
+
         Write-Verbose -Verbose "Selected content: `n$clContent"
 
         $releaseNotesFilePath = "$(Pipeline.Workspace)/release-notes.md"
         $clContent | Out-File -FilePath $releaseNotesFilePath -Encoding utf8
-  
+
         Write-Host "##vso[task.setvariable variable=ReleaseNotesFilePath;]$releaseNotesFilePath"
-  
+
         #if name has prelease then make prerelease true as a variable
         if ($releaseVersion -like '*-*') {
             Write-Host "##vso[task.setvariable variable=IsPreRelease;]true"

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -246,17 +246,17 @@ jobs:
 
   - pwsh: |
       Write-Verbose -Verbose "Copying Github Release files in $(Build.ArtifactStagingDirectory)/downloads to use in Release Pipeline"
-      
+
       Write-Verbose -Verbose "Creating output directory for GitHub Release files: $(ob_outputDirectory)/GitHubPackages"
       New-Item -Path $(ob_outputDirectory)/GitHubPackages -ItemType Directory -Force
-      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
-        Where-Object { $_.Extension -notin '.msix', '.nupkg' -and $_.Name -notmatch '-gc'} | 
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse |
+        Where-Object { $_.Extension -notin '.msix', '.nupkg' -and $_.Name -notmatch '-gc'} |
         Copy-Item -Destination $(ob_outputDirectory)/GitHubPackages -Recurse -Verbose
-      
+
       Write-Verbose -Verbose "Creating output directory for NuGet packages: $(ob_outputDirectory)/NuGetPackages"
       New-Item -Path $(ob_outputDirectory)/NuGetPackages -ItemType Directory -Force
-      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse | 
-        Where-Object { $_.Extension -eq '.nupkg' } | 
+      Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/downloads/*" -Recurse |
+        Where-Object { $_.Extension -eq '.nupkg' } |
         Copy-Item -Destination $(ob_outputDirectory)/NuGetPackages -Recurse -Verbose
     displayName: Copy downloads to Artifacts
 

--- a/.pipelines/templates/variable/release-shared.yml
+++ b/.pipelines/templates/variable/release-shared.yml
@@ -13,7 +13,7 @@ parameters:
     default: 'Not Initialized'
 
 variables:
-  - name: ob_signing_setup_enabled            
+  - name: ob_signing_setup_enabled
     value: false
   - name: ob_sdl_sbom_enabled
     value: ${{ parameters.SBOM }}

--- a/src/powershell-win-core/Properties/launchSettings.json
+++ b/src/powershell-win-core/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-{ 
+{
   "profiles": {
     "powershell-win-core": {
       "commandName": "Executable",


### PR DESCRIPTION
This PR removes trailing whitespace from all files in the repo with the following extensions:

* `.json`
* `.yaml`
* `.yml`

Additionally, it updates the `.editorconfig` to enforce automatic trimming of trailing whitespace for these file types going forward.

**Motivation:**

* Ensures consistent formatting across data files.
* Prevents accidental whitespace-only diffs.
* Aligns with general coding style guidelines.

_[Review with whitespace changes hidden](https://github.com/PowerShell/PowerShell/pull/25989/files?w=1)_