### PR TITLE
Remove redundant `CharSet` from `StructLayout` in structs without string-related fields

### DIFF
--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/UnsafeNativeMethods.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/UnsafeNativeMethods.cs
@@ -263,7 +263,7 @@ namespace System.Diagnostics.Eventing
             public short Milliseconds;
         }
 
-        [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Explicit)]
         [SecurityCritical]
         internal struct EvtVariant
         {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -924,7 +924,7 @@ namespace System.Management.Automation.Remoting.Client
         /// sequencing of data. Because of this the following structure will
         /// have only one string to hold stream information.
         /// </summary>
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct WSManStreamIDSetStruct
         {
             internal int streamIDsCount;
@@ -1073,7 +1073,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Unmanaged to Managed: WSMAN_OPERATION_INFO includes the struct directly, so this cannot be made internal to WsmanOptionSet.
         /// </summary>
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct WSManOptionSetStruct
         {
             internal int optionsCount;
@@ -1318,7 +1318,7 @@ namespace System.Management.Automation.Remoting.Client
 
         internal struct WSManShellDisconnectInfo : IDisposable
         {
-            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            [StructLayout(LayoutKind.Sequential)]
             private struct WSManShellDisconnectInfoInternal
             {
                 /// <summary>
@@ -1536,7 +1536,7 @@ namespace System.Management.Automation.Remoting.Client
                 return result;
             }
 
-            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            [StructLayout(LayoutKind.Sequential)]
             private struct WSManEnvironmentVariableSetInternal
             {
                 internal uint varsCount;
@@ -1559,7 +1559,7 @@ namespace System.Management.Automation.Remoting.Client
         /// </summary>
         internal class WSManProxyInfo : IDisposable
         {
-            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            [StructLayout(LayoutKind.Sequential)]
             private struct WSManProxyInfoInternal
             {
                 public int proxyAccessType;
@@ -2223,7 +2223,7 @@ namespace System.Management.Automation.Remoting.Client
             /// selectorSet and optionSet are handled differently because they are structs that contain pointers to arrays of structs.
             /// Most other data structures in the API point to structures using IntPtr rather than including the actual structure.
             /// </summary>
-            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            [StructLayout(LayoutKind.Sequential)]
             private struct WSManOperationInfoInternal
             {
                 internal WSManFragmentInternal fragment;
@@ -2295,7 +2295,7 @@ namespace System.Management.Automation.Remoting.Client
             /// <summary>
             /// Managed representation of WSMAN_SELECTOR_SET.
             /// </summary>
-            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            [StructLayout(LayoutKind.Sequential)]
             internal struct WSManSelectorSetStruct
             {
                 internal int numberKeys;

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
@@ -89,7 +89,7 @@ namespace System.Management.Automation.Remoting
     /// Explicit destruction and release of the IntPtrs is not required because
     /// their lifetime is managed by WinRM.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    [StructLayout(LayoutKind.Sequential)]
     internal class WSManPluginOperationShutdownContext // TODO: Rename to OperationShutdownContext when removing the MC++ module.
     {
         #region Internal Members


### PR DESCRIPTION
Remove explicit `CharSet` values from `[StructLayout]` attributes applied to structs that do not contain `char`, `string` or `StringBuilder` fields.

The `CharSet` field in `[StructLayout]` influences marshalling behavior only when a struct includes `char`, `string` or `StringBuilder` members. For structs that contain only value types or blittable types, specifying `CharSet` is redundant and has no effect on layout or marshaling.
