### PR TITLE
[release/v7.5] Fix the task name to not use the pre-release task

### DIFF
--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -210,7 +210,7 @@ jobs:
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
 
-    - task: MS-RDX-MRO.windows-store-publish-dev.package-task.store-package@3
+    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
       inputs:
         serviceEndpoint: '$(ServiceConnection)'


### PR DESCRIPTION
Backport of #26138 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26138$$$
-->

Triggered by @TravisEz13 on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This change fixes the MSIX package creation task to use the correct non-preview task name. Without this fix, the MSIX packaging would fail due to referencing a task that doesn't exist in the release branch context.

## Regression

- [ ] Yes
- [x] No

This is not fixing a regression; it's a correction to the build task configuration.

## Testing

The original PR verified that the task name matches the actual available task. This backport was verified by successfully cherry-picking the commit without conflicts. The change should be validated by ensuring the MSIX packaging workflow runs successfully with the corrected task name.

## Risk

- [ ] High
- [x] Medium
- [ ] Low

Risk is Medium because this affects the build/packaging infrastructure. While the change itself is minimal (a single task name correction), packaging changes can have broad impacts on release builds. However, this is a necessary fix to ensure MSIX packages can be created correctly. Note that not taking this change creates technical debt - future CI/CD improvements that build on this fix would become harder to backport, potentially requiring manual intervention for subsequent backports.
