### PR TITLE
Add tab completion for $PSBoundParameters.Keys switch cases and access patterns

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -446,7 +446,7 @@ namespace System.Management.Automation
 
             // Check if target is $PSBoundParameters
             if (targetAst is not VariableExpressionAst variableAst ||
-    !variableAst.VariablePath.UserPath.Equals("PSBoundParameters", StringComparison.OrdinalIgnoreCase))
+                !variableAst.VariablePath.UserPath.Equals("PSBoundParameters", StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -307,8 +307,7 @@ namespace System.Management.Automation
             else
             {
                 // Check for incomplete switch parsed as ErrorStatementAst
-                var errorStatementAst = lastAst.Parent as ErrorStatementAst;
-                if (errorStatementAst == null || errorStatementAst.Kind == null ||
+                if (lastAst.Parent is not ErrorStatementAst errorStatementAst || errorStatementAst.Kind == null ||
                     errorStatementAst.Kind.Kind != TokenKind.Switch)
                 {
                     return null;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -447,9 +447,8 @@ namespace System.Management.Automation
             }
 
             // Check if target is $PSBoundParameters
-            var variableAst = targetAst as VariableExpressionAst;
-            if (variableAst == null ||
-                !variableAst.VariablePath.UserPath.Equals("PSBoundParameters", StringComparison.OrdinalIgnoreCase))
+            if (targetAst is not VariableExpressionAst variableAst ||
+    !variableAst.VariablePath.UserPath.Equals("PSBoundParameters", StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -423,7 +423,7 @@ namespace System.Management.Automation
                 return null;
             }
 
-            Ast targetAst = null;
+            ExpressionAst targetAst = null;
 
             // Check for method invocation: $PSBoundParameters.ContainsKey('...') or $PSBoundParameters.Remove('...')
             if (lastAst.Parent is InvokeMemberExpressionAst invokeMemberAst)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -428,8 +428,8 @@ namespace System.Management.Automation
             if (lastAst.Parent is InvokeMemberExpressionAst invokeMemberAst)
             {
                 if (invokeMemberAst.Member is StringConstantExpressionAst memberName &&
-    (memberName.Value.Equals("ContainsKey", StringComparison.OrdinalIgnoreCase) ||
-     memberName.Value.Equals("Remove", StringComparison.OrdinalIgnoreCase)))
+                    (memberName.Value.Equals("ContainsKey", StringComparison.OrdinalIgnoreCase) ||
+                     memberName.Value.Equals("Remove", StringComparison.OrdinalIgnoreCase)))
                 {
                     targetAst = invokeMemberAst.Expression;
                 }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -418,7 +418,7 @@ namespace System.Management.Automation
             var lastAst = completionContext.RelatedAsts.Last();
 
             // Must be a string constant
-            if (!(lastAst is StringConstantExpressionAst stringAst))
+            if (lastAst is not StringConstantExpressionAst stringAst)
             {
                 return null;
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -505,19 +505,17 @@ namespace System.Management.Automation
                 quoteChar = "\"";
             }
 
-            foreach (var parameter in paramBlockAst.Parameters)
-            {
-                var parameterName = parameter.Name.VariablePath.UserPath;
-                if (parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
-                {
-                    var completionText = quoteChar + parameterName + quoteChar;
-                    result.Add(new CompletionResult(
-                        completionText,
-                        parameterName,
-                        CompletionResultType.ParameterValue,
-                        parameterName));
-                }
-            }
+            result.AddRange(
+                paramBlockAst.Parameters
+                    .Select(parameter => parameter.Name.VariablePath.UserPath)
+                    .Where(parameterName => parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
+                    .Select(parameterName =>
+                        new CompletionResult(
+                            quoteChar + parameterName + quoteChar,
+                            parameterName,
+                            CompletionResultType.ParameterValue,
+                            parameterName))
+            );
 
             return result.Count > 0 ? result : null;
         }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -404,18 +404,15 @@ namespace System.Management.Automation
             var result = new List<CompletionResult>();
             var wordToComplete = completionContext.WordToComplete ?? string.Empty;
 
-            foreach (var parameter in paramBlockAst.Parameters)
-            {
-                var parameterName = parameter.Name.VariablePath.UserPath;
-                if (parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
-                {
-                    result.Add(new CompletionResult(
-                        parameterName,
-                        parameterName,
-                        CompletionResultType.ParameterValue,
-                        parameterName));
-                }
-            }
+            result = paramBlockAst.Parameters
+                .Select(parameter => parameter.Name.VariablePath.UserPath)
+                .Where(parameterName => parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
+                .Select(parameterName => new CompletionResult(
+                    parameterName,
+                    parameterName,
+                    CompletionResultType.ParameterValue,
+                    parameterName))
+                .ToList();
 
             return result.Count > 0 ? result : null;
         }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -374,18 +374,7 @@ namespace System.Management.Automation
 
             // Generate completion results from parameter names
             var wordToComplete = completionContext.WordToComplete ?? string.Empty;
-
-            var result = paramBlockAst.Parameters
-                .Select(parameter => parameter.Name.VariablePath.UserPath)
-                .Where(parameterName => parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
-                .Select(parameterName => new CompletionResult(
-                    parameterName,
-                    parameterName,
-                    CompletionResultType.ParameterValue,
-                    parameterName))
-                .ToList();
-
-            return result.Count > 0 ? result : null;
+            return CreateParameterCompletionResults(paramBlockAst, wordToComplete);
         }
 
         /// <summary>
@@ -454,18 +443,7 @@ namespace System.Management.Automation
                 quoteChar = "\"";
             }
 
-            var result = paramBlockAst.Parameters
-                .Select(parameter => parameter.Name.VariablePath.UserPath)
-                .Where(parameterName => parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
-                .Select(parameterName =>
-                    new CompletionResult(
-                        quoteChar + parameterName + quoteChar,
-                        parameterName,
-                        CompletionResultType.ParameterValue,
-                        parameterName))
-                .ToList();
-
-            return result.Count > 0 ? result : null;
+            return CreateParameterCompletionResults(paramBlockAst, wordToComplete, quoteChar);
         }
 
         /// <summary>
@@ -495,6 +473,32 @@ namespace System.Management.Automation
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Creates completion results from parameter names with optional quote wrapping.
+        /// </summary>
+        /// <param name="paramBlockAst">The parameter block containing parameters to complete.</param>
+        /// <param name="wordToComplete">The partial word to match against parameter names.</param>
+        /// <param name="quoteChar">Optional quote character to wrap completion text (empty string for no quotes).</param>
+        /// <returns>A list of completion results, or null if no matches found.</returns>
+        private static List<CompletionResult> CreateParameterCompletionResults(
+            ParamBlockAst paramBlockAst,
+            string wordToComplete,
+            string quoteChar = "")
+        {
+            var result = paramBlockAst.Parameters
+                .Select(parameter => parameter.Name.VariablePath.UserPath)
+                .Where(parameterName => parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
+                .Select(parameterName =>
+                    new CompletionResult(
+                        quoteChar + parameterName + quoteChar,
+                        parameterName,
+                        CompletionResultType.ParameterValue,
+                        parameterName))
+                .ToList();
+
+            return result.Count > 0 ? result : null;
         }
 
         private static bool CompleteOperator(Token tokenAtCursor, Ast lastAst)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -324,18 +324,7 @@ namespace System.Management.Automation
                 }
 
                 // For ErrorStatementAst, the case value is in Bodies, condition is in Conditions
-                bool isInBodies = false;
-                if (errorStatementAst.Bodies != null)
-                {
-                    foreach (var body in errorStatementAst.Bodies)
-                    {
-                        if (body == lastAst)
-                        {
-                            isInBodies = true;
-                            break;
-                        }
-                    }
-                }
+                bool isInBodies = errorStatementAst.Bodies != null && errorStatementAst.Bodies.Any(body => body == lastAst);
 
                 if (!isInBodies)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -291,8 +291,7 @@ namespace System.Management.Automation
             Ast switchAst = null;
 
             // Check if we're in a switch statement (complete) or error statement (incomplete switch)
-            var switchStatementAst = lastAst.Parent as SwitchStatementAst;
-            if (switchStatementAst != null)
+            if (lastAst.Parent is SwitchStatementAst switchStatementAst)
             {
                 // Verify that the lastAst is one of the clause conditions (not in the body)
                 bool isClauseCondition = switchStatementAst.Clauses.Any(clause => clause.Item1 == lastAst);

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -392,10 +392,9 @@ namespace System.Management.Automation
             }
 
             // Generate completion results from parameter names
-            var result = new List<CompletionResult>();
             var wordToComplete = completionContext.WordToComplete ?? string.Empty;
 
-            result = paramBlockAst.Parameters
+            var result = paramBlockAst.Parameters
                 .Select(parameter => parameter.Name.VariablePath.UserPath)
                 .Where(parameterName => parameterName.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
                 .Select(parameterName => new CompletionResult(

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -441,7 +441,7 @@ namespace System.Management.Automation
                 targetAst = indexAst.Target;
             }
 
-            if (targetAst == null)
+            if (targetAst is null)
             {
                 return null;
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -295,15 +295,7 @@ namespace System.Management.Automation
             if (switchStatementAst != null)
             {
                 // Verify that the lastAst is one of the clause conditions (not in the body)
-                bool isClauseCondition = false;
-                foreach (var clause in switchStatementAst.Clauses)
-                {
-                    if (clause.Item1 == lastAst)
-                    {
-                        isClauseCondition = true;
-                        break;
-                    }
-                }
+                bool isClauseCondition = switchStatementAst.Clauses.Any(clause => clause.Item1 == lastAst);
 
                 if (!isClauseCondition)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -286,7 +286,7 @@ namespace System.Management.Automation
         private static List<CompletionResult> CompleteAgainstSwitchCaseCondition(CompletionContext completionContext)
         {
             var lastAst = completionContext.RelatedAsts.Last();
-            
+
             PipelineAst conditionPipeline = null;
             Ast switchAst = null;
 
@@ -317,7 +317,7 @@ namespace System.Management.Automation
             {
                 // Check for incomplete switch parsed as ErrorStatementAst
                 var errorStatementAst = lastAst.Parent as ErrorStatementAst;
-                if (errorStatementAst == null || errorStatementAst.Kind == null || 
+                if (errorStatementAst == null || errorStatementAst.Kind == null ||
                     errorStatementAst.Kind.Kind != TokenKind.Switch)
                 {
                     return null;
@@ -438,7 +438,7 @@ namespace System.Management.Automation
         private static List<CompletionResult> CompleteAgainstPSBoundParametersAccess(CompletionContext completionContext)
         {
             var lastAst = completionContext.RelatedAsts.Last();
-            
+
             // Must be a string constant
             if (!(lastAst is StringConstantExpressionAst stringAst))
             {
@@ -451,7 +451,7 @@ namespace System.Management.Automation
             if (lastAst.Parent is InvokeMemberExpressionAst invokeMemberAst)
             {
                 var memberName = invokeMemberAst.Member as StringConstantExpressionAst;
-                if (memberName != null && 
+                if (memberName != null &&
                     (memberName.Value.Equals("ContainsKey", StringComparison.OrdinalIgnoreCase) ||
                      memberName.Value.Equals("Remove", StringComparison.OrdinalIgnoreCase)))
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -428,10 +428,9 @@ namespace System.Management.Automation
             // Check for method invocation: $PSBoundParameters.ContainsKey('...') or $PSBoundParameters.Remove('...')
             if (lastAst.Parent is InvokeMemberExpressionAst invokeMemberAst)
             {
-                var memberName = invokeMemberAst.Member as StringConstantExpressionAst;
-                if (memberName != null &&
-                    (memberName.Value.Equals("ContainsKey", StringComparison.OrdinalIgnoreCase) ||
-                     memberName.Value.Equals("Remove", StringComparison.OrdinalIgnoreCase)))
+                if (invokeMemberAst.Member is StringConstantExpressionAst memberName &&
+    (memberName.Value.Equals("ContainsKey", StringComparison.OrdinalIgnoreCase) ||
+     memberName.Value.Equals("Remove", StringComparison.OrdinalIgnoreCase)))
                 {
                     targetAst = invokeMemberAst.Expression;
                 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -4012,4 +4012,141 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
         # https://github.com/PowerShell/PowerShell/issues/4744
         # TODO: move to test cases above once working
     }
+
+    Context "Tab completion for switch cases on `$PSBoundParameters.Keys" {
+        It "Should complete parameter names in switch case for `$PSBoundParameters.Keys" {
+            $inputScript = @"
+function Test-Func {
+    param(
+        [string]`$Param1,
+        [string]`$Param2,
+        [int]`$Count
+    )
+    switch (`$PSBoundParameters.Keys) {
+        P
+    }
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("P", $inputScript.IndexOf("Keys)")) + 1
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            $res.CompletionMatches | Should -HaveCount 2
+            $completionTexts = $res.CompletionMatches.CompletionText | Sort-Object
+            $completionTexts[0] | Should -BeExactly "Param1"
+            $completionTexts[1] | Should -BeExactly "Param2"
+        }
+
+        It "Should complete all parameter names when prefix matches single param" {
+            $inputScript = @"
+function Test-Func {
+    param(
+        [string]`$Name,
+        [int]`$Value
+    )
+    switch (`$PSBoundParameters.Keys) {
+        N
+    }
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("N", $inputScript.IndexOf("Keys)")) + 1
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "Name"
+        }
+
+        It "Should complete parameter names in scriptblock param" {
+            $inputScript = @"
+`$sb = {
+    param(
+        [string]`$ScriptParam1,
+        [string]`$ScriptParam2
+    )
+    switch (`$PSBoundParameters.Keys) {
+        S
+    }
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("S", $inputScript.IndexOf("Keys)")) + 1
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            $res.CompletionMatches | Should -HaveCount 2
+            $completionTexts = $res.CompletionMatches.CompletionText | Sort-Object
+            $completionTexts[0] | Should -BeExactly "ScriptParam1"
+            $completionTexts[1] | Should -BeExactly "ScriptParam2"
+        }
+
+    Context "Tab completion for `$PSBoundParameters access patterns" {
+        It "Should complete parameter names for ContainsKey method" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1, [string]`$Param2, [int]`$Count)
+    if (`$PSBoundParameters.ContainsKey('P')) { }
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("'P'") + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            $res.CompletionMatches | Should -HaveCount 2
+            $completionTexts = $res.CompletionMatches.CompletionText | Sort-Object
+            $completionTexts[0] | Should -BeExactly "'Param1'"
+            $completionTexts[1] | Should -BeExactly "'Param2'"
+        }
+
+        It "Should complete parameter names for indexer access" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1, [string]`$Param2, [int]`$Count)
+    `$value = `$PSBoundParameters['P']
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("'P'") + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            $res.CompletionMatches | Should -HaveCount 2
+            $completionTexts = $res.CompletionMatches.CompletionText | Sort-Object
+            $completionTexts[0] | Should -BeExactly "'Param1'"
+            $completionTexts[1] | Should -BeExactly "'Param2'"
+        }
+
+        It "Should complete parameter names for Remove method" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1, [string]`$Param2, [int]`$Count)
+    `$PSBoundParameters.Remove('C')
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("'C'") + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "'Count'"
+        }
+
+        It "Should complete with double quotes when using double-quoted string" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1, [string]`$Param2)
+    if (`$PSBoundParameters.ContainsKey("P")) { }
+}
+"@
+            $cursorPosition = $inputScript.IndexOf('"P"') + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            $res.CompletionMatches | Should -HaveCount 2
+            $completionTexts = $res.CompletionMatches.CompletionText | Sort-Object
+            $completionTexts[0] | Should -BeExactly '"Param1"'
+            $completionTexts[1] | Should -BeExactly '"Param2"'
+        }
+
+        It "Should not complete for non-PSBoundParameters variable" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1)
+    `$hash = @{}
+    `$value = `$hash['P']
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("'P'") + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            # Should not return Param1 as completion
+            $paramCompletion = $res.CompletionMatches | Where-Object { $_.CompletionText -eq "'Param1'" }
+            $paramCompletion | Should -BeNullOrEmpty
+        }
+    }
+    }
+
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -4133,7 +4133,7 @@ function Test-Func {
             $completionTexts[1] | Should -BeExactly '"Param2"'
         }
 
-        It "Should not complete for non-PSBoundParameters variable" {
+        It "Should not complete for non-PSBoundParameters variable with indexer" {
             $inputScript = @"
 function Test-Func {
     param([string]`$Param1)
@@ -4145,6 +4145,51 @@ function Test-Func {
             $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
             # Should not return Param1 as completion
             $paramCompletion = $res.CompletionMatches | Where-Object { $_.CompletionText -eq "'Param1'" }
+            $paramCompletion | Should -BeNullOrEmpty
+        }
+
+        It "Should not complete for non-PSBoundParameters variable with ContainsKey" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1)
+    `$hash = @{}
+    if (`$hash.ContainsKey('P')) { }
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("'P'") + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            # Should not return Param1 as completion
+            $paramCompletion = $res.CompletionMatches | Where-Object { $_.CompletionText -eq "'Param1'" }
+            $paramCompletion | Should -BeNullOrEmpty
+        }
+
+        It "Should not complete for non-PSBoundParameters variable with Remove" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1)
+    `$hash = @{}
+    `$hash.Remove('P')
+}
+"@
+            $cursorPosition = $inputScript.IndexOf("'P'") + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            # Should not return Param1 as completion
+            $paramCompletion = $res.CompletionMatches | Where-Object { $_.CompletionText -eq "'Param1'" }
+            $paramCompletion | Should -BeNullOrEmpty
+        }
+
+        It "Should not complete for non-PSBoundParameters variable with double quotes" {
+            $inputScript = @"
+function Test-Func {
+    param([string]`$Param1)
+    `$hash = @{}
+    if (`$hash.ContainsKey("P")) { }
+}
+"@
+            $cursorPosition = $inputScript.IndexOf('"P"') + 2
+            $res = TabExpansion2 -inputScript $inputScript -cursorColumn $cursorPosition
+            # Should not return Param1 as completion
+            $paramCompletion = $res.CompletionMatches | Where-Object { $_.CompletionText -eq '"Param1"' }
             $paramCompletion | Should -BeNullOrEmpty
         }
     }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -4072,6 +4072,7 @@ function Test-Func {
             $completionTexts[0] | Should -BeExactly "ScriptParam1"
             $completionTexts[1] | Should -BeExactly "ScriptParam2"
         }
+    }
 
     Context "Tab completion for `$PSBoundParameters access patterns" {
         It "Should complete parameter names for ContainsKey method" {
@@ -4147,6 +4148,4 @@ function Test-Func {
             $paramCompletion | Should -BeNullOrEmpty
         }
     }
-    }
-
 }


### PR DESCRIPTION
## PR Summary

Add tab completion for parameter names when working with `$PSBoundParameters` in various access patterns.

## PR Context

Fixes #25349

When writing functions that use `$PSBoundParameters` to check which parameters were bound, it's easy to make typos in parameter names. This PR adds tab completion support to help prevent such errors.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress)
- [x] [Added a change log entry](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#change-log)
- [x] [Appropriate test coverage added](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

## Description

This PR adds tab completion for parameter names in the following `$PSBoundParameters` access patterns:

### Supported Patterns

1. **Switch statement on Keys**
   ```powershell
   switch ($PSBoundParameters.Keys) {
       Para<Tab>  # Completes to Param1, Param2, etc.
   }
   ```

2. **ContainsKey method**
   ```powershell
   if ($PSBoundParameters.ContainsKey('<Tab>')) { }  # Completes to 'Param1', 'Param2', etc.
   ```

3. **Indexer access**
   ```powershell
   $value = $PSBoundParameters['<Tab>']  # Completes to 'Param1', 'Param2', etc.
   ```

4. **Remove method**
   ```powershell
   $PSBoundParameters.Remove('<Tab>')  # Completes to 'Param1', 'Param2', etc.
   ```

### Implementation Details

- Added `CompleteAgainstSwitchCaseCondition` method for switch case completion
- Added `CompleteAgainstPSBoundParametersAccess` method for ContainsKey, indexer, and Remove patterns
- Quote style is preserved (single or double quotes) in the completion text
- Switch case completions use bare words (no quotes) as is standard for switch cases

### Files Changed

- `src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs` - Added completion logic
- `test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1` - Added 8 test cases

## Testing

### Manual Testing

```powershell
function Test-Func {
    param(
        [string]$Param1,
        [string]$Param2,
        [int]$Count
    )
    
    # Test 1: Switch case - type 'P' then Tab
    switch ($PSBoundParameters.Keys) {
        P<Tab>  # Should complete to Param1, Param2
    }
    
    # Test 2: ContainsKey - type 'P' then Tab
    if ($PSBoundParameters.ContainsKey('P<Tab>')) { }  # Should complete to 'Param1', 'Param2'
    
    # Test 3: Indexer - type 'P' then Tab
    $value = $PSBoundParameters['P<Tab>']  # Should complete to 'Param1', 'Param2'
    
    # Test 4: Remove - type 'C' then Tab
    $PSBoundParameters.Remove('C<Tab>')  # Should complete to 'Count'
}
```

### Automated Tests

8 new test cases added covering:
- Switch case completion
- ContainsKey method completion
- Indexer access completion
- Remove method completion
- Double quote preservation
- Non-PSBoundParameters variables (negative test)
