### PR TITLE
[release/v7.5] Handle null reference exception in CsvCommands.cs: ConvertPSObjectToCSV

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (dictionary.Contains(propertyName))
                     {
-                        value = dictionary[propertyName].ToString();
+                        value = dictionary[propertyName]?.ToString();
                     }
                     else if (mshObject.Properties[propertyName] is PSPropertyInfo property)
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -212,6 +212,7 @@ Describe "ConvertTo-Csv" -Tags "CI" {
                 [ordered]@{ Number = $_; Letter = $Letters[$_] }
             }
             $CsvString = $Items | ConvertTo-Csv
+            $TestHashTable = [ordered]@{ 'first' = 'value1'; 'second' = $null; 'third' = 'value3' }
         }
 
         It 'should treat dictionary entries as properties' {
@@ -234,6 +235,13 @@ Describe "ConvertTo-Csv" -Tags "CI" {
             $NewCsvString = $Items | ConvertTo-Csv
             $NewCsvString[0] | Should -MatchExactly 'Extra'
             $NewCsvString | Select-Object -Skip 1 | Should -MatchExactly 'Surprise!'
+        }
+
+        It 'should properly convert hashtable with null and non-null values'{
+            $CsvResult = $TestHashTable | ConvertTo-Csv
+
+            $CsvResult[0] | Should -BeExactly "`"first`",`"second`",`"third`""
+            $CsvResult[1] | Should -BeExactly "`"value1`",$null,`"value3`""
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -11,6 +11,7 @@ Describe "Export-Csv" -Tags "CI" {
         $P1 = [pscustomobject]@{"P1" = "first"}
         $P2 = [pscustomobject]@{"P2" = "second"}
         $P11 = [pscustomobject]@{"P1" = "eleventh"}
+        $testHashTable = @{ 'first' = "value1"; 'second' = $null; 'third' = "value3" }
     }
 
     AfterEach {
@@ -247,6 +248,33 @@ Describe "Export-Csv" -Tags "CI" {
         $contents.Count | Should -Be 2
         $contents[0].Contains($delimiter) | Should -BeTrue
         $contents[1].Contains($delimiter) | Should -BeTrue
+    }
+
+    It "Should not throw when exporting hashtable with property that has null value"{
+        { $testHashTable | Export-Csv -Path $testCsv } | Should -Not -Throw
+    }
+
+    It "Should not throw when exporting PSCustomObject with property that has null value"{
+        $testObject = [pscustomobject]$testHashTable
+        { $testObject | Export-Csv -Path $testCsv } | Should -Not -Throw
+    }
+
+    It "Export hashtable with null and non-null values"{
+        $testHashTable | Export-Csv -Path $testCsv
+        $result2 = Import-CSV -Path $testCsv
+
+        $result2.first | Should -BeExactly "value1"
+        $result2.second | Should -BeNullOrEmpty
+        $result2.third | Should -BeExactly "value3"
+    }
+
+    It "Export hashtable with non-null values"{
+        $testTable = @{ 'first' = "value1"; 'second' = "value2" }
+        $testTable | Export-Csv -Path $testCsv
+        $results = Import-CSV -Path $testCsv
+
+        $results.first | Should -BeExactly "value1"
+        $results.second | Should -BeExactly "value2"
     }
 
     Context "UseQuotes parameter" {


### PR DESCRIPTION
Backport of #26144 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26144$$$
-->

Triggered by @travisez13 on behalf of @mikkas456

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

### Customer Impact

- [x] Found internally

This PR backports a fix for a null reference exception in CSV commands. The original PR addresses a bug where ConvertPSObjectToCSV would throw a null reference exception when processing certain objects. This improves reliability and prevents crashes when working with CSV data.

## Regression

- [ ] Yes
- [x] No

This is a bug fix, not a regression fix.

## Testing

The original PR included test cases to verify the null reference handling. The fix was validated through unit tests that cover the edge case scenarios. The backport maintains the same test coverage.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is a targeted bug fix with a narrow scope. The change only affects error handling in the CSV conversion logic and includes test coverage. The risk is low as it prevents exceptions without changing the core functionality of CSV commands.
