### PR TITLE
Add -Extension parameter to Join-Path cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -51,6 +51,12 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public SwitchParameter Resolve { get; set; }
 
+        /// <summary>
+        /// Gets or sets the extension to use for the resulting path.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public string Extension { get; set; }
+
         #endregion Parameters
 
         #region Command code
@@ -126,6 +132,16 @@ namespace Microsoft.PowerShell.Commands
                             pathNotFound.ErrorRecord,
                             pathNotFound));
                     continue;
+                }
+                // Change extension if specified
+                if (Extension != null && joinedPath != null)
+                {
+                    joinedPath = System.IO.Path.ChangeExtension(joinedPath, Extension);
+                    // Remove trailing dot when extension is empty string
+                    if (Extension.Length == 0 && joinedPath.EndsWith('.'))
+                    {
+                        joinedPath = joinedPath.Substring(0, joinedPath.Length - 1);
+                    }
                 }
 
                 if (Resolve)

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -53,6 +53,14 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Gets or sets the extension to use for the resulting path.
+        /// <para>
+        /// Behavior:
+        /// - If the path has an existing extension, it will be replaced with the specified extension.
+        /// - If the path does not have an extension, the specified extension will be added.
+        /// - If an empty string is provided, any existing extension will be removed.
+        /// - A leading dot in the extension is optional; if omitted, one will be added automatically.
+        /// - If the path refers to a directory, the extension is not added or modified.
+        /// </para>
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public string Extension { get; set; }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -148,7 +148,7 @@ namespace Microsoft.PowerShell.Commands
                     joinedPath = System.IO.Path.ChangeExtension(joinedPath, Extension);
 
                     // Remove trailing dot when extension is empty string
-                    if (Extension.Length == 0 && joinedPath.EndsWith('.'))
+                    if (Extension.Length == 0 && joinedPath.EndsWith('.', StringComparison.Ordinal))
                     {
                         joinedPath = joinedPath.Substring(0, joinedPath.Length - 1);
                     }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -141,8 +141,8 @@ namespace Microsoft.PowerShell.Commands
                     continue;
                 }
 
-                // Change extension if specified
-                if (Extension != null && joinedPath != null)
+                // If Extension parameter is present it is not null due to [ValidateNotNull].
+                if (Extension is not null)
                 {
                     joinedPath = System.IO.Path.ChangeExtension(joinedPath, Extension.Length == 0 ? null : Extension);
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -59,7 +59,6 @@ namespace Microsoft.PowerShell.Commands
         /// - If the path does not have an extension, the specified extension will be added.
         /// - If an empty string is provided, any existing extension will be removed.
         /// - A leading dot in the extension is optional; if omitted, one will be added automatically.
-        /// - If the path refers to a directory, the extension is not added or modified.
         /// </para>
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -53,6 +53,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Gets or sets the extension to use for the resulting path.
+        /// If not specified, the original extension (if any) is preserved.
         /// <para>
         /// Behavior:
         /// - If the path has an existing extension, it will be replaced with the specified extension.
@@ -62,6 +63,7 @@ namespace Microsoft.PowerShell.Commands
         /// </para>
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNull]
         public string Extension { get; set; }
 
         #endregion Parameters

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -144,13 +144,7 @@ namespace Microsoft.PowerShell.Commands
                 // Change extension if specified
                 if (Extension != null && joinedPath != null)
                 {
-                    joinedPath = System.IO.Path.ChangeExtension(joinedPath, Extension);
-
-                    // Remove trailing dot when extension is empty string
-                    if (Extension.Length == 0)
-                    {
-                        joinedPath = joinedPath.TrimEnd('.');
-                    }
+                    joinedPath = System.IO.Path.ChangeExtension(joinedPath, Extension.Length == 0 ? null : Extension);
                 }
 
                 if (Resolve)

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -148,9 +148,9 @@ namespace Microsoft.PowerShell.Commands
                     joinedPath = System.IO.Path.ChangeExtension(joinedPath, Extension);
 
                     // Remove trailing dot when extension is empty string
