### PR TITLE
Fix a regression in the API `CompletionCompleters.CompleteFilename()` that causes null reference exception

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4580,8 +4580,8 @@ namespace System.Management.Automation
                     return CommandCompletion.EmptyCompletionResult;
                 }
 
-                var lastAst = context.RelatedAsts[^1];
-                if (lastAst.Parent is UsingStatementAst usingStatement
+                var lastAst = context.RelatedAsts?[^1];
+                if (lastAst?.Parent is UsingStatementAst usingStatement
                     && usingStatement.UsingStatementKind is UsingStatementKind.Module or UsingStatementKind.Assembly
                     && lastAst.Extent.File is not null)
                 {

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -126,4 +126,27 @@ Describe "Tab completion bug fix" -Tags "CI" {
             $Runspace.Dispose()
         }
     }
+
+    It "Issue#26277 - [CompletionCompleters]::CompleteFilename('') should work" {
+        $testDir = Join-Path $TestDrive "TempTestDir"
+        $file1 = Join-Path $testDir "abc.ps1"
+        $file2 = Join-Path $testDir "def.py"
+
+        New-Item -ItemType Directory -Path $testDir > $null
+        New-Item -ItemType File -Path $file1 > $null
+        New-Item -ItemType File -Path $file2 > $null
+
+        try {
+            Push-Location -Path $testDir
+            $result = [System.Management.Automation.CompletionCompleters]::CompleteFilename("")
+            $result | Should -Not -Be $null
+            $result | Measure-Object | ForEach-Object -MemberName Count | Should -Be 2
+
+            $item1, $item2 = @($result)
+            $item1.ListItemText | Should -BeExactly 'abc.ps1'
+            $item2.ListItemText | Should -BeExactly 'def.py'
+        } finally {
+            Pop-Location
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #26277

The `RelatedAsts` value is `null` when calling `CompletionCompleters.CompleteFilename()` directly. This PR fixes the code to handle that case.

### PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
