### PR TITLE
Fix Invoke-RestMethod to support read-only files in multipart form data

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1995,7 +1995,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="file">The file to use for the <see cref="StreamContent"/></param>
         private static StreamContent GetMultipartFileContent(object fieldName, FileInfo file)
         {
-            StreamContent result = GetMultipartStreamContent(fieldName: fieldName, stream: new FileStream(file.FullName, FileMode.Open));
+            StreamContent result = GetMultipartStreamContent(fieldName: fieldName, stream: new FileStream(file.FullName, FileMode.Open, FileAccess.Read));
 
             result.Headers.ContentDisposition.FileName = file.Name;
             result.Headers.ContentDisposition.FileNameStar = file.Name;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1995,7 +1995,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="file">The file to use for the <see cref="StreamContent"/></param>
         private static StreamContent GetMultipartFileContent(object fieldName, FileInfo file)
         {
-            StreamContent result = GetMultipartStreamContent(fieldName: fieldName, stream: new FileStream(file.FullName, FileMode.Open, FileAccess.Read));
+            StreamContent result = GetMultipartStreamContent(fieldName: fieldName, stream: new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read));
 
             result.Headers.ContentDisposition.FileName = file.Name;
             result.Headers.ContentDisposition.FileNameStar = file.Name;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation.
+﻿# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 # This is a Pester test suite which validate the Web cmdlets.
@@ -1733,26 +1733,18 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             "ReadOnly test content" | Out-File -FilePath $readOnlyFile -Encoding utf8
             Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $true
 
-            try {
-                $form = @{TestFile = [System.IO.FileInfo]$readOnlyFile}
-                $uri = Get-WebListenerUrl -Test 'Multipart'
-                $response = Invoke-WebRequest -Uri $uri -Form $form -Method 'POST'
-                $result = $response.Content | ConvertFrom-Json
+            $form = @{TestFile = [System.IO.FileInfo]$readOnlyFile}
+            $uri = Get-WebListenerUrl -Test 'Multipart'
+            $response = Invoke-WebRequest -Uri $uri -Form $form -Method 'POST'
+            $result = $response.Content | ConvertFrom-Json
 
-                $result.Headers.'Content-Type' | Should -Match 'multipart/form-data'
-                $result.Files.Count | Should -Be 1
+            $result.Headers.'Content-Type' | Should -Match 'multipart/form-data'
+            $result.Files.Count | Should -Be 1
 
-                $result.Files[0].Name | Should -BeExactly "TestFile"
-                $result.Files[0].FileName | Should -BeExactly "readonly-test.txt"
-                $result.Files[0].ContentType | Should -BeExactly 'application/octet-stream'
-                $result.Files[0].Content | Should -Match "ReadOnly test content"
-            } finally {
-                # Clean up: remove read-only attribute before cleanup
-                if (Test-Path $readOnlyFile) {
-                    Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $false
-                    Remove-Item -Path $readOnlyFile -Force
-                }
-            }
+            $result.Files[0].Name | Should -BeExactly "TestFile"
+            $result.Files[0].FileName | Should -BeExactly "readonly-test.txt"
+            $result.Files[0].ContentType | Should -BeExactly 'application/octet-stream'
+            $result.Files[0].Content | Should -Match "ReadOnly test content"
         }
 
         It "Verifies Invoke-WebRequest -Form sets Content-Disposition FileName and FileNameStar." {
@@ -3602,25 +3594,17 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             "ReadOnly test content" | Out-File -FilePath $readOnlyFile -Encoding utf8
             Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $true
 
-            try {
-                $form = @{TestFile = [System.IO.FileInfo]$readOnlyFile}
-                $uri = Get-WebListenerUrl -Test 'Multipart'
-                $result = Invoke-RestMethod -Uri $uri -Form $form -Method 'POST'
+            $form = @{TestFile = [System.IO.FileInfo]$readOnlyFile}
+            $uri = Get-WebListenerUrl -Test 'Multipart'
+            $result = Invoke-RestMethod -Uri $uri -Form $form -Method 'POST'
 
-                $result.Headers.'Content-Type' | Should -Match 'multipart/form-data'
-                $result.Files.Count | Should -Be 1
+            $result.Headers.'Content-Type' | Should -Match 'multipart/form-data'
+            $result.Files.Count | Should -Be 1
 
-                $result.Files[0].Name | Should -Be "TestFile"
-                $result.Files[0].FileName | Should -Be "readonly-test.txt"
-                $result.Files[0].ContentType | Should -Be 'application/octet-stream'
-                $result.Files[0].Content | Should -Match "ReadOnly test content"
-            } finally {
-                # Clean up: remove read-only attribute before cleanup
-                if (Test-Path $readOnlyFile) {
-                    Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $false
-                    Remove-Item -Path $readOnlyFile -Force
-                }
-            }
+            $result.Files[0].Name | Should -Be "TestFile"
+            $result.Files[0].FileName | Should -Be "readonly-test.txt"
+            $result.Files[0].ContentType | Should -Be 'application/octet-stream'
+            $result.Files[0].Content | Should -Match "ReadOnly test content"
         }
 
         It "Verifies Invoke-RestMethod -Form sets Content-Disposition FileName and FileNameStar." {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1727,6 +1727,34 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             $result.Files[0].Content | Should -Match $file1Contents
         }
 
