### PR TITLE
Remove UseDotnet task and use the dotnet-install script 

### DIFF
--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -27,6 +27,9 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   - name: OfficialBuild
     type: boolean
     default: false
+  - name: disableNetworkIsolation
+    type: boolean
+    default: false
 
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
 
@@ -66,6 +69,8 @@ variables:
   - group: MSIXSigningProfile
   - name: templateFile
     value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
+  - name: disableNetworkIsolation
+    value: ${{ parameters.disableNetworkIsolation }}
 
 resources:
   pipelines:
@@ -96,6 +101,7 @@ extends:
         Network: KS3
       linuxEsrpSigning: true
       incrementalSDLBinaryAnalysis: true
+      disableNetworkIsolation: ${{ variables.disableNetworkIsolation }}
     globalSdl:
       disableLegacyManifest: true
       # disabled Armorty as we dont have any ARM templates to scan. It fails on some sample ARM templates.

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -1,0 +1,14 @@
+steps:
+  - pwsh: |
+      $version = Get-Content ./global.json | ConvertFrom-Json | Select-Object -ExpandProperty sdk | Select-Object -ExpandProperty version
+
+      Write-Verbose -Verbose "Installing .NET SDK with version $version"
+
+      Import-Module ./build.psm1 -Force
+      Install-Dotnet -Version $version -Verbose
+
+    displayName: 'Install dotnet SDK'
+    workingDirectory: $(PowerShellRoot)
+    env:
+       ob_restore_phase: true
+

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -1,5 +1,12 @@
 steps:
   - pwsh: |
+      $psRoot = '$(PowerShellRoot)'
+
+      if (-not (Test-Path $psRoot)) {
+        $psRoot = '$(Build.SourcesDirectory)/PowerShell'
+        Set-Location $psRoot -Verbose
+      }
+
       $version = Get-Content ./global.json | ConvertFrom-Json | Select-Object -ExpandProperty sdk | Select-Object -ExpandProperty version
 
       Write-Verbose -Verbose "Installing .NET SDK with version $version"

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -1,8 +1,6 @@
 steps:
   - pwsh: |
