### PR TITLE
Fix formatting to properly handle the `Reset` VT sequences that appear in the middle of a string

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ListWriter.cs
@@ -259,7 +259,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     _cachedBuilder.Append(headPadding).Append(str);
                 }
 
-                if (str.Contains(ValueStringDecorated.ESC) && !str.EndsWith(reset))
+                if (str.Contains(ValueStringDecorated.ESC) && !str.AsSpan().TrimEnd().EndsWith(reset, StringComparison.Ordinal))
                 {
                     _cachedBuilder.Append(reset);
                 }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -591,14 +591,15 @@ Billy Bob… Senior DevOps …  13
 
     It "Format 'MatchInfo' object correctly" {
         $str = 'mouclass     Mouse Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288            32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096'
-        $matchInfo = $str | Select-String 'mouse'
-        $matchInfo | Out-String -Width 150 | Out-File $outFile
+        $text = $str | Select-String 'mouse' | Out-String -Width 150
+
+        Write-Verbose "OutputRendering: $($PSStyle.OutputRendering)" -Verbose
+        Write-Verbose "Raw text: $($text.Replace("`e", "ESC"))" -Verbose
 
         $expected = @"
 mouclass     `e[7mMouse`e[0m Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288            
 32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096
 "@
-        $text = Get-Content $outFile -Raw
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }
 }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -590,16 +590,16 @@ Billy Bob… Senior DevOps …  13
     }
 
     It "Format 'MatchInfo' object correctly" {
-        $str = 'mouclass     Mouse Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288            32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096'
-        $text = $str | Select-String 'mouse' | Out-String -Width 150
-
-        Write-Verbose "OutputRendering: $($PSStyle.OutputRendering)" -Verbose
-        Write-Verbose "Raw text: $($text.Replace("`e", "ESC"))" -Verbose
-
         $expected = @"
-mouclass     `e[7mMouse`e[0m Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288            
-32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096
+`e[32;1mb : `e[0mmouclass     `e[7mMouse`e[0m Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288         `e[0m
+       32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096
 "@
+
+        ## This string mimics the VT decorated string for a 'MatchInfo' object that matches the word 'mouse'.
+        $str = "mouclass     `e[7mMouse`e[0m Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288            32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096"
+        $obj = [pscustomobject] @{ b = $str }
+        $text = $obj | Format-List | Out-String -Width 150
+
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }
 }

--- a/test/powershell/engine/Formatting/PSStyle.Tests.ps1
+++ b/test/powershell/engine/Formatting/PSStyle.Tests.ps1
@@ -488,7 +488,7 @@ Billy Bob… Senior DevOps …  13
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }
 
-    It "Word wrapping for string with escape sequences" {
+    It "Word wrapping for string with escape sequences (1)" {
        $expected = @"
 `e[32;1mLongDescription : `e[0m`e[33mPowerShell `e[0m
                   `e[33mscripting `e[0m
@@ -501,12 +501,75 @@ Billy Bob… Senior DevOps …  13
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }
 
-    It "Splitting multi-line string with escape sequences" {
+    It "Word wrapping for string with escape sequences (2)" {
+       $expected = @"
+`e[32;1mLongDescription : `e[0m`e[33mPowerShell`e[0m 
+                  scripting 
+                  language
+"@
+        $obj = [pscustomobject] @{ LongDescription = "`e[33mPowerShell`e[0m scripting language" }
+        $obj | Format-List | Out-String -Width 35 | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Word wrapping for string with escape sequences (3)" {
+       $expected = @"
+`e[32;1mLongDescription : `e[0m`e[33mPowerShell`e[0m 
+                  `e[32mscripting `e[0m
+                  `e[32mlanguage`e[0m
+"@
+        $obj = [pscustomobject] @{ LongDescription = "`e[33mPowerShell`e[0m `e[32mscripting language" }
+        $obj | Format-List | Out-String -Width 35 | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Word wrapping for string with escape sequences (4)" {
+       $expected = @"
+`e[32;1mLongDescription : `e[0m`e[33mPowerShell`e[0m 
+                  `e[32mscripting`e[0m 
+                  language
+"@
+        $obj = [pscustomobject] @{ LongDescription = "`e[33mPowerShell`e[0m `e[32mscripting`e[0m language" }
+        $obj | Format-List | Out-String -Width 35 | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Splitting multi-line string with escape sequences (1)" {
         $expected = @"
 `e[32;1mb : `e[0m`e[33mPowerShell is a task automation and configuration management program from Microsoft,`e[0m
     `e[33mconsisting of a command-line shell and the associated scripting language`e[0m
 "@
         $obj = [pscustomobject] @{ b = "`e[33mPowerShell is a task automation and configuration management program from Microsoft,`nconsisting of a command-line shell and the associated scripting language" }
+        $obj | Format-List | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Splitting multi-line string with escape sequences (2)" {
+        $expected = @"
+`e[32;1mb : `e[0m`e[33mPowerShell is a task automation and configuration management program from Microsoft,`e[0m
+    consisting of a command-line shell and the associated scripting language
+"@
+        $obj = [pscustomobject] @{ b = "`e[33mPowerShell is a task automation and configuration management program from Microsoft,`e[0m`nconsisting of a command-line shell and the associated scripting language" }
+        $obj | Format-List | Out-File $outFile
+
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Splitting multi-line string with escape sequences (3)" {
+        $expected = @"
+`e[32;1mb : `e[0m`e[33mPowerShell is a task automation and configuration management program from Microsoft,`e[0m
+    `e[32mconsisting of a command-line shell and the associated scripting language`e[0m
+"@
+        $obj = [pscustomobject] @{ b = "`e[33mPowerShell is a task automation and configuration management program from Microsoft,`e[0m`n`e[32mconsisting of a command-line shell and the associated scripting language" }
         $obj | Format-List | Out-File $outFile
 
         $text = Get-Content $outFile -Raw
@@ -522,6 +585,19 @@ Billy Bob… Senior DevOps …  13
         $obj = [pscustomobject] @{ b = "`e[33mC:\repos\PowerShell\src\powershell-win-core\bin\Debug\net8.0\win7-x64\publish\pwsh.exe" }
         $obj | Format-List | Out-String -Width 40 | Out-File $outFile
 
+        $text = Get-Content $outFile -Raw
+        $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
+    }
+
+    It "Format 'MatchInfo' object correctly" {
+        $str = 'mouclass     Mouse Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288            32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096'
+        $matchInfo = $str | Select-String 'mouse'
+        $matchInfo | Out-String -Width 150 | Out-File $outFile
+
+        $expected = @"
+mouclass     `e[7mMouse`e[0m Class Driver     Mouse Class Driver     Kernel        Manual     Running    OK         TRUE        FALSE        12,288            
+32,768      0                                 C:\WINDOWS\system32\drivers\mouclass.sys         4,096
+"@
         $text = Get-Content $outFile -Raw
         $text.Trim().Replace("`r", "") | Should -BeExactly $expected.Replace("`r", "")
     }


### PR DESCRIPTION
### PR Summary

Fix #25833
Also, this is a follow-up fix to #17316

When dealing with word wrapping with a string that contains VT sequences in the formatting system, the Reset VT sequences appear in the middle of the string are not handled properly, which caused the resulted string to be poorly decorated with VT sequences.

The Reset VT sequences in a string essentially void the previous VT sequences. So, any VT sequences appeared before the Reset should be cleared before processing the rest of the string.

For this script, the formatting results are as follows:
```pwsh
driverquery.exe /V > driverqueryV.txt # generate a searchable file
sls mouse .\driverqueryV.txt
```

Before the fix:

<img width="1243" height="217" alt="image" src="https://github.com/user-attachments/assets/e98ea149-0880-4640-928e-3847d8192eaa" />

After the fix:

<img width="1239" height="210" alt="image" src="https://github.com/user-attachments/assets/c2ae0532-7fb7-4d74-8287-7884ebd5ef75" />


### PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
