### PR TITLE
[release/v7.6] Update PSResourceGet package version to preview4

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
-    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-preview3" />
+    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-preview4" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.4.4-beta4" />
     <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   


### PR DESCRIPTION
Backport of #26404 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26404$$$
-->

Triggered by @TravisEz13 on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

### Tooling Impact

- [x] Required tooling change

Updates PSResourceGet package to version 1.2.0-preview4 for release/v7.6 to ensure compatibility with the release branch.

## Regression

- [x] No

This is a package version update to align with the release requirements.

## Testing

Verified by:
1. Cherry-pick applied cleanly with auto-merge
2. Only affects PSGalleryModules.csproj package reference
3. Change is a single-line version update
4. Original PR validated in main branch

## Risk

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: Package version updates can affect module loading and functionality. However, this is a required update for v7.6 and has been validated in the main branch. The change is minimal (single package version reference).