### PR TITLE
[release/v7.4] Update StableRelease to not be the latest

### DIFF
--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -6,5 +6,5 @@
   "LTSReleaseTag" : ["v7.2.13"],
   "NextReleaseTag": "v7.4.0-preview.5",
   "LTSRelease": { "Latest": true, "Package": true },
-  "StableRelease":  { "Latest": true, "Package": true }
+  "StableRelease":  { "Latest": false, "Package": true }
 }


### PR DESCRIPTION

This pull request makes a minor update to the release metadata, specifically adjusting the status of the stable release.

* The `StableRelease` entry in `tools/metadata.json` has been changed so that `Latest` is now set to `false` instead of `true`.

