### PR TITLE
Compare DateTime instances respecting their Kind in Test-Item (#25013)

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3397,16 +3397,22 @@ namespace Microsoft.PowerShell.Commands
                 // If the items see if we need to check the age of the file...
                 if (result && itemExistsDynamicParameters != null)
                 {
-                    DateTime lastWriteTime = fsinfo.LastWriteTime;
+                    DateTime lastWriteTimeUtc = fsinfo.LastWriteTimeUtc;
 
-                    if (itemExistsDynamicParameters.OlderThan.HasValue)
+                    if (itemExistsDynamicParameters.OlderThan is { } olderThan)
                     {
-                        result &= lastWriteTime < itemExistsDynamicParameters.OlderThan.Value;
+                        DateTime olderThanUtc = olderThan.Kind == DateTimeKind.Unspecified
+                            ? DateTime.SpecifyKind(olderThan, DateTimeKind.Utc)
+                            : olderThan.ToUniversalTime();
+                        result &= lastWriteTimeUtc < olderThanUtc;
                     }
 
-                    if (itemExistsDynamicParameters.NewerThan.HasValue)
+                    if (itemExistsDynamicParameters.NewerThan is { } newerThan)
                     {
-                        result &= lastWriteTime > itemExistsDynamicParameters.NewerThan.Value;
+                        DateTime newerThanUtc = newerThan.Kind == DateTimeKind.Unspecified
+                            ? DateTime.SpecifyKind(newerThan, DateTimeKind.Utc)
+                            : newerThan.ToUniversalTime();
+                        result &= lastWriteTimeUtc > newerThanUtc;
                     }
                 }
             }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -3401,17 +3401,13 @@ namespace Microsoft.PowerShell.Commands
 
                     if (itemExistsDynamicParameters.OlderThan is { } olderThan)
                     {
-                        DateTime olderThanUtc = olderThan.Kind == DateTimeKind.Unspecified
-                            ? DateTime.SpecifyKind(olderThan, DateTimeKind.Utc)
-                            : olderThan.ToUniversalTime();
+                        DateTime olderThanUtc = olderThan.ToUniversalTime();
                         result &= lastWriteTimeUtc < olderThanUtc;
                     }
 
                     if (itemExistsDynamicParameters.NewerThan is { } newerThan)
                     {
-                        DateTime newerThanUtc = newerThan.Kind == DateTimeKind.Unspecified
-                            ? DateTime.SpecifyKind(newerThan, DateTimeKind.Utc)
-                            : newerThan.ToUniversalTime();
+                        DateTime newerThanUtc = newerThan.ToUniversalTime();
                         result &= lastWriteTimeUtc > newerThanUtc;
                     }
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Fix #25013.

When comparing `DateTime` instances provided as parameter `-OlderThan`/`-NewerThan` in cmdlet `Test-Item`, now the `Kind` (local, UTC or unspecified) is correctly taken into account.

Tests have also been updated, but with a caveat! ⚠️
The impacted tests acquire significance when run in a timezone with some test-dependent criteria. To ensure the test behavior behavior in a **cross-platform, revertable, scoped (in-process, non-system-wide)** fashion, I temporarily set a custom timezone for the duration of each test. Unfortunately, the in-process local timezone can be set only **via reflection**, so any improvements to this tweaky approach are welcome.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
