### PR TITLE
[release/v7.4] Fix path to metadata.json in channel selection script

### DIFF
--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -1,7 +1,7 @@
 steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
-    $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
+    $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
     $LTS = $metadata.LTSRelease.Latest
     $Stable = $metadata.StableRelease.Latest
     $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'


### PR DESCRIPTION
Backport of #26180 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26180$$$
-->

Triggered by @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This backport fixes the path to `metadata.json` in the channel selection script (`.pipelines/templates/channelSelection.yml`). The original path `$repoRoot/tools/metadata.json` was incorrect in the Azure DevOps pipeline context and has been updated to `$(Build.SourcesDirectory)/PowerShell/tools/metadata.json`.

This change was part of PR #26180 (merge of v7.6.0-preview.5 release branch back to master), specifically from commit 873db3512. The fix is critical for the release pipeline's channel selection logic to function correctly.

## Regression

- [ ] Yes
- [x] No

This is a fix for infrastructure, not a regression.

## Testing

The fix has been validated in the v7.6.0-preview.5 release branch and merged back to master via PR #26180. It corrects the pipeline variable reference to properly locate the metadata.json file during builds.

## Risk

- [ ] High
- [x] Medium
- [ ] Low

**Medium** - This change modifies CI/CD infrastructure (Azure DevOps pipeline templates). While the change itself is small and straightforward (correcting a file path), it affects the release pipeline's channel selection logic. The risk is medium because:

1. The change impacts release pipeline automation
2. Incorrect channel selection could affect package publishing
3. However, the fix has already been validated in the v7.6.0-preview.5 branch and master
4. Not taking this change creates technical debt and could cause issues in future releases when the pipeline tries to determine the correct channel (LTS/Stable/Preview)

The fix aligns the 7.4 release branch with the corrected implementation already in master, reducing divergence in pipeline infrastructure.
