### PR TITLE
Fix template path for rebuild branch check in package.yml

### DIFF
--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -60,7 +60,7 @@ jobs:
       nativePathRoot: '$(Agent.TempDirectory)'
       ob_restore_phase: false
 
-  - template: rebuild-branch-check.yml@self
+  - template: /.pipelines/templates/rebuild-branch-check.yml@self
 
   - download: CoOrdinatedBuildPipeline
     artifact: drop_windows_build_windows_${{ parameters.runtime }}_release


### PR DESCRIPTION
## Summary

This PR fixes an incorrect template path reference in the Windows package build template.

## Issue

The package.yml template was referencing ebuild-branch-check.yml@self with a relative path, which caused the pipeline to fail with:

`
File /.pipelines/templates/packaging/windows/rebuild-branch-check.yml not found in repository
`

## Fix

Changed the template reference from:
`yaml
- template: rebuild-branch-check.yml@self
`

to:
`yaml
- template: /.pipelines/templates/rebuild-branch-check.yml@self
`

This uses an absolute path from the repository root, consistent with other template references in the file.

## Testing

This fix resolves the pipeline error and allows the Windows packaging pipeline to run successfully.