### PR TITLE
Fix the fuzzy test

### DIFF
--- a/test/fuzzing/FuzzingApp/Program.cs
+++ b/test/fuzzing/FuzzingApp/Program.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Text;
 using SharpFuzz;
-using System.Management.Automation.Remoting;
 
 namespace FuzzTests
 {
@@ -27,7 +25,7 @@ namespace FuzzTests
             {
                 Fuzzer.LibFuzzer.Run(Target.ExtractToken);
             }
-            catch (System.ArgumentNullException nex)
+            catch (ArgumentNullException nex)
             {
                 Console.WriteLine($"ArgumentNullException in main: {nex.Message}");
                 Console.WriteLine($"Stack Trace: {nex.StackTrace}");

--- a/test/fuzzing/FuzzingApp/Program.cs
+++ b/test/fuzzing/FuzzingApp/Program.cs
@@ -39,5 +39,5 @@ namespace FuzzTests
                 Environment.Exit(1);
             }
         }
-    }    
+    }
 }

--- a/test/fuzzing/FuzzingApp/Target.cs
+++ b/test/fuzzing/FuzzingApp/Target.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Text;
-using SharpFuzz;
 using System.Management.Automation.Remoting;
 
 namespace FuzzTests

--- a/test/fuzzing/FuzzingApp/Target.cs
+++ b/test/fuzzing/FuzzingApp/Target.cs
@@ -16,4 +16,3 @@ namespace FuzzTests
         }
     }
 }
-

--- a/test/fuzzing/FuzzingApp/powershell-fuzz-tests.csproj
+++ b/test/fuzzing/FuzzingApp/powershell-fuzz-tests.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\Test.Common.props"/>
+
   <PropertyGroup>
     <Description>PowerShell Fuzzing</Description>
     <AssemblyName>powershell-fuzz-tests</AssemblyName>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/fuzzing/runFuzzer.ps1
+++ b/test/fuzzing/runFuzzer.ps1
@@ -1,75 +1,65 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+<#
+1. libfuzzer-dotnet-windows.exe can be installed from https://github.com/Metalnem/libfuzzer-dotnet/releases
+
+2. sharpfuzz can be installed with dotnet-tool:
+   > dotnet tool install --global SharpFuzz.CommandLine --version 2.2.0
+
+Usage: sharpfuzz [path-to-assembly] [prefix ...]
+
+path-to-assembly:
+  The path to an assembly .dll file to instrument.
+
+prefix:
+  The class or the namespace to instrument.
+  If not present, all types in the assembly will be instrumented.
+  At least one prefix is required when instrumenting System.Private.CoreLib.
+
+Examples:
+  sharpfuzz Newtonsoft.Json.dll
+  sharpfuzz System.Private.CoreLib.dll System.Number
+  sharpfuzz System.Private.CoreLib.dll System.DateTimeFormat System.DateTimeParse
+#>
+
 param (
-    [string]$libFuzzer = ".\libfuzzer-dotnet-windows.exe",
-    [string]$project = ".\FuzzingApp\powershell-fuzz-tests.csproj",
-    [Parameter(Mandatory=$true)]
-    [string]$corpus,
+    [string]$libFuzzer = "$PSScriptRoot\libfuzzer-dotnet-windows.exe",
+    [string]$project = "$PSScriptRoot\FuzzingApp\powershell-fuzz-tests.csproj",
+    [string]$corpus = "$PSScriptRoot\inputs",
     [string]$command = "sharpfuzz.exe"
 )
 
 Set-StrictMode -Version Latest
 
-$outputDir = "out"
+$outputDir = "$PSScriptRoot\out"
 
 if (Test-Path $outputDir) {
     Remove-Item -Recurse -Force $outputDir
 }
 
-Write-Host "dotnet publish $project -c release -o $outputDir"
-dotnet publish $project -c release -o $outputDir
+Write-Host "dotnet publish $project -c Debug -o $outputDir"
+dotnet publish $project -c Debug -o $outputDir
 Write-Host "build completed"
 
 $projectName = (Get-Item $project).BaseName
 $projectDll = "$projectName.dll"
 $project = Join-Path $outputDir $projectDll
-
-$exclusions = @(
-    "dnlib.dll",
-    "SharpFuzz.dll",
-    "SharpFuzz.Common.dll"
-)
-
-$exclusions += $projectDll
-
-Write-Host "instrumenting: $project"
-& $command $project Target
-Write-Host "done instrumenting $project"
-
-$fuzzingTargets = Get-ChildItem $outputDir -Filter *.dll `
-| Where-Object { $_.Name -notin $exclusions } `
-| Where-Object { $_.Name -notlike "System.*.dll" }
-| Where-Object { $_.Name -notlike "Newtonsoft.*.dll" }
-| Where-Object { $_.Name -notlike "Microsoft.*.dll" }
-
-foreach ($fuzzingTarget in $fuzzingTargets) {
-    Write-Output "Instrumenting $fuzzingTarget"
-    & $command $fuzzingTarget.FullName
-
-    if ($LastExitCode -ne 0) {
-        Write-Error "An error occurred while instrumenting $fuzzingTarget"
-        exit 1
-    }
-}
-
 $smaDllPath = Join-Path $outputDir "System.Management.Automation.dll"
 
+## Instrument the specific class within the test assembly.
+Write-Host "instrumenting: $project"
+## !NOTE! If you instrument the class that defines "Main", it will fail.
+& $command $project "FuzzTests.Target"
+Write-Host "done instrumenting $project"
+
+## Instrument any other assemblies that need to be tested.
 Write-Host "instrumenting: $smaDllPath"
-& $command $smaDllPath Remoting
+& $command $smaDllPath "System.Management.Automation.Remoting.RemoteSessionHyperVSocketClient"
 Write-Host "done instrumenting: $smaDllPath"
-
-$fuzzingTargets += $projectDll
-$fuzzingTargets += $smaDllPath
-
-if (($fuzzingTargets | Measure-Object).Count -eq 0) {
-    Write-Error "No fuzzing targets found"
-    exit 1
-}
 
 $outputPath = Join-Path $outputDir "output.txt"
 
 Write-Host "launching fuzzer on $project"
 Write-Host "$libFuzzer --target_path=dotnet --target_arg=$project $corpus"
-& $libFuzzer --target_path=dotnet --target_arg=$project $corpus -max_len=1024 2>&1 `
-| Tee-Object -FilePath $outputPath
+& $libFuzzer --target_path=dotnet --target_arg=$project $corpus -max_len=1024 2>&1 | Tee-Object -FilePath $outputPath


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

1. Update `powershell-fuzz-tests.csproj` to use `Test.Common.props`. So, it doesn't need to update the target framework separately in future.
2. Update the `runFuzzer.ps1` file to correct the instrumentation and remove unneeded code.