### PR TITLE
Remove redundant `CharSet` from `StructLayout` attributes. Part 1

### DIFF
--- a/src/System.Management.Automation/namespaces/Win32Native.cs
+++ b/src/System.Management.Automation/namespaces/Win32Native.cs
@@ -76,14 +76,14 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         #region Struct
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct SID_AND_ATTRIBUTES
         {
             internal IntPtr Sid;
             internal uint Attributes;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct TOKEN_USER
         {
             internal SID_AND_ATTRIBUTES User;

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -594,7 +594,7 @@ namespace Microsoft.PowerShell
         internal const int E_FILENOTFOUND = unchecked((int)0x80070002); // File not found
         internal const int ERROR_FILE_NOT_FOUND = 2;                    // File not found
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct CRYPTOAPI_BLOB
         {
             internal uint cbData;

--- a/src/System.Management.Automation/security/nativeMethods.cs
+++ b/src/System.Management.Automation/security/nativeMethods.cs
@@ -1287,28 +1287,28 @@ namespace System.Management.Automation.Security
             UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct LUID
         {
             internal uint LowPart;
             internal uint HighPart;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct LUID_AND_ATTRIBUTES
         {
             internal LUID Luid;
             internal uint Attributes;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct TOKEN_PRIVILEGE
         {
             internal uint PrivilegeCount;
             internal LUID_AND_ATTRIBUTES Privilege;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct ACL
         {
             internal byte AclRevision;
@@ -1318,7 +1318,7 @@ namespace System.Management.Automation.Security
             internal ushort Sbz2;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct ACE_HEADER
         {
             internal byte AceType;
@@ -1326,7 +1326,7 @@ namespace System.Management.Automation.Security
             internal ushort AceSize;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct SYSTEM_AUDIT_ACE
         {
             internal ACE_HEADER Header;
@@ -1334,7 +1334,7 @@ namespace System.Management.Automation.Security
             internal uint SidStart;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct LSA_UNICODE_STRING
         {
             internal ushort Length;
@@ -1342,7 +1342,7 @@ namespace System.Management.Automation.Security
             internal IntPtr Buffer;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct CENTRAL_ACCESS_POLICY
         {
             internal IntPtr CAPID;

--- a/src/System.Management.Automation/utils/PlatformInvokes.cs
+++ b/src/System.Management.Automation/utils/PlatformInvokes.cs
@@ -444,28 +444,28 @@ namespace System.Management.Automation
                                                           out TOKEN_PRIVILEGE previousPrivilegeState,
                                                           ref int returnLength);
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct TOKEN_PRIVILEGE
         {
             internal uint PrivilegeCount;
             internal LUID_AND_ATTRIBUTES Privilege;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct LUID
         {
             internal uint LowPart;
             internal uint HighPart;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct LUID_AND_ATTRIBUTES
         {
             internal LUID Luid;
             internal uint Attributes;
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct PRIVILEGE_SET
         {
             internal uint PrivilegeCount;


### PR DESCRIPTION
Remove explicit `CharSet` values from `[StructLayout]` attributes applied to structs that do not contain `char`, `string` or `StringBuilder` fields.

The `CharSet` field in `[StructLayout]` influences marshalling behavior only when a struct includes `char`, `string` or `StringBuilder` members. For structs that contain only value types or blittable types, specifying `CharSet` is redundant and has no effect on layout or marshaling.


Subset of https://github.com/PowerShell/PowerShell/pull/26005.