### PR TITLE
Separate Store Automation Service Endpoints, Resolve AppID

### DIFF
--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -219,7 +219,7 @@ jobs:
         Write-Host "##vso[task.setvariable variable=ServiceConnection]$($config.ServiceEndpoint)"
         Write-Host "##vso[task.setvariable variable=SBConfigPath]$($sbConfigPath)"
 
-        #These variables are used in the next tasks to determine which ServiceEndpoint to use
+        # These variables are used in the next tasks to determine which ServiceEndpoint to use
         Write-Host "##vso[task.setvariable variable=LTS]$($IsLTS.ToString().ToLower())"
         Write-Host "##vso[task.setvariable variable=STABLE]$($IsStable.ToString().ToLower())"
         Write-Host "##vso[task.setvariable variable=PREVIEW]$($IsPreview.ToString().ToLower())"

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -240,21 +240,9 @@ jobs:
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
-      condition: eq('$(STABLE)', 'true')
+      condition: or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true'))
       inputs:
         serviceEndpoint: 'StoreAppPublish-Stable'
-        sbConfigPath: '$(SBConfigPath)'
-        sourceFolder: '$(BundleDir)'
-        contents: '*.msixBundle'
-        outSBName: 'PowerShellStorePackage'
-        pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
-        pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
-
-    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
-      displayName: 'Create StoreBroker Package'
-      condition: eq('$(LTS)', 'true')
-      inputs:
-        serviceEndpoint: 'StoreAppPublish-LTS'
         sbConfigPath: '$(SBConfigPath)'
         sourceFolder: '$(BundleDir)'
         contents: '*.msixBundle'

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -228,7 +228,7 @@ jobs:
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
-      condition: eq(variables['PREVIEW'], 'true')
+      condition: eq('$(PREVIEW)', 'true')
       inputs:
         serviceEndpoint: 'StoreAppPublish-Preview'
         sbConfigPath: '$(SBConfigPath)'
@@ -240,7 +240,7 @@ jobs:
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
-      condition: eq(variables['STABLE'], 'true')
+      condition: eq('$(STABLE)', 'true')
       inputs:
         serviceEndpoint: 'StoreAppPublish-Stable'
         sbConfigPath: '$(SBConfigPath)'
@@ -252,7 +252,7 @@ jobs:
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
-      condition: eq(variables['LTS'], 'true')
+      condition: eq('$(LTS)', 'true')
       inputs:
         serviceEndpoint: 'StoreAppPublish-LTS'
         sbConfigPath: '$(SBConfigPath)'

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -218,13 +218,43 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=ServiceConnection]$($config.ServiceEndpoint)"
         Write-Host "##vso[task.setvariable variable=SBConfigPath]$($sbConfigPath)"
+
+        #These variables are used in the next tasks to determine which ServiceEndpoint to use
+        Write-Host "##vso[task.setvariable variable=LTS]$($IsLTS.ToString().ToLower())"
+        Write-Host "##vso[task.setvariable variable=STABLE]$($IsStable.ToString().ToLower())"
+        Write-Host "##vso[task.setvariable variable=PREVIEW]$($IsPreview.ToString().ToLower())"
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
+      condition: eq(variables['PREVIEW'], 'true')
       inputs:
-        serviceEndpoint: 'StoreAppPublish-Private'
+        serviceEndpoint: 'StoreAppPublish-Preview'
+        sbConfigPath: '$(SBConfigPath)'
+        sourceFolder: '$(BundleDir)'
+        contents: '*.msixBundle'
+        outSBName: 'PowerShellStorePackage'
+        pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
+        pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
+
+    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
+      displayName: 'Create StoreBroker Package'
+      condition: eq(variables['STABLE'], 'true')
+      inputs:
+        serviceEndpoint: 'StoreAppPublish-Stable'
+        sbConfigPath: '$(SBConfigPath)'
+        sourceFolder: '$(BundleDir)'
+        contents: '*.msixBundle'
+        outSBName: 'PowerShellStorePackage'
+        pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
+        pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
+
+    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
+      displayName: 'Create StoreBroker Package'
+      condition: eq(variables['LTS'], 'true')
+      inputs:
+        serviceEndpoint: 'StoreAppPublish-LTS'
         sbConfigPath: '$(SBConfigPath)'
         sourceFolder: '$(BundleDir)'
         contents: '*.msixBundle'

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -227,7 +227,7 @@ jobs:
       displayName: Update PDPs and SBConfig.json
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
-      displayName: 'Create StoreBroker Package'
+      displayName: 'Create StoreBroker Package (Preview)'
       condition: eq('$(PREVIEW)', 'true')
       inputs:
         serviceEndpoint: 'StoreAppPublish-Preview'
@@ -239,7 +239,7 @@ jobs:
         pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
-      displayName: 'Create StoreBroker Package'
+      displayName: 'Create StoreBroker Package (Stable/LTS)'
       condition: or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true'))
       inputs:
         serviceEndpoint: 'StoreAppPublish-Stable'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -90,7 +90,7 @@ jobs:
     displayName: 'Publish LTS StoreBroker Package'
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['LTS'], 'true'))
     inputs:
