### PR TITLE
DOCS: Fix typo in changelog (ubuntu-lastest -> ubuntu-latest)

### DIFF
--- a/CHANGELOG/7.4.md
+++ b/CHANGELOG/7.4.md
@@ -118,7 +118,7 @@
 <li> Migrate MacOS Signing to OneBranch (#25412)</li>
 <li> Remove call to NuGet (#25410)</li>
 <li> Restore a script needed for build from the old release pipeline cleanup (#25201) (#25408)</li>
-<li> Switch to ubuntu-lastest for CI (#25406)</li>
+<li> Switch to ubuntu-latest for CI (#25406)</li>
 <li> Update GitHub Actions to work in private GitHub repository (#25403)</li>
 <li> Simplify PR Template (#25407)</li>
 <li> Disable SBOM generation on set variables job in release build (#25341)</li>


### PR DESCRIPTION
This PR corrects a small typo in the CHANGELOG/7.4.md file.

An entry for the v7.5.0-preview.2 release incorrectly referred to the GitHub Actions runner as **ubuntu-lastest**. This has been corrected to the canonical **ubuntu-latest**.

This change prevents confusion and ensures that users who might copy-paste the runner name from the changelog do not encounter errors in their own CI workflows.


