### PR TITLE
Update `host-powershell` doc

### DIFF
--- a/docs/host-powershell/sample/MyApp/MyApp.csproj
+++ b/docs/host-powershell/sample/MyApp/MyApp.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>MyApp</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win10-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.1.1" /> 
-    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="6.1.1" />
-    <PackageReference Include="Microsoft.WSMan.Management" Version="6.1.1"/>
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.3" /> 
+    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.5.3" />
+    <PackageReference Include="Microsoft.WSMan.Management" Version="7.5.3"/>
   </ItemGroup>
 
 </Project>

--- a/docs/host-powershell/sample/MyApp/MyApp.csproj
+++ b/docs/host-powershell/sample/MyApp/MyApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>MyApp</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.3" /> 
-    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.5.3" />
-    <PackageReference Include="Microsoft.WSMan.Management" Version="7.5.3"/>
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.1" /> 
+    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.6.1" />
+    <PackageReference Include="Microsoft.WSMan.Management" Version="7.6.1"/>
   </ItemGroup>
 
 </Project>

--- a/docs/host-powershell/sample/MyApp/Program.cs
+++ b/docs/host-powershell/sample/MyApp/Program.cs
@@ -6,7 +6,7 @@ using System.Management.Automation;
 
 namespace Application.Test
 {
-    public class Program
+    public static class Program
     {
         /// <summary>
         /// Managed entry point shim, which starts the actual program.


### PR DESCRIPTION
- Enable `TreatWarningsAsErrors`
- Enable `Nullable`
- Fix NETSDK1138: The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.
- Fix NuGet Warnings NU1901, NU1902, NU1903, NU1904: Package has a known vulnerability (https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu1901-nu1904)
- Fix NETSDK1206: Found version-specific or distribution-specific runtime identifier(s): win10-x64, win10-x86, win7-x64, win7-x86, win8-x64, win8-x86, win81-x64, win81-x86. Affected libraries: Microsoft.Management.Infrastructure. In .NET 8.0 and higher, assets for version-specific and distribution-specific runtime identifiers will not be found by default. See https://aka.ms/dotnet/rid-usage for details.
- Fix CA1052: Type 'Program' is a static holder type but is neither static nor NotInheritable (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052)
