### PR TITLE
Fix CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -522,6 +522,10 @@ dotnet_diagnostic.CA1858.severity = warning
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
 dotnet_diagnostic.CA1860.severity = warning
 
+# CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862
+dotnet_diagnostic.CA1862.severity = warning
+
 # CA1865: Use char overload
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865
 dotnet_diagnostic.CA1865.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -524,7 +524,7 @@ dotnet_diagnostic.CA1860.severity = warning
 
 # CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862
-dotnet_diagnostic.CA1862.severity = warning
+dotnet_diagnostic.CA1862.severity = suggestion
 
 # CA1865: Use char overload
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -976,12 +976,8 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             }
 
             // Check if the path is local and assert if not:
-            string machineNameMassaged = pathElts.MachineName.ToLowerInvariant();
-            machineNameMassaged = machineNameMassaged.TrimStart('\\');
-            Debug.Assert(machineNameMassaged == System.Environment.MachineName.ToLowerInvariant());
-
-            string lowerEngCtrName = pathElts.CounterName.ToLowerInvariant();
-            string lowerEngObjectName = pathElts.ObjectName.ToLowerInvariant();
+            string machineNameMassaged = pathElts.MachineName.TrimStart('\\');
+            Debug.Assert(machineNameMassaged.Equals(System.Environment.MachineName, StringComparison.OrdinalIgnoreCase));
 
             // Get the registry index
             RegistryKey rootKey = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Perflib\\009");
@@ -993,7 +989,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             for (int enumIndex = 1; enumIndex < regCounters.Length; enumIndex++)
             {
                 string regString = regCounters[enumIndex];
-                if (regString.ToLowerInvariant() == lowerEngCtrName)
+                if (regString.Equals(pathElts.CounterName, StringComparison.OrdinalIgnoreCase))
                 {
                     try
                     {
@@ -1004,7 +1000,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                         return PdhResults.PDH_INVALID_PATH;
                     }
                 }
-                else if (regString.ToLowerInvariant() == lowerEngObjectName)
+                else if (regString.Equals(pathElts.ObjectName, StringComparison.OrdinalIgnoreCase))
                 {
                     try
                     {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -797,8 +797,10 @@ namespace Microsoft.PowerShell
         private static bool MatchSwitch(string switchKey, string match, string smallestUnambiguousMatch)
         {
             Dbg.Assert(!string.IsNullOrEmpty(match), "need a value");
+#pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
             Dbg.Assert(match.Trim().ToLowerInvariant() == match, "match should be normalized to lowercase w/ no outside whitespace");
             Dbg.Assert(smallestUnambiguousMatch.Trim().ToLowerInvariant() == smallestUnambiguousMatch, "match should be normalized to lowercase w/ no outside whitespace");
+#pragma warning restore CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
             Dbg.Assert(match.Contains(smallestUnambiguousMatch), "sUM should be a substring of match");
 
             return (switchKey.Length >= smallestUnambiguousMatch.Length


### PR DESCRIPTION
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862