-      $psRoot = '$(PowerShellRoot)'
-
-      if (-not (Test-Path $psRoot)) {
+      if (-not (Test-Path '$(RepoRoot)')) {
         $psRoot = '$(Build.SourcesDirectory)/PowerShell'
         Set-Location $psRoot -Verbose
       }
@@ -15,7 +13,7 @@ steps:
       Install-Dotnet -Version $version -Verbose
 
     displayName: 'Install dotnet SDK'
-    workingDirectory: $(PowerShellRoot)
+    workingDirectory: $(RepoRoot)
     env:
        ob_restore_phase: true
 

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -87,6 +87,8 @@ jobs:
     env:
       ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
+  - template: /.pipelines/templates/install-dotnet.yml@self
+
   - pwsh: |
       $packageType = '$(PackageType)'
       Write-Verbose -Verbose "packageType = $packageType"

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -105,7 +105,7 @@ jobs:
       Import-Module "$repoRoot/build.psm1"
       Import-Module "$repoRoot/tools/packaging"
 
-      Start-PSBootstrap -Scenario Package
+      Start-PSBootstrap -Scenario Both
 
       $psOptionsPath = "$(Pipeline.Workspace)/CoOrdinatedBuildPipeline/${unsignedDrop}/psoptions/psoptions.json"
 

--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -64,12 +64,7 @@ jobs:
       AnalyzeInPipeline: false
       Language: csharp
 
-  - task: UseDotNet@2
-    inputs:
-      useGlobalJson: true
-      workingDirectory: $(PowerShellRoot)
-    env:
-      ob_restore_phase: true
+  - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |
       $runtime = $env:RUNTIME

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -39,12 +39,8 @@ jobs:
       sudo chown $env:USER "$(Agent.TempDirectory)/PowerShell"
     displayName: 'Create $(Agent.TempDirectory)/PowerShell'
 
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      useGlobalJson: true
-      packageType: 'sdk'
-      workingDirectory: $(PowerShellRoot)
+    ## We cross compile for arm64, so the arch is always x64
+  - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |
       Import-Module $(PowerShellRoot)/build.psm1 -Force

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -94,8 +94,8 @@ jobs:
     parameters:
       repoRoot: $(PowerShellRoot)
 
-  - task: NuGetToolInstaller@1
-    displayName: 'Install NuGet.exe'
+  # - task: NuGetToolInstaller@1
+  #   displayName: 'Install NuGet.exe'
 
   - template: /.pipelines/templates/install-dotnet.yml@self
 

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -94,9 +94,6 @@ jobs:
     parameters:
       repoRoot: $(PowerShellRoot)
 
-  # - task: NuGetToolInstaller@1
-  #   displayName: 'Install NuGet.exe'
-
   - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -97,12 +97,7 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet.exe'
 
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      useGlobalJson: true
-      packageType: 'sdk'
-      workingDirectory: '$(PowerShellRoot)'
+  - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |
       Set-Location -Path '$(PowerShellRoot)'

--- a/.pipelines/templates/release-validate-fxdpackages.yml
+++ b/.pipelines/templates/release-validate-fxdpackages.yml
@@ -61,12 +61,7 @@ jobs:
         Get-ChildItem "$(Pipeline.Workspace)/PSPackagesOfficial/$artifactName" -Recurse
       displayName: 'Capture Downloaded Artifacts'
 
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
-      inputs:
-        useGlobalJson: true
-        packageType: 'sdk'
-        workingDirectory: $(Build.SourcesDirectory)/PowerShell"
+    - template: /.pipelines/templates/install-dotnet.yml@self
 
     - pwsh: |
         $artifactName = '$(artifactName)'

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -38,12 +38,7 @@ jobs:
         Get-ChildItem "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg" -Recurse
       displayName: 'Capture Downloaded Artifacts'
 
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
-      inputs:
-        useGlobalJson: true
-        packageType: 'sdk'
-        workingDirectory: $(REPOROOT)
+    - template: /.pipelines/templates/install-dotnet.yml@self
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -46,12 +46,7 @@ jobs:
         Get-ChildItem "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg" -Recurse
       displayName: 'Capture Downloaded Artifacts'
 
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
-      inputs:
-        useGlobalJson: true
-        packageType: 'sdk'
-        workingDirectory: $(REPOROOT)
+    - template: /.pipelines/templates/install-dotnet.yml@self
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)"

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -29,11 +29,9 @@ jobs:
     parameters:
       ReleaseTagVar: $(ReleaseTagVar)
 
-  - template: /.pipelines/templates/cloneToOfficialPath.yml@self
-
   - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
     parameters:
-      repoRoot: $(PowerShellRoot)
+      repoRoot: $(RepoRoot)
       ob_restore_phase: true
 
   - template: /.pipelines/templates/install-dotnet.yml@self
@@ -95,8 +93,6 @@ jobs:
   - template: /.pipelines/templates/SetVersionVariables.yml@self
     parameters:
       ReleaseTagVar: $(ReleaseTagVar)
-
-  - template: /.pipelines/templates/cloneToOfficialPath.yml@self
 
   - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
     parameters:

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -25,19 +25,18 @@ jobs:
     env:
       ob_restore_phase: true
 
+  - template: /.pipelines/templates/SetVersionVariables.yml@self
+    parameters:
+      ReleaseTagVar: $(ReleaseTagVar)
+
+  - template: /.pipelines/templates/cloneToOfficialPath.yml@self
+
   - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
     parameters:
-      repoRoot: $(Build.SourcesDirectory)/PowerShell
+      repoRoot: $(PowerShellRoot)
       ob_restore_phase: true
 
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      useGlobalJson: true
-      packageType: 'sdk'
-      workingDirectory: $(Build.SourcesDirectory)/PowerShell"
-    env:
-      ob_restore_phase: true
+  - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |
       New-Item -Path '$(ob_outputDirectory)' -ItemType Directory -Force
