### PR TITLE
Fix InvalidOperation in strict mode when array objects contain a defined property that is an empty array in all cases

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3217,17 +3217,18 @@ namespace System.Management.Automation
                 return null;
             }
 
-            for (int i = 0; i < result.Count; i++)
+            var flattened = new List<object>();
+            foreach (var o in result)
             {
-                FlattenResults(result[i], result);
+                FlattenResults(o, flattened);
             }
 
-            if (result.Count == 1)
+            if (flattened.Count == 1)
             {
-                return result[0];
+                return flattened[0];
             }
 
-            return result.ToArray();
+            return flattened.ToArray();
         }
 
         private static void MethodInvokerWorker(CallSite invokeMemberSite,

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3217,9 +3217,9 @@ namespace System.Management.Automation
                 return null;
             }
 
-            foreach (var o in result)
+            for (int i = 0; i < result.Count; i++)
             {
-                FlattenResults(o, result);
+                FlattenResults(result[i], result);
             }
 
             if (result.Count == 1)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3218,9 +3218,9 @@ namespace System.Management.Automation
             }
 
             var flattened = new List<object>();
-            foreach (var o in result)
+            foreach (object obj in result)
             {
-                FlattenResults(o, flattened);
+                FlattenResults(obj, flattened);
             }
 
             if (flattened.Count == 1)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3184,7 +3184,7 @@ namespace System.Management.Automation
                 var o = getMemberBinderSite.Target.Invoke(getMemberBinderSite, current);
                 if (o != AutomationNull.Value)
                 {
-                    FlattenResults(o, result);
+                    result.Add(o);
                 }
                 else
                 {
@@ -3206,11 +3206,6 @@ namespace System.Management.Automation
 
             PropertyGetterWorker(getMemberBinderSite, enumerator, context, result);
 
-            if (result.Count == 1)
-            {
-                return result[0];
-            }
-
             if (result.Count == 0)
             {
                 if (context.IsStrictVersion(2))
@@ -3220,6 +3215,16 @@ namespace System.Management.Automation
                 }
 
                 return null;
+            }
+
+            foreach (var o in result)
+            {
+                FlattenResults(o, result);
+            }
+
+            if (result.Count == 1)
+            {
+                return result[0];
             }
 
             return result.ToArray();
@@ -3645,7 +3650,8 @@ namespace System.Management.Automation
     internal static class MemberInvocationLoggingOps
     {
         private static readonly Lazy<bool> DumpLogAMSIContent = new Lazy<bool>(
-            () => {
+            () =>
+            {
                 object result = Environment.GetEnvironmentVariable("__PSDumpAMSILogContent");
                 if (result != null && LanguagePrimitives.TryConvertTo(result, out int value))
                 {

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3651,8 +3651,7 @@ namespace System.Management.Automation
     internal static class MemberInvocationLoggingOps
     {
         private static readonly Lazy<bool> DumpLogAMSIContent = new Lazy<bool>(
-            () =>
-            {
+            () => {
                 object result = Environment.GetEnvironmentVariable("__PSDumpAMSILogContent");
                 if (result != null && LanguagePrimitives.TryConvertTo(result, out int value))
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

Fixes #26353 

# PR Summary

Checks the length of the array of collected property values before flattening into a results array instead of after to avoid the case where there are collected empty arrays, but flattening leads to an unpopulated results array.

## PR Context

This PR makes the strict mode behavior surrounding array object property access via dot notation consistent by avoiding an error in the case that an array consists entirely of objects which have some property with an empty array value and that property is accessed. This is useful because it simplifies code that deals with lists of objects where a given property might be expected to not be populated, e.g. wanting to find all tags on a list of, say, photos, where a user may have not specified tags on any of the photos in the list.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
