### PR TITLE
Disable IDE0049: PreferBuiltInOrFrameworkType

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1342,7 +1342,7 @@ dotnet_diagnostic.IDE0048.severity = suggestion
 
 # IDE0049: PreferBuiltInOrFrameworkType
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049
-dotnet_diagnostic.IDE0049.severity = warning
+dotnet_diagnostic.IDE0049.severity = suggestion
 
 # IDE0050: ConvertAnonymousTypeToTuple
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0050


### PR DESCRIPTION
Temporarily disable this rule until all violations are addressed.

Not all rule violations were resolved in https://github.com/PowerShell/PowerShell/pull/14491. Since the rule has internal setting `EnforceOnBuild.Never` it doesn’t affect builds, however it still produces distracting warnings during design-time analysis.

https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0049

Related: https://github.com/PowerShell/PowerShell/issues/25922