### PR TITLE
Refactor IsComputerNameValid character validation

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2031,11 +2031,7 @@ $result
                     hasNonDigit = true;
                     continue;
                 }
-                else if (char.IsAsciiDigit(t))
-                {
-                    continue;
-                }
-                else
+                else if (!char.IsAsciiDigit(t))
                 {
                     return false;
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2026,18 +2026,13 @@ $result
 
             foreach (char t in computerName)
             {
-                if (char.IsAsciiLetter(t))
+                if (t is '-' || char.IsAsciiLetter(t))
                 {
                     hasNonDigit = true;
                     continue;
                 }
                 else if (char.IsAsciiDigit(t))
                 {
-                    continue;
-                }
-                else if (t is '-')
-                {
-                    hasNonDigit = true;
                     continue;
                 }
                 else

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2026,7 +2026,7 @@ $result
 
             foreach (char t in computerName)
             {
-                if (char.IsAsciiLetter(t) || t is '-' )
+                if (char.IsAsciiLetter(t) || t is '-')
                 {
                     hasAsciiLetterOrHyphen = true;
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2019,7 +2019,7 @@ $result
         /// <returns></returns>
         internal static bool IsComputerNameValid(string computerName)
         {
-            bool allDigits = true;
+            bool hasNonDigit = false;
 
             if (computerName.Length >= 64)
                 return false;
@@ -2028,7 +2028,7 @@ $result
             {
                 if (char.IsAsciiLetter(t))
                 {
-                    allDigits = false;
+                    hasNonDigit = true;
                     continue;
                 }
                 else if (char.IsAsciiDigit(t))
@@ -2037,7 +2037,7 @@ $result
                 }
                 else if (t is '-')
                 {
-                    allDigits = false;
+                    hasNonDigit = true;
                     continue;
                 }
                 else
@@ -2046,7 +2046,7 @@ $result
                 }
             }
 
-            return !allDigits;
+            return hasNonDigit;
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2026,17 +2026,16 @@ $result
 
             foreach (char t in computerName)
             {
-                if (t >= 'A' && t <= 'Z' ||
-                    t >= 'a' && t <= 'z')
+                if (char.IsAsciiLetter(t))
                 {
                     allDigits = false;
                     continue;
                 }
-                else if (t >= '0' && t <= '9')
+                else if (char.IsAsciiDigit(t))
                 {
                     continue;
                 }
-                else if (t == '-')
+                else if (t is '-')
                 {
                     allDigits = false;
                     continue;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2029,7 +2029,6 @@ $result
                 if (char.IsAsciiLetter(t) || t is '-' )
                 {
                     hasNonDigit = true;
-                    continue;
                 }
                 else if (!char.IsAsciiDigit(t))
                 {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2026,7 +2026,7 @@ $result
 
             foreach (char t in computerName)
             {
-                if (t is '-' || char.IsAsciiLetter(t))
+                if (char.IsAsciiLetter(t) || t is '-' )
                 {
                     hasNonDigit = true;
                     continue;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -2019,7 +2019,7 @@ $result
         /// <returns></returns>
         internal static bool IsComputerNameValid(string computerName)
         {
-            bool hasNonDigit = false;
+            bool hasAsciiLetterOrHyphen = false;
 
             if (computerName.Length >= 64)
                 return false;
@@ -2028,7 +2028,7 @@ $result
             {
                 if (char.IsAsciiLetter(t) || t is '-' )
                 {
-                    hasNonDigit = true;
+                    hasAsciiLetterOrHyphen = true;
                 }
                 else if (!char.IsAsciiDigit(t))
                 {
@@ -2036,7 +2036,7 @@ $result
                 }
             }
 
-            return hasNonDigit;
+            return hasAsciiLetterOrHyphen;
         }
 
         /// <summary>


### PR DESCRIPTION
Simplify and modernize the implementation of `IsComputerNameValid` by using built-in char classification helpers instead of manual character range checks.

The boolean logic was clarified by replacing `allDigits` (with negated return) with a `hasNonDigit` variable.

Subset of https://github.com/PowerShell/PowerShell/pull/26270

Contributes to https://github.com/PowerShell/PowerShell/issues/26275