### PR TITLE
Fix SA1003: Symbols should be spaced correctly

### DIFF
--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Extensions.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Extensions.cs
@@ -107,7 +107,7 @@ namespace System.Management.Automation.SecurityAccountsManager.Extensions
             byte[] sidBinary = new byte[sid.BinaryLength];
             sid.GetBinaryForm(sidBinary, 0);
 
-            return System.BitConverter.ToUInt32(sidBinary, sidBinary.Length-4);
+            return System.BitConverter.ToUInt32(sidBinary, sidBinary.Length - 4);
         }
 
         /// <summary>
@@ -130,12 +130,13 @@ namespace System.Management.Automation.SecurityAccountsManager.Extensions
 
             // The Identifier Authority is six bytes wide,
             // in big-endian format, starting at the third byte
-            long authority = (long) (((long)sidBinary[2]) << 40) +
-                                    (((long)sidBinary[3]) << 32) +
-                                    (((long)sidBinary[4]) << 24) +
-                                    (((long)sidBinary[5]) << 16) +
-                                    (((long)sidBinary[6]) <<  8) +
-                                    (((long)sidBinary[7])      );
+            long authority =
+                (((long)sidBinary[2]) << 40) +
+                (((long)sidBinary[3]) << 32) +
+                (((long)sidBinary[4]) << 24) +
+                (((long)sidBinary[5]) << 16) +
+                (((long)sidBinary[6]) << 8) +
+                (((long)sidBinary[7]));
 
             return authority;
         }

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
@@ -1247,7 +1247,7 @@ namespace System.Management.Automation.SecurityAccountsManager
 
                 status = SamApi.SamCreateUser2InDomain(domainHandle,
                     ref str,
-                    (int) SamApi.USER_NORMAL_ACCOUNT,
+                    (int)SamApi.USER_NORMAL_ACCOUNT,
                     Win32.MAXIMUM_ALLOWED,
                     out userHandle,
                     out grantedAccess,
@@ -1473,7 +1473,7 @@ namespace System.Management.Automation.SecurityAccountsManager
 
                     Marshal.Copy(memberIds, idArray, 0, (int)memberCount);
 
-                    for (int i=0; i < memberCount; i++)
+                    for (int i = 0; i < memberCount; i++)
                     {
                         var sid = new SecurityIdentifier(idArray[i]);
                         yield return MakeLocalPrincipalObject(LookupAccountInfo(sid));


### PR DESCRIPTION
Follow-up https://github.com/PowerShell/PowerShell/pull/14476

Contributes to https://github.com/PowerShell/PowerShell/issues/26238.