### PR TITLE
[release/v7.4] Fix template path for rebuild branch check in package.yml

### DIFF
--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -60,7 +60,7 @@ jobs:
       nativePathRoot: '$(Agent.TempDirectory)'
       ob_restore_phase: false
 
-  - template: rebuild-branch-check.yml@self
+  - template: /.pipelines/templates/rebuild-branch-check.yml@self
 
   - download: CoOrdinatedBuildPipeline
     artifact: drop_windows_build_windows_${{ parameters.runtime }}_release


### PR DESCRIPTION
Backport of #26425 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
\$\$\\$\$\$
-->

Triggered by @TravisEz13 on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change

Fixes template path reference for rebuild branch check in Windows package build pipeline. The template path was using a relative reference that doesn't resolve correctly, causing pipeline issues.

## Regression

- [x] No

This is a fix for a template path issue, not a regression.

## Testing

Verified by:
1. Confirming the backport applies cleanly on release/v7.4
2. Template path now uses absolute reference: /.pipelines/templates/rebuild-branch-check.yml@self
3. Related prerequisite PR #26418 already backported the rebuild-branch-check.yml template

## Risk

- [ ] High
- [x] Medium  
- [ ] Low

Medium risk: Changes build pipeline template reference but is necessary for correct template resolution. The change is minimal (path fix only) and the target template already exists in the release branch.