### PR TITLE
[release/v7.4] Fix the task name to not use the pre-release task

### DIFF
--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -208,7 +208,7 @@ jobs:
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
 
-    - task: MS-RDX-MRO.windows-store-publish-dev.package-task.store-package@3
+    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
       inputs:
         serviceEndpoint: '$(ServiceConnection)'


### PR DESCRIPTION
Backport of #26138 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26138$$$
-->

Triggered by @TravisEz13 on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This backport fixes the task name in the build pipeline to not use the pre-release task. This is a required change to ensure the build pipeline uses the correct task version for the v7.4 release branch.

## Regression

- [ ] Yes
- [x] No

This is not a regression fix, but a correction to ensure the build pipeline uses the appropriate task for this release branch.

## Testing

The original PR was verified by checking the build pipeline configuration. The same verification applies to this backport - ensuring that the build pipeline on the release/v7.4 branch uses the correct non-pre-release task.

## Risk

- [ ] High
- [x] Medium
- [ ] Low

**Medium** risk: This change modifies the build pipeline configuration which is critical infrastructure. However, the change is minimal (single line task name change) and follows the established pattern for release branches. The risk is medium because:
- Changes to CI/CD infrastructure can have broad impact if incorrect
- Not taking this change would create technical debt, making it difficult to apply future CI/CD changes that build on top of this correction
- The change has been tested in the main branch and is a straightforward adaptation for the release branch