-      serviceEndpoint: 'StoreAppPublish-Private'
+      serviceEndpoint: 'StoreAppPublish-LTS'
       appId: '$(AppID-LTS)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
@@ -103,7 +103,7 @@ jobs:
     displayName: 'Publish Stable StoreBroker Package'
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['STABLE'], 'true'))
     inputs:
-      serviceEndpoint: 'StoreAppPublish-Private'
+      serviceEndpoint: 'StoreAppPublish-Stable'
       appId: '$(AppID-Stable)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
@@ -116,7 +116,7 @@ jobs:
     displayName: 'Publish Preview StoreBroker Package'
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['PREVIEW'], 'true'))
     inputs:
-      serviceEndpoint: 'StoreAppPublish-Private'
+      serviceEndpoint: 'StoreAppPublish-Preview'
       appId: '$(AppID-Preview)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -90,7 +90,7 @@ jobs:
           $appID = '$(AppID-Stable)'
         }
 
-        Write-Host "##vso[task.setvariable variable=APPID]$appID
+        Write-Host "##vso[task.setvariable variable=APPID]$appID"
         Write-Verbose -Verbose "Selected channel: $currentChannel"
         Write-Verbose -Verbose "Conditional tasks will handle the publishing based on channel variables"
     displayName: 'Validate Channel Selection'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -99,7 +99,7 @@ jobs:
     displayName: 'Validate Channel Selection'
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
-    displayName: 'Publish LTS/Stable StoreBroker Package'
+    displayName: 'Publish StoreBroker Package (Stable/LTS)'
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true')))
     inputs:
       serviceEndpoint: 'StoreAppPublish-Stable'
@@ -112,7 +112,7 @@ jobs:
       targetPublishMode: 'Immediate'
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
-    displayName: 'Publish Preview StoreBroker Package'
+    displayName: 'Publish StoreBroker Package (Preview)'
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq('$(PREVIEW)', 'true'))
     inputs:
       serviceEndpoint: 'StoreAppPublish-Preview'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -88,7 +88,7 @@ jobs:
         }
         elseif ($IsStable) {
           $appID = '$(AppID-Stable)'
-        } 
+        }
         else {
           $appID = '$(AppID-Preview)'
         }

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -81,13 +81,16 @@ jobs:
             exit 1
           }
 
-        # If LTS or Stable need to assign the correct AppID for the shared task.
+        # Assign AppID for Store-Publish Task
         $appID = $null
         if ($IsLTS) {
           $appID = '$(AppID-LTS)'
         }
-        elseif ($IsStable){
+        elseif ($IsStable) {
           $appID = '$(AppID-Stable)'
+        } 
+        else {
+          $appID = '$(AppID-Preview)'
         }
 
         Write-Host "##vso[task.setvariable variable=AppID]$appID"
@@ -113,7 +116,7 @@ jobs:
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq('$(PREVIEW)', 'true'))
     inputs:
       serviceEndpoint: 'StoreAppPublish-Preview'
-      appId: '$(AppID-Preview)'
+      appId: '$(AppID)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
       zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -73,7 +73,6 @@ jobs:
 
         Write-Verbose -Verbose "Channel Selection - LTS: $(LTS), Stable: $(STABLE), Preview: $(PREVIEW)"
 
-        # Determine the current channel for logging purposes
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
@@ -81,7 +80,17 @@ jobs:
             Write-Error "No valid channel detected"
             exit 1
           }
-                       
+
+        # If LTS or Stable need to assign the correct AppID for the shared task.
+        $appID = $null
+        if ($IsLTS) {
+          $appID = '$(AppID-LTS)'
+        }
+        elseif ($IsStable){
+          $appID = '$(AppID-Stable)'
+        }
+
+        Write-Host "##vso[task.setvariable variable=APPID]$appID
         Write-Verbose -Verbose "Selected channel: $currentChannel"
         Write-Verbose -Verbose "Conditional tasks will handle the publishing based on channel variables"
     displayName: 'Validate Channel Selection'
@@ -91,7 +100,7 @@ jobs:
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true')))
     inputs:
       serviceEndpoint: 'StoreAppPublish-Stable'
-      appId: '$(AppID-LTS)'
+      appId: '$(AppID)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
       zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -43,14 +43,14 @@ jobs:
         }
         $middleURL = ''
         $tagString = "$(ReleaseTag)"
-        if ($tagString -match '-') {
+        if ($tagString -match '-preview') {
           $middleURL = "preview"
         }
         elseif ($tagString -match '(\d+\.\d+)') {
           $middleURL = $matches[1]
         }
 
-        $endURL = $tagString -replace '[v\.]',''
+        $endURL = $tagString -replace '^v','' -replace '\.',''
         $message = "Changelog: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/$middleURL.md#$endURL"
         Write-Verbose -Verbose "Release Notes for the Store:"
         Write-Verbose -Verbose "$message"
@@ -90,7 +90,7 @@ jobs:
           $appID = '$(AppID-Stable)'
         }
 
