### PR TITLE
Add rebuild branch support with conditional MSIX signing

### DIFF
--- a/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run/Run.ps1
+++ b/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run/Run.ps1
@@ -354,6 +354,9 @@ try {
     $skipPublish = $metadataContent.SkipPublish
     $lts = $metadataContent.LTS
 
+    # Check if this is a rebuild version (e.g., 7.4.13-rebuild.5)
+    $isRebuild = $releaseVersion -match '-rebuild\.'
+
     if ($releaseVersion.Contains('-')) {
         $channel = 'preview'
         $packageNames = @('powershell-preview')
@@ -363,7 +366,8 @@ try {
         $packageNames = @('powershell')
     }
 
-    if ($lts) {
+    # Only add LTS package if not a rebuild branch
+    if ($lts -and -not $isRebuild) {
         $packageNames += @('powershell-lts')
     }
 

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -296,9 +296,20 @@ extends:
         - template: /.pipelines/templates/SetVersionVariables.yml@self
           parameters:
             ReleaseTagVar: $(ReleaseTagVar)
+        - template: /.pipelines/templates/rebuild-branch-check.yml@self
         - powershell: |
             $metadata = Get-Content '$(Build.SourcesDirectory)/PowerShell/tools/metadata.json' -Raw | ConvertFrom-Json
-            $LTS = $metadata.LTSRelease.Package
+
+            # Use the rebuild branch check from the template
+            $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+            # Don't mark as LTS release for rebuild branches
+            $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
+
+            if ($isRebuildBranch) {
+              Write-Verbose -Message "Rebuild branch detected, not marking as LTS release" -Verbose
+            }
+
             @{ ReleaseVersion = "$(Version)"; LTSRelease = $LTS } | ConvertTo-Json | Out-File "$(Build.StagingDirectory)\release.json"
             Get-Content "$(Build.StagingDirectory)\release.json"
 

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -293,6 +293,8 @@ extends:
       dependsOn: [windows_package_build]  # Only depends on unsigned packages
       jobs:
       - template: /.pipelines/templates/package-create-msix.yml@self
+        parameters:
+          OfficialBuild: ${{ parameters.OfficialBuild }}
 
     - stage: upload
       displayName: 'Upload'

--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -2,13 +2,27 @@ steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
     $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
+    $releaseTag = '$(OutputReleaseTag.releaseTag)'
+
+    # Rebuild branches should be treated as preview builds
+    $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
+
     $LTS = $metadata.LTSRelease.Latest
     $Stable = $metadata.StableRelease.Latest
-    $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'
+    $isPreview = $releaseTag -match '-'
 
-    $IsLTS = [bool]$LTS
-    $IsStable = [bool]$Stable
-    $IsPreview = [bool]$isPreview
+    # If this is a rebuild branch, force preview mode and ignore LTS metadata
+    if ($isRebuildBranch) {
+        $IsLTS = $false
+        $IsStable = $false
+        $IsPreview = $true
+        Write-Verbose -Message "Rebuild branch detected, forcing Preview channel" -Verbose
+    }
+    else {
+        $IsLTS = [bool]$LTS
+        $IsStable = [bool]$Stable
+        $IsPreview = [bool]$isPreview
+    }
 
     $channelVars = @{
         IsLTS     = $IsLTS

--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -5,6 +5,10 @@ steps:
     $releaseTag = '$(OutputReleaseTag.releaseTag)'
 
     # Rebuild branches should be treated as preview builds
+    # NOTE: The following regex is duplicated from rebuild-branch-check.yml.
+    # This duplication is necessary because channelSelection.yml does not call rebuild-branch-check.yml,
+    # and is used in contexts where that check may not have run.
+    # If you update this regex, also update it in rebuild-branch-check.yml to keep them in sync.
     $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
 
     $LTS = $metadata.LTSRelease.Latest

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -149,7 +149,7 @@ jobs:
       $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
 
       # Don't build LTS packages for rebuild branches
-      $LTS = ($metadata.LTSRelease.Package -eq 'True') -and -not $isRebuildBranch
+      $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
 
       if ($isRebuildBranch) {
         Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -62,6 +62,8 @@ jobs:
     parameters:
       nativePathRoot: '$(Agent.TempDirectory)'
 
+  - template: rebuild-branch-check.yml@self
+
   - download: CoOrdinatedBuildPipeline
     artifact: ${{ parameters.unsignedDrop }}
     displayName: 'Download unsigned artifacts'
@@ -139,7 +141,21 @@ jobs:
       }
 
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
-      $LTS = $metadata.LTSRelease.Package
+
+      Write-Verbose -Verbose "metadata:"
+      $metadata | Out-String | Write-Verbose -Verbose
+
+      # Use the rebuild branch check from the template
+      $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+      # Don't build LTS packages for rebuild branches
+      $LTS = ($metadata.LTSRelease.Package -eq 'True') -and -not $isRebuildBranch
+
+      if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose
+      }
+
+      Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
         Write-Verbose -Message "LTS Release: $LTS"

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -60,6 +60,8 @@ jobs:
     parameters:
       nativePathRoot: '$(Agent.TempDirectory)'
 
+  - template: rebuild-branch-check.yml@self
+
   - download: CoOrdinatedBuildPipeline
     artifact: macosBinResults-${{ parameters.buildArchitecture }}
 
@@ -103,7 +105,21 @@ jobs:
       Get-PSOptions | Write-Verbose -Verbose
 
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
-      $LTS = $metadata.LTSRelease.Package
+
+      Write-Verbose -Verbose "metadata:"
+      $metadata | Out-String | Write-Verbose -Verbose
+
+      # Use the rebuild branch check from the template
+      $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+      # Don't build LTS packages for rebuild branches
+      $LTS = ($metadata.LTSRelease.Package -eq 'True') -and -not $isRebuildBranch
+
+      if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose
+      }
+
+      Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
         Write-Verbose -Message "LTS Release: $LTS"

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -113,7 +113,7 @@ jobs:
       $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
 
       # Don't build LTS packages for rebuild branches
-      $LTS = ($metadata.LTSRelease.Package -eq 'True') -and -not $isRebuildBranch
+      $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
 
       if ($isRebuildBranch) {
         Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: OfficialBuild
+    type: boolean
+    default: false
+
 jobs:
 - job: CreateMSIXBundle
   displayName: Create .msixbundle file
@@ -49,7 +54,7 @@ jobs:
           **/*.msix
         targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
       displayName: Download windows x86 packages
-    
+
     # Finds the makeappx tool on the machine with image: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
     - pwsh: |
         $cmd = Get-Command makeappx.exe -ErrorAction Ignore
@@ -99,12 +104,13 @@ jobs:
 
     - task: onebranch.pipeline.signing@1
       displayName: Sign MsixBundle
+      condition: eq('${{ parameters.OfficialBuild }}', 'true')
       inputs:
         command: 'sign'
         signing_profile: $(MSIXProfile)
         files_to_sign: '**/*.msixbundle'
         search_root: '$(BundleDir)'
-    
+
     - pwsh: |
         $signedBundle = Get-ChildItem -Path $(BundleDir) -Filter "*.msixbundle" -File
         Write-Verbose -Verbose "Signed bundle: $signedBundle"
@@ -126,12 +132,12 @@ jobs:
         Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Recurse | Select-Object -ExpandProperty FullName
         Test-Path -Path '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP-Private.xml' | Write-Verbose -Verbose
       displayName: Output Pipeline.Workspace and System.DefaultWorkingDirectory
-    
+
     - template: channelSelection.yml@self
 
     - pwsh: |
         $IsLTS = '$(ChannelSelection.IsLTS)' -eq 'true'
-        $IsStable = '$(ChannelSelection.IsStable)' -eq 'true' 
+        $IsStable = '$(ChannelSelection.IsStable)' -eq 'true'
         $IsPreview = '$(ChannelSelection.IsPreview)' -eq 'true'
 
         Write-Verbose -Verbose "Channel Selection - LTS: $IsLTS, Stable: $IsStable, Preview: $IsPreview"
@@ -161,11 +167,11 @@ jobs:
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
-          else { 
+          else {
             Write-Error "No valid channel detected"
             exit 1
           }
-                       
+
         $config = $channelConfigs[$currentChannel]
         Write-Verbose -Verbose "Selected channel: $currentChannel"
         Write-Verbose -Verbose "App Store Name: $($config.AppStoreName)"
@@ -181,7 +187,7 @@ jobs:
           # Create namespace manager for XML with default namespace
           $nsManager = New-Object System.Xml.XmlNamespaceManager($pdpXml.NameTable)
           $nsManager.AddNamespace("pd", "http://schemas.microsoft.com/appx/2012/ProductDescription")
-          
+
           $appStoreNameElement = $pdpXml.SelectSingleNode("//pd:AppStoreName", $nsManager)
           if ($appStoreNameElement) {
             $appStoreNameElement.SetAttribute("_locID", $config.AppStoreName)
@@ -220,11 +226,29 @@ jobs:
         Write-Host "##vso[task.setvariable variable=SBConfigPath]$($sbConfigPath)"
 
         # These variables are used in the next tasks to determine which ServiceEndpoint to use
-        Write-Host "##vso[task.setvariable variable=LTS]$($IsLTS.ToString().ToLower())"
-        Write-Host "##vso[task.setvariable variable=STABLE]$($IsStable.ToString().ToLower())"
-        Write-Host "##vso[task.setvariable variable=PREVIEW]$($IsPreview.ToString().ToLower())"
+        $ltsValue = $IsLTS.ToString().ToLower()
+        $stableValue = $IsStable.ToString().ToLower()
+        $previewValue = $IsPreview.ToString().ToLower()
+        
+        Write-Verbose -Verbose "About to set variables:"
+        Write-Verbose -Verbose "  LTS=$ltsValue"
+        Write-Verbose -Verbose "  STABLE=$stableValue"
+        Write-Verbose -Verbose "  PREVIEW=$previewValue"
+        
+        Write-Host "##vso[task.setvariable variable=LTS]$ltsValue"
+        Write-Host "##vso[task.setvariable variable=STABLE]$stableValue"
+        Write-Host "##vso[task.setvariable variable=PREVIEW]$previewValue"
+        
+        Write-Verbose -Verbose "Variables set successfully"
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
+
+    - pwsh: |
+        Write-Verbose -Verbose "Checking variables after UpdateConfigs:"
+        Write-Verbose -Verbose "LTS=$(LTS)"
+        Write-Verbose -Verbose "STABLE=$(STABLE)"
+        Write-Verbose -Verbose "PREVIEW=$(PREVIEW)"
+      displayName: Debug - Check Variables
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package (Preview)'
@@ -260,14 +284,14 @@ jobs:
         $submissionPackageDir = "$(System.DefaultWorkingDirectory)/SBOutDir"
         $jsonFile = "$submissionPackageDir/PowerShellStorePackage.json"
         $zipFile = "$submissionPackageDir/PowerShellStorePackage.zip"
-    
+
         if ((Test-Path $jsonFile) -and (Test-Path $zipFile)) {
           Write-Verbose -Verbose "Uploading StoreBroker Package files:"
           Write-Verbose -Verbose "JSON File: $jsonFile"
           Write-Verbose -Verbose "ZIP File: $zipFile"
 
           Copy-Item -Path $submissionPackageDir -Destination "$(ob_outputDirectory)" -Verbose -Recurse
-        } 
+        }
 
         else {
           Write-Error "Required files not found in $submissionPackageDir"

--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -137,7 +137,7 @@ jobs:
       $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
 
       # Don't build LTS packages for rebuild branches
-      $LTS = ($metadata.LTSRelease.Package -eq 'True') -and -not $isRebuildBranch
+      $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
 
       if ($isRebuildBranch) {
         Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose

--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -60,6 +60,8 @@ jobs:
       nativePathRoot: '$(Agent.TempDirectory)'
       ob_restore_phase: false
 
+  - template: rebuild-branch-check.yml@self
+
   - download: CoOrdinatedBuildPipeline
     artifact: drop_windows_build_windows_${{ parameters.runtime }}_release
     displayName: Download signed artifacts
@@ -127,7 +129,21 @@ jobs:
       Get-PSOptions | Write-Verbose -Verbose
 
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
-      $LTS = $metadata.LTSRelease.Package
+
+      Write-Verbose -Verbose "metadata:"
+      $metadata | Out-String | Write-Verbose -Verbose
+
+      # Use the rebuild branch check from the template
+      $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+      # Don't build LTS packages for rebuild branches
+      $LTS = ($metadata.LTSRelease.Package -eq 'True') -and -not $isRebuildBranch
+
+      if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose
+      }
+
+      Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
         Write-Verbose -Message "LTS Release: $LTS"

--- a/.pipelines/templates/rebuild-branch-check.yml
+++ b/.pipelines/templates/rebuild-branch-check.yml
@@ -1,0 +1,17 @@
+# This template checks if the current branch is a rebuild branch
+# and sets an output variable IsRebuildBranch that can be used by other templates
+steps:
+- pwsh: |
+    # Check if this is a rebuild branch (e.g., rebuild/v7.4.13-rebuild.5)
+    $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
+
+    $value = if ($isRebuildBranch) { 'true' } else { 'false' }
+    Write-Verbose -Message "IsRebuildBranch: $value" -Verbose
+
+    if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected: $(Build.SourceBranch)" -Verbose
+    }
+
+    Write-Host "##vso[task.setvariable variable=IsRebuildBranch;isOutput=true]$value"
+  name: RebuildBranchCheck
+  displayName: Check if Rebuild Branch


### PR DESCRIPTION

This pull request introduces improved handling for "rebuild" branches across the build and packaging pipelines. The main goal is to ensure that rebuild branches are not treated as LTS (Long Term Support) releases, and that LTS packages are not built or published from these branches. The changes also add better diagnostics and parameterization for official builds.

Key changes include:

**Rebuild Branch Detection and Propagation:**

* Added a new template, `rebuild-branch-check.yml`, which detects if the current branch is a rebuild branch and sets an output variable (`IsRebuildBranch`) for use in other templates and scripts.
* Integrated the rebuild branch check into major build and packaging templates (`linux-package-build.yml`, `mac-package-build.yml`, `packaging/windows/package.yml`, and `PowerShell-Coordinated_Packages-Official.yml`), ensuring consistent detection across platforms. [[1]](diffhunk://#diff-c4deeac235a73bb18401801ffa4dbcba3977cfb09599cd432e2a5940de12734eR65-R66) [[2]](diffhunk://#diff-88d2abacc35dc8631d9c0e94c7e5d1ccdffc9426d13a16183b3c45f7841688b5R63-R64) [[3]](diffhunk://#diff-2732d3af912d14b43947dfbd196d6eb82cb4f3865d62d448c03c6f31d3024d07R63-R64) [[4]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR299-R312)

**LTS Handling Adjustments:**

* Modified scripts and templates to prevent LTS packages from being built or published when on a rebuild branch. This includes logic updates in PowerShell scripts and YAML templates to check the `IsRebuildBranch` variable before marking a build as LTS or adding LTS packages. [[1]](diffhunk://#diff-c4deeac235a73bb18401801ffa4dbcba3977cfb09599cd432e2a5940de12734eL142-R158) [[2]](diffhunk://#diff-88d2abacc35dc8631d9c0e94c7e5d1ccdffc9426d13a16183b3c45f7841688b5L106-R122) [[3]](diffhunk://#diff-2732d3af912d14b43947dfbd196d6eb82cb4f3865d62d448c03c6f31d3024d07L130-R146) [[4]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR299-R312) [[5]](diffhunk://#diff-0787409ff9de87a5c8d9c7776e5c0200f5c9d7d9db85cd3b8c5520802555b860R357-R359) [[6]](diffhunk://#diff-0787409ff9de87a5c8d9c7776e5c0200f5c9d7d9db85cd3b8c5520802555b860L366-R370)

**Channel and Preview Logic Improvements:**

* Updated the channel selection logic to force preview mode for rebuild branches, ensuring that such builds are never treated as stable or LTS releases.

**Pipeline Parameterization and Diagnostics:**

* Enhanced the `package-create-msix.yml` template to accept an `OfficialBuild` parameter and only sign MSIX bundles for official builds. Added more verbose logging and a debug step to check variable values during the pipeline. [[1]](diffhunk://#diff-b09ac31caeda1400a115a970686df9fc86ed1f1c648277e2ed3d7e6973f7bb4bR1-R5) [[2]](diffhunk://#diff-b09ac31caeda1400a115a970686df9fc86ed1f1c648277e2ed3d7e6973f7bb4bR107) [[3]](diffhunk://#diff-b09ac31caeda1400a115a970686df9fc86ed1f1c648277e2ed3d7e6973f7bb4bL223-R252) [[4]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R296-R297)

These changes collectively ensure that rebuild branches are handled safely and consistently, preventing accidental LTS releases and improving traceability in the build process.