### PR TITLE
Update `github-action-markdown-link-check`

### DIFF
--- a/.github/workflows/markdownLink.yml
+++ b/.github/workflows/markdownLink.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1
+    - uses: tcort/github-action-markdown-link-check@f3d33029dca1c4a24b87e2df648f9f4604ef6533 # v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/markdownLink.yml
+++ b/.github/workflows/markdownLink.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+    - uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/markdownLinkDaily.yml
+++ b/.github/workflows/markdownLinkDaily.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Check Links
-      uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+      uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/markdownLinkDaily.yml
+++ b/.github/workflows/markdownLinkDaily.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Check Links
-      uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba # v1
+      uses: tcort/github-action-markdown-link-check@f3d33029dca1c4a24b87e2df648f9f4604ef6533 # v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'


### PR DESCRIPTION
- Move to the `tcort` fork as the `gaurav-nelson` one is deprecated.
- Update from ~`1.0.14` to `v1.1.0`

Fix https://github.com/PowerShell/PowerShell/issues/26113