### PR TITLE
Invert OfficialBuild booleans, remove windows manual validation, add macOS smoke test link

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -1,6 +1,9 @@
 trigger: none
 
 parameters:
+  - name: OfficialBuild
+    type: boolean
+    default: true
   - name: InternalSDKBlobURL
     displayName: URL to the blob having internal .NET SDK
     type: string
@@ -27,9 +30,6 @@ parameters:
     default: false
   - name: FORCE_CODEQL
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
-    type: boolean
-    default: false
-  - name: OfficialBuild
     type: boolean
     default: false
 

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -1,6 +1,9 @@
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
+  - name: OfficialBuild
+    type: boolean
+    default: true
   - name: ForceAzureBlobDelete
     displayName: Delete Azure Blob
     type: string
@@ -24,9 +27,6 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
 

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -1,6 +1,9 @@
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
+  - name: OfficialBuild
+    type: boolean
+    default: true
   - name: 'debug'
     displayName: 'Enable debug output'
     type: boolean
@@ -13,9 +16,6 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
 name: ev2-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
 

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -1,6 +1,9 @@
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
+  - name: OfficialBuild
+    type: boolean
+    default: true
   - name: 'debug'
     displayName: 'Enable debug output'
     type: boolean
@@ -23,9 +26,6 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     default: false
   - name: SkipPSInfraInstallers
     displayName: Skip Copying Archives and Installers to PSInfrastructure Public Location
-    type: boolean
-    default: false
-  - name: OfficialBuild
     type: boolean
     default: false
 
@@ -224,17 +224,10 @@ extends:
       jobs:
       - template: /.pipelines/templates/approvalJob.yml@self
         parameters:
-          displayName: Validate Windows Packages
-          jobName: ValidateWinPkg
-          instructions: |
-            Validate zip package on windows
-
-      - template: /.pipelines/templates/approvalJob.yml@self
-        parameters:
           displayName: Validate OSX Packages
           jobName: ValidateOsxPkg
           instructions: |
-            Validate tar.gz package on osx-arm64
+            Run MacOS smoke test https://dev.azure.com/mscodehub/PowerShellCore/_build?definitionId=3662&_a=summary
 
     - stage: ReleaseAutomation
       dependsOn: []

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -351,7 +351,7 @@ extends:
           displayName: Add manifest entry to winget
           jobName: UpdateWinGet
           instructions: |
-            This is typically done by the community 1-2 days after the release.
+            Run the workflow here https://github.com/PowerShell/Infrastructure/actions/workflows/winget.yml
 
     - stage: PublishMsix
       dependsOn: PushGitTagAndMakeDraftPublic

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -351,7 +351,7 @@ function Get-ChangeLog
 
     $version = $ThisReleaseTag.TrimStart('v')
 
-    Write-Output "## [${version}] - $(Get-Date -Format yyyy-MM-dd)`n"
+    Write-Output "## [${version}]`n"
 
     PrintChangeLog -clSection $clUntagged -sectionTitle 'UNTAGGED - Please classify'
     PrintChangeLog -clSection $clBreakingChange -sectionTitle 'Breaking Changes'

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -426,6 +426,9 @@ function Get-ChangeLogMessage
         '^Build\(deps\): ' {
             return $OriginalMessage.replace($Matches.0,'')
         }
+        '^\[release/v\d+\.\d+\]\s*' {
+            return $OriginalMessage.replace($Matches.0,'')
+        }
         default {
             return $OriginalMessage
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates several Azure DevOps pipeline YAML files to change the default value of the `OfficialBuild` parameter from `false` to `true`. This ensures that builds are treated as official by default across multiple pipelines. Additionally, there is a minor update to the manual validation instructions for MacOS packages in the release pipeline.

Parameter default updates:

* Changed the default value of the `OfficialBuild` boolean parameter to `true` in `.pipelines/PowerShell-Coordinated_Packages-Official.yml`, `.pipelines/PowerShell-Packages-Official.yml`, `.pipelines/PowerShell-Release-Official-Azure.yml`, and `.pipelines/PowerShell-Release-Official.yml` to make official builds the default behavior. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR4-R6) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R4-R6) [[3]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eR4-R6) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR4-R6)
* Removed redundant `OfficialBuild` parameter definitions with a default of `false` from the same files to avoid confusion and duplication. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL32-L34) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L27-L29) [[3]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL16-L18) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL28-L30)

Pipeline instructions update:

* Updated the manual validation instructions for MacOS packages in `.pipelines/PowerShell-Release-Official.yml` to reference the MacOS smoke test pipeline link, improving clarity for validation steps.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
