### PR TITLE
Avoid possible multiple enumerations in ImportModuleCommand.IsPs1xmlFileHelper_IsPresentInEntries

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1371,7 +1371,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private bool IsPs1xmlFileHelper_IsPresentInEntries(RemoteDiscoveryHelper.CimModuleFile cimModuleFile, IEnumerable<string> manifestEntries)
+        private bool IsPs1xmlFileHelper_IsPresentInEntries(RemoteDiscoveryHelper.CimModuleFile cimModuleFile, List<string> manifestEntries)
         {
             const string ps1xmlExt = ".ps1xml";
             string fileName = cimModuleFile.FileName;


### PR DESCRIPTION
Fix [CA1851: Possible multiple enumerations of 'IEnumerable' collection](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851)