@@ -93,19 +92,18 @@ jobs:
     env:
       ob_restore_phase: true
 
+  - template: /.pipelines/templates/SetVersionVariables.yml@self
+    parameters:
+      ReleaseTagVar: $(ReleaseTagVar)
+
+  - template: /.pipelines/templates/cloneToOfficialPath.yml@self
+
   - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
     parameters:
       repoRoot: $(Build.SourcesDirectory)/PowerShell
       ob_restore_phase: true
 
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      useGlobalJson: true
-      packageType: 'sdk'
-      workingDirectory: $(Build.SourcesDirectory)/PowerShell"
-    env:
-      ob_restore_phase: true
+  - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |
       New-Item -Path '$(ob_outputDirectory)' -ItemType Directory -Force

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -65,12 +65,7 @@ jobs:
       AnalyzeInPipeline: false
       Language: csharp
 
-  - task: UseDotNet@2
-    inputs:
-      useGlobalJson: true
-      workingDirectory: $(PowerShellRoot)
-    env:
-      ob_restore_phase: true
+  - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |
       $runtime = switch ($env:Architecture)
@@ -144,6 +139,7 @@ jobs:
         }
 
       Import-Module -Name $(PowerShellRoot)/build.psm1 -Force
+      Find-Dotnet
 
       ## Build global tool
       Write-Verbose -Message "Building PowerShell global tool for Windows.x64" -Verbose
@@ -238,6 +234,9 @@ jobs:
           We also delete pdbs, content and contentFiles folder which are not necessary.
           After that, we repack using Compress-Archive and rename it back to a nupkg.
         #>
+
+      Import-Module -Name $(PowerShellRoot)/build.psm1 -Force
+      Find-Dotnet
 
       $packagingStrings = Import-PowerShellDataFile "$(PowerShellRoot)\tools\packaging\packaging.strings.psd1"
 

--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -109,6 +109,8 @@ jobs:
 
       Start-PSBootstrap -Scenario Package
 
