### PR TITLE
[release/v7.6] Update PSReadLine to v2.4.5

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-preview3" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
-    <PackageReference Include="PSReadLine" Version="2.4.4-beta4" />
+    <PackageReference Include="PSReadLine" Version="2.4.5" />
     <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   
   </ItemGroup>
 


### PR DESCRIPTION
Backport of #26282 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26282$$$
-->

Triggered by @travisez13 on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates PSReadLine package reference in build configuration. Required to ensure v7.6 release includes PSReadLine v2.4.5 with latest bug fixes and improvements.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified PSReadLine v2.4.5 package version in PowerShell.Common.props. Confirmed package update aligns with PSReadLine release notes. Change is straightforward version update following established pattern.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk: This is a standard PSReadLine version update to v2.4.5. PSReadLine is a well-tested module and version updates follow established packaging patterns. No API changes or breaking modifications expected.
