### PR TITLE
Update the WCF packages to the latest version that is compatible with v4.10.3

### DIFF
--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -23,17 +23,10 @@
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="System.IO.Packaging" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="10.0.0-rc.2.25502.107" />
-    <!--
-        the following package(s) are from https://github.com/dotnet/wcf
-        they are pinned to the version 4.10.x due to a breaking change in newer versions.
-        see https://github.com/PowerShell/PowerShell/issues/19238 for details.
-     -->
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.10.3" NoWarn="NU1605" />
+    <!-- the following package(s) are from https://github.com/dotnet/wcf -->
+    <PackageReference Include="System.ServiceModel.Http" Version="10.0.0-rc.2.final" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.0-rc.2.final" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.0-rc.2.final" />
     <!-- the source could not be found for the following package(s) -->
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="10.0.0-rc.2.25502.107" />
   </ItemGroup>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -23,8 +23,6 @@
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="System.IO.Packaging" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing due to NU1510 -->
-    <!-- PackageReference Include="System.Text.Encodings.Web" Version="9.0.2" /-->
     <!--
         the following package(s) are from https://github.com/dotnet/wcf
         they are pinned to the version 4.10.x due to a breaking change in newer versions.

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -34,17 +34,10 @@
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing due to NU1510 -->
-    <!-- PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" /-->
     <PackageReference Include="System.DirectoryServices" Version="10.0.0-rc.2.25502.107" />
-    <!--PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" /-->
     <PackageReference Include="System.Management" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing System.Security.AccessControl as per NU1510 -->
