### PR TITLE
Enable CA1860: Avoid using 'Enumerable.Any()' extension method

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -514,6 +514,10 @@ dotnet_diagnostic.CA1847.severity = warning
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
 dotnet_diagnostic.CA1858.severity = warning
 
+# CA1860: Avoid using 'Enumerable.Any()' extension method
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+dotnet_diagnostic.CA1860.severity = warning
+
 # CA1868: Unnecessary call to 'Contains' for sets
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1868
 dotnet_diagnostic.CA1868.severity = warning

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -1611,7 +1611,7 @@ namespace System.Management.Automation
             bool needToReAddInstanceMembersAndTypeNames = !object.ReferenceEquals(GetKeyForResurrectionTables(this), GetKeyForResurrectionTables(returnValue));
             if (needToReAddInstanceMembersAndTypeNames)
             {
-                Diagnostics.Assert(!returnValue.InstanceMembers.Any(), "needToReAddInstanceMembersAndTypeNames should mean that the new object has a fresh/empty list of instance members");
+                Diagnostics.Assert(returnValue.InstanceMembers.Count == 0, "needToReAddInstanceMembersAndTypeNames should mean that the new object has a fresh/empty list of instance members");
                 foreach (PSMemberInfo member in this.InstanceMembers)
                 {
                     if (member.IsHidden)


### PR DESCRIPTION
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
