### PR TITLE
[release/v7.5] Convert Azure DevOps Linux Packaging pipeline to GitHub Actions workflow

### DIFF
--- a/.github/actions/test/linux-packaging/action.yml
+++ b/.github/actions/test/linux-packaging/action.yml
@@ -1,12 +1,5 @@
 name: linux_packaging
-description: 'Test very basic Linux packaging'
-
-# This isn't working yet
-# It fails with
-
-# ERROR:  While executing gem ... (Gem::FilePermissionError)
-# You don't have write permissions for the /var/lib/gems/2.7.0 directory.
-#   WARNING: Installation of gem dotenv 2.8.1 failed! Must resolve manually.
+description: 'Linux packaging for PowerShell'
 
 runs:
   using: composite
@@ -15,58 +8,64 @@ runs:
     if: success() || failure()
     run: 'Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose'
     shell: pwsh
+
+  - uses: actions/setup-dotnet@v5
+    with:
+      global-json-file: ./global.json
+
   - name: Download Build Artifacts
     uses: actions/download-artifact@v4
     with:
-      path: "${{ github.workspace }}"
+      name: build
+      path: "${{ runner.workspace }}/build"
+
   - name: Capture Artifacts Directory
     continue-on-error: true
-    run: Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
+    run: Get-ChildItem "${{ runner.workspace }}/build/*" -Recurse
     shell: pwsh
 
   - name: Bootstrap
     run: |-
       Import-Module ./build.psm1
       Start-PSBootstrap -Scenario Package
+      Write-Verbose -Verbose "Start Sync-PSTags"
+      Sync-PSTags -AddRemoteIfMissing
+      Write-Verbose -Verbose "End Sync-PSTags"
     shell: pwsh
-  - name: Capture Artifacts Directory
-    continue-on-error: true
-    run: Import-Module ./build.psm1
+
+  - name: Extract Build ZIP
+    run: |-
+      $destinationFolder = "${{ runner.workspace }}/bins"
+      $archiveFile = "${{ runner.workspace }}/build/build.zip"
+
+      Write-Verbose "Extracting $archiveFile to $destinationFolder" -Verbose
+      New-Item -ItemType Directory -Path $destinationFolder -Force | Out-Null
+      Expand-Archive -Path $archiveFile -DestinationPath $destinationFolder -Force
     shell: pwsh
-  - name: Extract Files
-    uses: actions/github-script@v7.0.0
-    env:
-      DESTINATION_FOLDER: "${{ github.workspace }}/bins"
-      ARCHIVE_FILE_PATTERNS: "${{ github.workspace }}/build/build.zip"
-    with:
-      script: |-
-        const fs = require('fs').promises
-        const path = require('path')
-        const target = path.resolve(process.env.DESTINATION_FOLDER)
-        const patterns = process.env.ARCHIVE_FILE_PATTERNS
-        const globber = await glob.create(patterns)
-        await io.mkdirP(path.dirname(target))
-        for await (const file of globber.globGenerator()) {
-          if ((await fs.lstat(file)).isDirectory()) continue
-          await exec.exec(`7z x ${file} -o${target} -aoa`)
-        }
+
   - name: Fix permissions
     continue-on-error: true
     run: |-
-      find "${{ github.workspace }}/bins" -type d -exec chmod +rwx {} \;
-      find "${{ github.workspace }}/bins" -type f -exec chmod +rw {} \;
+      find "${{ runner.workspace }}/bins" -type d -exec chmod +rwx {} \;
+      find "${{ runner.workspace }}/bins" -type f -exec chmod +rw {} \;
     shell: bash
+
   - name: Capture Extracted Build ZIP
     continue-on-error: true
-    run: Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
+    run: Get-ChildItem "${{ runner.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
     shell: pwsh
-  - name: Packaging Tests
-    if: success()
+
+  - name: Create Packages
+    env:
+      BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.workspace }}/packages
     run: |-
+      # Create the artifacts staging directory
+      New-Item -ItemType Directory -Path "$env:BUILD_ARTIFACTSTAGINGDIRECTORY" -Force | Out-Null
+
       Import-Module ./tools/ci.psm1
-      Restore-PSOptions -PSOptionsPath '${{ github.workspace }}/build/psoptions.json'
+      Restore-PSOptions -PSOptionsPath '${{ runner.workspace }}/build/psoptions.json'
       $options = (Get-PSOptions)
-      $rootPath = '${{ github.workspace }}/bins'
+      $rootPath = '${{ runner.workspace }}/bins'
       $originalRootPath = Split-Path -path $options.Output
       $path = Join-Path -path $rootPath -ChildPath (split-path -leaf -path $originalRootPath)
       $pwshPath = Join-Path -path $path -ChildPath 'pwsh'
@@ -75,21 +74,24 @@ runs:
       Set-PSOptions $options
       Invoke-CIFinish
     shell: pwsh
