### PR TITLE
[release/v7.5] Fix path to metadata.json in channel selection script

### DIFF
--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -1,7 +1,7 @@
 steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
-    $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
+    $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
     $LTS = $metadata.LTSRelease.Latest
     $Stable = $metadata.StableRelease.Latest
     $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'


### PR DESCRIPTION
Backport of d6f89ef3f to release/v7.5

Triggered by @TravisEz13 on behalf of @TravisEz13 

Original CL LabelL CL-BuildPackaging

Fixes the undefined variable in channelSelection.yml by using Build.SourcesDirectory pipeline variable instead.

This resolves the error: Cannot find path 'C:\tools\metadata.json' because it does not exist.