### PR TITLE
Include `stylecop.json` in build

### DIFF
--- a/.github/actions/infrastructure/path-filters/action.yml
+++ b/.github/actions/infrastructure/path-filters/action.yml
@@ -102,7 +102,7 @@ runs:
           const buildModuleChanged = files.some(file => file === 'build.psm1');
           console.log(`✓ build.psm1 changed: ${buildModuleChanged}`);
 
-          const globalConfigChanged = files.some(file => file === '.globalconfig' || file === 'nuget.config' || file === 'global.json');
+          const globalConfigChanged = files.some(file => file === '.globalconfig' || file === 'nuget.config' || file === 'global.json' || file === 'stylecop.json');
           console.log(`✓ Global config changed: ${globalConfigChanged}`);
 
           const packagingChanged = files.some(file =>

--- a/Analyzers.props
+++ b/Analyzers.props
@@ -3,4 +3,8 @@
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
 </Project>

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project=".\Analyzers.props" />
+  <Import Project=".\Analyzers.props" Condition="'$(RunAnalyzers)' != 'false'" />
 
   <!--
       The 'version' property is populated with the default value in 'Microsoft.NET.DefaultAssemblyInfo.targets'

--- a/test/Test.Common.props
+++ b/test/Test.Common.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\Analyzers.props" />
+  <Import Project="..\Analyzers.props" Condition="'$(RunAnalyzers)' != 'false'" />
 
   <PropertyGroup>
     <Product>PowerShell Test</Product>


### PR DESCRIPTION
Include `stylecop.json` as an additional file in MSBuild, otherwise it has no effect.