### PR TITLE
Remove unnecessary `CS0618` suppressions from Variant APIs

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
@@ -34,9 +34,7 @@ namespace Microsoft.PowerShell
                 throw new ArgumentException("PropVariantNullString", nameof(value));
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete (might get deprecated in future versions
             _valueType = (ushort)VarEnum.VT_LPWSTR;
-#pragma warning restore CS0618 // Type or member is obsolete (might get deprecated in future versions
             _ptr = Marshal.StringToCoTaskMemUni(value);
         }
 

--- a/src/System.Management.Automation/engine/COM/ComInvoker.cs
+++ b/src/System.Management.Automation/engine/COM/ComInvoker.cs
@@ -7,9 +7,6 @@ using System.Runtime.InteropServices;
 
 using COM = System.Runtime.InteropServices.ComTypes;
 
-// Disable obsolete warnings about VarEnum and COM-marshaling APIs in CoreCLR
-#pragma warning disable 618
-
 namespace System.Management.Automation
 {
     internal static class ComInvoker

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -141,9 +141,6 @@ namespace System.Management.Automation
             return "UnknownCustomtype";
         }
 
-        // Disable obsolete warning about VarEnum in CoreCLR
-#pragma warning disable 618
-
         /// <summary>
         /// This function gets a string representation of the Type Descriptor
         /// This is used in generating signature for Properties and Methods.
@@ -258,8 +255,6 @@ namespace System.Management.Automation
             VarEnum vt = (VarEnum)typedesc.vt;
             return VarEnumSelector.GetTypeForVarEnum(vt);
         }
-
-#pragma warning restore 618
 
         /// <summary>
         /// Converts a FuncDesc out of GetFuncDesc into a MethodInformation.


### PR DESCRIPTION
The VarEnum and COM-marshaling APIs have had the obsolete attribute removed, therefore [`CS0618`](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/cs0618) suppression is unnecessary.

References: https://github.com/dotnet/corefx/pull/35161
