### PR TITLE
Respect -Repeat/-MtuSize/-Traceroute:$false in Test-Connection

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -264,7 +264,6 @@ namespace Microsoft.PowerShell.Commands
 
             foreach (var targetName in TargetName)
             {
-
                 if (MtuSize)
                 {
                     ProcessMTUSize(targetName);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -242,14 +242,13 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            switch (ParameterSetName)
+            if (Repeat)
             {
-                case RepeatPingParameterSet:
-                    Count = int.MaxValue;
-                    break;
-                case TcpPortParameterSet:
-                    SetCountForTcpTest();
-                    break;
+                Count = int.MaxValue;
+            }
+            else if (ParameterSetName == TcpPortParameterSet)
+            {
+                SetCountForTcpTest();
             }
         }
 
@@ -265,21 +264,23 @@ namespace Microsoft.PowerShell.Commands
 
             foreach (var targetName in TargetName)
             {
-                switch (ParameterSetName)
+
+                if (MtuSize)
                 {
-                    case DefaultPingParameterSet:
-                    case RepeatPingParameterSet:
-                        ProcessPing(targetName);
-                        break;
-                    case MtuSizeDetectParameterSet:
-                        ProcessMTUSize(targetName);
-                        break;
-                    case TraceRouteParameterSet:
-                        ProcessTraceroute(targetName);
-                        break;
-                    case TcpPortParameterSet:
-                        ProcessConnectionByTCPPort(targetName);
-                        break;
+                    ProcessMTUSize(targetName);
+                }
+                else if (Traceroute)
+                {
+                    ProcessTraceroute(targetName);
+                }
+                else if (ParameterSetName == TcpPortParameterSet)
+                {
+                    ProcessConnectionByTCPPort(targetName);
+                }
+                else
+                {
+                    // None of the switch parameters are true: handle default ping or -Repeat
+                    ProcessPing(targetName);
                 }
             }
         }
@@ -298,7 +299,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void SetCountForTcpTest()
         {
-            if (Repeat.IsPresent)
+            if (Repeat)
             {
                 Count = int.MaxValue;
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -258,6 +258,15 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
                 $pingResults.Where( { $_.Status -eq 'Success' }, 'Default', 1 ).BufferSize | Should -Be 32
             }
         }
+
+        It "Repeat with explicit false should behave like default ping" {
+            # -Repeat:$false should behave the same as not specifying -Repeat
+            $pingResults = Test-Connection $targetAddress -Repeat:$false
+            
+            # Should get exactly 4 pings (the default Count value)
+            $pingResults.Count | Should -Be 4
+            $pingResults[0].Address | Should -BeExactly $targetAddress
+        }
     }
 
     Context "MTUSizeDetect" {
@@ -290,6 +299,16 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
 
             $result | Should -BeOfType Int32
             $result | Should -BeGreaterThan 0
+        }
+
+        It "MtuSize with explicit false should behave like default ping" {
+            # -MtuSize:$false should behave the same as not specifying -MtuSize (default ping)
+            $pingResults = Test-Connection $targetAddress -MtuSize:$false
+            
+            # Should return PingStatus, not PingMtuStatus
+            $pingResults[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingStatus
+            # Should get 4 pings (the default Count value)
+            $pingResults.Count | Should -Be 4
         }
     }
 
@@ -331,6 +350,16 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
             $results = Test-Connection 127.0.0.1 -Traceroute
 
             $results.Hostname | Should -Not -BeNullOrEmpty
+        }
+
+        It "Traceroute with explicit false should behave like default ping" {
+            # -Traceroute:$false should behave the same as not specifying -Traceroute (default ping)
+            $pingResults = Test-Connection $targetAddress -Traceroute:$false
+            
+            # Should return PingStatus, not TraceStatus
+            $pingResults[0] | Should -BeOfType Microsoft.PowerShell.Commands.TestConnectionCommand+PingStatus
+            # Should get 4 pings (the default Count value)
+            $pingResults.Count | Should -Be 4
         }
     }
 }


### PR DESCRIPTION
# PR Summary

This PR fixes the issue where `-Repeat:$false`, `-MtuSize:$false`, and `-Traceroute:$false` are not respected in `Test-Connection`, causing them to behave the same as their `$true` counterparts.

Fixes #26475
Related to #25242

## PR Context

When any of these switch parameters is explicitly set to `$false`, the cmdlet incorrectly performs the associated operation (continuous ping, MTU detection, or traceroute) instead of performing a standard ping. This occurs because the code uses a switch statement on `ParameterSetName` without checking the actual boolean values of the parameters.

This fix changes the parameter set resolution logic from a switch statement to an if-else chain that directly checks each parameter's boolean value, ensuring that explicit `$false` values are properly respected.

### Changes

- Modified `TestConnectionCommand.cs`: Changed switch statement to if-else chain that checks `Repeat`, `MtuSize`, and `Traceroute` property values instead of just the parameter set name
- Added 3 test cases in `Test-Connection.Tests.ps1` to verify each switch parameter respects `$false`

### Testing

**New tests added:**
1. "Repeat with explicit false should behave like default ping"
2. "MtuSize with explicit false should behave like default ping"
3. "Traceroute with explicit false should behave like default ping"

**Test results:**
- Pre-fix: All 3 new tests fail
  - `-Repeat:$false` runs continuously instead of 4 pings
  - `-MtuSize:$false` returns `PingMtuStatus` instead of `PingStatus`
  - `-Traceroute:$false` returns `TraceStatus` instead of `PingStatus`
- Post-fix: All 3 new tests pass
  - Each returns standard `PingStatus` with 4 pings
- All existing tests continue to pass

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
    - This fix corrects incorrect behavior to match expected behavior; no documentation changes needed
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)