### PR TITLE
Fix build to only enable ready-to-run for the Release configuration

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -193,6 +193,10 @@
   <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' ">
     <!-- If we specify Environment too, it searches that first, no matter what order we specify-->
     <AppHostDotNetSearch>Global</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <!-- Enable ready-to-run only for Release configuration -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' And '$(Configuration)' == 'Release' ">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -199,6 +199,10 @@
 
   <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' ">
     <AppHostDotNetSearch>AppLocal</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <!-- Enable ready-to-run only for Release configuration -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' And '$(Configuration)' == 'Release' ">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix build to only enable ready-to-run for the Release configuration.
Currently, `Start-PSBuild` will enable ready-to-run even for 'Debug' configuration, which makes it impossible to debug the code. This PR fixes it to only enable ready-to-run for Release configuration.