+        It "Verifies Invoke-WebRequest -Form supports read-only file values" {
+            # Create a read-only test file
+            $readOnlyFile = Join-Path $TestDrive "readonly-test.txt"
+            "ReadOnly test content" | Out-File -FilePath $readOnlyFile -Encoding utf8
+            Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $true
+
+            try {
+                $form = @{TestFile = [System.IO.FileInfo]$readOnlyFile}
+                $uri = Get-WebListenerUrl -Test 'Multipart'
+                $response = Invoke-WebRequest -Uri $uri -Form $form -Method 'POST'
+                $result = $response.Content | ConvertFrom-Json
+
+                $result.Headers.'Content-Type' | Should -Match 'multipart/form-data'
+                $result.Files.Count | Should -Be 1
+
+                $result.Files[0].Name | Should -BeExactly "TestFile"
+                $result.Files[0].FileName | Should -BeExactly "readonly-test.txt"
+                $result.Files[0].ContentType | Should -BeExactly 'application/octet-stream'
+                $result.Files[0].Content | Should -Match "ReadOnly test content"
+            } finally {
+                # Clean up: remove read-only attribute before cleanup
+                if (Test-Path $readOnlyFile) {
+                    Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $false
+                    Remove-Item -Path $readOnlyFile -Force
+                }
+            }
+        }
+
         It "Verifies Invoke-WebRequest -Form sets Content-Disposition FileName and FileNameStar." {
             $ContentDisposition = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new("attachment")
             $ContentDisposition.FileName = $fileName
@@ -3566,6 +3594,33 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             $result.Files[0].FileName | Should -Be $file1Name
             $result.Files[0].ContentType | Should -Be 'application/octet-stream'
             $result.Files[0].Content | Should -Match $file1Contents
+        }
+
+        It "Verifies Invoke-RestMethod -Form supports read-only file values" {
+            # Create a read-only test file
+            $readOnlyFile = Join-Path $TestDrive "readonly-test.txt"
+            "ReadOnly test content" | Out-File -FilePath $readOnlyFile -Encoding utf8
+            Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $true
+
+            try {
+                $form = @{TestFile = [System.IO.FileInfo]$readOnlyFile}
+                $uri = Get-WebListenerUrl -Test 'Multipart'
+                $result = Invoke-RestMethod -Uri $uri -Form $form -Method 'POST'
+
+                $result.Headers.'Content-Type' | Should -Match 'multipart/form-data'
+                $result.Files.Count | Should -Be 1
+
+                $result.Files[0].Name | Should -Be "TestFile"
+                $result.Files[0].FileName | Should -Be "readonly-test.txt"
+                $result.Files[0].ContentType | Should -Be 'application/octet-stream'
+                $result.Files[0].Content | Should -Match "ReadOnly test content"
+            } finally {
+                # Clean up: remove read-only attribute before cleanup
+                if (Test-Path $readOnlyFile) {
+                    Set-ItemProperty -Path $readOnlyFile -Name IsReadOnly -Value $false
+                    Remove-Item -Path $readOnlyFile -Force
+                }
+            }
         }
 
         It "Verifies Invoke-RestMethod -Form sets Content-Disposition FileName and FileNameStar." {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 # This is a Pester test suite which validate the Web cmdlets.


### PR DESCRIPTION
## Summary

This PR fixes issue #25482 where `Invoke-RestMethod` and `Invoke-WebRequest` fail when uploading read-only files via the `-Form` parameter.

## Changes

### Code Fix
- **File**: `src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs`
- **Change**: Added `FileAccess.Read` parameter to `FileStream` constructor in `GetMultipartFileContent()` method
- **Impact**: Allows read-only files to be uploaded successfully

### Test Coverage
- **File**: `test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1`
- **Added Tests**:
  - `Invoke-WebRequest -Form supports read-only file values`
  - `Invoke-RestMethod -Form supports read-only file values`
- **Test Coverage**: Both cmdlets are tested with read-only files, including proper cleanup

## Root Cause

The `GetMultipartFileContent()` method was opening files with `FileMode.Open` without specifying `FileAccess`, which defaults to `FileAccess.ReadWrite`. This caused an "Access denied" error when attempting to upload read-only files.

## Fix

Changed the FileStream initialization from:
```csharp
new FileStream(file.FullName, FileMode.Open)
```

To:
```csharp
new FileStream(file.FullName, FileMode.Open, FileAccess.Read)
```

Since the file is only being read for upload, `FileAccess.Read` is the correct access mode and allows read-only files to be processed.

## Related Issue

Fixes #25482