-                    if (Extension.Length == 0 && joinedPath.EndsWith('.', StringComparison.Ordinal))
+                    if (Extension.Length == 0)
                     {
-                        joinedPath = joinedPath.Substring(0, joinedPath.Length - 1);
+                        joinedPath = joinedPath.TrimEnd('.');
                     }
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -133,10 +133,12 @@ namespace Microsoft.PowerShell.Commands
                             pathNotFound));
                     continue;
                 }
+
                 // Change extension if specified
                 if (Extension != null && joinedPath != null)
                 {
                     joinedPath = System.IO.Path.ChangeExtension(joinedPath, Extension);
+
                     // Remove trailing dot when extension is empty string
                     if (Extension.Length == 0 && joinedPath.EndsWith('.'))
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -84,4 +84,33 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result = Join-Path -Path $Path -ChildPath $ChildPath
     $result | Should -BeExactly $ExpectedResult
   }
+  It "should change extension when -Extension parameter is specified" {
+    $result = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ".log"
+    $result | Should -BeExactly "C:\folder\file.log"
+  }
+  It "should add extension to file without extension" {
+    $result = Join-Path -Path "C:\folder" -ChildPath "file" -Extension ".txt"
+    $result | Should -BeExactly "C:\folder\file.txt"
+  }
+  It "should remove extension when empty string is specified" {
+    $result = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ""
+    $result | Should -BeExactly "C:\folder\file"
+  }
+  It "should change extension for multiple paths" {
+    $result = Join-Path -Path "C:\folder1", "C:\folder2" -ChildPath "file.txt" -Extension ".log"
+    $result.Count | Should -Be 2
+    $result[0] | Should -BeExactly "C:\folder1\file.log"
+    $result[1] | Should -BeExactly "C:\folder2\file.log"
+  }
+  It "should handle extension with or without leading dot" {
+    $result1 = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ".log"
+    $result2 = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension "log"
+    $result1 | Should -BeExactly "C:\folder\file.log"
+    $result2 | Should -BeExactly "C:\folder\file.log"
+  }
+  It "should accept Extension from pipeline by property name" {
+    $obj = [PSCustomObject]@{ Path = "C:\folder"; ChildPath = "file.txt"; Extension = ".log" }
+    $result = $obj | Join-Path
+    $result | Should -BeExactly "C:\folder\file.log"
+  }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -96,6 +96,10 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ""
     $result | Should -BeExactly "folder${SepChar}file"
   }
