### PR TITLE
Fix the task name to not use the pre-release task

### DIFF
--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -208,7 +208,7 @@ jobs:
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
 
-    - task: MS-RDX-MRO.windows-store-publish-dev.package-task.store-package@3
+    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
       inputs:
         serviceEndpoint: '$(ServiceConnection)'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Use `MS-RDX-MRO.windows-store-publish.package-task.store-package` instead of `MS-RDX-MRO.windows-store-publish-dev.package-task.store-package`.
