### PR TITLE
Remove `ThreadJob` module and update `PSReadLine` to 2.4.4-beta4

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -15,8 +15,7 @@
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-preview3" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-    <PackageReference Include="PSReadLine" Version="2.3.6" />
-    <PackageReference Include="ThreadJob" Version="2.1.0" />
+    <PackageReference Include="PSReadLine" Version="2.4.4-beta4" />
     <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   
   </ItemGroup>
 

--- a/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
+++ b/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
@@ -12,13 +12,13 @@ Describe "PSReadLine" -tags "CI" {
         Import-Module PSReadLine
         $module = Get-Module PSReadLine
         $module.Name | Should -BeExactly 'PSReadLine'
-        $module.Version | Should -Match '^2.3.\d$'
+        $module.Version | Should -Match '^2.4.\d$'
     }
 
     It "Should be installed to `$PSHOME" {
         $module = Get-Module (Join-Path -Path $PSHOME -ChildPath "Modules" -AdditionalChildPath "PSReadLine") -ListAvailable
         $module.Name | Should -BeExactly 'PSReadLine'
-        $module.Version | Should -Match '^2.3.\d$'
+        $module.Version | Should -Match '^2.4.\d$'
         $module.Path | Should -Be (Join-Path -Path $PSHOME -ChildPath "Modules/PSReadLine/PSReadLine.psd1")
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Remove `ThreadJob` module and update `PSReadLine` to 2.4.4-beta4

1. Remove `ThreadJob` based on https://github.com/PowerShell/ThreadJob/issues/30. PowerShell Committe decided that "ThreadJob module will be deprecated and removed in PS 7.6".
2. Update `PSReadLine` to 2.4.4-beta4 per the conversation with @theJasonHelmick about shipping the PSReadLine 2.4 GA along with PowerShell 7.6.