### PR TITLE
Switch parameter standardization

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -923,7 +923,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 CimTestCimSessionContext context = new(proxy, wrapper);
                 proxy.ContextObject = context;
                 // Skip test the connection if user intend to
-                if (cmdlet.SkipTestConnection.IsPresent)
+                if (cmdlet.SkipTestConnection.IsSpecified)
                 {
                     AddSessionToCache(proxy.CimSession, context, new CmdletOperationBase(cmdlet));
                 }

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -654,7 +654,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// </summary>
         public SwitchParameter KeyOnly
         {
-            set { this.OperationOptions.KeysOnly = value.IsPresent; }
+            set { this.OperationOptions.KeysOnly = value.IsSpecified; }
         }
 
         /// <summary>
@@ -664,7 +664,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             set
             {
-                if (value.IsPresent)
+                if (value.IsSpecified)
                 {
                     this.OperationOptions.Flags = CimOperationFlags.PolymorphismShallow;
                 }

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/ExportCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/ExportCounterCommand.cs
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.Commands
             //
             SetOutputFormat();
 
-            if (Circular.IsPresent && _maxSize == 0)
+            if (Circular.IsSpecified && _maxSize == 0)
             {
                 string msg = string.Format(CultureInfo.InvariantCulture, _resourceMgr.GetString("CounterCircularNoMaxSize"));
                 Exception exc = new Exception(msg);
@@ -255,7 +255,7 @@ namespace Microsoft.PowerShell.Commands
                     ReportPdhError(res, true);
                 }
 
-                res = _pdhHelper.OpenLogForWriting(_resolvedPath, _outputFormat, Force.IsPresent, _maxSize * 1024 * 1024, Circular.IsPresent, null);
+                res = _pdhHelper.OpenLogForWriting(_resolvedPath, _outputFormat, Force.IsSpecified, _maxSize * 1024 * 1024, Circular.IsSpecified, null);
                 if (res == PdhResults.PDH_FILE_ALREADY_EXISTS)
                 {
                     string msg = string.Format(CultureInfo.InvariantCulture, _resourceMgr.GetString("CounterFileExists"), _resolvedPath);

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            if (Continuous.IsPresent && _maxSamplesSpecified)
+            if (Continuous.IsSpecified && _maxSamplesSpecified)
             {
                 Exception exc = new(string.Format(CultureInfo.CurrentCulture, _resourceMgr.GetString("CounterContinuousOrMaxSamples")));
                 ThrowTerminatingError(new ErrorRecord(exc, "CounterContinuousOrMaxSamples", ErrorCategory.InvalidArgument, null));
@@ -488,7 +488,7 @@ namespace Microsoft.PowerShell.Commands
             bool bSkip = true;
             uint sampleReads = 0;
 
-            if (Continuous.IsPresent)
+            if (Continuous.IsSpecified)
             {
                 _maxSamples = KEEP_ON_SAMPLING;
             }

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -525,7 +525,7 @@ namespace Microsoft.PowerShell.Commands
                                 //
                                 // Skip direct channels matching the wildcard unless -Force is present.
                                 //
-                                if (!Force.IsPresent &&
+                                if (!Force.IsSpecified &&
                                     WildcardPattern.ContainsWildcardCharacters(logPattern) &&
                                         (logObj.LogType == EventLogType.Debug ||
                                         logObj.LogType == EventLogType.Analytical))
@@ -624,7 +624,7 @@ namespace Microsoft.PowerShell.Commands
         {
             using (EventLogSession eventLogSession = CreateSession())
             {
-                if (!Oldest.IsPresent)
+                if (!Oldest.IsSpecified)
                 {
                     //
                     // Do minimal parsing of xmlQuery to determine if any direct channels or ETL files are in it.
@@ -1544,7 +1544,7 @@ namespace Microsoft.PowerShell.Commands
         //
         private void TerminateForNonEvtxFileWithoutOldest(string fileName)
         {
-            if (!Oldest.IsPresent)
+            if (!Oldest.IsSpecified)
             {
                 if (System.IO.Path.GetExtension(fileName).Equals(".etl", StringComparison.OrdinalIgnoreCase) ||
                     System.IO.Path.GetExtension(fileName).Equals(".evt", StringComparison.OrdinalIgnoreCase))
@@ -1584,7 +1584,7 @@ namespace Microsoft.PowerShell.Commands
                 return false;
             }
 
-            if (!Oldest.IsPresent)
+            if (!Oldest.IsSpecified)
             {
                 if (logObj.LogType == EventLogType.Debug || logObj.LogType == EventLogType.Analytical)
                 {
@@ -1896,7 +1896,7 @@ namespace Microsoft.PowerShell.Commands
                         EventLogConfiguration logObj = new(logLink.LogName, eventLogSession);
                         if (logObj.LogType == EventLogType.Debug || logObj.LogType == EventLogType.Analytical)
                         {
-                            if (!Force.IsPresent)
+                            if (!Force.IsSpecified)
                             {
                                 continue;
                             }
@@ -1988,7 +1988,7 @@ namespace Microsoft.PowerShell.Commands
 
                         if (logObj.LogType == EventLogType.Debug || logObj.LogType == EventLogType.Analytical)
                         {
-                            if (WildcardPattern.ContainsWildcardCharacters(logPattern) && !Force.IsPresent)
+                            if (WildcardPattern.ContainsWildcardCharacters(logPattern) && !Force.IsSpecified)
                             {
                                 continue;
                             }

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.Cmdletization
                     queryJob.SuppressOutputForwarding = true;
                 }
 
-                bool discardNonPipelineResults = (actionAgainstResults != null) || !this.AsJob.IsPresent;
+                bool discardNonPipelineResults = (actionAgainstResults != null) || !this.AsJob.IsSpecified;
                 HandleJobOutput(
                     queryJob,
                     sessionForJob,
@@ -225,7 +225,7 @@ namespace Microsoft.PowerShell.Cmdletization
 
             if (methodInvocationJob != null)
             {
-                bool discardNonPipelineResults = !this.AsJob.IsPresent;
+                bool discardNonPipelineResults = !this.AsJob.IsSpecified;
                 HandleJobOutput(
                     methodInvocationJob,
                     sessionForJob,
@@ -379,7 +379,7 @@ namespace Microsoft.PowerShell.Cmdletization
                 StartableJob childJob = this.DoCreateQueryJob(sessionForJob, query, actionAgainstResults: null);
                 if (childJob != null)
                 {
-                    if (!this.AsJob.IsPresent)
+                    if (!this.AsJob.IsSpecified)
                     {
                         _parentJob.AddChildJobAndPotentiallyBlock(this.Cmdlet, childJob, ThrottlingJob.ChildJobFlags.None);
                     }
@@ -416,7 +416,7 @@ namespace Microsoft.PowerShell.Cmdletization
                             objectInstance,
                             methodInvocationInfo,
                             passThru,
-                            closureOverAsJob.IsPresent);
+                            closureOverAsJob.IsSpecified);
 
                         if (methodInvocationJob != null)
                         {
@@ -426,7 +426,7 @@ namespace Microsoft.PowerShell.Cmdletization
 
                 if (queryJob != null)
                 {
-                    if (!this.AsJob.IsPresent)
+                    if (!this.AsJob.IsSpecified)
                     {
                         _parentJob.AddChildJobAndPotentiallyBlock(this.Cmdlet, queryJob, ThrottlingJob.ChildJobFlags.CreatesChildJobs);
                     }
@@ -583,10 +583,10 @@ namespace Microsoft.PowerShell.Cmdletization
 
             foreach (TSession sessionForJob in this.GetSessionsToActAgainst(objectInstance))
             {
-                StartableJob childJob = this.DoCreateInstanceMethodInvocationJob(sessionForJob, objectInstance, methodInvocationInfo, passThru, this.AsJob.IsPresent);
+                StartableJob childJob = this.DoCreateInstanceMethodInvocationJob(sessionForJob, objectInstance, methodInvocationInfo, passThru, this.AsJob.IsSpecified);
                 if (childJob != null)
                 {
-                    if (!this.AsJob.IsPresent)
+                    if (!this.AsJob.IsSpecified)
                     {
                         _parentJob.AddChildJobAndPotentiallyBlock(this.Cmdlet, childJob, ThrottlingJob.ChildJobFlags.None);
                     }
@@ -611,7 +611,7 @@ namespace Microsoft.PowerShell.Cmdletization
                 StartableJob childJob = this.DoCreateStaticMethodInvocationJob(sessionForJob, methodInvocationInfo);
                 if (childJob != null)
                 {
-                    if (!this.AsJob.IsPresent)
+                    if (!this.AsJob.IsSpecified)
                     {
                         _parentJob.AddChildJobAndPotentiallyBlock(this.Cmdlet, childJob, ThrottlingJob.ChildJobFlags.None);
                     }
@@ -628,15 +628,15 @@ namespace Microsoft.PowerShell.Cmdletization
         /// </summary>
         public override void BeginProcessing()
         {
-            if (this.AsJob.IsPresent)
+            if (this.AsJob.IsSpecified)
             {
                 MshCommandRuntime commandRuntime = (MshCommandRuntime)this.Cmdlet.CommandRuntime; // PSCmdlet.CommandRuntime is always MshCommandRuntime
                 string conflictingParameter = null;
-                if (commandRuntime.WhatIf.IsPresent)
+                if (commandRuntime.WhatIf.IsSpecified)
                 {
                     conflictingParameter = "WhatIf";
                 }
-                else if (commandRuntime.Confirm.IsPresent)
+                else if (commandRuntime.Confirm.IsSpecified)
                 {
                     conflictingParameter = "Confirm";
                 }
@@ -656,7 +656,7 @@ namespace Microsoft.PowerShell.Cmdletization
                 jobName: this.GenerateParentJobName(),
                 jobTypeName: CIMJobType,
                 maximumConcurrentChildJobs: this.ThrottleLimit,
-                cmdletMode: !this.AsJob.IsPresent);
+                cmdletMode: !this.AsJob.IsSpecified);
         }
 
         /// <summary>
@@ -665,7 +665,7 @@ namespace Microsoft.PowerShell.Cmdletization
         public override void EndProcessing()
         {
             _parentJob.EndOfChildJobs();
-            if (this.AsJob.IsPresent)
+            if (this.AsJob.IsSpecified)
             {
                 this.Cmdlet.WriteObject(_parentJob);
                 this.Cmdlet.JobRepository.Add(_parentJob);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -1198,7 +1198,7 @@ $result
         protected override void ProcessRecord()
         {
             object[] flags = new object[] { 1, 0 };
-            if (Force.IsPresent)
+            if (Force.IsSpecified)
                 flags[0] = forcedShutdown;
 
             ProcessWSManProtocol(flags);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetWMIObjectCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetWMIObjectCommand.cs
@@ -210,7 +210,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                if (List.IsPresent)
+                if (List.IsSpecified)
                 {
                     if (!this.ValidateClassFormat())
                     {
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell.Commands
 
                     foreach (string name in ComputerName)
                     {
-                        if (this.Recurse.IsPresent)
+                        if (this.Recurse.IsSpecified)
                         {
                             Queue namespaceElement = new Queue();
                             namespaceElement.Enqueue(this.Namespace);
@@ -349,7 +349,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // When -List is not specified and -Recurse is specified, we need the -Class parameter to compose the right query string
-                if (this.Recurse.IsPresent && string.IsNullOrEmpty(Class))
+                if (this.Recurse.IsSpecified && string.IsNullOrEmpty(Class))
                 {
                     string errorMsg = string.Format(CultureInfo.InvariantCulture, WmiResources.WmiParameterMissing, "-Class");
                     ErrorRecord er = new ErrorRecord(new InvalidOperationException(errorMsg), "InvalidOperationException", ErrorCategory.InvalidOperation, null);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
         {
             foreach (Process process in MatchingProcesses())
             {
-                if (Module.IsPresent && FileVersionInfo.IsPresent)
+                if (Module.IsSpecified && FileVersionInfo.IsSpecified)
                 {
                     ProcessModule tempmodule = null;
                     try
@@ -594,7 +594,7 @@ namespace Microsoft.PowerShell.Commands
                         WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModuleFileVer, "CouldNotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
                     }
                 }
-                else if (Module.IsPresent)
+                else if (Module.IsSpecified)
                 {
                     try
                     {
@@ -627,7 +627,7 @@ namespace Microsoft.PowerShell.Commands
                         WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModules, "CouldNotEnumerateModules", ErrorCategory.PermissionDenied);
                     }
                 }
-                else if (FileVersionInfo.IsPresent)
+                else if (FileVersionInfo.IsSpecified)
                 {
                     try
                     {
@@ -670,7 +670,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    WriteObject(IncludeUserName.IsPresent ? AddUserNameToProcess(process) : process);
+                    WriteObject(IncludeUserName.IsSpecified ? AddUserNameToProcess(process) : process);
                 }
             }
         }
@@ -2131,7 +2131,7 @@ namespace Microsoft.PowerShell.Commands
 #endif
             }
 
-            if (PassThru.IsPresent)
+            if (PassThru.IsSpecified)
             {
                 if (process != null)
                 {
@@ -2145,7 +2145,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            if (Wait.IsPresent)
+            if (Wait.IsSpecified)
             {
                 if (process != null)
                 {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -637,13 +637,13 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (ServiceController service in MatchingServices())
                 {
-                    if (!DependentServices.IsPresent && !RequiredServices.IsPresent)
+                    if (!DependentServices.IsSpecified && !RequiredServices.IsSpecified)
                     {
                         WriteObject(AddProperties(scManagerHandle, service));
                     }
                     else
                     {
-                        if (DependentServices.IsPresent)
+                        if (DependentServices.IsSpecified)
                         {
                             foreach (ServiceController dependantserv in service.DependentServices)
                             {
@@ -651,7 +651,7 @@ namespace Microsoft.PowerShell.Commands
                             }
                         }
 
-                        if (RequiredServices.IsPresent)
+                        if (RequiredServices.IsSpecified)
                         {
                             foreach (ServiceController servicedependedon in service.ServicesDependedOn)
                             {
@@ -1932,7 +1932,7 @@ namespace Microsoft.PowerShell.Commands
                         SetServiceSecurityDescriptor(service, SecurityDescriptorSddl, hService);
                     }
 
-                    if (PassThru.IsPresent)
+                    if (PassThru.IsSpecified)
                     {
                         // To display the service, refreshing the service would not show the display name after updating
                         ServiceController displayservice = new(Name);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -298,7 +298,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void SetCountForTcpTest()
         {
-            if (Repeat.IsPresent)
+            if (Repeat.IsSpecified)
             {
                 Count = int.MaxValue;
             }
@@ -312,7 +312,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (!TryResolveNameOrAddress(targetNameOrAddress, out _, out IPAddress? targetAddress))
             {
-                if (Quiet.IsPresent)
+                if (Quiet.IsSpecified)
                 {
                     WriteObject(false);
                 }
@@ -370,7 +370,7 @@ namespace Microsoft.PowerShell.Commands
                     stopwatch.Reset();
                 }
 
-                if (!Detailed.IsPresent)
+                if (!Detailed.IsSpecified)
                 {
                     WriteObject(status == SocketError.Success);
                     return;
@@ -406,7 +406,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (!TryResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
-                if (!Quiet.IsPresent)
+                if (!Quiet.IsSpecified)
                 {
                     WriteObject(false);
                 }
@@ -415,7 +415,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             int currentHop = 1;
-            PingOptions pingOptions = new(currentHop, DontFragment.IsPresent);
+            PingOptions pingOptions = new(currentHop, DontFragment.IsSpecified);
             PingReply reply;
             PingReply discoveryReply;
             int timeout = TimeoutSeconds * 1000;
@@ -475,7 +475,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         reply = SendCancellablePing(hopAddress, timeout, buffer, pingOptions, timer);
 
-                        if (!Quiet.IsPresent)
+                        if (!Quiet.IsSpecified)
                         {
                             var status = new PingStatus(
                                 Source,
@@ -524,7 +524,7 @@ namespace Microsoft.PowerShell.Commands
                 && (discoveryReply.Status == IPStatus.TtlExpired
                     || discoveryReply.Status == IPStatus.TimedOut));
 
-            if (Quiet.IsPresent)
+            if (Quiet.IsSpecified)
             {
                 WriteObject(currentHop <= MaxHops);
             }
@@ -551,7 +551,7 @@ namespace Microsoft.PowerShell.Commands
             PingReply? reply, replyResult = null;
             if (!TryResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
-                if (Quiet.IsPresent)
+                if (Quiet.IsSpecified)
                 {
                     WriteObject(-1);
                 }
@@ -640,7 +640,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            if (Quiet.IsPresent)
+            if (Quiet.IsSpecified)
             {
                 WriteObject(CurrentMTUSize);
             }
@@ -683,7 +683,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (!TryResolveNameOrAddress(targetNameOrAddress, out string resolvedTargetName, out IPAddress? targetAddress))
             {
-                if (Quiet.IsPresent)
+                if (Quiet.IsSpecified)
                 {
                     WriteObject(false);
                 }
@@ -695,7 +695,7 @@ namespace Microsoft.PowerShell.Commands
             byte[] buffer = GetSendBuffer(BufferSize);
 
             PingReply reply;
-            PingOptions pingOptions = new(MaxHops, DontFragment.IsPresent);
+            PingOptions pingOptions = new(MaxHops, DontFragment.IsSpecified);
             int timeout = TimeoutSeconds * 1000;
             int delay = Delay * 1000;
 
@@ -720,7 +720,7 @@ namespace Microsoft.PowerShell.Commands
                     continue;
                 }
 
-                if (Quiet.IsPresent)
+                if (Quiet.IsSpecified)
                 {
                     // Return 'true' only if all pings have completed successfully.
                     quietResult &= reply.Status == IPStatus.Success;
@@ -743,7 +743,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            if (Quiet.IsPresent)
+            if (Quiet.IsSpecified)
             {
                 WriteObject(quietResult);
             }
@@ -807,7 +807,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 catch (Exception ex)
                 {
-                    if (!Quiet.IsPresent)
+                    if (!Quiet.IsSpecified)
                     {
                         string message = StringUtil.Format(
                             TestConnectionResources.NoPingResult,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -291,7 +291,7 @@ namespace Microsoft.PowerShell.Commands
                     // will not recognize the new time zone settings
                     TimeZoneInfo.ClearCachedData();
 
-                    if (PassThru.IsPresent)
+                    if (PassThru.IsSpecified)
                     {
                         // return the TimeZoneInfo object for the (new) current local time zone
                         WriteObject(TimeZoneInfo.Local);
@@ -314,7 +314,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                if (PassThru.IsPresent)
+                if (PassThru.IsSpecified)
                 {
                     // show the user the time zone settings that would have been used.
                     WriteObject(InputObject);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
@@ -838,7 +838,7 @@ namespace Microsoft.PowerShell.Commands
             _state = WmiState.Running;
             RaiseWmiOperationState(null, WmiState.Running);
             ConnectionOptions options = getObject.GetConnectionOption();
-            if (getObject.List.IsPresent)
+            if (getObject.List.IsSpecified)
             {
                 if (!getObject.ValidateClassFormat())
                 {
@@ -855,7 +855,7 @@ namespace Microsoft.PowerShell.Commands
 
                 try
                 {
-                    if (getObject.Recurse.IsPresent)
+                    if (getObject.Recurse.IsSpecified)
                     {
                         ArrayList namespaceArray = new ArrayList();
                         ArrayList sinkArray = new ArrayList();

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (pr.Name.Equals("UseDefaultCredentials", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (UseDefaultCredential.IsPresent)
+                    if (UseDefaultCredential.IsSpecified)
                     {
                         bool flag = true;
                         pr.SetValue(instance, flag as object, null);
@@ -322,7 +322,7 @@ namespace Microsoft.PowerShell.Commands
             DiscoveryClientProtocol dcp = new DiscoveryClientProtocol();
 
             // if paramset is defaultcredential, set the flag in wcclient
-            if (_usedefaultcredential.IsPresent)
+            if (_usedefaultcredential.IsSpecified)
                 dcp.UseDefaultCredentials = true;
 
             // if paramset is credential, assign the credentials

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -1013,7 +1013,7 @@ namespace Microsoft.PowerShell.Commands
                 compilationOptions = GetDefaultCompilationOptions();
             }
 
-            if (!IgnoreWarnings.IsPresent)
+            if (!IgnoreWarnings.IsSpecified)
             {
                 compilationOptions = compilationOptions.WithGeneralDiagnosticOption(defaultDiagnosticOption);
             }
@@ -1050,7 +1050,7 @@ namespace Microsoft.PowerShell.Commands
                     break;
             }
 
-            if (!string.IsNullOrEmpty(_outputAssembly) && !PassThru.IsPresent)
+            if (!string.IsNullOrEmpty(_outputAssembly) && !PassThru.IsSpecified)
             {
                 CompileToAssembly(syntaxTrees, compilationOptions, emitOptions);
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -307,7 +307,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // write headers (row1: typename + row2: column names)
-                if (!_isActuallyAppending && !NoHeader.IsPresent)
+                if (!_isActuallyAppending && !NoHeader.IsSpecified)
                 {
                     if (NoTypeInformation == false)
                     {
@@ -732,7 +732,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 _propertyNames = ExportCsvHelper.BuildPropertyNames(InputObject, _propertyNames);
 
-                if (!NoHeader.IsPresent)
+                if (!NoHeader.IsSpecified)
                 {
                     if (NoTypeInformation == false)
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.Commands
         {
             get { return OutputMode == OutputModeOption.Multiple ? new SwitchParameter(true) : new SwitchParameter(false); }
 
-            set { this.OutputMode = value.IsPresent ? OutputModeOption.Multiple : OutputModeOption.None; }
+            set { this.OutputMode = value.IsSpecified ? OutputModeOption.Multiple : OutputModeOption.None; }
         }
 
         #endregion Input Parameters

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetUnique.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Commands
                 if (string.Equals(
                     inputString,
                     _lastObjectAsString,
-                    CaseInsensitive.IsPresent ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture))
+                    CaseInsensitive.IsSpecified ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture))
                 {
                     isUnique = false;
                 }
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Commands
                 _comparer ??= new ObjectCommandComparer(
                     ascending: true,
                     CultureInfo.CurrentCulture,
-                    caseSensitive: !CaseInsensitive.IsPresent);
+                    caseSensitive: !CaseInsensitive.IsSpecified);
 
                 isUnique = (_comparer.Compare(InputObject, _lastObject) != 0);
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Group-Object.cs
@@ -512,9 +512,9 @@ namespace Microsoft.PowerShell.Commands
             s_tracer.WriteLine(_groups.Count);
             if (_groups.Count > 0)
             {
-                if (AsHashTable.IsPresent)
+                if (AsHashTable.IsSpecified)
                 {
-                    StringComparer comparer = CaseSensitive.IsPresent
+                    StringComparer comparer = CaseSensitive.IsSpecified
                         ? StringComparer.CurrentCulture
                         : StringComparer.CurrentCultureIgnoreCase;
                     var hashtable = new Hashtable(comparer);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ImplicitRemotingCommands.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _force = value.IsPresent;
+                _force = value.IsSpecified;
             }
         }
 
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.Commands
                 ThrowTerminatingError(error);
             }
 
-            DirectoryInfo directory = PathUtils.CreateModuleDirectory(this, this.OutputModule, this.Force.IsPresent);
+            DirectoryInfo directory = PathUtils.CreateModuleDirectory(this, this.OutputModule, this.Force.IsSpecified);
 
             // Creating a temporary directory where files will be created.
             // Then, copy the files from this location to the location specified in OutputModule
@@ -886,7 +886,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentNullException(nameof(commandName));
             }
 
-            if (this.AllowClobber.IsPresent)
+            if (this.AllowClobber.IsSpecified)
             {
                 return true;
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MarkdownOptionCommands.cs
@@ -172,7 +172,7 @@ namespace Microsoft.PowerShell.Commands
 
             var setOption = PSMarkdownOptionInfoCache.Set(this.CommandInfo, mdOptionInfo);
 
-            if (PassThru.IsPresent)
+            if (PassThru.IsSpecified)
             {
                 WriteObject(setOption);
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -642,7 +642,7 @@ namespace Microsoft.PowerShell.Commands
                     ObjectCommandComparer comparer = new(
                         ascending: true,
                         CultureInfo.CurrentCulture,
-                        caseSensitive: !CaseInsensitive.IsPresent);
+                        caseSensitive: !CaseInsensitive.IsSpecified);
 
                     if ((comparer.Compare(obj.BaseObject, uniqueObj.WrittenObject.BaseObject) == 0) &&
                         (uniqueObj.NotePropertyCount == addedNoteProperties.Count))

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommand.cs
@@ -369,7 +369,7 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                _commandViewModelObj = _showCommandProxy.GetCommandViewModel(new ShowCommandCommandInfo(commandInfo), _noCommonParameter.ToBool(), _importedModules, this.Name.Contains('\\'));
+                _commandViewModelObj = _showCommandProxy.GetCommandViewModel(new ShowCommandCommandInfo(commandInfo), _noCommonParameter.IsSpecified, _importedModules, this.Name.Contains('\\'));
                 _showCommandProxy.ShowCommandWindow(_commandViewModelObj, _passThrough);
             }
             catch (TargetInvocationException ti)
@@ -394,7 +394,7 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                _showCommandProxy.ShowAllModulesWindow(_importedModules, _commands, _noCommonParameter.ToBool(), _passThrough);
+                _showCommandProxy.ShowAllModulesWindow(_importedModules, _commands, _noCommonParameter.IsSpecified, _passThrough);
             }
             catch (TargetInvocationException ti)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -513,7 +513,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Determines whether writing to a file should Resume and append rather than overwrite.
         /// </summary>
-        internal bool ShouldResume => Resume.IsPresent && _resumeSuccess;
+        internal bool ShouldResume => Resume.IsSpecified && _resumeSuccess;
 
         internal bool ShouldSaveToOutFile => !string.IsNullOrEmpty(OutFile);
 
@@ -546,7 +546,7 @@ namespace Microsoft.PowerShell.Commands
 
                 // If the request contains an authorization header and PreserveAuthorizationOnRedirect is not set,
                 // it needs to be stripped on the first redirect.
-                bool keepAuthorizationOnRedirect = PreserveAuthorizationOnRedirect.IsPresent
+                bool keepAuthorizationOnRedirect = PreserveAuthorizationOnRedirect.IsSpecified
                                                    && WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization);
 
                 bool handleRedirect = keepAuthorizationOnRedirect || AllowInsecureRedirect || PreserveHttpMethodOnRedirect;
@@ -580,7 +580,7 @@ namespace Microsoft.PowerShell.Commands
 
                             // Check if the Resume range was not satisfiable because the file already completed downloading.
                             // This happens when the local file is the same size as the remote file.
-                            if (Resume.IsPresent
+                            if (Resume.IsSpecified
                                 && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable
                                 && response.Content.Headers.ContentRange.HasLength
                                 && response.Content.Headers.ContentRange.Length == _resumeFileSize)
@@ -885,14 +885,14 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Output ??
-            if (PassThru.IsPresent && OutFile is null)
+            if (PassThru.IsSpecified && OutFile is null)
             {
                 ErrorRecord error = GetValidationError(WebCmdletStrings.OutFileMissing, "WebCmdletOutFileMissingException", nameof(PassThru));
                 ThrowTerminatingError(error);
             }
 
             // Resume requires OutFile.
-            if (Resume.IsPresent && OutFile is null)
+            if (Resume.IsSpecified && OutFile is null)
             {
                 ErrorRecord error = GetValidationError(WebCmdletStrings.OutFileMissing, "WebCmdletOutFileMissingException", nameof(Resume));
                 ThrowTerminatingError(error);
@@ -901,7 +901,7 @@ namespace Microsoft.PowerShell.Commands
             _qualifiedOutFile = ShouldSaveToOutFile ? QualifiedOutFile : null;
 
             // OutFile must not be a directory to use Resume.
-            if (Resume.IsPresent && Directory.Exists(_qualifiedOutFile))
+            if (Resume.IsSpecified && Directory.Exists(_qualifiedOutFile))
             {
                 ErrorRecord error = GetValidationError(WebCmdletStrings.ResumeNotFilePath, "WebCmdletResumeNotFilePathException", _qualifiedOutFile);
                 ThrowTerminatingError(error);
@@ -972,7 +972,7 @@ namespace Microsoft.PowerShell.Commands
             // Proxy and NoProxy parameters are mutually exclusive.
             // If NoProxy is provided, WebSession will turn off the proxy
             // and if Proxy is provided NoProxy will be turned off.
-            if (NoProxy.IsPresent)
+            if (NoProxy.IsSpecified)
             {
                 WebSession.NoProxy = true;
             }
@@ -1013,7 +1013,7 @@ namespace Microsoft.PowerShell.Commands
 
             WebSession.UnixSocket = UnixSocket;
 
-            WebSession.SkipCertificateCheck = SkipCertificateCheck.IsPresent;
+            WebSession.SkipCertificateCheck = SkipCertificateCheck.IsSpecified;
 
             // Store the other supplied headers
             if (Headers is not null)
@@ -1134,7 +1134,7 @@ namespace Microsoft.PowerShell.Commands
 
             // If the file to resume downloading exists, create the Range request header using the file size.
             // If not, create a Range to request the entire file.
-            if (Resume.IsPresent)
+            if (Resume.IsSpecified)
             {
                 FileInfo fileInfo = new(QualifiedOutFile);
 
@@ -1354,7 +1354,7 @@ namespace Microsoft.PowerShell.Commands
                 // Request again without the Range header because the server indicated the range was not satisfiable.
                 // This happens when the local file is larger than the remote file.
                 // If the size of the remote file is the same as the local file, there is nothing to resume.
-                if (Resume.IsPresent
+                if (Resume.IsSpecified
                     && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable
                     && (response.Content.Headers.ContentRange.HasLength
                     && response.Content.Headers.ContentRange.Length != _resumeFileSize))

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -119,14 +119,14 @@ namespace Microsoft.PowerShell.Commands
         private bool ConvertFromJsonHelper(string input)
         {
             ErrorRecord error = null;
-            object result = JsonObject.ConvertFromJson(input, AsHashtable.IsPresent, Depth, DateKind, out error);
+            object result = JsonObject.ConvertFromJson(input, AsHashtable.IsSpecified, Depth, DateKind, out error);
 
             if (error != null)
             {
                 ThrowTerminatingError(error);
             }
 
-            WriteObject(result, !NoEnumerate.IsPresent);
+            WriteObject(result, !NoEnumerate.IsSpecified);
             return (result != null);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -120,8 +120,8 @@ namespace Microsoft.PowerShell.Commands
 
                 var context = new JsonObject.ConvertToJsonContext(
                     Depth,
-                    EnumsAsStrings.IsPresent,
-                    Compress.IsPresent,
+                    EnumsAsStrings.IsSpecified,
+                    Compress.IsSpecified,
                     EscapeHandling,
                     targetCmdlet: this,
                     _cancellationSource.Token);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            WriteObject(InputObject, !NoEnumerate.IsPresent);
+            WriteObject(InputObject, !NoEnumerate.IsSpecified);
         }
     }
     #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.Commands
 
             HostInformationMessage informationMessage = new();
             informationMessage.Message = result;
-            informationMessage.NoNewLine = NoNewline.IsPresent;
+            informationMessage.NoNewLine = NoNewline.IsSpecified;
 
             try
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
@@ -234,7 +234,7 @@ namespace Microsoft.PowerShell.Commands
 
                 System.Management.Automation.Remoting.PSSenderInfo psSenderInfo =
                     this.SessionState.PSVariable.GetValue("PSSenderInfo") as System.Management.Automation.Remoting.PSSenderInfo;
-                Host.UI.StartTranscribing(effectiveFilePath, psSenderInfo, IncludeInvocationHeader.ToBool(), UseMinimalHeader.IsPresent);
+                Host.UI.StartTranscribing(effectiveFilePath, psSenderInfo, IncludeInvocationHeader.IsSpecified, UseMinimalHeader.IsSpecified);
 
                 // ch.StartTranscribing(effectiveFilePath, Append);
 

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Commands/NewLocalUserCommand.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Commands/NewLocalUserCommand.cs
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            if (this.HasParameter("AccountExpires") && AccountNeverExpires.IsPresent)
+            if (this.HasParameter("AccountExpires") && AccountNeverExpires.IsSpecified)
             {
                 InvalidParametersException ex = new InvalidParametersException("AccountExpires", "AccountNeverExpires");
                 ThrowTerminatingError(ex.MakeErrorRecord());
@@ -255,11 +255,11 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
 
-                    if (AccountNeverExpires.IsPresent)
+                    if (AccountNeverExpires.IsSpecified)
                         user.AccountExpires = null;
 
                     // Password will be null if NoPassword was given
-                    user = sam.CreateLocalUser(user, Password, PasswordNeverExpires.IsPresent);
+                    user = sam.CreateLocalUser(user, Password, PasswordNeverExpires.IsSpecified);
 
                     WriteObject(user);
                 }

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Commands/SetLocalUserCommand.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Commands/SetLocalUserCommand.cs
@@ -213,7 +213,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            if (this.HasParameter("AccountExpires") && AccountNeverExpires.IsPresent)
+            if (this.HasParameter("AccountExpires") && AccountNeverExpires.IsSpecified)
             {
                 InvalidParametersException ex = new InvalidParametersException("AccountExpires", "AccountNeverExpires");
                 ThrowTerminatingError(ex.MakeErrorRecord());
@@ -287,7 +287,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (AccountNeverExpires.IsPresent)
+                if (AccountNeverExpires.IsSpecified)
                     delta.AccountExpires = null;
 
                 sam.UpdateLocalUser(user, delta, Password, passwordNeverExpires);

--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        if (Password == null && !NoPromptForPassword.IsPresent)
+                        if (Password == null && !NoPromptForPassword.IsSpecified)
                         {
                             try
                             {

--- a/src/Microsoft.WSMan.Management/InvokeWSManAction.cs
+++ b/src/Microsoft.WSMan.Management/InvokeWSManAction.cs
@@ -276,7 +276,7 @@ namespace Microsoft.WSMan.Management
                 IWSManResourceLocator m_resource = helper.InitializeResourceLocator(optionset, selectorset, null, null, m_wsmanObject, resourceuri);
 
                 // create the session object
-                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsPresent);
+                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsSpecified);
 
                 string rootNode = helper.GetRootNodeName(helper.WSManOp, m_resource.ResourceUri, action);
                 string input = helper.ProcessInput(m_wsmanObject, filepath, helper.WSManOp, rootNode, valueset, m_resource, m_session);

--- a/src/Microsoft.WSMan.Management/PingWSMan.cs
+++ b/src/Microsoft.WSMan.Management/PingWSMan.cs
@@ -150,7 +150,7 @@ namespace Microsoft.WSMan.Management
             IWSManSession m_SessionObj = null;
             try
             {
-                m_SessionObj = helper.CreateSessionObject(wsmanObject, Authentication, null, Credential, connectionStr, CertificateThumbprint, usessl.IsPresent);
+                m_SessionObj = helper.CreateSessionObject(wsmanObject, Authentication, null, Credential, connectionStr, CertificateThumbprint, usessl.IsSpecified);
                 m_SessionObj.Timeout = 1000; // 1 sec. we are putting this low so that Test-WSMan can return promptly if the server goes unresponsive.
                 XmlDocument xmldoc = new XmlDocument();
                 xmldoc.LoadXml(m_SessionObj.Identify(0));

--- a/src/Microsoft.WSMan.Management/WSManConnections.cs
+++ b/src/Microsoft.WSMan.Management/WSManConnections.cs
@@ -288,7 +288,7 @@ namespace Microsoft.WSMan.Management
                 helper.AssertError(helper.GetResourceMsgFromResourcetext("ConnectFailure"), false, computername);
             }
 
-            helper.CreateWsManConnection(ParameterSetName, connectionuri, port, computername, applicationname, usessl.IsPresent, Authentication, sessionoption, Credential, CertificateThumbprint);
+            helper.CreateWsManConnection(ParameterSetName, connectionuri, port, computername, applicationname, usessl.IsSpecified, Authentication, sessionoption, Credential, CertificateThumbprint);
         }
     }
     #endregion

--- a/src/Microsoft.WSMan.Management/WSManInstance.cs
+++ b/src/Microsoft.WSMan.Management/WSManInstance.cs
@@ -589,7 +589,7 @@ namespace Microsoft.WSMan.Management
             try
             {
                 IWSManResourceLocator m_resource = helper.InitializeResourceLocator(optionset, selectorset, fragment, dialect, m_wsmanObject, resourceuri);
-                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsPresent);
+                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsSpecified);
 
                 if (!enumerate)
                 {
@@ -969,7 +969,7 @@ namespace Microsoft.WSMan.Management
                 }
 
                 IWSManResourceLocator m_resource = helper.InitializeResourceLocator(optionset, selectorset, fragment, dialect, m_wsmanObject, resourceuri);
-                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsPresent);
+                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsSpecified);
                 string rootNode = helper.GetRootNodeName(helper.WSManOp, m_resource.ResourceUri, null);
                 string input = helper.ProcessInput(m_wsmanObject, filepath, helper.WSManOp, rootNode, valueset, m_resource, m_session);
 
@@ -1264,7 +1264,7 @@ namespace Microsoft.WSMan.Management
                 }
 
                 IWSManResourceLocator m_resource = helper.InitializeResourceLocator(optionset, selectorset, null, null, m_wsmanObject, resourceuri);
-                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsPresent);
+                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsSpecified);
                 string ResourceURI = helper.GetURIWithFilter(resourceuri.ToString(), null, selectorset, helper.WSManOp);
                 try
                 {
@@ -1565,7 +1565,7 @@ namespace Microsoft.WSMan.Management
             {
                 IWSManResourceLocator m_resource = helper.InitializeResourceLocator(optionset, selectorset, null, null, m_wsmanObject, resourceuri);
                 // create the session object
-                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsPresent);
+                m_session = helper.CreateSessionObject(m_wsmanObject, Authentication, sessionoption, Credential, connectionStr, CertificateThumbprint, usessl.IsSpecified);
                 string rootNode = helper.GetRootNodeName(helper.WSManOp, m_resource.ResourceUri, null);
                 string input = helper.ProcessInput(m_wsmanObject, filepath, helper.WSManOp, rootNode, valueset, m_resource, m_session);
 

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -397,7 +397,7 @@ namespace Microsoft.PowerShell.Commands
                 _commandScores = new List<CommandScore>();
             }
 
-            if (ShowCommandInfo.IsPresent && Syntax.IsPresent)
+            if (ShowCommandInfo.IsSpecified && Syntax.IsSpecified)
             {
                 ThrowTerminatingError(
                     new ErrorRecord(
@@ -559,7 +559,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        if (ShowCommandInfo.IsPresent)
+                        if (ShowCommandInfo.IsSpecified)
                         {
                             // Write output as ShowCommandCommandInfo object.
                             WriteObject(
@@ -1336,7 +1336,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (isCommandMatch)
                 {
-                    if (Syntax.IsPresent && current is AliasInfo ai)
+                    if (Syntax.IsSpecified && current is AliasInfo ai)
                     {
                         // If the matching command was an alias, then use the resolved command
                         // instead of the alias...

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2710,7 +2710,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void EndProcessing()
         {
-            if (_off.IsPresent)
+            if (_off.IsSpecified)
             {
                 _version = new Version(0, 0);
             }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1005,7 +1005,7 @@ namespace System.Management.Automation
             }
 
             if (objType == typeof(SwitchParameter))
-                return ((SwitchParameter)obj).ToBool();
+                return ((SwitchParameter)obj).IsSpecified;
 
             IList objectArray = obj as IList;
             if (objectArray != null)
@@ -3305,7 +3305,7 @@ namespace System.Management.Automation
                                                          TypeTable backupTable)
         {
             typeConversion.WriteLine("Converting SwitchParameter to boolean.");
-            return ((SwitchParameter)valueToConvert).ToBool();
+            return ((SwitchParameter)valueToConvert).IsSpecified;
         }
 
         private static bool ConvertIListToBool(object valueToConvert,

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.Commands
                 powerShell.AddCommand("Get-Module");
                 powerShell.AddParameter("ListAvailable", true);
 
-                if (Refresh.IsPresent)
+                if (Refresh.IsSpecified)
                 {
                     powerShell.AddParameter("Refresh", true);
                 }
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void AssertListAvailableMode()
         {
-            if (!this.ListAvailable.IsPresent)
+            if (!this.ListAvailable.IsSpecified)
             {
                 string errorMessage = Modules.RemoteDiscoveryWorksOnlyInListAvailableMode;
                 ArgumentException argumentException = new ArgumentException(errorMessage);
@@ -397,7 +397,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else if (ParameterSetName.Equals(ParameterSet_AvailableLocally, StringComparison.OrdinalIgnoreCase))
             {
-                if (ListAvailable.IsPresent)
+                if (ListAvailable.IsSpecified)
                 {
                     GetAvailableLocallyModules(names, moduleSpecTable, this.All);
                 }

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1816,7 +1816,7 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
             // Make sure that only one of (Global | Scope) is specified
-            if (Global.IsPresent && _isScopeSpecified)
+            if (Global.IsSpecified && _isScopeSpecified)
             {
                 InvalidOperationException ioe = new InvalidOperationException(Modules.GlobalAndScopeParameterCannotBeSpecifiedTogether);
                 ErrorRecord er = new ErrorRecord(ioe, "Modules_GlobalAndScopeParameterCannotBeSpecifiedTogether",

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -1181,7 +1181,7 @@ namespace Microsoft.PowerShell.Commands
                 BuildModuleManifest(result, nameof(IconUri), Modules.IconUri, IconUri != null, () => QuoteName(IconUri), streamWriter);
                 BuildModuleManifest(result, nameof(ReleaseNotes), Modules.ReleaseNotes, !string.IsNullOrEmpty(ReleaseNotes), () => QuoteName(ReleaseNotes), streamWriter);
                 BuildModuleManifest(result, nameof(Prerelease), Modules.Prerelease, !string.IsNullOrEmpty(Prerelease), () => QuoteName(Prerelease), streamWriter);
-                BuildModuleManifest(result, nameof(RequireLicenseAcceptance), Modules.RequireLicenseAcceptance, RequireLicenseAcceptance.IsPresent, () => RequireLicenseAcceptance.IsPresent ? "$true" : "$false", streamWriter);
+                BuildModuleManifest(result, nameof(RequireLicenseAcceptance), Modules.RequireLicenseAcceptance, RequireLicenseAcceptance.IsSpecified, () => RequireLicenseAcceptance.IsSpecified ? "$true" : "$false", streamWriter);
                 BuildModuleManifest(result, nameof(ExternalModuleDependencies), Modules.ExternalModuleDependencies, ExternalModuleDependencies != null && ExternalModuleDependencies.Length > 0, () => QuoteNames(ExternalModuleDependencies, streamWriter), streamWriter);
 
                 result.Append("    } ");

--- a/src/System.Management.Automation/engine/MshCmdlet.cs
+++ b/src/System.Management.Automation/engine/MshCmdlet.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
@@ -74,14 +75,24 @@ namespace System.Management.Automation
     /// </summary>
     public readonly struct SwitchParameter
     {
-        private readonly bool _isPresent;
+        private readonly bool _isSpecified;
         /// <summary>
-        /// Returns true if the parameter was specified on the command line, false otherwise.
+        /// Returns true if the parameter was present on the command line and specified with the value $true, false otherwise.
         /// </summary>
         /// <value>True if the parameter was specified, false otherwise</value>
+        public bool IsSpecified
+        {
+            get { return _isSpecified; }
+        }
+        /// <summary>
+        /// Returns true if the parameter was present on the command line and specified with the value $true, false otherwise.
+        /// </summary>
+        /// <value>True if the parameter was specified, false otherwise</value>
+        /// <seealso cref="IsSpecified"/>
+        [Obsolete("Use the IsSpecified property."), Browsable(false)]
         public bool IsPresent
         {
-            get { return _isPresent; }
+            get { return _isSpecified; }
         }
         /// <summary>
         /// Implicit cast operator for casting SwitchParameter to bool.
@@ -90,7 +101,7 @@ namespace System.Management.Automation
         /// <returns>The corresponding boolean value.</returns>
         public static implicit operator bool(SwitchParameter switchParameter)
         {
-            return switchParameter.IsPresent;
+            return switchParameter.IsSpecified;
         }
 
         /// <summary>
@@ -107,9 +118,11 @@ namespace System.Management.Automation
         /// Explicit method to convert a SwitchParameter to a boolean value.
         /// </summary>
         /// <returns>The boolean equivalent of the SwitchParameter.</returns>
+        /// <seealso cref="IsSpecified"/>
+        [Obsolete("Use the IsSpecified property."), Browsable(false)]
         public bool ToBool()
         {
-            return _isPresent;
+            return _isSpecified;
         }
 
         /// <summary>
@@ -120,7 +133,7 @@ namespace System.Management.Automation
         /// </param>
         public SwitchParameter(bool isPresent)
         {
-            _isPresent = isPresent;
+            _isSpecified = isPresent;
         }
 
         /// <summary>
@@ -141,11 +154,11 @@ namespace System.Management.Automation
         {
             if (obj is bool)
             {
-                return _isPresent == (bool)obj;
+                return _isSpecified == (bool)obj;
             }
             else if (obj is SwitchParameter)
             {
-                return _isPresent == ((SwitchParameter)obj).IsPresent;
+                return _isSpecified == ((SwitchParameter)obj).IsSpecified;
             }
             else
             {
@@ -158,7 +171,7 @@ namespace System.Management.Automation
         /// <returns>The hash code for this cobject.</returns>
         public override int GetHashCode()
         {
-            return _isPresent.GetHashCode();
+            return _isSpecified.GetHashCode();
         }
 
         /// <summary>
@@ -228,7 +241,7 @@ namespace System.Management.Automation
         /// <returns>The string for this object.</returns>
         public override string ToString()
         {
-            return _isPresent.ToString();
+            return _isSpecified.ToString();
         }
     }
 

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -1094,7 +1094,7 @@ namespace System.Management.Automation
 
                                 if (currentValue is SwitchParameter)
                                 {
-                                    currentValue = ((SwitchParameter)currentValue).IsPresent;
+                                    currentValue = ((SwitchParameter)currentValue).IsSpecified;
                                 }
 
                                 boType = currentValue.GetType();

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1335,7 +1335,7 @@ namespace System.Management.Automation
 
                         if (context.DynamicParameters is Microsoft.PowerShell.Commands.GetChildDynamicParameters dynParam)
                         {
-                            isFileOrDirectoryPresent = dynParam.File.IsPresent || dynParam.Directory.IsPresent;
+                            isFileOrDirectoryPresent = dynParam.File.IsSpecified || dynParam.Directory.IsSpecified;
                         }
 
                         if (string.Equals(childName, "*", StringComparison.OrdinalIgnoreCase) && isFileOrDirectoryPresent)

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -310,7 +310,7 @@ namespace Microsoft.PowerShell.Commands
                     baseId = id;
 
                     // get id,count,newest values
-                    if (!newest.IsPresent)
+                    if (!newest.IsSpecified)
                     {
                         // get older entries
 
@@ -390,7 +390,7 @@ namespace Microsoft.PowerShell.Commands
                     // eg if size is 5 and then the entries can be 7,6,1,2,3
                     if (_capacity != DefaultHistorySize)
                         SmallestID = SmallestIDinBuffer();
-                    if (!newest.IsPresent)
+                    if (!newest.IsSpecified)
                     {
                         // get oldest count entries
                         index = 1;
@@ -485,7 +485,7 @@ namespace Microsoft.PowerShell.Commands
                     SmallestID = SmallestIDinBuffer();
                 if (count != 0)
                 {
-                    if (!newest.IsPresent)
+                    if (!newest.IsSpecified)
                     {
                         long id = 1;
                         if (_capacity != DefaultHistorySize)

--- a/src/System.Management.Automation/engine/remoting/commands/ConnectPSSession.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ConnectPSSession.cs
@@ -930,7 +930,7 @@ namespace Microsoft.PowerShell.Commands
             if (ParameterSetName == ConnectPSSessionCommand.ComputerNameParameterSet ||
                 ParameterSetName == ConnectPSSessionCommand.ComputerNameGuidParameterSet)
             {
-                string scheme = UseSSL.IsPresent ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
+                string scheme = UseSSL.IsSpecified ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
 
                 foreach (string computerName in ComputerName)
                 {

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -581,7 +581,7 @@ else
                     args: new object[] {
                                             file,
                                             shellName,
-                                            ShowSecurityDescriptorUI.ToBool(),
+                                            ShowSecurityDescriptorUI.IsSpecified,
                                             force,
                                             whatIf,
                                             confirm,
@@ -3482,7 +3482,7 @@ Set-PSSessionConfiguration $args[0] $args[1] $args[2] $args[3] $args[4] $args[5]
                                                force,
                                                sddl,
                                                isSddlSpecified,
-                                               ShowSecurityDescriptorUI.ToBool(),
+                                               ShowSecurityDescriptorUI.IsSpecified,
                                                WSManNativeApi.ResourceURIPrefix + shellName,
                                                shellNotFoundErrorMsg,
                                                shellNotPowerShellMsg,
@@ -3639,7 +3639,7 @@ Set-PSSessionConfiguration $args[0] $args[1] $args[2] $args[3] $args[4] $args[5]
 
             if (isUseSharedProcessSpecified)
             {
-                optionsTable[UseSharedProcessToken] = UseSharedProcess.ToBool().ToString();
+                optionsTable[UseSharedProcessToken] = UseSharedProcess.IsSpecified.ToString();
             }
 
             setOptionsSb.InvokeUsingCmdlet(

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
@@ -401,8 +401,8 @@ namespace Microsoft.PowerShell.Commands
                 result.MaximumConnectionRedirectionCount = this.MaximumRedirection;
             }
 
-            result.NoCompression = this.NoCompression.IsPresent;
-            result.NoMachineProfile = this.NoMachineProfile.IsPresent;
+            result.NoCompression = this.NoCompression.IsSpecified;
+            result.NoMachineProfile = this.NoMachineProfile.IsSpecified;
 
             result.MaximumReceivedDataSizePerCommand = _maxRecvdDataSizePerCommand;
             result.MaximumReceivedObjectSize = _maxRecvdObjectSize;

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -1439,7 +1439,7 @@ namespace Microsoft.PowerShell.Commands
 
             // create helper objects for computer names
             RemoteRunspace remoteRunspace = null;
-            string scheme = UseSSL.IsPresent ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
+            string scheme = UseSSL.IsSpecified ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
 
             for (int i = 0; i < ResolvedComputerNames.Length; i++)
             {
@@ -1858,7 +1858,7 @@ namespace Microsoft.PowerShell.Commands
                     // Hyper-V container uses Hype-V socket as transport.
                     // Windows Server container uses named pipe as transport.
                     //
-                    connectionInfo = ContainerConnectionInfo.CreateContainerConnectionInfo(input, RunAsAdministrator.IsPresent, this.ConfigurationName);
+                    connectionInfo = ContainerConnectionInfo.CreateContainerConnectionInfo(input, RunAsAdministrator.IsSpecified, this.ConfigurationName);
 
                     resolvedNameList.Add(connectionInfo.ComputerName);
 

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -687,7 +687,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 WSManConnectionInfo connectionInfo = null;
                 connectionInfo = new WSManConnectionInfo();
-                string scheme = UseSSL.IsPresent ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
+                string scheme = UseSSL.IsSpecified ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
                 connectionInfo.ComputerName = resolvedComputerName;
                 connectionInfo.Port = Port;
                 connectionInfo.AppName = ApplicationName;
@@ -1216,7 +1216,7 @@ namespace Microsoft.PowerShell.Commands
                 // Hyper-V container uses Hype-V socket as transport.
                 // Windows Server container uses named pipe as transport.
                 //
-                connectionInfo = ContainerConnectionInfo.CreateContainerConnectionInfo(ContainerId, RunAsAdministrator.IsPresent, this.ConfigurationName);
+                connectionInfo = ContainerConnectionInfo.CreateContainerConnectionInfo(ContainerId, RunAsAdministrator.IsSpecified, this.ConfigurationName);
 
                 connectionInfo.CreateContainerProcess();
                 remoteRunspace = CreateTemporaryRemoteRunspaceForPowerShellDirect(this.Host, connectionInfo);

--- a/src/System.Management.Automation/engine/remoting/commands/ReceivePSSession.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ReceivePSSession.cs
@@ -566,7 +566,7 @@ namespace Microsoft.PowerShell.Commands
                 ParameterSetName == ReceivePSSessionCommand.ComputerInstanceIdParameterSet)
             {
                 // Create the WSManConnectionInfo object for the specified computer name.
-                string scheme = UseSSL.IsPresent ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
+                string scheme = UseSSL.IsSpecified ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
 
                 connectionInfo.Scheme = scheme;
                 connectionInfo.ComputerName = ResolveComputerName(ComputerName);

--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -588,7 +588,7 @@ namespace Microsoft.PowerShell.Commands
                 ThrowTerminatingError(errorRecord);
             }
 
-            if (RunAs32.IsPresent && Environment.Is64BitProcess)
+            if (RunAs32.IsSpecified && Environment.Is64BitProcess)
             {
                 // We cannot start a 32-bit 'pwsh' process from a 64-bit 'pwsh' installation.
                 string message = RemotingErrorIdStrings.RunAs32NotSupported;

--- a/src/System.Management.Automation/engine/remoting/commands/WaitJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/WaitJob.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.Commands
 
                 Dbg.Assert(_blockedJobs.All(j => !_finishedJobs.Contains(j)), "Job cannot be in *both* _blockedJobs and _finishedJobs");
 
-                if (this.Any.IsPresent)
+                if (this.Any.IsSpecified)
                 {
                     if (_finishedJobs.Count > 0)
                     {

--- a/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
@@ -453,7 +453,7 @@ namespace Microsoft.PowerShell.Commands
             if (ParameterSetName == GetPSSessionCommand.ComputerNameParameterSet ||
                 ParameterSetName == GetPSSessionCommand.ComputerInstanceIdParameterSet)
             {
-                string scheme = UseSSL.IsPresent ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
+                string scheme = UseSSL.IsSpecified ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
 
                 foreach (string computerName in ComputerName)
                 {

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -798,7 +798,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     WSManConnectionInfo connectionInfo = null;
                     connectionInfo = new WSManConnectionInfo();
-                    string scheme = UseSSL.IsPresent ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
+                    string scheme = UseSSL.IsSpecified ? WSManConnectionInfo.HttpsScheme : WSManConnectionInfo.HttpScheme;
                     connectionInfo.ComputerName = resolvedComputerNames[i];
                     connectionInfo.Port = Port;
                     connectionInfo.AppName = ApplicationName;
@@ -1015,7 +1015,7 @@ namespace Microsoft.PowerShell.Commands
                     // Hyper-V container uses Hype-V socket as transport.
                     // Windows Server container uses named pipe as transport.
                     //
-                    connectionInfo = ContainerConnectionInfo.CreateContainerConnectionInfo(input, RunAsAdministrator.IsPresent, this.ConfigurationName);
+                    connectionInfo = ContainerConnectionInfo.CreateContainerConnectionInfo(input, RunAsAdministrator.IsSpecified, this.ConfigurationName);
 
                     resolvedNameList.Add(connectionInfo.ComputerName);
 

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.Commands
         {
             set
             {
-                if (value.ToBool())
+                if (value.IsSpecified)
                 {
                     _viewTokenToAdd = HelpView.DetailedView;
                 }
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.Commands
         {
             set
             {
-                if (value.ToBool())
+                if (value.IsSpecified)
                 {
                     _viewTokenToAdd = HelpView.FullView;
                 }
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.Commands
         {
             set
             {
-                if (value.ToBool())
+                if (value.IsSpecified)
                 {
                     _viewTokenToAdd = HelpView.ExamplesView;
                 }

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (!_isInitialized)
                 {
-                    if (_path == null && Recurse.IsPresent)
+                    if (_path == null && Recurse.IsSpecified)
                     {
                         PSArgumentException e = new PSArgumentException(StringUtil.Format(HelpDisplayStrings.CannotSpecifyRecurseWithoutPath));
                         ThrowTerminatingError(e.ErrorRecord);

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6834,7 +6834,7 @@ namespace Microsoft.PowerShell.Commands
 #if !UNIX
                     streamName = dynParams.Stream;
 #endif
-                    suppressNewline = dynParams.NoNewline.IsPresent;
+                    suppressNewline = dynParams.NoNewline.IsSpecified;
                 }
             }
 

--- a/test/powershell/engine/ExperimentalFeature/assets/ExpTest/ExpTest.cs
+++ b/test/powershell/engine/ExperimentalFeature/assets/ExpTest/ExpTest.cs
@@ -61,12 +61,12 @@ namespace ExperimentalFeatureTest
             string message = $"Hello World {Name}.";
             if (ExperimentalFeature.IsEnabled("ExpTest.FeatureOne"))
             {
-                if (SwitchOne.IsPresent)
+                if (SwitchOne.IsSpecified)
                 {
                     message += "-SwitchOne is on.";
                 }
 
-                if (SwitchTwo.IsPresent)
+                if (SwitchTwo.IsSpecified)
                 {
                     message += "-SwitchTwo is on.";
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Replace SwitchParameter.IsPresent and SwitchParameter.ToBool() with SwitchParameter.IsSpecified and standardize the codebase to it.

## PR Context

In discussion on #26140, it has come up that there are in fact three ways to do the identical conversion of a `SwitchParameter` to a `bool` value that indicates whether it is specified in the invocation:

- A `SwitchParameter` can be implicitly converted to `bool`. This is documented as the recommended way to process switches from PowerShell code: [The `SwitchParameter` type implicitly converts to Boolean](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters?view=powershell-7.5#:~:text=The%20SwitchParameter%20type%20implicitly%20converts%20to%20Boolean)
- A property `.IsPresent`, which is used in 135 places across the current codebase.
- A method `.ToBool()`, which is used in 11 places across the current codebase.

The C# codebase does not use the implicit conversion anywhere.

The `.ToBool()` method is descriptive only of the _what_ but not the _why_; where it is used, it's not describing the meaning of the bool value.

The `.IsPresent` property is poorly-named, because it suggests that it is return a value indicating whether the switch is, in fact, present when a switch can be present _but explicitly $false_, in which case `.IsPresent == false`:

```
New-Guid -Empty
New-Guid -Empty:$false
```

It has been deemed a bug that these two commands return identical output, and PR #26140 fixes this. There is a similar issue with `Get-Uptime -Since`, fixed by PR #26141.

This PR has two aims:

- Replace `.IsPresent` and `.ToBool()` with a more semantically-accurate property `.IsSpecified`. (The old ones cannot be deleted, per se, since they're part of the public API, but they can be marked `[Obsolete]`.)
- Standardize the codebase on this one method of determining the semantic value of a `SwitchParameter`.

I searched for existing documentation of `.IsPresent` and `.ToBool()`, and as far as I can tell, they are only explicitly documented in the XmlDoc for their members in the source code, and `.IsSpecified` is presented here with equivalent XmlDoc documentation. The implicit convention for the use of the new property `.IsSpecified` is internal to the PowerShell codebase. I have thus checked `Not Applicable` for the documentation section of the PR checklist. If this is in error, let me know and I'll amend as appropriate. 🙂 

Closes: #26149 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
