### PR TITLE
[release/v7.6] Add network isolation policy parameter to vPack pipeline

### DIFF
--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -23,6 +23,14 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   displayName: 'Enable debug output'
   type: boolean
   default: false
+- name: netiso
+  displayName: "Network Isolation Policy"
+  type: string
+  values:
+    - KS4
+    - R1
+    - Netlock
+  default: "R1"
 
 name: vPack_$(Build.SourceBranchName)_Prod.${{ parameters.OfficialBuild }}_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
 
@@ -53,6 +61,8 @@ variables:
     value: ${{ iif ( parameters.OfficialBuild, 'v2/Microsoft.Official.yml@onebranchTemplates', 'v2/Microsoft.NonOfficial.yml@onebranchTemplates' ) }}
   - group: DotNetPrivateBuildAccess
   - group: certificate_logical_to_actual
+  - name: netiso
+    value: ${{ parameters.netiso }}
 # We shouldn't be using PATs anymore
 #  - group: mscodehub-feed-read-general
 
@@ -68,6 +78,11 @@ extends:
   parameters:
     platform:
       name: 'windows_undocked' # windows undocked
+
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+        Network: ${{ variables.netiso }}
 
     cloudvault:
       enabled: false


### PR DESCRIPTION
Backport of #26223 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26223$$$
-->

Triggered by @travisez13 on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Optional tooling enhancement that allows build engineers to specify network isolation policies (KS4, R1, Netlock) for vPack builds. Default behavior remains unchanged (RS1). Enables more flexible build environment configuration for testing and security scenarios.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by running the vPack pipeline with different network isolation policy values. The parameter is correctly propagated and used in Windows host configuration. Clean cherry-pick with no conflicts.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: Changes CI/CD pipeline configuration to add network isolation policy support. This is a parameter addition with a safe default (RS1), so existing builds will continue working unchanged. The change has been validated in master and previously backported to v7.4 and v7.5 without issues.
