### PR TITLE
[release/v7.4] Separate Store Automation Service Endpoints, Resolve AppID

### DIFF
--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -204,14 +204,32 @@ jobs:
         }
 
         Write-Host "##vso[task.setvariable variable=ServiceConnection]$($config.ServiceEndpoint)"
-        Write-Host "##vso[task.setvariable variable=SBConfigPath]$($config.SBConfigPath)"
+        Write-Host "##vso[task.setvariable variable=SBConfigPath]$($sbConfigPath)"
+
+        # These variables are used in the next tasks to determine which ServiceEndpoint to use
+        Write-Host "##vso[task.setvariable variable=LTS]$($IsLTS.ToString().ToLower())"
+        Write-Host "##vso[task.setvariable variable=STABLE]$($IsStable.ToString().ToLower())"
+        Write-Host "##vso[task.setvariable variable=PREVIEW]$($IsPreview.ToString().ToLower())"
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
 
-    - task: MS-RDX-MRO.windows-store-publish-dev.package-task.store-package@3
-      displayName: 'Create StoreBroker Package'
+    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
+      displayName: 'Create StoreBroker Package (Preview)'
+      condition: eq('$(PREVIEW)', 'true')
       inputs:
-        serviceEndpoint: '$(ServiceConnection)'
+        serviceEndpoint: 'StoreAppPublish-Preview'
+        sbConfigPath: '$(SBConfigPath)'
+        sourceFolder: '$(BundleDir)'
+        contents: '*.msixBundle'
+        outSBName: 'PowerShellStorePackage'
+        pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
+        pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
+
+    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
+      displayName: 'Create StoreBroker Package (Stable/LTS)'
+      condition: or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true'))
+      inputs:
+        serviceEndpoint: 'StoreAppPublish-Stable'
         sbConfigPath: '$(SBConfigPath)'
         sourceFolder: '$(BundleDir)'
         contents: '*.msixBundle'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -63,6 +63,10 @@ jobs:
     inputs:
       targetType: inline
       script: |
+        $IsLTS = '$(LTS)' -eq 'true'
+        $IsStable = '$(STABLE)' -eq 'true'
+        $IsPreview = '$(PREVIEW)' -eq 'true'
+
         Write-Verbose -Verbose "Channel Selection - LTS: $(LTS), Stable: $(Stable), Preview: $(Preview)"
 
         $currentChannel = if ($IsLTS) { 'LTS' }

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -47,7 +47,7 @@ jobs:
           $middleURL = $matches[1]
         }
 
-        $endURL = $tagString -replace '[v\.]',''
+        $endURL = $tagString -replace '^v','' -replace '\.',''
         $message = "Changelog: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/$middleURL.md#$endURL"
         Write-Verbose -Verbose "Release Notes for the Store:"
         Write-Verbose -Verbose "$message"
@@ -65,23 +65,6 @@ jobs:
       script: |
         Write-Verbose -Verbose "Channel Selection - LTS: $(LTS), Stable: $(Stable), Preview: $(Preview)"
 
-        # Define app configurations for each channel using secret variables
-        $channelConfigs = @{
-          'LTS' = @{
-            AppId = '$(AppID-LTS)'
-            ServiceEndpoint = 'StoreAppPublish-Stable'
-          }
-          'Stable' = @{
-            AppId = '$(AppID-Stable)'
-            ServiceEndpoint = 'StoreAppPublish-Stable'
-          }
-          'Preview' = @{
-            AppId = '$(AppID-Preview)'
-            ServiceEndpoint = 'StoreAppPublish-Preview'
-          }
-        }
-
-        # Determine the current channel
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
@@ -89,24 +72,43 @@ jobs:
             Write-Error "No valid channel detected"
             exit 1
           }