-    <!-- PackageReference Include="System.Security.AccessControl" Version="6.0.1" /-->
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="System.Security.Permissions" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing due to NU1510 -->
-    <!-- PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.2" /-->
     <!-- the following package(s) are from the powershell org -->
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.PowerShell.Native" Version="700.0.0-preview.2" />

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -1,15 +1,5 @@
 [
   {
-    "Pattern": "_manifest\\spdx_2.2\\bsi.json",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "_manifest\\spdx_2.2\\manifest.cat",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "Accessibility.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -90,11 +80,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "cs/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "cs/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -160,6 +145,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "cs\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "cs\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "cs\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "cs\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "D3DCompiler_47_cor3.dll",
     "FileType": "NonProduct",
     "Architecture": [
@@ -198,11 +203,6 @@
   },
   {
     "Pattern": "de/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "de/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -272,6 +272,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "de\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "de\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "de\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "de\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "DirectWriteForwarder.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -313,11 +333,6 @@
   },
   {
     "Pattern": "es/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "es/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -387,6 +402,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "es\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "es\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "es\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "es\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "fr/Microsoft.CodeAnalysis.CSharp.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -418,11 +453,6 @@
   },
   {
     "Pattern": "fr/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "fr/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -492,6 +522,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "fr\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "fr\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "fr\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "fr\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "getfilesiginforedist.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -548,11 +598,6 @@
   },
   {
     "Pattern": "it/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "it/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -622,6 +667,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "it\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "it\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "it\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "it\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "ja/Microsoft.CodeAnalysis.CSharp.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -653,11 +718,6 @@
   },
   {
     "Pattern": "ja/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "ja/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -727,6 +787,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "ja\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ja\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ja\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ja\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "Json.More.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -773,11 +853,6 @@
   },
   {
     "Pattern": "ko/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "ko/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -843,6 +918,26 @@
   },
   {
     "Pattern": "ko/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -1112,11 +1207,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "Modules/ThreadJob/*.psd1",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "Modules\\Microsoft.PowerShell.PSResourceGet\\Microsoft.PowerShell.PSResourceGet.pdb",
     "FileType": "NonProduct",
     "Architecture": null
@@ -1153,16 +1243,6 @@
   },
   {
     "Pattern": "Modules\\PSReadLine\\.signature.p7s",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "Modules\\ThreadJob\\.signature.p7s",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "Modules\\ThreadJob\\ThreadJob.psm1",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -1247,11 +1327,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "pl/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "pl/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -1313,6 +1388,26 @@
   },
   {
     "Pattern": "pl/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -1467,11 +1562,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "pt-BR/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "pt-BR/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -1533,6 +1623,26 @@
   },
   {
     "Pattern": "pt-BR/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -2432,11 +2542,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "ru/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "ru/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -2498,6 +2603,26 @@
   },
   {
     "Pattern": "ru/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -3317,11 +3442,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "System.Private.ServiceModel.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "System.Private.Uri.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -3603,6 +3723,11 @@
   },
   {
     "Pattern": "System.ServiceModel.Http.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "System.ServiceModel.NetFramingBase.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -3902,11 +4027,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "tr/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "tr/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -3968,6 +4088,26 @@
   },
   {
     "Pattern": "tr/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -4047,11 +4187,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "zh-Hans/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "zh-Hans/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -4117,6 +4252,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "zh-Hans\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hans\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hans\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hans\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "zh-Hant/Microsoft.CodeAnalysis.CSharp.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -4148,11 +4303,6 @@
   },
   {
     "Pattern": "zh-Hant/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "zh-Hant/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -4218,6 +4368,26 @@
   },
   {
     "Pattern": "zh-Hant/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -1,5 +1,15 @@
 [
   {
+    "Pattern": "_manifest\\spdx_2.2\\bsi.json",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "_manifest\\spdx_2.2\\manifest.cat",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "Accessibility.dll",
     "FileType": "NonProduct",
     "Architecture": null

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -284,6 +284,18 @@ function Start-PSPackage {
                 $createdSpdxPathSha = New-Item -Path $manifestSpdxPathSha -Force
                 Write-Verbose -Verbose "Created manifest.spdx.json.sha256 file: $createdSpdxPathSha"
             }
+
+            $bsiJsonPath = (Join-Path -Path $Source "_manifest\spdx_2.2\bsi.json")
+            if (-not (Test-Path -Path $bsiJsonPath)) {
+                $createdBsiJsonPath = New-Item -Path $bsiJsonPath -Force
+                Write-Verbose -Verbose "Created bsi.json file: $createdBsiJsonPath"
+            }
+
+            $manifestCatPath = (Join-Path -Path $Source "_manifest\spdx_2.2\manifest.cat")
+            if (-not (Test-Path -Path $manifestCatPath)) {
+                $createdCatPath = New-Item -Path $manifestCatPath -Force
+                Write-Verbose -Verbose "Created manifest.cat file: $createdCatPath"
+            }
         }
 
         # If building a symbols package, we add a zip of the parent to publish

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -5519,6 +5519,7 @@ function Send-AzdoFile {
         Copy-Item -Path $Path -Destination $logFile
     }
 
+    Write-Verbose "Capture the log file as '$newName'" -Verbose
     if($env:TF_BUILD) {
         ## In Azure DevOps
         Write-Host "##vso[artifact.upload containerfolder=$newName;artifactname=$newName]$logFile"
@@ -5533,9 +5534,9 @@ function Send-AzdoFile {
         }
 
         Copy-Item -Path $logFile -Destination $destinationPath -Force -Verbose
+    } else {
+        Write-Warning "This environment is neither Azure Devops nor GitHub Actions. Cannot capture the log file in this environment."
     }
-
-    Write-Verbose "Log file captured as $newName" -Verbose
 }
 
 # Class used for serializing and deserialing a BOM into Json

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -5525,6 +5525,7 @@ function Send-AzdoFile {
     } elseif ($env:GITHUB_WORKFLOW -and $env:RUNNER_WORKSPACE) {
         ## In GitHub Actions
         $destinationPath = Join-Path -Path $env:RUNNER_WORKSPACE -ChildPath $newName
+        Write-Verbose "Upload $logFile in GitHub Action" -Verbose
 
         # Create the folder if it does not exist
         if (!(Test-Path -Path $destinationPath)) {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -5522,10 +5522,10 @@ function Send-AzdoFile {
     if($env:TF_BUILD) {
         ## In Azure DevOps
         Write-Host "##vso[artifact.upload containerfolder=$newName;artifactname=$newName]$logFile"
-    } elseif ($env:GITHUB_WORKFLOW -and $env:RUNNER_WORKSPACE) {
+    } elseif ($env:GITHUB_WORKFLOW -and $env:SYSTEM_ARTIFACTSDIRECTORY) {
         ## In GitHub Actions
-        $destinationPath = Join-Path -Path $env:RUNNER_WORKSPACE -ChildPath $newName
-        Write-Verbose "Upload $logFile in GitHub Action" -Verbose
+        $destinationPath = $env:SYSTEM_ARTIFACTSDIRECTORY
+        Write-Verbose "Upload '$logFile' to '$destinationPath' in GitHub Action" -Verbose
 
         # Create the folder if it does not exist
         if (!(Test-Path -Path $destinationPath)) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #19238

1. Remove the `PackageReference` items that were commented out.
2. Update the WCF packages to use the latest compatible version `10.0.0-rc.2.final`.

The `10.0.0-rc.2.final` version `ServiceModel` packages are backward compatible:
- The packages `System.ServiceModel.Duplex`, `System.ServiceModel.Security`, and `System.Private.ServiceModel` are discontinued.
- The package `System.ServiceModel.Primitives` ships 3 facade assemblies
   - `System.ServiceModel.dll`
   - `System.ServiceModel.Duplex.dll`
   - `System.ServiceModel.Security.dll`

- The package `System.Private.ServiceModel` is no longer needed, as every package now carries its own implementation.

**I have verified that the `ActiveDirectory` module can be correctly imported with in PowerShell built with the `10.0.0-rc.2.final` WCF packages.**

----------------

**Before this change**, the `*ServiceModel*` assemblies carried by PowerShell are:
```
System.Private.ServiceModel
System.ServiceModel
System.ServiceModel.Duplex
System.ServiceModel.Http
System.ServiceModel.NetTcp
System.ServiceModel.Primitives
System.ServiceModel.Security
System.ServiceModel.Syndication
System.ServiceModel.Web
```

**After this change**, the `*ServiceModel*` assemblies carried by PowerShell are:

```
System.ServiceModel
System.ServiceModel.Duplex
System.ServiceModel.Http
System.ServiceModel.NetFramingBase
System.ServiceModel.NetTcp
System.ServiceModel.Primitives
System.ServiceModel.Security
System.ServiceModel.Syndication
System.ServiceModel.Web
```

The difference of **Before** vs. **After** is shown below. The `System.Private.ServiceModel.dll` is no longer needed with the latest version, and the `System.ServiceModel.NetFramingBase.dll` is a new dependency of the `System.ServiceModel.NetTcp.dll`.

```
PS> Compare-Object -ReferenceObject $before -DifferenceObject $after

InputObject                        SideIndicator
-----------                        -------------
System.ServiceModel.NetFramingBase =>
System.Private.ServiceModel        <=
```