### PR TITLE
Respect -Shuffle:$false in Get-Random

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommandBase.cs
@@ -488,7 +488,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (EffectiveParameterSet == MyParameterSet.RandomListItem)
             {
-                if (ParameterSetName == ShuffleParameterSet)
+                if (Shuffle)
                 {
                     // this allows for $null to be in an array passed to InputObject
                     foreach (object item in InputObject ?? _nullInArray)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -162,6 +162,12 @@ Describe "Get-Random" -Tags "CI" {
         $randomNumber | Should -BeIn 1, 2, 3, 5, 8, 13
     }
 
+    It "Should return a single random item when -Shuffle:`$false is used" {
+        $randomNumber = Get-Random -InputObject 1, 2, 3, 5, 8, 13 -Shuffle:$false
+        $randomNumber.Count | Should -Be 1
+        $randomNumber | Should -BeIn 1, 2, 3, 5, 8, 13
+    }
+
     It "Should return for a string collection " {
         $randomNumber = Get-Random -InputObject "red", "yellow", "blue"
         $randomNumber | Should -Be ("red" -or "yellow" -or "blue")


### PR DESCRIPTION
# PR Summary

This PR fixes the issue where `-Shuffle:$false` is not respected in `Get-Random`, causing it to behave the same as `-Shuffle:$true`.

Fixes #26456
Related to #25242

## PR Context

When `-Shuffle:$false` is explicitly specified for `Get-Random`, the cmdlet incorrectly returns all items in shuffled order instead of returning a single random item. This occurs because the code checks `ParameterSetName` (a string) instead of checking the actual boolean value of the `Shuffle` parameter.

This fix changes the condition from checking the parameter set name to directly checking the `Shuffle` property value, ensuring that explicit `$false` values are properly respected.

### Changes

- Modified `GetRandomCommandBase.cs` line 491: Changed `if (ParameterSetName == ShuffleParameterSet)` to `if (Shuffle)`
- Added test case in `Get-Random.Tests.ps1` to verify `-Shuffle:$false` returns a single item

### Testing

- Added new test: "Should return a single random item when -Shuffle:$false is used"
- The test verifies that `-Shuffle:$false` returns exactly one item from the input collection
- Pre-fix: Test fails (returns 6 items instead of 1)
- Post-fix: Test passes (returns 1 item as expected)
- All existing tests continue to pass

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
    - This fix corrects incorrect behavior to match expected behavior; no documentation changes needed
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)