-                       
-        $config = $channelConfigs[$currentChannel]
+
+        # Assign AppID for Store-Publish Task
+        $appID = $null
+        if ($IsLTS) {
+          $appID = '$(AppID-LTS)'
+        }
+        elseif ($IsStable) {
+          $appID = '$(AppID-Stable)'
+        }
+        else {
+          $appID = '$(AppID-Preview)'
+        }
+
+        Write-Host "##vso[task.setvariable variable=AppID]$appID"
         Write-Verbose -Verbose "Selected channel: $currentChannel"
-        Write-Verbose -Verbose "App ID: $($config.AppId)"
-        Write-Verbose -Verbose "Service Endpoint: $($config.ServiceEndpoint)"
-        
-        # Set pipeline variables for use in the store-publish task
-        Write-Host "##vso[task.setvariable variable=SelectedAppId]$($config.AppId)"
-        Write-Host "##vso[task.setvariable variable=SelectedServiceEndpoint]$($config.ServiceEndpoint)"
-        Write-Host "##vso[task.setvariable variable=SelectedChannel]$currentChannel"
-    displayName: 'Set StoreBroker Configurations'
+        Write-Verbose -Verbose "Conditional tasks will handle the publishing based on channel variables"
+    displayName: 'Validate Channel Selection'
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
-    displayName: 'Publish LTS StoreBroker Package'
-    condition: ne('${{ parameters.skipMSIXPublish }}', 'true')
+    displayName: 'Publish StoreBroker Package (Stable/LTS)'
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true')))
     inputs:
-      serviceEndpoint: '$(SelectedServiceEndpoint)'
-      appId: '$(SelectedAppId)'
+      serviceEndpoint: 'StoreAppPublish-Stable'
+      appId: '$(AppID)'
+      inputMethod: JsonAndZip
+      jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
+      zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'
+      numberOfPackagesToKeep: 2
+      jsonZipUpdateMetadata: true
+      targetPublishMode: 'Immediate'
+
+  - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
+    displayName: 'Publish StoreBroker Package (Preview)'
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq('$(PREVIEW)', 'true'))
+    inputs:
+      serviceEndpoint: 'StoreAppPublish-Preview'
+      appId: '$(AppID)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
       zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'


### PR DESCRIPTION
Backport of #26210 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26210$$$
-->

Triggered by @TravisEz13 on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change

This PR separates the Microsoft Store automation service endpoints to use dedicated endpoints for Preview builds (`StoreAppPublish-Preview`) and Stable/LTS builds (`StoreAppPublish-Stable`), replacing the previous single `StoreAppPublish-Private` endpoint. It also resolves AppID dynamically based on the channel (LTS/Stable/Preview).

## Regression

- [ ] Yes
- [x] No

This change improves the Store publishing infrastructure and is not fixing a regression.

## Testing

The original PR was tested in the main branch CI/CD pipeline. This backport includes merge conflict resolution where:
- The task name was already updated to `MS-RDX-MRO.windows-store-publish.package-task.store-package@3` by PR #26395
- The changes to split tasks by channel and use separate service endpoints were merged cleanly

## Risk

- [x] High
- [ ] Medium
- [ ] Low

**Risk Level: High**

This change modifies critical CI/CD infrastructure for Microsoft Store publishing. While the changes are well-tested in the main branch, they affect:
1. Service endpoint configuration for Store publishing
2. Task splitting logic based on channel selection (Preview vs Stable/LTS)
3. AppID resolution logic

Not taking this change would create technical debt and make it difficult to apply future CI/CD changes that build on top of this infrastructure improvement. However, any issues with Store publishing could block releases.

## Merge Conflicts Resolution

Conflicts occurred in two files during the backport:


### `.pipelines/templates/release-MSIX-Publish.yml`
- **Conflict**: Different approaches to channel configuration and AppID assignment
- **Resolution**: Accepted incoming changes that simplify the logic by:
  - Removing the complex `$channelConfigs` hashtable
  - Using direct if/elseif logic for AppID assignment
  - Consolidating three separate publish tasks into two (Stable/LTS combined, Preview separate)
  - Using dynamically assigned `$(AppID)` variable instead of multiple intermediate variables
