### PR TITLE
Ensure data-serialization files end with one newline

### DIFF
--- a/.github/ISSUE_TEMPLATE/WG_member_request.yaml
+++ b/.github/ISSUE_TEMPLATE/WG_member_request.yaml
@@ -64,4 +64,3 @@ body:
       I have the following public links to articles, code, or other resources that demonstrate my skills...
   validations:
     required: true
-

--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -302,4 +302,3 @@ jobs:
     displayName: 'List artifacts'
     env:
       ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
-

--- a/.vsts-ci/psresourceget-acr.yml
+++ b/.vsts-ci/psresourceget-acr.yml
@@ -153,4 +153,3 @@ stages:
 
         Publish-TestResults -Title "PSResourceGet - ACR tests" -Path $outputFilePath -Type NUnit
       displayName: 'PSResourceGet ACR functional tests using AzAuth'
-


### PR DESCRIPTION
Ensure all data-serialization files end with a single newline character.

### Affected file types

* `.json`
* `.yaml`
* `.yml`

### Justification

Ensuring that each file ends with exactly one newline follows POSIX conventions (where a line is defined as ending with a newline) and improves consistency across editors and tools. It also prevents unnecessary diffs caused by extra blank lines, keeping version history cleaner and easier to review.

### Notes

A [Python script](https://gist.github.com/xtqqczze/91a99b7bb113b7ee9ba3442616bdddd8) was used to apply these changes.