+      Find-Dotnet
+
       $signedFilesPath, $psoptionsFilePath = if ($env:RUNTIME -eq 'minsize') {
           "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_x64_${runtime}\$signedFolder"
           "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_x64_${runtime}\psoptions\psoptions.json"

--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -107,7 +107,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      Start-PSBootstrap -Scenario Package
+      Start-PSBootstrap -Scenario Both
 
       Find-Dotnet
 

--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -78,12 +78,7 @@ jobs:
     env:
       ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
-  - task: UseDotNet@2
-    inputs:
-      useGlobalJson: true
-      workingDirectory: $(REPOROOT)
-    env:
-      ob_restore_phase: true
+  - template: /.pipelines/templates/install-dotnet.yml@self
 
   - pwsh: |
       $msixUrl = '$(makeappUrl)'

--- a/build.psm1
+++ b/build.psm1
@@ -2092,8 +2092,8 @@ function Install-Dotnet {
     # Note that when it is null, Invoke-Expression (but not &) must be used to interpolate properly
     $sudo = if (!$NoSudo) { "sudo" }
 
-    # $installObtainUrl = "https://dot.net/v1"
-    $installObtainUrl = "https://dotnet.microsoft.com/download/dotnet/scripts/v1"
+    $installObtainUrl = "https://builds.dotnet.microsoft.com/dotnet/scripts/v1"
+    #$installObtainUrl = "https://dotnet.microsoft.com/download/dotnet/scripts/v1"
     $uninstallObtainUrl = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain"
 
     # Install for Linux and OS X
@@ -2160,66 +2160,31 @@ function Install-Dotnet {
         Remove-Item -ErrorAction SilentlyContinue -Recurse -Force ~\AppData\Local\Microsoft\dotnet
         $installScript = "dotnet-install.ps1"
         Invoke-WebRequest -Uri $installObtainUrl/$installScript -OutFile $installScript
-        if (-not $environment.IsCoreCLR) {
-            $installArgs = @{}
-            if ($Version) {
-                $installArgs += @{ Version = $Version }
-            } elseif ($Channel) {
-                $installArgs += @{ Quality = $Quality }
-                $installArgs += @{ Channel = $Channel }
-            }
 
-            if ($InstallDir) {
-                $installArgs += @{ InstallDir = $InstallDir }
-            }
-
-            if ($AzureFeed) {
-                $installArgs += @{AzureFeed = $AzureFeed}
-            }
-
-            if ($FeedCredential) {
-                $installArgs += @{FeedCredential = $FeedCredential}
-            }
-
-            $installArgs += @{ SkipNonVersionedFiles = $true }
-
-            $installArgs | Out-String | Write-Verbose -Verbose
-
-            & ./$installScript @installArgs
+        $installArgs = @{}
+        if ($Version) {
+            $installArgs += @{ Version = $Version }
+        } elseif ($Channel) {
+            $installArgs += @{ Quality = $Quality }
+            $installArgs += @{ Channel = $Channel }
         }
-        else {
-            # dotnet-install.ps1 uses APIs that are not supported in .NET Core, so we run it with Windows PowerShell
-            $fullPSPath = Join-Path -Path $env:windir -ChildPath "System32\WindowsPowerShell\v1.0\powershell.exe"
-            $fullDotnetInstallPath = Join-Path -Path (Convert-Path -Path $PWD.Path) -ChildPath $installScript
 
-            if ($Version) {
-                $psArgs = @('-NoLogo', '-NoProfile', '-File', $fullDotnetInstallPath, '-Version', $Version)
-            }
-            elseif ($Channel) {
-                $psArgs = @('-NoLogo', '-NoProfile', '-File', $fullDotnetInstallPath, '-Channel', $Channel, '-Quality', $Quality)
-            }
-
-            if ($InstallDir) {
-                $psArgs += @('-InstallDir', $InstallDir)
-            }
-
-            if ($AzureFeed) {
-                $psArgs += @('-AzureFeed', $AzureFeed)
-            }
-
-            if ($FeedCredential) {
-                $psArgs += @('-FeedCredential', $FeedCredential)
-            }
-
-            $psArgs += @('-SkipNonVersionedFiles')
-
-            # Removing the verbose message to not expose the secret
-            # $psArgs -join ' ' | Write-Verbose -Verbose
-
-            Start-NativeExecution {
-                & $fullPSPath @psArgs
-            }
+        if ($InstallDir) {
+            $installArgs += @{ InstallDir = $InstallDir }
         }
+
+        if ($AzureFeed) {
+            $installArgs += @{AzureFeed = $AzureFeed}
+        }
+
+        if ($FeedCredential) {
+            $installArgs += @{FeedCredential = $FeedCredential}
+        }
+
+        $installArgs += @{ SkipNonVersionedFiles = $true }
+
+        $installArgs | Out-String | Write-Verbose -Verbose
+        & ./$installScript @installArgs
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request refactors how the .NET SDK is installed in the build pipelines by introducing a new reusable template and updating all relevant pipeline templates to use it. It also updates the `Install-Dotnet` function to use a new download URL and cleans up legacy code paths. Additionally, it introduces a new pipeline parameter to control network isolation. These changes improve maintainability, consistency, and flexibility across the build system.

**Pipeline .NET SDK Installation Refactor:**

* Added a new reusable template `install-dotnet.yml` for installing the .NET SDK, replacing multiple direct usages of the `UseDotNet@2` task across all major pipeline templates (`linux.yml`, `mac.yml`, `nupkg.yml`, `release-validate-fxdpackages.yml`, `release-validate-globaltools.yml`, `release-validate-sdk.yml`, `testartifacts.yml`, `windows-hosted-build.yml`, `windows-package-build.yml`, `linux-package-build.yml`). This centralizes and standardizes .NET installation logic. [[1]](diffhunk://#diff-7570e585001d4b7fba396c24c2ea2100dd94bd8c7961bd39a665e68a1c747f18R1-R21) [[2]](diffhunk://#diff-d57c933d863854f9d912e16e721ee4f97370454f265d73be75d62448be712056L67-R67) [[3]](diffhunk://#diff-36df43c9f4f3a05ba28d68446fe703429dd357f723690b0e1f9e47e50ff4ecdcL42-R43) [[4]](diffhunk://#diff-fef5d4fa72338febdeb6ec147c8a2dc2c59e458b0071f8ddbf15380d991eb9e0L97-R97) [[5]](diffhunk://#diff-efba0748346b488ed8332d07fa48164d736cba35526a17ac866dfb208306c9d6L64-R64) [[6]](diffhunk://#diff-6b7dccdd599f42253a0c0addbf6ad1e25952685bf0e42ee871d0358523a6694dL41-R41) [[7]](diffhunk://#diff-7fd1753df22414f945db9dae9369e8d700d930705d20e4e3fbff38eef3f4a433L49-R49) [[8]](diffhunk://#diff-032e37392c0cd1959e52181ad8a495660cc31f5649bab66df0b40897a5e62aceR28-R39) [[9]](diffhunk://#diff-032e37392c0cd1959e52181ad8a495660cc31f5649bab66df0b40897a5e62aceR95-R106) [[10]](diffhunk://#diff-75adb3400c53c5cbe183c86d9d543a4cda81cd7664b45c4bf3ce77478e8ff098L68-R68) [[11]](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daL81-R81) [[12]](diffhunk://#diff-c4deeac235a73bb18401801ffa4dbcba3977cfb09599cd432e2a5940de12734eR90-R91)

* Updated scripts in `windows-hosted-build.yml` and `windows-package-build.yml` to explicitly call `Find-Dotnet` after .NET installation, ensuring the correct .NET executable is located before proceeding. [[1]](diffhunk://#diff-75adb3400c53c5cbe183c86d9d543a4cda81cd7664b45c4bf3ce77478e8ff098R142) [[2]](diffhunk://#diff-75adb3400c53c5cbe183c86d9d543a4cda81cd7664b45c4bf3ce77478e8ff098R238-R240) [[3]](diffhunk://#diff-d0b811523496c4ea179f07fb27b0ff420971ae4fbfd98aa78be262400e35e9daR112-R113)

**Improvements to Install-Dotnet Script:**

* Changed the `Install-Dotnet` function in `build.psm1` to use the new download URL `https://builds.dotnet.microsoft.com/dotnet/scripts/v1`, and removed legacy code that handled different PowerShell environments, simplifying the function. [[1]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL2095-R2096) [[2]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL2163-R2163) [[3]](diffhunk://#diff-1eb6991ceacad71a638a32bcf0a4ec906c7ec150f5086732ab6d7702a624914aL2187-L2223)

**Pipeline Flexibility and Parameters:**

* Added a new parameter `disableNetworkIsolation` to `.pipelines/PowerShell-Packages-Official.yml`, allowing builds to optionally disable network isolation via pipeline configuration, and propagated this parameter through variables and template invocations. [[1]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R30-R32) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R72-R73) [[3]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R104)

**Other Pipeline Improvements:**

* Updated the test artifacts pipeline to use new templates for setting version variables and cloning to the official path, further modularizing the pipeline. [[1]](diffhunk://#diff-032e37392c0cd1959e52181ad8a495660cc31f5649bab66df0b40897a5e62aceR28-R39) [[2]](diffhunk://#diff-032e37392c0cd1959e52181ad8a495660cc31f5649bab66df0b40897a5e62aceR95-R106)

## PR Context

Allows the ability to use pre-release .NET SDKs

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