+  It "should preserve dots in base name when removing extension with empty string" {
+    $result = Join-Path -Path "folder" -ChildPath "file...txt" -Extension ""
+    $result | Should -BeExactly "folder${SepChar}file.."
+  }
   It "should change extension for multiple paths" {
     $result = Join-Path -Path "folder1", "folder2" -ChildPath "file.txt" -Extension ".log"
     $result.Count | Should -Be 2
@@ -111,6 +115,10 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
   It "should replace only the last extension for files with multiple dots" {
     $result = Join-Path -Path "folder" -ChildPath "file.backup.txt" -Extension ".log"
     $result | Should -BeExactly "folder${SepChar}file.backup.log"
+  }
+  It "should preserve dots in base name when changing extension" {
+    $result = Join-Path -Path "folder" -ChildPath "file...txt" -Extension ".md"
+    $result | Should -BeExactly "folder${SepChar}file...md"
   }
   It "should add extension to directory-like path" {
     $result = Join-Path -Path "folder" -ChildPath "subfolder" -Extension ".log"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -85,40 +85,40 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result | Should -BeExactly $ExpectedResult
   }
   It "should change extension when -Extension parameter is specified" {
-    $result = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ".log"
-    $result | Should -BeExactly "C:\folder\file.log"
+    $result = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ".log"
+    $result | Should -BeExactly "folder${SepChar}file.log"
   }
   It "should add extension to file without extension" {
-    $result = Join-Path -Path "C:\folder" -ChildPath "file" -Extension ".txt"
-    $result | Should -BeExactly "C:\folder\file.txt"
+    $result = Join-Path -Path "folder" -ChildPath "file" -Extension ".txt"
+    $result | Should -BeExactly "folder${SepChar}file.txt"
   }
   It "should remove extension when empty string is specified" {
-    $result = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ""
-    $result | Should -BeExactly "C:\folder\file"
+    $result = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ""
+    $result | Should -BeExactly "folder${SepChar}file"
   }
   It "should change extension for multiple paths" {
-    $result = Join-Path -Path "C:\folder1", "C:\folder2" -ChildPath "file.txt" -Extension ".log"
+    $result = Join-Path -Path "folder1", "folder2" -ChildPath "file.txt" -Extension ".log"
     $result.Count | Should -Be 2
-    $result[0] | Should -BeExactly "C:\folder1\file.log"
-    $result[1] | Should -BeExactly "C:\folder2\file.log"
+    $result[0] | Should -BeExactly "folder1${SepChar}file.log"
+    $result[1] | Should -BeExactly "folder2${SepChar}file.log"
   }
   It "should handle extension with or without leading dot" {
-    $result1 = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ".log"
-    $result2 = Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension "log"
-    $result1 | Should -BeExactly "C:\folder\file.log"
-    $result2 | Should -BeExactly "C:\folder\file.log"
+    $result1 = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ".log"
+    $result2 = Join-Path -Path "folder" -ChildPath "file.txt" -Extension "log"
+    $result1 | Should -BeExactly "folder${SepChar}file.log"
+    $result2 | Should -BeExactly "folder${SepChar}file.log"
   }
   It "should replace only the last extension for files with multiple dots" {
-    $result = Join-Path -Path "C:\folder" -ChildPath "file.backup.txt" -Extension ".log"
-    $result | Should -BeExactly "C:\folder\file.backup.log"
+    $result = Join-Path -Path "folder" -ChildPath "file.backup.txt" -Extension ".log"
+    $result | Should -BeExactly "folder${SepChar}file.backup.log"
   }
   It "should add extension to directory-like path" {
-    $result = Join-Path -Path "C:\folder" -ChildPath "subfolder" -Extension ".log"
-    $result | Should -BeExactly "C:\folder\subfolder.log"
+    $result = Join-Path -Path "folder" -ChildPath "subfolder" -Extension ".log"
+    $result | Should -BeExactly "folder${SepChar}subfolder.log"
   }
   It "should change extension when joining multiple child path segments" {
-    $result = Join-Path -Path "C:\folder" -ChildPath "subfolder" "file.txt" -Extension ".log"
-    $result | Should -BeExactly "C:\folder\subfolder\file.log"
+    $result = Join-Path -Path "folder" -ChildPath "subfolder" "file.txt" -Extension ".log"
+    $result | Should -BeExactly "folder${SepChar}subfolder${SepChar}file.log"
   }
   It "should resolve path when -Extension changes to existing file" {
     New-Item -Path TestDrive:\testfile.log -ItemType File -Force | Out-Null
@@ -130,8 +130,8 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
       Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
   }
   It "should accept Extension from pipeline by property name" {
-    $obj = [PSCustomObject]@{ Path = "C:\folder"; ChildPath = "file.txt"; Extension = ".log" }
+    $obj = [PSCustomObject]@{ Path = "folder"; ChildPath = "file.txt"; Extension = ".log" }
     $result = $obj | Join-Path
-    $result | Should -BeExactly "C:\folder\file.log"
+    $result | Should -BeExactly "folder${SepChar}file.log"
   }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -120,6 +120,15 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result = Join-Path -Path "C:\folder" -ChildPath "subfolder" "file.txt" -Extension ".log"
     $result | Should -BeExactly "C:\folder\subfolder\file.log"
   }
