### PR TITLE
Respect -Shuffle:$false in Get-SecureRandom

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-SecureRandom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-SecureRandom.Tests.ps1
@@ -150,6 +150,12 @@ Describe "Get-SecureRandom" -Tags "CI" {
         $randomNumber | Should -BeIn 1, 2, 3, 5, 8, 13
     }
 
+    It "Should return a single random item when -Shuffle:`$false is used" {
+        $randomNumber = Get-SecureRandom -InputObject 1, 2, 3, 5, 8, 13 -Shuffle:$false
+        $randomNumber.Count | Should -Be 1
+        $randomNumber | Should -BeIn 1, 2, 3, 5, 8, 13
+    }
+
     It "Should return for a string collection " {
         $randomNumber = Get-SecureRandom -InputObject "red", "yellow", "blue"
         $randomNumber | Should -Be ("red" -or "yellow" -or "blue")


### PR DESCRIPTION
# PR Summary

This PR adds a test case for `Get-SecureRandom` to verify the fix for `-Shuffle:$false` handling. The underlying issue was already fixed in PR #26457, which corrected the base class `GetRandomCommandBase` that `Get-SecureRandom` inherits from.

Fixes #26458
Related to #25242

## PR Context

The cmdlet `Get-SecureRandom` inherits from `GetRandomCommandBase`, which was fixed in PR #26457 to correctly handle explicit `-Shuffle:$false` parameter values. Since the fix was made in the base class, it automatically applies to `Get-SecureRandom` as well.

This PR adds a test case to ensure the fix works correctly for `Get-SecureRandom`.

### Changes

- Added test case in `Get-SecureRandom.Tests.ps1`: "Should return a single random item when -Shuffle:$false is used"

### Testing

- The new test verifies that `-Shuffle:$false` returns exactly one item from the input collection
- Pre-fix behavior: Returns all 6 items in shuffled order
- Post-fix behavior: Returns 1 item as expected
- All existing tests continue to pass

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
    - This fix corrects incorrect behavior to match expected behavior; no documentation changes needed
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)