-        Write-Host "##vso[task.setvariable variable=APPID]$appID"
+        Write-Host "##vso[task.setvariable variable=AppID]$appID"
         Write-Verbose -Verbose "Selected channel: $currentChannel"
         Write-Verbose -Verbose "Conditional tasks will handle the publishing based on channel variables"
     displayName: 'Validate Channel Selection'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -43,14 +43,14 @@ jobs:
         }
         $middleURL = ''
         $tagString = "$(ReleaseTag)"
-        if ($tagString -match '-preview') {
+        if ($tagString -match '-') {
           $middleURL = "preview"
         }
         elseif ($tagString -match '(\d+\.\d+)') {
           $middleURL = $matches[1]
         }
 
-        $endURL = $tagString -replace '^v|\.', ''
+        $endURL = $tagString -replace '[v\.]',''
         $message = "Changelog: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/$middleURL.md#$endURL"
         Write-Verbose -Verbose "Release Notes for the Store:"
         Write-Verbose -Verbose "$message"
@@ -87,10 +87,10 @@ jobs:
     displayName: 'Validate Channel Selection'
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
-    displayName: 'Publish LTS StoreBroker Package'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['LTS'], 'true'))
+    displayName: 'Publish LTS/Stable StoreBroker Package'
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true')))
     inputs:
-      serviceEndpoint: 'StoreAppPublish-LTS'
+      serviceEndpoint: 'StoreAppPublish-Stable'
       appId: '$(AppID-LTS)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
@@ -100,21 +100,8 @@ jobs:
       targetPublishMode: 'Immediate'
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
-    displayName: 'Publish Stable StoreBroker Package'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['STABLE'], 'true'))
-    inputs:
-      serviceEndpoint: 'StoreAppPublish-Stable'
-      appId: '$(AppID-Stable)'
-      inputMethod: JsonAndZip
-      jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
-      zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'
-      numberOfPackagesToKeep: 2
-      jsonZipUpdateMetadata: true
-      targetPublishMode: 'Immediate'
-
-  - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
     displayName: 'Publish Preview StoreBroker Package'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['PREVIEW'], 'true'))
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq('$(PREVIEW)', 'true'))
     inputs:
       serviceEndpoint: 'StoreAppPublish-Preview'
       appId: '$(AppID-Preview)'
@@ -124,8 +111,3 @@ jobs:
       numberOfPackagesToKeep: 2
       jsonZipUpdateMetadata: true
       targetPublishMode: 'Immediate'
-
-  - pwsh: |
-      Get-Content -Path "$(System.DefaultWorkingDirectory)/SBLog.txt" -ErrorAction SilentlyContinue
-    displayName: Upload Store Failure Log
-    condition: failed()


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates the MSIX packaging and publishing pipelines to improve channel selection logic and streamline how packages are published to different channels (LTS, Stable, Preview). The changes primarily focus on conditional task execution, variable management, and service endpoint selection for publishing tasks.

**Channel selection and variable management:**

* Added explicit setting of the `LTS`, `STABLE`, and `PREVIEW` variables to control which ServiceEndpoint is used in subsequent tasks within `.pipelines/templates/package-create-msix.yml`.
* Improved channel selection logic by assigning the correct `AppID` based on whether the build is LTS or Stable, and set it as a pipeline variable for use in publishing tasks. [[1]](diffhunk://#diff-b6f7fe53ea2dbbc2c2ff7431bedf6b2820c4e2c9a9fa7bb64d03747ffb38c9eaR84-R103) [[2]](diffhunk://#diff-b6f7fe53ea2dbbc2c2ff7431bedf6b2820c4e2c9a9fa7bb64d03747ffb38c9eaL76)

**Publishing task improvements:**

* Consolidated the publishing tasks for LTS and Stable channels into a single task, using the new `AppID` variable and the correct service endpoint (`StoreAppPublish-Stable`). The Preview channel now uses its own dedicated task and endpoint (`StoreAppPublish-Preview`). [[1]](diffhunk://#diff-b6f7fe53ea2dbbc2c2ff7431bedf6b2820c4e2c9a9fa7bb64d03747ffb38c9eaR84-R103) [[2]](diffhunk://#diff-b6f7fe53ea2dbbc2c2ff7431bedf6b2820c4e2c9a9fa7bb64d03747ffb38c9eaL117-L131)
* Updated conditions for publishing tasks to use the new channel variables and improved endpoint selection, ensuring packages are published to the correct channel. [[1]](diffhunk://#diff-b09ac31caeda1400a115a970686df9fc86ed1f1c648277e2ed3d7e6973f7bb4bR221-R245) [[2]](diffhunk://#diff-b6f7fe53ea2dbbc2c2ff7431bedf6b2820c4e2c9a9fa7bb64d03747ffb38c9eaL117-L131)

**Minor improvements:**

* Simplified string replacement logic for changelog URL generation in the release pipeline.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
