### PR TITLE
Move package validation to package pipeline

### DIFF
--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -299,3 +299,9 @@ extends:
       dependsOn: [prep, mac_package, windows_package_sign, linux_package, nupkg, msixbundle]  # prep needed for BuildInfo JSON
       jobs:
       - template: /.pipelines/templates/uploadToAzure.yml@self
+
+    - stage: validatePackages
+      displayName: 'Validate Packages'
+      dependsOn: [upload]
+      jobs:
+      - template: /.pipelines/templates/release-validate-packagenames.yml@self

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -216,12 +216,6 @@ extends:
           arm64: 'yes'
           enableCredScan: false
 
-    - stage: validatePackages
-      displayName: 'Validate Packages'
-      dependsOn: []
-      jobs:
-      - template: /.pipelines/templates/release-validate-packagenames.yml@self
-
     - stage: ManualValidation
       dependsOn: []
       displayName: Manual Validation
@@ -272,7 +266,6 @@ extends:
       dependsOn:
         - ManualValidation
         - ReleaseAutomation
-        - validatePackages
         - fxdpackages
         - gbltool
         - validateSdk
@@ -365,7 +358,7 @@ extends:
             This is typically done by the community 1-2 days after the release.
 
     - stage: PublishMsix
-      dependsOn: 
+      dependsOn:
         - setReleaseTagAndChangelog
         - PushGitTagAndMakeDraftPublic
       displayName: Publish MSIX to store


### PR DESCRIPTION

This pull request updates the package validation workflow in the pipeline YAML files to improve the sequencing and location of the package validation stage. The main change is moving the `validatePackages` stage from the release pipeline to the package build pipeline, ensuring validation occurs earlier in the process.

Pipeline workflow changes:

* Added the `validatePackages` stage to `.pipelines/PowerShell-Packages-Official.yml`, placing package name validation immediately after the upload stage in the package build pipeline.
* Removed the `validatePackages` stage from `.pipelines/PowerShell-Release-Official.yml`, so package validation is no longer performed in the release pipeline.
* Updated the dependencies in the release pipeline to remove references to the now-absent `validatePackages` stage.