### PR TITLE
Fix incorrect parsing of `#` in CsvCommands, add missing tests for the spec-compliant behavior

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1354,7 +1354,7 @@ namespace Microsoft.PowerShell.Commands
                 string rawLine = raw.ToString();
 
                 // File starts with '#' and contains '#Fields:' is W3C Extended Log File Format
-                if (values.Count > 0 && rawLine.StartsWith("#Fields: "))
+                if (rawLine.Length > 0 && rawLine.StartsWith("#Fields: ") && values.Count > 0)
                 {
                     values[0] = values[0].Substring(9);
                     Header = values;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1377,7 +1377,7 @@ namespace Microsoft.PowerShell.Commands
         /// which is getting trimmed along with blankspaces supplied through the CSV.
         /// </summary>
         /// <param name="values">The list of string values to trim trailing empty entries from.</param>
-        internal void TrimEmptiesAtEnd(List<string> values)
+        private void TrimEmptiesAtEnd(List<string> values)
         {
             while (values.Count > 1 && values[values.Count - 1].Equals(string.Empty))
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1377,7 +1377,7 @@ namespace Microsoft.PowerShell.Commands
         /// which is getting trimmed along with blankspaces supplied through the CSV.
         /// </summary>
         /// <param name="values">The list of string values to trim trailing empty entries from.</param>
-        private void TrimEmptiesAtEnd(List<string> values)
+        private static void TrimEmptiesAtEnd(List<string> values)
         {
             while (values.Count > 1 && values[values.Count - 1].Equals(string.Empty))
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -99,9 +99,19 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
 #Fields: a,b,c
 1,2,3
 '@
+        $testColumnsWithFieldsSwapped = @'
+#Fields: a,b,c
+#Version: 1.0
+1,2,3
+'@
         $testColumnsWithFieldsSpaceDelimited = @'
 #Version: 1.0
 #Fields: a b c
+1 2 3
+'@
+        $testColumnsWithFieldsSpaceDelimitedSwapped = @'
+#Fields: a b c
+#Version: 1.0
 1 2 3
 '@
     }
@@ -124,7 +134,7 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
         $actualData[0]."1" | Should -Be "4"
     }
 
-    It "Should handle #Fields directive as header" {
+    It "Should handle #Fields directive as header when #Fields directive is second line" {
         $actualData = $testColumnsWithFields | ConvertFrom-Csv
 
         $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
@@ -133,8 +143,26 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
         $actualData[0]."a" | Should -Be "1"
     }
 
-    It "Should handle #Fields directive as header when space delimited" -Pending {
+    It "Should handle #Fields directive as header when #Fields directive is first line" -Pending {
+        $actualData = $testColumnsWithFieldsSwapped | ConvertFrom-Csv
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+
+    It "Should handle #Fields directive as header when space delimited and when #Fields directive is second line" -Pending {
         $actualData = $testColumnsWithFieldsSpaceDelimited | ConvertFrom-Csv -Delimiter ' '
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+
+    It "Should handle #Fields directive as header when space delimited and when #Fields directive is first line" -Pending {
+        $actualData = $testColumnsWithFieldsSpaceDelimitedSwapped | ConvertFrom-Csv -Delimiter ' '
 
         $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -98,6 +98,10 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
 #Fields: a,b,c
 1,2,3
 '@
+        $testColumnsWithFieldsSpaceDelimited = @'
+#Fields: a b c
+1 2 3
+'@
     }
 
     It "Should handle quoted # in header" {
@@ -120,6 +124,18 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
 
     It "Should handle #Fields lines as header" {
         $actualData = $testColumnsWithFields | ConvertFrom-Csv
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+
+    It "Should handle #Fields lines as header when space delimited" {
+        $testPath = Join-Path $TestDrive "FieldsSpace.csv"
+        Set-Content $testPath -Value $testColumnsWithFieldsSpaceDelimited
+
+        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ' '
 
         $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -84,7 +84,7 @@ Describe "ConvertFrom-Csv DRT Unit Tests" -Tags "CI" {
 Describe "ConvertFrom-Csv containing #" -Tags "CI" {
     BeforeAll {
         $testColumnsWithQuotedHashtag = @'
-"#","b","c",
+"#","b","c"
 1,2,3
 '@
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -27,10 +27,10 @@ a,b,c
     }
 
     It "Should have expected results when using piped inputs" {
-        $csvContent   = Get-Content $testcsv
+        $csvContent = Get-Content $testcsv
         $actualresult = $csvContent | ConvertFrom-Csv
 
-        ,$actualresult | Should -BeOfType System.Array
+        , $actualresult | Should -BeOfType System.Array
         $actualresult[0] | Should -BeOfType PSCustomObject
 
         #Should have a name property in the result
@@ -42,10 +42,10 @@ a,b,c
     }
 
     It "Should actually delimit the output" {
-        $csvContent   = Get-Content $testcsv
+        $csvContent = Get-Content $testcsv
         $actualresult = $csvContent | ConvertFrom-Csv -Delimiter ";"
 
-        ,$actualresult | Should -BeOfType System.Array
+        , $actualresult | Should -BeOfType System.Array
         $actualresult[0] | Should -BeOfType PSCustomObject
 
         # ConvertFrom-Csv takes the first line of the input as a header by default
@@ -53,9 +53,9 @@ a,b,c
     }
 
     It "Should be able to have multiple columns" {
-        $actualData   = $testColumns | ConvertFrom-Csv
+        $actualData = $testColumns | ConvertFrom-Csv
 
-        $actualLength = $($( $actualData | Get-Member) | Where-Object {$_.MemberType -eq "NoteProperty" }).Length
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
 
         $actualLength | Should -Be 3
     }
@@ -72,7 +72,7 @@ Describe "ConvertFrom-Csv DRT Unit Tests" -Tags "CI" {
     It "Test ConvertFrom-Csv with pipelined InputObject and Header" {
         $inputObject = [pscustomobject]@{ First = 1; Second = 2 }
         $res = $inputObject | ConvertTo-Csv
-        $result = $res | ConvertFrom-Csv -Header "Header1","Header2"
+        $result = $res | ConvertFrom-Csv -Header "Header1", "Header2"
 
         $result[0].Header1 | Should -BeExactly "First"
         $result[0].Header2 | Should -BeExactly "Second"
@@ -95,7 +95,7 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
 '@
 
         $testColumnsWithFields = @'
-#Fields: a b c
+#Fields: a,b,c
 1,2,3
 '@
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -80,3 +80,50 @@ Describe "ConvertFrom-Csv DRT Unit Tests" -Tags "CI" {
         $result[1].Header2 | Should -BeExactly "2"
     }
 }
+
+Describe "ConvertFrom-Csv containing #" -Tags "CI" {
+    BeforeAll {
+        $testColumnsWithQuotedHashtag = @'
+"#","b","c",
+1,2,3
+'@
+
+        $testColumnsWithUnquotedHashtag = @'
+#,b,c
+1,2,3
+4,5,6
+'@
+
+        $testColumnsWithFields = @'
+#Fields: a b c
+1,2,3
+'@
+    }
+
+    It "Should handle quoted # in header" {
+        $actualData = $testColumnsWithQuotedHashtag | ConvertFrom-Csv
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."#" | Should -Be "1"
+    }
+
+    It "Should handle unquoted # in header as comment" {
+        $actualData = $testColumnsWithUnquotedHashtag | ConvertFrom-Csv
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."1" | Should -Be "4"
+    }
+
+    It "Should handle #Fields lines as header" {
+        $actualData = $testColumnsWithFields | ConvertFrom-Csv
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -95,10 +95,12 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
 '@
 
         $testColumnsWithFields = @'
+#Version: 1.0
 #Fields: a,b,c
 1,2,3
 '@
         $testColumnsWithFieldsSpaceDelimited = @'
+#Version: 1.0
 #Fields: a b c
 1 2 3
 '@
@@ -122,7 +124,7 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
         $actualData[0]."1" | Should -Be "4"
     }
 
-    It "Should handle #Fields lines as header" {
+    It "Should handle #Fields directive as header" {
         $actualData = $testColumnsWithFields | ConvertFrom-Csv
 
         $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
@@ -131,11 +133,8 @@ Describe "ConvertFrom-Csv containing #" -Tags "CI" {
         $actualData[0]."a" | Should -Be "1"
     }
 
-    It "Should handle #Fields lines as header when space delimited" {
-        $testPath = Join-Path $TestDrive "FieldsSpace.csv"
-        Set-Content $testPath -Value $testColumnsWithFieldsSpaceDelimited
-
-        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ' '
+    It "Should handle #Fields directive as header when space delimited" -Pending {
+        $actualData = $testColumnsWithFieldsSpaceDelimited | ConvertFrom-Csv -Delimiter ' '
 
         $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -27,10 +27,10 @@ a,b,c
     }
 
     It "Should have expected results when using piped inputs" {
-        $csvContent = Get-Content $testcsv
+        $csvContent   = Get-Content $testcsv
         $actualresult = $csvContent | ConvertFrom-Csv
 
-        , $actualresult | Should -BeOfType System.Array
+        ,$actualresult | Should -BeOfType System.Array
         $actualresult[0] | Should -BeOfType PSCustomObject
 
         #Should have a name property in the result
@@ -42,10 +42,10 @@ a,b,c
     }
 
     It "Should actually delimit the output" {
-        $csvContent = Get-Content $testcsv
+        $csvContent   = Get-Content $testcsv
         $actualresult = $csvContent | ConvertFrom-Csv -Delimiter ";"
 
-        , $actualresult | Should -BeOfType System.Array
+        ,$actualresult | Should -BeOfType System.Array
         $actualresult[0] | Should -BeOfType PSCustomObject
 
         # ConvertFrom-Csv takes the first line of the input as a header by default
@@ -55,7 +55,7 @@ a,b,c
     It "Should be able to have multiple columns" {
         $actualData = $testColumns | ConvertFrom-Csv
 
-        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+        $actualLength = $($( $actualData | Get-Member) | Where-Object {$_.MemberType -eq "NoteProperty" }).Length
 
         $actualLength | Should -Be 3
     }
@@ -72,7 +72,7 @@ Describe "ConvertFrom-Csv DRT Unit Tests" -Tags "CI" {
     It "Test ConvertFrom-Csv with pipelined InputObject and Header" {
         $inputObject = [pscustomobject]@{ First = 1; Second = 2 }
         $res = $inputObject | ConvertTo-Csv
-        $result = $res | ConvertFrom-Csv -Header "Header1", "Header2"
+        $result = $res | ConvertFrom-Csv -Header "Header1","Header2"
 
         $result[0].Header1 | Should -BeExactly "First"
         $result[0].Header2 | Should -BeExactly "Second"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -53,7 +53,7 @@ a,b,c
     }
 
     It "Should be able to have multiple columns" {
-        $actualData = $testColumns | ConvertFrom-Csv
+        $actualData   = $testColumns | ConvertFrom-Csv
 
         $actualLength = $($( $actualData | Get-Member) | Where-Object {$_.MemberType -eq "NoteProperty" }).Length
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -182,3 +182,59 @@ Describe "Import-Csv with different newlines" -Tags "CI" {
         $returnObject[1].h3 | Should -Be 23
     }
 }
+
+Describe "Import-Csv containing #" -Tags "CI" {
+    BeforeAll {
+        $testColumnsWithQuotedHashtag = @'
+"#","b","c",
+1,2,3
+'@
+
+        $testColumnsWithUnquotedHashtag = @'
+#,b,c
+1,2,3
+4,5,6
+'@
+
+        $testColumnsWithFields = @'
+#Fields: a b c
+1,2,3
+'@
+    }
+
+    It "Should handle quoted # in header" {
+        $testPath = Join-Path $TestDrive "QuotedHashtag.csv"
+        Set-Content $testPath -Value $testColumnsWithQuotedHashtag
+
+        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ','
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."#" | Should -Be "1"
+    }
+
+    It "Should handle unquoted # in header as comment" {
+        $testPath = Join-Path $TestDrive "UnquotedHashtag.csv"
+        Set-Content $testPath -Value $testColumnsWithUnquotedHashtag
+
+        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ','
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."1" | Should -Be "4"
+    }
+
+    It "Should handle #Fields lines as header" {
+        $testPath = Join-Path $TestDrive "Fields.csv"
+        Set-Content $testPath -Value $testColumnsWithFields
+
+        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ','
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -201,9 +201,19 @@ Describe "Import-Csv containing #" -Tags "CI" {
 #Fields: a,b,c
 1,2,3
 '@
+        $testColumnsWithFieldsSwapped = @'
+#Fields: a,b,c
+#Version: 1.0
+1,2,3
+'@
         $testColumnsWithFieldsSpaceDelimited = @'
 #Version: 1.0
 #Fields: a b c
+1 2 3
+'@
+        $testColumnsWithFieldsSpaceDelimitedSwapped = @'
+#Fields: a b c
+#Version: 1.0
 1 2 3
 '@
     }
@@ -232,7 +242,7 @@ Describe "Import-Csv containing #" -Tags "CI" {
         $actualData[0]."1" | Should -Be "4"
     }
 
-    It "Should handle #Fields directive as header" {
+    It "Should handle #Fields directive as header when #Fields directive is second line" {
         $testPath = Join-Path $TestDrive "Fields.csv"
         Set-Content $testPath -Value $testColumnsWithFields
 
@@ -244,9 +254,33 @@ Describe "Import-Csv containing #" -Tags "CI" {
         $actualData[0]."a" | Should -Be "1"
     }
 
-    It "Should handle #Fields directive as header when space delimited" -Pending {
+    It "Should handle #Fields directive as header when #Fields directive is first line" -Pending {
+        $testPath = Join-Path $TestDrive "Fields.csv"
+        Set-Content $testPath -Value $testColumnsWithFieldsSwapped
+
+        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ','
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+
+    It "Should handle #Fields directive as header when space delimited and when #Fields directive is second line" -Pending {
         $testPath = Join-Path $TestDrive "FieldsSpace.csv"
         Set-Content $testPath -Value $testColumnsWithFieldsSpaceDelimited
+
+        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ' '
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+
+    It "Should handle #Fields directive as header when space delimited and when #Fields directive is first line" -Pending {
+        $testPath = Join-Path $TestDrive "FieldsSpace.csv"
+        Set-Content $testPath -Value $testColumnsWithFieldsSpaceDelimitedSwapped
 
         $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ' '
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -186,7 +186,7 @@ Describe "Import-Csv with different newlines" -Tags "CI" {
 Describe "Import-Csv containing #" -Tags "CI" {
     BeforeAll {
         $testColumnsWithQuotedHashtag = @'
-"#","b","c",
+"#","b","c"
 1,2,3
 '@
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -45,7 +45,7 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
         @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
         @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
-    ) {
+    ){
         param($expectedHeader, $file, $content, $delimiter)
 
         $testPath = Join-Path $TestDrive $file
@@ -68,7 +68,7 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
         @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
         @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
-    ) {
+    ){
         param($expectedHeader, $file, $content, $delimiter)
 
         $testPath = Join-Path $TestDrive $file
@@ -98,22 +98,22 @@ Describe "Import-Csv File Format Tests" -Tags "CI" {
         $TestImportCsv_W3C_ELF = Join-Path -Path (Join-Path $PSScriptRoot -ChildPath assets) -ChildPath TestImportCsv_W3C_ELF.csv
 
         $testCSVfiles = $TestImportCsv_NoHeader, $TestImportCsv_WithHeader, $TestImportCsv_W3C_ELF
-        $orginalHeader = "Column1", "Column2", "Column 3"
-        $customHeader = "test1", "test2", "test3"
+        $orginalHeader = "Column1","Column2","Column 3"
+        $customHeader = "test1","test2","test3"
     }
     # Test set is the same for all file formats
     foreach ($testCsv in $testCSVfiles) {
-        $FileName = (Get-ChildItem $testCsv).Name
+       $FileName = (Get-ChildItem $testCsv).Name
         Context "Next test file: $FileName" {
             BeforeAll {
-                $CustomHeaderParams = @{Header = $customHeader; Delimiter = "," }
+                $CustomHeaderParams = @{Header = $customHeader; Delimiter = ","}
                 if ($FileName -eq "TestImportCsv_NoHeader.csv") {
                     # The file does not have header
                     # (w/o Delimiter here we get throw (bug?))
-                    $HeaderParams = @{Header = $orginalHeader; Delimiter = "," }
+                    $HeaderParams = @{Header = $orginalHeader; Delimiter = ","}
                 } else {
                     # The files have header
-                    $HeaderParams = @{Delimiter = "," }
+                    $HeaderParams = @{Delimiter = ","}
                 }
 
             }
@@ -148,7 +148,7 @@ Describe "Import-Csv #Type Tests" -Tags "CI" {
         Remove-Item -Path $testfile -Force -ErrorAction SilentlyContinue
         $processlist = (Get-Process)[0..1]
         $processlist | Export-Csv -Path $testfile -Force -IncludeTypeInformation
-        $expectedProcessTypes = "System.Diagnostics.Process", "CSV:System.Diagnostics.Process"
+        $expectedProcessTypes = "System.Diagnostics.Process","CSV:System.Diagnostics.Process"
     }
 
     It "Test import-csv import Object" {
@@ -167,7 +167,7 @@ Describe "Import-Csv with different newlines" -Tags "CI" {
         @{ name = "CR"; newline = "`r" }
         @{ name = "LF"; newline = "`n" }
         @{ name = "CRLF"; newline = "`r`n" }
-    ) {
+) {
         param($newline)
         $csvFile = Join-Path $TestDrive -ChildPath $((New-Guid).Guid)
         $delimiter = ','

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -197,10 +197,12 @@ Describe "Import-Csv containing #" -Tags "CI" {
 '@
 
         $testColumnsWithFields = @'
+#Version: 1.0
 #Fields: a,b,c
 1,2,3
 '@
         $testColumnsWithFieldsSpaceDelimited = @'
+#Version: 1.0
 #Fields: a b c
 1 2 3
 '@
@@ -230,8 +232,8 @@ Describe "Import-Csv containing #" -Tags "CI" {
         $actualData[0]."1" | Should -Be "4"
     }
 
-    It "Should handle #Fields lines as header" {
-        $testPath = Join-Path $TestDrive "FieldsSpace.csv"
+    It "Should handle #Fields directive as header" {
+        $testPath = Join-Path $TestDrive "Fields.csv"
         Set-Content $testPath -Value $testColumnsWithFields
 
         $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ','
@@ -242,8 +244,8 @@ Describe "Import-Csv containing #" -Tags "CI" {
         $actualData[0]."a" | Should -Be "1"
     }
 
-    It "Should handle #Fields lines as header when space delimited" {
-        $testPath = Join-Path $TestDrive "Fields.csv"
+    It "Should handle #Fields directive as header when space delimited" -Pending {
+        $testPath = Join-Path $TestDrive "FieldsSpace.csv"
         Set-Content $testPath -Value $testColumnsWithFieldsSpaceDelimited
 
         $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ' '

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -200,6 +200,10 @@ Describe "Import-Csv containing #" -Tags "CI" {
 #Fields: a,b,c
 1,2,3
 '@
+        $testColumnsWithFieldsSpaceDelimited = @'
+#Fields: a b c
+1 2 3
+'@
     }
 
     It "Should handle quoted # in header" {
@@ -227,10 +231,22 @@ Describe "Import-Csv containing #" -Tags "CI" {
     }
 
     It "Should handle #Fields lines as header" {
-        $testPath = Join-Path $TestDrive "Fields.csv"
+        $testPath = Join-Path $TestDrive "FieldsSpace.csv"
         Set-Content $testPath -Value $testColumnsWithFields
 
         $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ','
+
+        $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
+
+        $actualLength | Should -Be 3
+        $actualData[0]."a" | Should -Be "1"
+    }
+
+    It "Should handle #Fields lines as header when space delimited" {
+        $testPath = Join-Path $TestDrive "Fields.csv"
+        Set-Content $testPath -Value $testColumnsWithFieldsSpaceDelimited
+
+        $actualData = Get-ChildItem -Path $testPath | Import-Csv -Delimiter ' '
 
         $actualLength = $($( $actualData | Get-Member) | Where-Object { $_.MemberType -eq "NoteProperty" }).Length
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -45,7 +45,7 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
         @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
         @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
-        ){
+    ) {
         param($expectedHeader, $file, $content, $delimiter)
 
         $testPath = Join-Path $TestDrive $file
@@ -68,7 +68,7 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
         @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
         @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
-        ){
+    ) {
         param($expectedHeader, $file, $content, $delimiter)
 
         $testPath = Join-Path $TestDrive $file
@@ -98,22 +98,22 @@ Describe "Import-Csv File Format Tests" -Tags "CI" {
         $TestImportCsv_W3C_ELF = Join-Path -Path (Join-Path $PSScriptRoot -ChildPath assets) -ChildPath TestImportCsv_W3C_ELF.csv
 
         $testCSVfiles = $TestImportCsv_NoHeader, $TestImportCsv_WithHeader, $TestImportCsv_W3C_ELF
-        $orginalHeader = "Column1","Column2","Column 3"
-        $customHeader = "test1","test2","test3"
+        $orginalHeader = "Column1", "Column2", "Column 3"
+        $customHeader = "test1", "test2", "test3"
     }
     # Test set is the same for all file formats
     foreach ($testCsv in $testCSVfiles) {
-       $FileName = (Get-ChildItem $testCsv).Name
+        $FileName = (Get-ChildItem $testCsv).Name
         Context "Next test file: $FileName" {
             BeforeAll {
-                $CustomHeaderParams = @{Header = $customHeader; Delimiter = ","}
+                $CustomHeaderParams = @{Header = $customHeader; Delimiter = "," }
                 if ($FileName -eq "TestImportCsv_NoHeader.csv") {
                     # The file does not have header
                     # (w/o Delimiter here we get throw (bug?))
-                    $HeaderParams = @{Header = $orginalHeader; Delimiter = ","}
+                    $HeaderParams = @{Header = $orginalHeader; Delimiter = "," }
                 } else {
                     # The files have header
-                    $HeaderParams = @{Delimiter = ","}
+                    $HeaderParams = @{Delimiter = "," }
                 }
 
             }
@@ -148,7 +148,7 @@ Describe "Import-Csv #Type Tests" -Tags "CI" {
         Remove-Item -Path $testfile -Force -ErrorAction SilentlyContinue
         $processlist = (Get-Process)[0..1]
         $processlist | Export-Csv -Path $testfile -Force -IncludeTypeInformation
-        $expectedProcessTypes = "System.Diagnostics.Process","CSV:System.Diagnostics.Process"
+        $expectedProcessTypes = "System.Diagnostics.Process", "CSV:System.Diagnostics.Process"
     }
 
     It "Test import-csv import Object" {
@@ -167,7 +167,7 @@ Describe "Import-Csv with different newlines" -Tags "CI" {
         @{ name = "CR"; newline = "`r" }
         @{ name = "LF"; newline = "`n" }
         @{ name = "CRLF"; newline = "`r`n" }
-        ) {
+    ) {
         param($newline)
         $csvFile = Join-Path $TestDrive -ChildPath $((New-Guid).Guid)
         $delimiter = ','
@@ -197,7 +197,7 @@ Describe "Import-Csv containing #" -Tags "CI" {
 '@
 
         $testColumnsWithFields = @'
-#Fields: a b c
+#Fields: a,b,c
 1,2,3
 '@
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -45,7 +45,7 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
         @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
         @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
-    ){
+){
         param($expectedHeader, $file, $content, $delimiter)
 
         $testPath = Join-Path $TestDrive $file
@@ -68,7 +68,7 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
         @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
         @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
-    ){
+){
         param($expectedHeader, $file, $content, $delimiter)
 
         $testPath = Join-Path $TestDrive $file
@@ -167,7 +167,7 @@ Describe "Import-Csv with different newlines" -Tags "CI" {
         @{ name = "CR"; newline = "`r" }
         @{ name = "LF"; newline = "`n" }
         @{ name = "CRLF"; newline = "`r`n" }
-) {
+        ) {
         param($newline)
         $csvFile = Join-Path $TestDrive -ChildPath $((New-Guid).Guid)
         $delimiter = ','


### PR DESCRIPTION
# PR Summary

Fixes #26419
Fixes #13907

This pull request improves the handling of CSV files containing lines starting with `#` or `#Fields:` in both the `Import-Csv` and `ConvertFrom-Csv` cmdlets. The main focus is to correctly distinguish between comment lines, header lines, and quoted fields containing `#`, ensuring compatibility with the W3C Extended Log File Format. This is accomplished by modifying the `ReadHeader()` method of `CsvCommands` to check if the raw line starts with a `#`, instead of checking if the first parsed header value starts with a `#`. The changes also include new unit tests to verify these behaviors in `Import-Csv` and `ConvertFrom-Csv` cmdlets.

## PR Context

This pull requests fix a bug pointed out by #26419, which is that this CSV incorrectly gets its header row skipped, despite not starting with a `#` character.

```
"#","b","c"
"1","2","3"
"4","5","6"
```

Before, this would skip the header row of "#","b","c" and make "1","2","3" the header, with the first row having values of "1"="4", "2"="5","3"="6". Now, the first row will be correctly parsed as a header, and the first row will correctly be "#"="1", "b"="2", "c"="3", with the second row being "#"="4", "b"="5", "c"="6".

The original implementation broke the [public contract documented on the Import-Csv page](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/import-csv?view=powershell-7.6#:~:text=Import%2DCsv%20also,File%20Format.), which follows the [W3C Extended Log File Format](https://www.w3.org/TR/WD-logfile.html):

> Lines starting with the hash character (`#`) are treated as comments and ignored unless the comment starts with `#Fields:` and contains delimited list of column names. In that case, the cmdlet uses those column names.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
