### PR TITLE
[release/v7.5] Add network isolation policy parameter to vPack pipeline

### DIFF
--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -24,6 +24,14 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   displayName: 'Enable debug output'
   type: boolean
   default: false
+- name: netiso
+  displayName: "Network Isolation Policy"
+  type: string
+  values:
+    - KS4
+    - R1
+    - Netlock
+  default: "R1"
 
 name: vPack_$(Build.SourceBranchName)_Prod.${{ parameters.OfficialBuild }}_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
 
@@ -54,6 +62,8 @@ variables:
     value: ${{ iif ( parameters.OfficialBuild, 'v2/Microsoft.Official.yml@onebranchTemplates', 'v2/Microsoft.NonOfficial.yml@onebranchTemplates' ) }}
   - group: DotNetPrivateBuildAccess
   - group: certificate_logical_to_actual
+  - name: netiso
+    value: ${{ parameters.netiso }}
 # We shouldn't be using PATs anymore
 #  - group: mscodehub-feed-read-general
 
@@ -69,6 +79,11 @@ extends:
   parameters:
     platform:
       name: 'windows_undocked' # windows undocked
+
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+        Network: ${{ variables.netiso }}
 
     cloudvault:
       enabled: false


### PR DESCRIPTION
Backport of #26223 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26223$$$
-->

Triggered by @TravisEz13 on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This change adds the network isolation policy parameter to the vPack pipeline, ensuring compliance requirements are met during the packaging process. This is required for proper package signing and validation.

## Regression

- [ ] Yes
- [x] No

This is not a regression fix, but an enhancement to the build infrastructure to meet compliance requirements.

## Testing

This change was tested in the original PR through CI pipeline execution. The backport maintains the same changes without modification, so the same testing approach applies.

## Risk

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: This changes build infrastructure (vPack pipeline configuration). While the change itself is straightforward (adding a parameter), build infrastructure changes require careful validation. The parameter addition ensures proper network isolation during packaging which is important for security and compliance. Not taking this change would create technical debt for future CI/CD updates that depend on this parameter being available.