### PR TITLE
Respect -ListAvailable:$false in Get-TimeZone

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.Commands
             // make sure we've got the latest time zone settings
             TimeZoneInfo.ClearCachedData();
 
-            if (this.ParameterSetName.Equals("ListAvailable", StringComparison.OrdinalIgnoreCase))
+            if (ListAvailable)
             {
                 // output the list of all available time zones
                 WriteObject(TimeZoneInfo.GetSystemTimeZones(), true);

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -71,6 +71,12 @@ Describe "Get-Timezone test cases" -Tags "CI" {
         $oneExpectedOffset | Should -BeIn $observedIdList
     }
 
+    It "Call with -ListAvailable:`$false returns current TimeZoneInfo (not list)" {
+        $result = Get-TimeZone -ListAvailable:$false
+        $result | Should -BeOfType TimeZoneInfo
+        $result.Id | Should -Be ([System.TimeZoneInfo]::Local).Id
+    }
+
     It "Call Get-TimeZone using ID param and single item" {
         $selectedTZ = $TimeZonesAvailable[0]
         (Get-TimeZone -Id $selectedTZ.Id).Id | Should -Be $selectedTZ.Id


### PR DESCRIPTION
# PR Summary

This PR fixes the issue where `-ListAvailable:$false` is not respected in `Get-TimeZone`, causing it to behave the same as `-ListAvailable:$true`.

Fixes #26462
Related to #25242

## PR Context

When `-ListAvailable:$false` is explicitly specified for `Get-TimeZone`, the cmdlet incorrectly returns all available time zones instead of returning only the current time zone. This occurs because the code checks `ParameterSetName` (a string) instead of checking the actual boolean value of the `ListAvailable` parameter.

This fix changes the condition from checking the parameter set name to directly checking the `ListAvailable` property value, ensuring that explicit `$false` values are properly respected.

### Changes

- Modified `TimeZoneCommands.cs` line 57: Changed `if (this.ParameterSetName.Equals("ListAvailable", StringComparison.OrdinalIgnoreCase))` to `if (ListAvailable)`
- Added test case in `TimeZone.Tests.ps1` to verify `-ListAvailable:$false` returns only the current time zone

### Testing

- Added new test: "Call with -ListAvailable:$false returns current TimeZoneInfo (not list)"
- The test verifies that `-ListAvailable:$false` returns a single TimeZoneInfo object representing the current time zone
- Pre-fix: Test fails (returns all 142 time zones instead of 1)
- Post-fix: Test passes (returns 1 current time zone as expected)
- All existing tests continue to pass

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
    - This fix corrects incorrect behavior to match expected behavior; no documentation changes needed
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)