-  - name: Upload packages
-    run: |-
-      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.deb" -Recurse | ForEach-Object {
-        $packagePath = $_.FullName
-        Write-Host "Uploading $packagePath"
-        Write-Host "##vso[artifact.upload containerfolder=deb;artifactname=deb]$packagePath"
-      }
-      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.rpm" -Recurse | ForEach-Object {
-        $packagePath = $_.FullName
-        Write-Host "Uploading $packagePath"
-        Write-Host "##vso[artifact.upload containerfolder=rpm;artifactname=rpm]$packagePath"
-      }
-      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.tar.gz" -Recurse | ForEach-Object {
-        $packagePath = $_.FullName
-        Write-Host "Uploading $packagePath"
-        Write-Host "##vso[artifact.upload containerfolder=rpm;artifactname=rpm]$packagePath"
-      }
-    shell: pwsh
+
+  - name: Upload deb packages
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-deb
+      path: ${{ runner.workspace }}/packages/*.deb
+      if-no-files-found: ignore
+
+  - name: Upload rpm packages
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-rpm
+      path: ${{ runner.workspace }}/packages/*.rpm
+      if-no-files-found: ignore
+
+  - name: Upload tar.gz packages
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-tar
+      path: ${{ runner.workspace }}/packages/*.tar.gz
+      if-no-files-found: ignore

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -227,24 +227,22 @@ jobs:
       - linux_test_unelevated_ci
       - linux_test_unelevated_others
       - analyze
+      - linux_packaging
     if: always()
     uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@v1.0.0
     with:
       needs_context: ${{ toJson(needs) }}
-  # TODO: Enable this when we have a Linux packaging workflow
-
-  # ERROR:  While executing gem ... (Gem::FilePermissionError)
-  # You don't have write permissions for the /var/lib/gems/2.7.0 directory.
-  #   WARNING: Installation of gem dotenv 2.8.1 failed! Must resolve manually.
-
-  # linux_packaging:
-  #   name: Attempt Linux Packaging
-  #   needs: ci_build
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v4.1.0
-  #       with:
-  #         fetch-depth: 1000
-  #     - name: Verify xUnit test results
-  #       uses: "./.github/actions/test/linux-packaging"
+  linux_packaging:
+    name: Linux Packaging
+    needs:
+      - ci_build
+      - changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Linux Packaging
+        uses: "./.github/actions/test/linux-packaging"

--- a/build.psm1
+++ b/build.psm1
@@ -2241,7 +2241,7 @@ function Install-GlobalGem {
         # We cannot guess if the user wants to run gem install as root on linux and windows,
         # but macOs usually requires sudo
         $gemsudo = ''
-        if($environment.IsMacOS -or $env:TF_BUILD) {
+        if($environment.IsMacOS -or $env:TF_BUILD -or $env:GITHUB_ACTIONS) {
             $gemsudo = $sudo
         }
 


### PR DESCRIPTION
Backport of #26225 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26225$$$
-->

Triggered by @TravisEz13 on behalf of @copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change

This PR converts the Azure DevOps Linux Packaging pipeline to GitHub Actions workflow, enabling Linux packaging in the CI pipeline. The change:
- Updates the `linux-packaging` composite action to use GitHub Actions equivalents for all Azure DevOps-specific tasks
- Enables the `linux_packaging` job in the Linux CI workflow
- Fixes gem permission errors by updating `Install-GlobalGem` to detect GitHub Actions environment
- Fixes git describe errors by using deep checkout (fetch-depth: 0) and calling Sync-PSTags

## Regression

- [ ] Yes
- [x] No

This is not a regression fix, but rather an enhancement to enable Linux packaging in GitHub Actions.

## Testing

The original PR was tested through the GitHub Actions CI pipeline. The backport maintains the same functionality and testing approach:
- Linux packaging job runs as part of the CI workflow
- All packaging requirements are validated through the CI checks
- The changes were successfully applied to the 7.5 release branch with one minor conflict in `.github/workflows/linux-ci.yml` (the job was commented out in 7.5 but is enabled by this PR)

## Risk

- [x] High
- [ ] Medium
- [ ] Low

**High Risk** - This change affects the build and packaging infrastructure:
- Modifies core packaging workflows and composite actions
- Changes how Linux packages (deb, rpm, tar.gz) are built and uploaded
- Updates the CI pipeline structure and dependencies
- Requires proper testing to ensure packages are correctly generated for the release branch

The risk is mitigated by:
- The changes mirror a working implementation already tested on the main branch
- Only affects the CI/CD pipeline, not the PowerShell runtime code
- Can be validated through CI checks before merge

## Merge Conflicts

One merge conflict occurred in `.github/workflows/linux-ci.yml`:
- **Conflict**: The release/v7.5 branch had the `linux_packaging` job commented out due to previous gem permission errors
- **Resolution**: Accepted the incoming changes that enable and update the job with fixes applied
- **Changes**: Added `linux_packaging` to ready_to_merge dependencies, uncommented the job, updated to use ubuntu-latest and actions/checkout@v5 with fetch-depth: 0