### PR TITLE
Correct handling of explicit -Since:$false parameter value in Get-Uptime

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
@@ -38,12 +38,12 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Since.ToBool())
                 {
-                    // return Datetime when the system started up
+                    // Caller requests absolute point in time of last boot
                     WriteObject(DateTime.Now.Subtract(uptime));
                 }
                 else
                 {
-                    // return TimeSpan of time since the system started up
+                    // Caller requests span of time since last boot
                     WriteObject(uptime);
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
@@ -38,12 +38,12 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Since)
                 {
-                    // Caller requests absolute point in time of last boot
+                    // Output the time of the last system boot.
                     WriteObject(DateTime.Now.Subtract(uptime));
                 }
                 else
                 {
-                    // Caller requests span of time since last boot
+                    // Output the time elapsed since the last system boot.
                     WriteObject(uptime);
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
@@ -36,16 +36,15 @@ namespace Microsoft.PowerShell.Commands
             {
                 TimeSpan uptime = TimeSpan.FromSeconds(Stopwatch.GetTimestamp() / Stopwatch.Frequency);
 
-                switch (ParameterSetName)
+                if (Since.ToBool())
                 {
-                    case TimespanParameterSet:
-                        // return TimeSpan of time since the system started up
-                        WriteObject(uptime);
-                        break;
-                    case SinceParameterSet:
-                        // return Datetime when the system started up
-                        WriteObject(DateTime.Now.Subtract(uptime));
-                        break;
+                    // return Datetime when the system started up
+                    WriteObject(DateTime.Now.Subtract(uptime));
+                }
+                else
+                {
+                    // return TimeSpan of time since the system started up
+                    WriteObject(uptime);
                 }
             }
             else

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUptime.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 TimeSpan uptime = TimeSpan.FromSeconds(Stopwatch.GetTimestamp() / Stopwatch.Frequency);
 
-                if (Since.ToBool())
+                if (Since)
                 {
                     // Caller requests absolute point in time of last boot
                     WriteObject(DateTime.Now.Subtract(uptime));

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Uptime.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Uptime.Tests.ps1
@@ -25,6 +25,10 @@ Describe "Get-Uptime" -Tags "CI" {
         $upt = Get-Uptime -Since
         $upt | Should -BeOfType DateTime
     }
+    It "Get-Uptime -Since:`$false return TimeSpan" {
+        $upt = Get-Uptime -Since:$false
+        $upt | Should -BeOfType TimeSpan
+    }
     It "Get-Uptime throw if IsHighResolution == false" {
         # Enable the test hook
         [system.management.automation.internal.internaltesthooks]::SetTestHook('StopwatchIsNotHighResolution', $true)


### PR DESCRIPTION
Fix Get-Uptime's handling of -Since to check the switch's value, rather than only its presence, allowing parameter values to be passed through easily.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR adds a test to reproduce the bug described in issue #25015, and then updates the implementation of the `Get-Uptime` cmdlet to fix the bug, making the test pass.

## PR Context

Fixes #25015
Related to #25242

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
