### PR TITLE
Remove Gitter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Want to chat with other members of the PowerShell community?
 
 There are dozens of topic-specific channels on our community-driven PowerShell Virtual User Group, which you can join on:
 
-* [Gitter](https://gitter.im/PowerShell/PowerShell)
 * [Discord](https://discord.gg/PowerShell)
 * [IRC](https://web.libera.chat/#powershell) on Libera.Chat
 * [Slack](https://aka.ms/psslack)


### PR DESCRIPTION
Last activity there was years ago.

See also: https://github.com/dotnet/runtime/pull/114841