### PR TITLE
Fix R2R for fxdependent packaging 

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -186,21 +186,25 @@
   <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependent' ">
     <!-- Specify both to keep existing behavior because we have not had complaints about this scenario -->
     <AppHostDotNetSearch>EnvironmentVariable;Global</AppHostDotNetSearch>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>false</PublishReadyToRunEmitSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' ">
     <!-- If we specify Environment too, it searches that first, no matter what order we specify-->
     <AppHostDotNetSearch>Global</AppHostDotNetSearch>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' ">
     <AppHostDotNetSearch>AppLocal</AppHostDotNetSearch>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>
 
   <!-- Define all OS, release configuration properties -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <Optimize>true</Optimize>
     <DebugType>portable</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates the `PowerShell.Common.props` file to make the `PublishReadyToRun` and `PublishReadyToRunEmitSymbols` settings conditional based on the deployment type, instead of always enabling them for Release builds. This change improves control over ReadyToRun publishing behavior for different deployment scenarios.

Deployment-specific ReadyToRun settings:

* For `FxDependent` deployments, disables `PublishReadyToRun` and `PublishReadyToRunEmitSymbols`.
* For `FxDependentDeployment` and `SelfContained` deployments, enables `PublishReadyToRun` and `PublishReadyToRunEmitSymbols`.

General build configuration:

* Removes unconditional enabling of `PublishReadyToRun` and `PublishReadyToRunEmitSymbols` in the `Release` configuration, relying instead on the deployment-specific settings above.

## PR Context

Issue introduced by - https://github.com/PowerShell/PowerShell/pull/25837

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
