### PR TITLE
[release/v7.5] Specify .NET Search by Build Type

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -176,6 +176,27 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
+  <!-- Define properties for Framework dependent deployments in Packages
+        https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#apphostdotnetsearch
+        For FxDependent, we want to search for the apphost in the Environment or global location,
+        as this was not causing any issues.
+        For FxDependentDeployment, we want to search ONLY in global location.
+        For SelfContained, we want to search in the app local location.
+  -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependent' ">
+    <!-- Specify both to keep existing behavior because we have not had complaints about this scenario -->
+    <AppHostDotNetSearch>EnvironmentVariable;Global</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' ">
+    <!-- If we specify Environment too, it searches that first, no matter what order we specify-->
+    <AppHostDotNetSearch>Global</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' ">
+    <AppHostDotNetSearch>AppLocal</AppHostDotNetSearch>
+  </PropertyGroup>
+
   <!-- Define all OS, release configuration properties -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PublishReadyToRun>true</PublishReadyToRun>


### PR DESCRIPTION
Backport of #25837 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:25837$$$
-->

Triggered by @TravisEz13 on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change

This backports build system improvements that specify .NET search behavior by build type (FxDependent, FxDependentDeployment, SelfContained). This is a prerequisite for PR #26290 which enables ready-to-run compilation only for Release configuration.

## Regression

- [ ] No

This is a build infrastructure improvement that adds more granular control over AppHostDotNetSearch and PublishReadyToRun settings based on deployment type.

## Testing

Verified by:
1. Cherry-pick applied cleanly to release/v7.5
2. Changes limited to build configuration files (PowerShell.Common.props and build.psm1)
3. Original PR was tested and merged to main branch

This change enables proper deployment-specific configuration for framework-dependent and self-contained builds.

## Risk

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: Changes build configuration properties that affect how PowerShell binaries are packaged and deployed. However, this is necessary infrastructure for enabling ready-to-run improvements (PR #26290) and has been validated in the main branch. The changes provide more explicit control over build behavior rather than changing existing functionality.