### PR TITLE
Enable CA1858: Use 'StartsWith' instead of 'IndexOf'

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -510,6 +510,10 @@ dotnet_diagnostic.CA1846.severity = warning
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
 dotnet_diagnostic.CA1847.severity = warning
 
+# CA1858: Use 'StartsWith' instead of 'IndexOf'
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+dotnet_diagnostic.CA1858.severity = warning
+
 # CA1868: Unnecessary call to 'Contains' for sets
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1868
 dotnet_diagnostic.CA1868.severity = warning

--- a/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
@@ -311,8 +311,7 @@ namespace Microsoft.PowerShell.Commands
                 byte[] iv = null;
 
                 // If this is a V2 package
-                if (String.IndexOf(SecureStringHelper.SecureStringExportHeader,
-                        StringComparison.OrdinalIgnoreCase) == 0)
+                if (String.StartsWith(SecureStringHelper.SecureStringExportHeader, StringComparison.OrdinalIgnoreCase))
                 {
                     try
                     {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8286,7 +8286,7 @@ namespace System.Management.Automation.Internal
             ArgumentNullException.ThrowIfNull(streamName);
 
             string adjustedStreamName = streamName.Trim();
-            if (adjustedStreamName.IndexOf(':') != 0)
+            if (!adjustedStreamName.StartsWith(':'))
             {
                 adjustedStreamName = ":" + adjustedStreamName;
             }

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -4539,7 +4539,7 @@ namespace System.Management.Automation
                 }
             }
 
-            if (path.IndexOf(StringLiterals.HomePath, StringComparison.Ordinal) == 0)
+            if (path.StartsWith(StringLiterals.HomePath, StringComparison.Ordinal))
             {
                 // Support the single "~"
                 if (path.Length == 1)
@@ -4638,7 +4638,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                if (path.IndexOf(StringLiterals.HomePath, StringComparison.Ordinal) == 0)
+                if (path.StartsWith(StringLiterals.HomePath, StringComparison.Ordinal))
                 {
                     // Strip of the ~ and the \ or / if present
 

--- a/src/System.Management.Automation/security/Authenticode.cs
+++ b/src/System.Management.Automation/security/Authenticode.cs
@@ -115,8 +115,8 @@ namespace System.Management.Automation
             if (!string.IsNullOrEmpty(timeStampServerUrl))
             {
                 if ((timeStampServerUrl.Length <= 7) || (
-                    (timeStampServerUrl.IndexOf("http://", StringComparison.OrdinalIgnoreCase) != 0) &&
-                    (timeStampServerUrl.IndexOf("https://", StringComparison.OrdinalIgnoreCase) != 0)))
+                    !timeStampServerUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                    !timeStampServerUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase)))
                 {
                     throw PSTraceSource.NewArgumentException(
                         nameof(certificate),


### PR DESCRIPTION
> It's more efficient and clearer to call [String.StartsWith](https://learn.microsoft.com/dotnet/api/system.string.startswith) than to call [String.IndexOf](https://learn.microsoft.com/dotnet/api/system.string.indexof) and compare the result with zero to determine whether a string starts with a given prefix.
IndexOf searches the entire string, while StartsWith only compares at the beginning of the string.

https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
