### PR TITLE
[release/v7.4] Fix merge conflict checker for empty file lists and filter *.cs files

### DIFF
--- a/.github/actions/infrastructure/merge-conflict-checker/README.md
+++ b/.github/actions/infrastructure/merge-conflict-checker/README.md
@@ -56,8 +56,10 @@ jobs:
 - **File Handling**:
   - Checks only files that were added, modified, or renamed
   - Skips deleted files
+  - **Filters out `*.cs` files** (C# files are excluded from merge conflict checking)
   - Skips binary/unreadable files
   - Skips directories
+- **Empty File List**: Gracefully handles cases where no files need checking (e.g., PRs that only delete files)
 
 ## Example Output
 

--- a/.github/actions/infrastructure/merge-conflict-checker/action.yml
+++ b/.github/actions/infrastructure/merge-conflict-checker/action.yml
@@ -25,7 +25,8 @@ runs:
       run: |
         # Get changed files from environment variable (secure against injection)
         $changedFilesJson = $env:CHANGED_FILES_JSON
-        $changedFiles = $changedFilesJson | ConvertFrom-Json
+        # Ensure we always have an array (ConvertFrom-Json returns null for empty JSON arrays)
+        $changedFiles = @($changedFilesJson | ConvertFrom-Json)
 
         # Import ci.psm1 and run the check
         Import-Module "$env:GITHUB_WORKSPACE/tools/ci.psm1" -Force

--- a/test/infrastructure/ciModule.Tests.ps1
+++ b/test/infrastructure/ciModule.Tests.ps1
@@ -30,11 +30,17 @@ Describe "Test-MergeConflictMarker" {
     }
 
     Context "When no files are provided" {
-        It "Should handle empty file array" {
-            # The function parameter has Mandatory validation which rejects empty arrays by design
-            # This test verifies that behavior
+        It "Should handle empty file array gracefully" {
+            # The function now accepts empty arrays to handle cases like delete-only PRs
             $emptyArray = @()
-            { Test-MergeConflictMarker -File $emptyArray -WorkspacePath $script:testWorkspace -OutputPath $script:testOutputPath -SummaryPath $script:testSummaryPath } | Should -Throw -ExpectedMessage "*empty array*"
+            Test-MergeConflictMarker -File $emptyArray -WorkspacePath $script:testWorkspace -OutputPath $script:testOutputPath -SummaryPath $script:testSummaryPath
+            
+            $outputs = Get-Content $script:testOutputPath
+            $outputs | Should -Contain "files-checked=0"
+            $outputs | Should -Contain "conflicts-found=0"
+            
+            $summary = Get-Content $script:testSummaryPath -Raw
+            $summary | Should -Match "No Files to Check"
         }
     }
 


### PR DESCRIPTION
Backport of #26365 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
\$\$\\$\$\$
-->

Triggered by @TravisEz13 on behalf of @Copilot

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This backport fixes the merge conflict checker script in CI to properly handle empty file lists and filter C# files. The original PR fixed issues where the script would fail when no files matched certain patterns, causing false positives in merge conflict detection.

## Regression

- [ ] Yes
- [x] No

This is a fix for tooling, not a regression fix.

## Testing

The fix was tested in the original PR #26365 where it resolved issues with the merge conflict checker script failing on empty file lists. The changes ensure the script properly handles edge cases:
- Empty arrays when no files match filters
- Filtering out *.cs files from conflict checks
- Proper handling of file list parameters

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is a low-risk change as it only affects CI tooling scripts used for merge conflict detection. The changes improve the robustness of the checker by handling edge cases that previously caused false failures. The fix does not affect runtime PowerShell functionality or user-facing features.