### PR TITLE
Correct handling of explicit -Empty:$false parameter value in New-Guid

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewGuidCommand.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                guid = ParameterSetName is "Empty" ? Guid.Empty : Guid.NewGuid();
+                guid = Empty.ToBool() ? Guid.Empty : Guid.NewGuid();
             }
 
             WriteObject(guid);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Guid.Tests.ps1
@@ -17,6 +17,11 @@ Describe "New-Guid" -Tags "CI" {
         $guid.ToString() | Should -BeExactly "00000000-0000-0000-0000-000000000000"
     }
 
+    It "Should respect explicit false value for -Empty" {
+        $guid = New-Guid -Empty:$false
+        $guid.ToString() | Should -Not -BeExactly "00000000-0000-0000-0000-000000000000"
+    }
+
     It "Should convert a string to a guid" {
         $guid1 = New-Guid
         $guid2 = New-Guid -InputObject $guid1.ToString()


### PR DESCRIPTION
Fix New-Guid's handling of -Empty to check the switch's value, rather than only its presence, allowing parameter values to be passed through easily.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds a test to reproduce the bug described in issue #25276, and then updates the implementation of the `New-Guid` cmdlet to fix the bug, making the test pass.

## PR Context

Fixes #25276
Related to #25242

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
