### PR TITLE
[release/v7.4] Update the macos package name for preview releases to match the previous pattern

### DIFF
--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -82,7 +82,7 @@ jobs:
   - pwsh: |
       $message = @()
       Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -filter *.pkg | ForEach-Object {
-          if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx(\.10\.12)?\-(x64|arm64)\.pkg')
+          if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx\-(x64|arm64)\.pkg')
           {
               $messageInstance = "$($_.Name) is not a valid package name"
               $message += $messageInstance

--- a/test/packaging/macos/package-validation.tests.ps1
+++ b/test/packaging/macos/package-validation.tests.ps1
@@ -82,12 +82,13 @@ Describe "Verify macOS Package" {
             $script:package | Should -Not -BeNullOrEmpty
 
             # Regex pattern for valid macOS PKG package names.
+            # This pattern matches the validation used in release-validate-packagenames.yml
             # Valid examples:
-            # - powershell-7.4.13-osx-x64.pkg (Intel x64 - note: x64 with hyphens for compatibility)
-            # - powershell-7.4.13-osx-arm64.pkg (Apple Silicon)
-            # - powershell-preview-7.6.0-preview.6-osx-x64.pkg
-            # - powershell-lts-7.4.13-osx-arm64.pkg
-            $pkgPackageNamePattern = '^powershell(-preview|-lts)?-\d+\.\d+\.\d+(-[a-z]+\.\d+)?-osx-(x64|arm64)\.pkg$'
+            # - powershell-7.4.13-osx-x64.pkg (Stable release)
+            # - powershell-7.6.0-preview.6-osx-x64.pkg (Preview version string)
+            # - powershell-7.4.13-rebuild.5-osx-arm64.pkg (Rebuild version)
+            # - powershell-lts-7.4.13-osx-arm64.pkg (LTS package)
+            $pkgPackageNamePattern = '^powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx\-(x64|arm64)\.pkg$'
 
             $script:package.Name | Should -Match $pkgPackageNamePattern -Because "Package name should follow the standard naming convention"
         }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1145,14 +1145,11 @@ function New-UnixPackage {
         }
 
         # Determine if the version is a preview version
-        $IsPreview = Test-IsPreview -Version $Version -IsLTS:$LTS
-
-        # Preview versions have preview in the name
+        # Only LTS packages get a prefix in the name
+        # Preview versions are identified by the version string itself (e.g., 7.6.0-preview.6)
+        # Rebuild versions are also identified by the version string (e.g., 7.4.13-rebuild.5)
         $Name = if($LTS) {
             "powershell-lts"
-        }
-        elseif ($IsPreview) {
-            "powershell-preview"
         }
         else {
             "powershell"


### PR DESCRIPTION
Backport of #26429 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26429$$$
-->

Triggered by @TravisEz13 on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change

This backports a fix for macOS package naming for preview releases to ensure consistent naming patterns across releases.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

- [ ] Yes
- [x] No

This is a packaging improvement to maintain consistent naming patterns, not fixing a regression.

## Testing

Original PR was tested through CI/CD pipeline validation. Backport verified by:
1. Cherry-pick applied cleanly without conflicts
2. Changes are isolated to packaging configuration
3. No functional code changes that require additional testing

## Risk

- [ ] High
- [x] Medium  
- [ ] Low

Medium risk as it affects packaging infrastructure, but changes are well-scoped to macOS preview package naming only. Not taking this change would create inconsistency in package naming patterns between versions.