### PR TITLE
Respect -Qualifier/-NoQualifier/-Leaf/-IsAbsolute:$false in Split-Path

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -389,7 +389,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    // None of the switch parameters are true: handle -Parent or -LiteralPath
+                    // None of the switch parameters are true: default to -Parent behavior
                     try
                     {
                         result =

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -289,137 +289,125 @@ namespace Microsoft.PowerShell.Commands
             {
                 string result = null;
 
-                switch (ParameterSetName)
+                // Check switch parameters in order of specificity
+                if (IsAbsolute)
                 {
-                    case isAbsoluteSet:
-                        string ignored;
-                        bool isPathAbsolute =
-                            SessionState.Path.IsPSAbsolute(pathsToParse[index], out ignored);
+                    string ignored;
+                    bool isPathAbsolute =
+                        SessionState.Path.IsPSAbsolute(pathsToParse[index], out ignored);
 
-                        WriteObject(isPathAbsolute);
+                    WriteObject(isPathAbsolute);
+                    continue;
+                }
+                else if (Qualifier)
+                {
+                    int separatorIndex = pathsToParse[index].IndexOf(':');
+
+                    if (separatorIndex < 0)
+                    {
+                        FormatException e =
+                            new(
+                                StringUtil.Format(NavigationResources.ParsePathFormatError, pathsToParse[index]));
+                        WriteError(
+                            new ErrorRecord(
+                                e,
+                                "ParsePathFormatError", // RENAME
+                                ErrorCategory.InvalidArgument,
+                                pathsToParse[index]));
                         continue;
+                    }
+                    else
+                    {
+                        // Check to see if it is provider or drive qualified
 
-                    case qualifierSet:
-                        int separatorIndex = pathsToParse[index].IndexOf(':');
-
-                        if (separatorIndex < 0)
+                        if (SessionState.Path.IsProviderQualified(pathsToParse[index]))
                         {
-                            FormatException e =
-                                new(
-                                    StringUtil.Format(NavigationResources.ParsePathFormatError, pathsToParse[index]));
-                            WriteError(
-                                new ErrorRecord(
-                                    e,
-                                    "ParsePathFormatError", // RENAME
-                                    ErrorCategory.InvalidArgument,
-                                    pathsToParse[index]));
-                            continue;
+                            // The plus 2 is for the length of the provider separator
+                            // which is "::"
+
+                            result =
+                                pathsToParse[index].Substring(
+                                    0,
+                                    separatorIndex + 2);
                         }
                         else
                         {
-                            // Check to see if it is provider or drive qualified
-
-                            if (SessionState.Path.IsProviderQualified(pathsToParse[index]))
-                            {
-                                // The plus 2 is for the length of the provider separator
-                                // which is "::"
-
-                                result =
-                                    pathsToParse[index].Substring(
-                                        0,
-                                        separatorIndex + 2);
-                            }
-                            else
-                            {
-                                result =
-                                    pathsToParse[index].Substring(
-                                        0,
-                                        separatorIndex + 1);
-                            }
-                        }
-
-                        break;
-
-                    case parentSet:
-                    case literalPathSet:
-                        try
-                        {
                             result =
-                                SessionState.Path.ParseParent(
-                                    pathsToParse[index],
-                                    string.Empty,
-                                    CmdletProviderContext,
-                                    true);
+                                pathsToParse[index].Substring(
+                                    0,
+                                    separatorIndex + 1);
                         }
-                        catch (PSNotSupportedException)
+                    }
+                }
+                else if (Leaf || LeafBase || Extension)
+                {
+                    try
+                    {
+                        result =
+                            SessionState.Path.ParseChildName(
+                                pathsToParse[index],
+                                CmdletProviderContext,
+                                true);
+                        if (LeafBase)
                         {
-                            // Since getting the parent path is not supported,
-                            // the provider must be a container, item, or drive
-                            // provider.  Since the paths for these types of
-                            // providers can't be split, asking for the parent
-                            // is asking for an empty string.
-                            result = string.Empty;
+                            result = System.IO.Path.GetFileNameWithoutExtension(result);
                         }
-
-                        break;
-
-                    case leafSet:
-                    case leafBaseSet:
-                    case extensionSet:
-                        try
+                        else if (Extension)
                         {
-                            // default handles leafSet
-                            result =
-                                SessionState.Path.ParseChildName(
-                                    pathsToParse[index],
-                                    CmdletProviderContext,
-                                    true);
-                            if (LeafBase)
-                            {
-                                result = System.IO.Path.GetFileNameWithoutExtension(result);
-                            }
-                            else if (Extension)
-                            {
-                                result = System.IO.Path.GetExtension(result);
-                            }
+                            result = System.IO.Path.GetExtension(result);
                         }
-                        catch (PSNotSupportedException)
-                        {
-                            // Since getting the leaf part of a path is not supported,
-                            // the provider must be a container, item, or drive
-                            // provider.  Since the paths for these types of
-                            // providers can't be split, asking for the leaf
-                            // is asking for the specified path back.
-                            result = pathsToParse[index];
-                        }
-                        catch (DriveNotFoundException driveNotFound)
-                        {
-                            WriteError(
-                                new ErrorRecord(
-                                    driveNotFound.ErrorRecord,
-                                    driveNotFound));
-                            continue;
-                        }
-                        catch (ProviderNotFoundException providerNotFound)
-                        {
-                            WriteError(
-                                new ErrorRecord(
-                                    providerNotFound.ErrorRecord,
-                                    providerNotFound));
-                            continue;
-                        }
-
-                        break;
-
-                    case noQualifierSet:
-                        result = RemoveQualifier(pathsToParse[index]);
-                        break;
-
-                    default:
-                        Dbg.Diagnostics.Assert(
-                            false,
-                            "Only a known parameter set should be called");
-                        break;
+                    }
+                    catch (PSNotSupportedException)
+                    {
+                        // Since getting the leaf part of a path is not supported,
+                        // the provider must be a container, item, or drive
+                        // provider.  Since the paths for these types of
+                        // providers can't be split, asking for the leaf
+                        // is asking for the specified path back.
+                        result = pathsToParse[index];
+                    }
+                    catch (DriveNotFoundException driveNotFound)
+                    {
+                        WriteError(
+                            new ErrorRecord(
+                                driveNotFound.ErrorRecord,
+                                driveNotFound));
+                        continue;
+                    }
+                    catch (ProviderNotFoundException providerNotFound)
+                    {
+                        WriteError(
+                            new ErrorRecord(
+                                providerNotFound.ErrorRecord,
+                                providerNotFound));
+                        continue;
+                    }
+                }
+                else if (NoQualifier)
+                {
+                    result = RemoveQualifier(pathsToParse[index]);
+                }
+                else
+                {
+                    // None of the switch parameters are true: handle -Parent or -LiteralPath
+                    try
+                    {
+                        result =
+                            SessionState.Path.ParseParent(
+                                pathsToParse[index],
+                                string.Empty,
+                                CmdletProviderContext,
+                                true);
+                    }
+                    catch (PSNotSupportedException)
+                    {
+                        // Since getting the parent path is not supported,
+                        // the provider must be a container, item, or drive
+                        // provider.  Since the paths for these types of
+                        // providers can't be split, asking for the parent
+                        // is asking for an empty string.
+                        result = string.Empty;
+                    }
                 }
 
                 if (result != null)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -96,7 +96,33 @@ Describe "Split-Path" -Tags "CI" {
 	Split-Path -Parent "\\server1\share1"        | Should -BeExactly "${dirSep}${dirSep}server1"
     }
 
-    It 'Does not split a drive leter'{
-    Split-Path -Path 'C:\' | Should -BeNullOrEmpty
+    It 'Does not split a drive leter' {
+        Split-Path -Path 'C:\' | Should -BeNullOrEmpty
+    }
+
+    It "Should handle explicit -Qualifier:$false parameter value correctly" {
+        # When -Qualifier:$false is specified, it should behave like -Parent (default)
+        # For env:PATH, the parent is empty string
+        $result = Split-Path -Path "env:PATH" -Qualifier:$false
+        $result | Should -BeNullOrEmpty
+    }
+
+    It "Should handle explicit -NoQualifier:`$false parameter value correctly" {
+        # When -NoQualifier:$false is specified, it should behave like -Parent (default)
+        # For env:PATH with no qualifier, we expect empty string (parent of PATH in env drive)
+        $result = Split-Path -Path "env:PATH" -NoQualifier:$false
+        $result | Should -BeNullOrEmpty
+    }
+
+    It "Should handle explicit -Leaf:`$false parameter value correctly" {
+        # When -Leaf:$false is specified, it should behave like -Parent (default)
+        $dirSep = [string]([System.IO.Path]::DirectorySeparatorChar)
+        Split-Path -Path "/usr/bin" -Leaf:$false | Should -BeExactly "${dirSep}usr"
+    }
+
+    It "Should handle explicit -IsAbsolute:`$false parameter value correctly" {
+        # When -IsAbsolute:$false is specified, it should behave like -Parent (default)
+        $dirSep = [string]([System.IO.Path]::DirectorySeparatorChar)
+        Split-Path -Path "fs:/usr/bin" -IsAbsolute:$false | Should -BeExactly "fs:${dirSep}usr"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -96,7 +96,7 @@ Describe "Split-Path" -Tags "CI" {
 	Split-Path -Parent "\\server1\share1"        | Should -BeExactly "${dirSep}${dirSep}server1"
     }
 
-    It 'Does not split a drive leter' {
+    It 'Does not split a drive letter' {
         Split-Path -Path 'C:\' | Should -BeNullOrEmpty
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -100,7 +100,7 @@ Describe "Split-Path" -Tags "CI" {
         Split-Path -Path 'C:\' | Should -BeNullOrEmpty
     }
 
-    It "Should handle explicit -Qualifier:$false parameter value correctly" {
+    It "Should handle explicit -Qualifier:`$false parameter value correctly" {
         # When -Qualifier:$false is specified, it should behave like -Parent (default)
         # For env:PATH, the parent is empty string
         $result = Split-Path -Path "env:PATH" -Qualifier:$false


### PR DESCRIPTION
# PR Summary

This PR fixes the issue where `-Qualifier:$false`, `-NoQualifier:$false`, `-Leaf:$false`, and `-IsAbsolute:$false` are not respected in `Split-Path`, causing them to behave the same as their `$true` counterparts.

Fixes #26470
Related to #25242

## PR Context

When these switch parameters are explicitly set to `$false` for `Split-Path`, the cmdlet incorrectly behaves as if they were set to `$true`. This occurs because the code uses `ParameterSetName` (a string) in a switch statement instead of checking the actual boolean values of the switch parameters.

This fix converts the switch statement to an if-else chain that directly checks each switch parameter's boolean value, ensuring that explicit `$false` values are properly respected.

### Changes

- Modified `ParsePathCommand.cs`: Converted the switch statement to an if-else chain that checks the actual boolean values of `-IsAbsolute`, `-Qualifier`, `-Leaf`/`-LeafBase`/`-Extension`, and `-NoQualifier`
- Added 4 test cases in `Split-Path.Tests.ps1` to verify each switch parameter respects `:$false`

### Testing

- Added new tests for explicit `:$false` parameter handling:
  - "Should handle explicit -Qualifier:`$false parameter value correctly"
  - "Should handle explicit -NoQualifier:`$false parameter value correctly"
  - "Should handle explicit -Leaf:`$false parameter value correctly"
  - "Should handle explicit -IsAbsolute:`$false parameter value correctly"
- Each test verifies that when the switch parameter is set to `$false`, the cmdlet falls back to default behavior (returning the parent path)
- Pre-fix: All 4 new tests fail
- Post-fix: All 4 new tests pass
- All 11 existing tests continue to pass

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
    - This fix corrects incorrect behavior to match expected behavior; no documentation changes needed
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)