+  It "should resolve path when -Extension changes to existing file" {
+    New-Item -Path TestDrive:\testfile.log -ItemType File -Force | Out-Null
+    $result = Join-Path -Path TestDrive: -ChildPath "testfile.txt" -Extension ".log" -Resolve
+    $result | Should -BeLike "*testfile.log"
+  }
+  It "should throw error when -Extension changes to non-existing file with -Resolve" {
+    { Join-Path -Path TestDrive: -ChildPath "testfile.txt" -Extension ".nonexistent" -Resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
+      Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
+  }
   It "should accept Extension from pipeline by property name" {
     $obj = [PSCustomObject]@{ Path = "C:\folder"; ChildPath = "file.txt"; Extension = ".log" }
     $result = $obj | Join-Path

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -84,13 +84,46 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result = Join-Path -Path $Path -ChildPath $ChildPath
     $result | Should -BeExactly $ExpectedResult
   }
-  It "should change extension when -Extension parameter is specified" {
-    $result = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ".log"
-    $result | Should -BeExactly "folder${SepChar}file.log"
-  }
-  It "should add extension to file without extension" {
-    $result = Join-Path -Path "folder" -ChildPath "file" -Extension ".txt"
-    $result | Should -BeExactly "folder${SepChar}file.txt"
+  It "should handle extension parameter: <TestName>" -TestCases @(
+    @{
+      TestName = "change extension"
+      Path = "folder"
+      ChildPath = "file.txt"
+      Extension = ".log"
+      ExpectedResult = "folder${SepChar}file.log"
+    }
+    @{
+      TestName = "add extension to file without extension"
+      Path = "folder"
+      ChildPath = "file"
+      Extension = ".txt"
+      ExpectedResult = "folder${SepChar}file.txt"
+    }
+    @{
+      TestName = "extension without leading dot"
+      Path = "folder"
+      ChildPath = "file.txt"
+      Extension = "log"
+      ExpectedResult = "folder${SepChar}file.log"
+    }
+    @{
+      TestName = "double extension with dot"
+      Path = "folder"
+      ChildPath = "file.txt"
+      Extension = ".tar.gz"
+      ExpectedResult = "folder${SepChar}file.tar.gz"
+    }
+    @{
+      TestName = "double extension without dot"
+      Path = "folder"
+      ChildPath = "file.txt"
+      Extension = "tar.gz"
+      ExpectedResult = "folder${SepChar}file.tar.gz"
+    }
+  ) {
+    param($TestName, $Path, $ChildPath, $Extension, $ExpectedResult)
+    $result = Join-Path -Path $Path -ChildPath $ChildPath -Extension $Extension
+    $result | Should -BeExactly $ExpectedResult
   }
   It "should remove extension when empty string is specified" {
     $result = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ""
@@ -105,12 +138,6 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result.Count | Should -Be 2
     $result[0] | Should -BeExactly "folder1${SepChar}file.log"
     $result[1] | Should -BeExactly "folder2${SepChar}file.log"
-  }
-  It "should handle extension with or without leading dot" {
-    $result1 = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ".log"
-    $result2 = Join-Path -Path "folder" -ChildPath "file.txt" -Extension "log"
-    $result1 | Should -BeExactly "folder${SepChar}file.log"
-    $result2 | Should -BeExactly "folder${SepChar}file.log"
   }
   It "should replace only the last extension for files with multiple dots" {
     $result = Join-Path -Path "folder" -ChildPath "file.backup.txt" -Extension ".log"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -108,6 +108,18 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result1 | Should -BeExactly "C:\folder\file.log"
     $result2 | Should -BeExactly "C:\folder\file.log"
   }
+  It "should replace only the last extension for files with multiple dots" {
+    $result = Join-Path -Path "C:\folder" -ChildPath "file.backup.txt" -Extension ".log"
+    $result | Should -BeExactly "C:\folder\file.backup.log"
+  }
+  It "should add extension to directory-like path" {
+    $result = Join-Path -Path "C:\folder" -ChildPath "subfolder" -Extension ".log"
+    $result | Should -BeExactly "C:\folder\subfolder.log"
+  }
+  It "should change extension when joining multiple child path segments" {
+    $result = Join-Path -Path "C:\folder" -ChildPath "subfolder" "file.txt" -Extension ".log"
+    $result | Should -BeExactly "C:\folder\subfolder\file.log"
+  }
   It "should accept Extension from pipeline by property name" {
     $obj = [PSCustomObject]@{ Path = "C:\folder"; ChildPath = "file.txt"; Extension = ".log" }
     $result = $obj | Join-Path

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -87,43 +87,38 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
   It "should handle extension parameter: <TestName>" -TestCases @(
     @{
       TestName = "change extension"
-      Path = "folder"
       ChildPath = "file.txt"
       Extension = ".log"
-      ExpectedResult = "folder${SepChar}file.log"
+      ExpectedChildPath = "file.log"
     }
     @{
       TestName = "add extension to file without extension"
-      Path = "folder"
       ChildPath = "file"
       Extension = ".txt"
-      ExpectedResult = "folder${SepChar}file.txt"
+      ExpectedChildPath = "file.txt"
     }
     @{
       TestName = "extension without leading dot"
-      Path = "folder"
       ChildPath = "file.txt"
       Extension = "log"
-      ExpectedResult = "folder${SepChar}file.log"
+      ExpectedChildPath = "file.log"
     }
     @{
       TestName = "double extension with dot"
-      Path = "folder"
       ChildPath = "file.txt"
       Extension = ".tar.gz"
-      ExpectedResult = "folder${SepChar}file.tar.gz"
+      ExpectedChildPath = "file.tar.gz"
     }
     @{
       TestName = "double extension without dot"
-      Path = "folder"
       ChildPath = "file.txt"
       Extension = "tar.gz"
-      ExpectedResult = "folder${SepChar}file.tar.gz"
+      ExpectedChildPath = "file.tar.gz"
     }
   ) {
-    param($TestName, $Path, $ChildPath, $Extension, $ExpectedResult)
-    $result = Join-Path -Path $Path -ChildPath $ChildPath -Extension $Extension
-    $result | Should -BeExactly $ExpectedResult
+    param($TestName, $ChildPath, $Extension, $ExpectedChildPath)
+    $result = Join-Path -Path "folder" -ChildPath $ChildPath -Extension $Extension
+    $result | Should -BeExactly "folder${SepChar}${ExpectedChildPath}"
   }
   It "should remove extension when empty string is specified" {
     $result = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ""

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -115,40 +115,58 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
       Extension = "tar.gz"
       ExpectedChildPath = "file.tar.gz"
     }
+    @{
+      TestName = "remove extension with empty string"
+      ChildPath = "file.txt"
+      Extension = ""
+      ExpectedChildPath = "file"
+    }
+    @{
+      TestName = "preserve dots in base name when removing extension with empty string"
+      ChildPath = "file...txt"
+      Extension = ""
+      ExpectedChildPath = "file.."
+    }
+    @{
+      TestName = "replace only the last extension for files with multiple dots"
+      ChildPath = "file.backup.txt"
+      Extension = ".log"
+      ExpectedChildPath = "file.backup.log"
+    }
+    @{
+      TestName = "preserve dots in base name when changing extension"
+      ChildPath = "file...txt"
+      Extension = ".md"
+      ExpectedChildPath = "file...md"
+    }
+    @{
+      TestName = "add extension to directory-like path"
+      ChildPath = "subfolder"
+      Extension = ".log"
+      ExpectedChildPath = "subfolder.log"
+    }
   ) {
     param($TestName, $ChildPath, $Extension, $ExpectedChildPath)
     $result = Join-Path -Path "folder" -ChildPath $ChildPath -Extension $Extension
     $result | Should -BeExactly "folder${SepChar}${ExpectedChildPath}"
   }
-  It "should remove extension when empty string is specified" {
-    $result = Join-Path -Path "folder" -ChildPath "file.txt" -Extension ""
-    $result | Should -BeExactly "folder${SepChar}file"
-  }
-  It "should preserve dots in base name when removing extension with empty string" {
-    $result = Join-Path -Path "folder" -ChildPath "file...txt" -Extension ""
-    $result | Should -BeExactly "folder${SepChar}file.."
+  It "should handle extension parameter with multiple child path segments: <TestName>" -TestCases @(
+    @{
+      TestName = "change extension when joining multiple child path segments"
+      ChildPaths = @("subfolder", "file.txt")
+      Extension = ".log"
+      ExpectedPath = "folder${SepChar}subfolder${SepChar}file.log"
+    }
+  ) {
+    param($TestName, $ChildPaths, $Extension, $ExpectedPath)
+    $result = Join-Path -Path "folder" -ChildPath $ChildPaths -Extension $Extension
+    $result | Should -BeExactly $ExpectedPath
   }
   It "should change extension for multiple paths" {
     $result = Join-Path -Path "folder1", "folder2" -ChildPath "file.txt" -Extension ".log"
     $result.Count | Should -Be 2
     $result[0] | Should -BeExactly "folder1${SepChar}file.log"
     $result[1] | Should -BeExactly "folder2${SepChar}file.log"
-  }
-  It "should replace only the last extension for files with multiple dots" {
-    $result = Join-Path -Path "folder" -ChildPath "file.backup.txt" -Extension ".log"
-    $result | Should -BeExactly "folder${SepChar}file.backup.log"
-  }
-  It "should preserve dots in base name when changing extension" {
-    $result = Join-Path -Path "folder" -ChildPath "file...txt" -Extension ".md"
-    $result | Should -BeExactly "folder${SepChar}file...md"
-  }
-  It "should add extension to directory-like path" {
-    $result = Join-Path -Path "folder" -ChildPath "subfolder" -Extension ".log"
-    $result | Should -BeExactly "folder${SepChar}subfolder.log"
-  }
-  It "should change extension when joining multiple child path segments" {
-    $result = Join-Path -Path "folder" -ChildPath "subfolder" "file.txt" -Extension ".log"
-    $result | Should -BeExactly "folder${SepChar}subfolder${SepChar}file.log"
   }
   It "should resolve path when -Extension changes to existing file" {
     New-Item -Path TestDrive:\testfile.log -ItemType File -Force | Out-Null


### PR DESCRIPTION
# PR Summary

This PR adds a new `-Extension` parameter to `Join-Path` cmdlet that allows changing the file extension of the resulting path, providing parity with `Split-Path`'s extension handling capabilities.

Fixes #20724

## PR Context

The `Split-Path` cmdlet has an `-Extension` parameter that retrieves the file extension from a path. However, `Join-Path` lacks the ability to set or change extensions when joining paths. This enhancement adds an `-Extension` string parameter to `Join-Path` that modifies the extension of the final joined path.

### Changes

- Modified `CombinePathCommand.cs`: Added `-Extension` parameter with `ValueFromPipelineByPropertyName` support
- Uses `System.IO.Path.ChangeExtension()` to modify the extension
- Handles empty string extension by removing the trailing dot for cleaner output
- Added 6 test cases in `Join-Path.Tests.ps1`

### Testing

**New tests added:**
1. "should change extension when -Extension parameter is specified"
2. "should add extension to file without extension"
3. "should remove extension when empty string is specified"
4. "should change extension for multiple paths"
5. "should handle extension with or without leading dot"
6. "should accept Extension from pipeline by property name"

**Examples:**
```powershell
# Change extension
Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ".log"
# Output: C:\folder\file.log

# Add extension
Join-Path -Path "C:\folder" -ChildPath "file" -Extension ".txt"
# Output: C:\folder\file.txt

# Remove extension
Join-Path -Path "C:\folder" -ChildPath "file.txt" -Extension ""
# Output: C:\folder\file

# Pipeline input
[PSCustomObject]@{ Path = "C:\folder"; ChildPath = "file.txt"; Extension = ".log" } | Join-Path
# Output: C:\folder\file.log
```

**Test results:**
- All 6 new tests pass
- All existing tests continue to pass

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Documentation needed
    - New `-Extension` parameter should be documented in `Join-Path` cmdlet help https://github.com/MicrosoftDocs/PowerShell-Docs/issues/12535
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)