### PR TITLE
Add Delimiter parameter to Get-Clipboard

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Management.Automation.Language;
 using Microsoft.PowerShell.Commands.Internal;
 
 namespace Microsoft.PowerShell.Commands
@@ -38,6 +40,7 @@ namespace Microsoft.PowerShell.Commands
         /// The delimiters to use when splitting the clipboard content.
         /// </summary>
         [Parameter]
+        [ArgumentCompleter(typeof(DelimiterCompleter))]
         public string[] Delimiter { get; set; } = [Environment.NewLine];
 
         private bool _raw;
@@ -78,6 +81,36 @@ namespace Microsoft.PowerShell.Commands
             }
 
             return result;
+        }
+    }
+
+    /// <summary>
+    /// Provides argument completion for the Delimiter parameter.
+    /// </summary>
+    public sealed class DelimiterCompleter : IArgumentCompleter
+    {
+        /// <summary>
+        /// Provides argument completion for the Delimiter parameter.
+        /// </summary>
+        /// <param name="commandName">The name of the command that is being completed.</param>
+        /// <param name="parameterName">The name of the parameter that is being completed.</param>
+        /// <param name="wordToComplete">The input text to filter the results by.</param>
+        /// <param name="commandAst">The ast of the command that triggered the completion.</param>
+        /// <param name="fakeBoundParameters">The parameters bound to the command.</param>
+        /// <returns>Completion results.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            wordToComplete ??= string.Empty;
+            var pattern = new WildcardPattern(wordToComplete + '*', WildcardOptions.IgnoreCase);
+            if (pattern.IsMatch("CRLF") || pattern.IsMatch("Windows"))
+            {
+                yield return new CompletionResult("\"`r`n\"", "CRLF", CompletionResultType.ParameterValue, "Windows (CRLF)");
+            }
+
+            if (pattern.IsMatch("LF") || pattern.IsMatch("Unix") || pattern.IsMatch("Linux"))
+            {
+                yield return new CompletionResult("\"`n\"", "LF", CompletionResultType.ParameterValue, "UNIX (LF)");
+            }
         }
     }
 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
@@ -34,6 +34,12 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
+        /// <summary>
+        /// The delimiters to use when splitting the clipboard content.
+        /// </summary>
+        [Parameter]
+        public string[] Delimiter { get; set; } = [Environment.NewLine];
+
         private bool _raw;
 
         /// <summary>
@@ -68,8 +74,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                string[] splitSymbol = { Environment.NewLine };
-                result.AddRange(textContent.Split(splitSymbol, StringSplitOptions.None));
+                result.AddRange(textContent.Split(Delimiter, StringSplitOptions.None));
             }
 
             return result;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// The delimiters to use when splitting the clipboard content.
+        /// Gets or sets the delimiters to use when splitting the clipboard content.
         /// </summary>
         [Parameter]
         [ArgumentCompleter(typeof(DelimiterCompleter))]

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
@@ -36,6 +36,13 @@ Describe 'Clipboard cmdlet tests' -Tag CI {
             Get-Clipboard -Raw | Should -BeExactly "1$([Environment]::NewLine)2"
         }
 
+        It 'Get-Clipboard -Delimiter should return items based on the delimiter' {
+            Set-Clipboard -Value "Line1`r`nLine2`nLine3"
+            $result = Get-Clipboard -Delimiter "`r`n", "`n"
+            $result.Count | Should -Be 3
+            $result | ForEach-Object -Process {$_.Length | Should -Be "LineX".Length}
+        }
+
         It 'Set-Clipboard -Append will add text' {
             'hello' | Set-Clipboard
             'world' | Set-Clipboard -Append


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR adds a Delimiter parameter to Get-Clipboard allowing users to customize the delimiters used to split the content.
This was discussed in this issue: https://github.com/PowerShell/PowerShell/issues/25480
Note that I made the parameter a string array, rather than string. The reason for this is that it allows users to set a default value of
```
"`r`n", "`n"
```
to handle both Windows and Linux line endings. If it was just a single string you'd have to be aware of the line endings before running the command.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Fixes https://github.com/PowerShell/PowerShell/issues/25480
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/12406
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
