### PR TITLE
Correct handling of explicit -[Operator]:$false parameter values in Where-Object

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1441,8 +1441,11 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ieq;
-                _forceBooleanEvaluation = false;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ieq;
+                    _forceBooleanEvaluation = false;
+                }
             }
         }
 
@@ -1459,7 +1462,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ceq;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ceq;
+                }
             }
         }
 
@@ -1477,7 +1483,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ine;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ine;
+                }
             }
         }
 
@@ -1494,7 +1503,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cne;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cne;
+                }
             }
         }
 
@@ -1512,7 +1524,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Igt;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Igt;
+                }
             }
         }
 
@@ -1529,7 +1544,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cgt;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cgt;
+                }
             }
         }
 
@@ -1547,7 +1565,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ilt;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ilt;
+                }
             }
         }
 
@@ -1564,7 +1585,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Clt;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Clt;
+                }
             }
         }
 
@@ -1582,7 +1606,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ige;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ige;
+                }
             }
         }
 
@@ -1599,7 +1626,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cge;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cge;
+                }
             }
         }
 
@@ -1617,7 +1647,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ile;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ile;
+                }
             }
         }
 
@@ -1634,7 +1667,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cle;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cle;
+                }
             }
         }
 
@@ -1652,7 +1688,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ilike;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ilike;
+                }
             }
         }
 
@@ -1669,7 +1708,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Clike;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Clike;
+                }
             }
         }
 
@@ -1687,7 +1729,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Inotlike;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Inotlike;
+                }
             }
         }
 
@@ -1704,7 +1749,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cnotlike;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cnotlike;
+                }
             }
         }
 
@@ -1722,7 +1770,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Imatch;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Imatch;
+                }
             }
         }
 
@@ -1739,7 +1790,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cmatch;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cmatch;
+                }
             }
         }
 
@@ -1757,7 +1811,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Inotmatch;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Inotmatch;
+                }
             }
         }
 
@@ -1774,7 +1831,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cnotmatch;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cnotmatch;
+                }
             }
         }
 
@@ -1792,7 +1852,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Icontains;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Icontains;
+                }
             }
         }
 
@@ -1809,7 +1872,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Ccontains;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Ccontains;
+                }
             }
         }
 
@@ -1827,7 +1893,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Inotcontains;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Inotcontains;
+                }
             }
         }
 
@@ -1844,7 +1913,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cnotcontains;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cnotcontains;
+                }
             }
         }
 
@@ -1862,7 +1934,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.In;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.In;
+                }
             }
         }
 
@@ -1879,7 +1954,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cin;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cin;
+                }
             }
         }
 
@@ -1897,7 +1975,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Inotin;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Inotin;
+                }
             }
         }
 
@@ -1914,7 +1995,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Cnotin;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Cnotin;
+                }
             }
         }
 
@@ -1931,7 +2015,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Is;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Is;
+                }
             }
         }
 
@@ -1948,7 +2035,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.IsNot;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.IsNot;
+                }
             }
         }
 
@@ -1965,7 +2055,10 @@ namespace Microsoft.PowerShell.Commands
 
             set
             {
-                _binaryOperator = TokenKind.Not;
+                if (value)
+                {
+                    _binaryOperator = TokenKind.Not;
+                }
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -143,7 +143,7 @@ Describe "Where-Object" -Tags "CI" {
         $Result[1] | Should -Be $dynObj
     }
 
-    Context "Switch parameter explicit $false handling" {
+    Context "Switch parameter explicit `$false handling" {
         BeforeAll {
             $testData = @(
                 [PSCustomObject]@{ Name = 'Alice'; Age = 25; City = 'New York' }
@@ -153,76 +153,130 @@ Describe "Where-Object" -Tags "CI" {
         }
 
         It "-EQ:`$false should behave like default boolean evaluation" {
-            # With -EQ:False, the parameter is not specified, so default boolean evaluation applies
+            # With -EQ:$false, the parameter is not specified, so default boolean evaluation applies
             # "... | Where-Object Name" is equivalent to "... | Where-Object {$true -eq $_.Name}"
             # Non-empty strings are truthy
             $result = $testData | Where-Object Name -EQ:$false
             $result | Should -HaveCount 3
         }
 
-        It "-GT:$false should behave like default boolean evaluation" {
-            # With -GT:False, the parameter is not specified, so default boolean evaluation applies
+        It "-GT:`$false should behave like default boolean evaluation" {
+            # With -GT:$false, the parameter is not specified, so default boolean evaluation applies
             $result = $testData | Where-Object Age -GT:$false
             $result | Should -HaveCount 3
         }
 
-        It "-Like:$false should behave like default boolean evaluation" {
-            # With -Like:False, the parameter is not specified, so default boolean evaluation applies
+        It "-LT:`$false should behave like default boolean evaluation" {
+            # With -LT:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -LT:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-NE:`$false should behave like default boolean evaluation" {
+            # With -NE:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -NE:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-GE:`$false should behave like default boolean evaluation" {
+            # With -GE:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -GE:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-LE:`$false should behave like default boolean evaluation" {
+            # With -LE:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -LE:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-NotLike:`$false should behave like default boolean evaluation" {
+            # With -NotLike:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object City -NotLike:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-NotMatch:`$false should behave like default boolean evaluation" {
+            # With -NotMatch:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -NotMatch:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-NotContains:`$false should behave like default boolean evaluation" {
+            # With -NotContains:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -NotContains:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-NotIn:`$false should behave like default boolean evaluation" {
+            # With -NotIn:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -NotIn:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-IsNot:`$false should behave like default boolean evaluation" {
+            # With -IsNot:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -IsNot:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-Like:`$false should behave like default boolean evaluation" {
+            # With -Like:$false, the parameter is not specified, so default boolean evaluation applies
             $result = $testData | Where-Object City -Like:$false
             $result | Should -HaveCount 3
         }
 
-        It "-Match:$false should behave like default boolean evaluation" {
-            # With -Match:False, the parameter is not specified, so default boolean evaluation applies
+        It "-Match:`$false should behave like default boolean evaluation" {
+            # With -Match:$false, the parameter is not specified, so default boolean evaluation applies
             $result = $testData | Where-Object Name -Match:$false
             $result | Should -HaveCount 3
         }
 
-        It "-Contains:$false should behave like default boolean evaluation" {
-            # With -Contains:False, the parameter is not specified, so default boolean evaluation applies
+        It "-Contains:`$false should behave like default boolean evaluation" {
+            # With -Contains:$false, the parameter is not specified, so default boolean evaluation applies
             # "... | Where-Object Name" checks if Name property is truthy
             $result = $testData | Where-Object Name -Contains:$false
             $result | Should -HaveCount 3
         }
 
-        It "-In:$false should behave like default boolean evaluation" {
-            # With -In:False, the parameter is not specified, so default boolean evaluation applies
+        It "-In:`$false should behave like default boolean evaluation" {
+            # With -In:$false, the parameter is not specified, so default boolean evaluation applies
             # "... | Where-Object Name" checks if Name property is truthy
             $result = $testData | Where-Object Name -In:$false
             $result | Should -HaveCount 3
         }
 
-        It "-Is:$false should behave like default boolean evaluation" {
-            # With -Is:False, the parameter is not specified, so default boolean evaluation applies
+        It "-Is:`$false should behave like default boolean evaluation" {
+            # With -Is:$false, the parameter is not specified, so default boolean evaluation applies
             # "... | Where-Object Name" checks if Name property is truthy
             $result = $testData | Where-Object Name -Is:$false
             $result | Should -HaveCount 3
         }
 
-        It "-Not:$false should behave like default boolean evaluation" {
+        It "-Not:`$false should behave like default boolean evaluation" {
             $testData2 = @(
                 [PSCustomObject]@{ Name = ''; Value = 1 }
                 [PSCustomObject]@{ Name = 'Test'; Value = 2 }
             )
-            # With -Not:False, the parameter is not specified, so default boolean evaluation applies
+            # With -Not:$false, the parameter is not specified, so default boolean evaluation applies
             # "... | Where-Object Name" returns objects where Name is truthy (non-empty)
             $result = $testData2 | Where-Object Name -Not:$false
             $result | Should -HaveCount 1
             $result.Name | Should -Be 'Test'
         }
 
-        It "-GT:$false with -Value should throw an error requiring an operator" {
+        It "-GT:`$false with -Value should throw an error requiring an operator" {
             # When a switch parameter is set to $false with -Value specified,
             # it should throw an error because no valid operator is active
             { $testData | Where-Object Age -GT:$false -Value 25 } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
         }
 
-        It "-EQ:$false with -Value should throw an error requiring an operator" {
+        It "-EQ:`$false with -Value should throw an error requiring an operator" {
             # Similar behavior for -EQ:$false with -Value
             { $testData | Where-Object Name -EQ:$false -Value 'Alice' } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
         }
 
-        It "-Like:$false with -Value should throw an error requiring an operator" {
+        It "-Like:`$false with -Value should throw an error requiring an operator" {
             # Similar behavior for -Like:$false with -Value
             { $testData | Where-Object Name -Like:$false -Value 'A*' } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -280,5 +280,104 @@ Describe "Where-Object" -Tags "CI" {
             # Similar behavior for -Like:$false with -Value
             { $testData | Where-Object Name -Like:$false -Value 'A*' } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
         }
+
+        It "-CEQ:`$false should behave like default boolean evaluation" {
+            # With -CEQ:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CEQ:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CNE:`$false should behave like default boolean evaluation" {
+            # With -CNE:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CNE:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CGT:`$false should behave like default boolean evaluation" {
+            # With -CGT:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -CGT:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CLT:`$false should behave like default boolean evaluation" {
+            # With -CLT:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -CLT:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CGE:`$false should behave like default boolean evaluation" {
+            # With -CGE:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -CGE:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CLE:`$false should behave like default boolean evaluation" {
+            # With -CLE:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -CLE:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CLike:`$false should behave like default boolean evaluation" {
+            # With -CLike:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object City -CLike:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CNotLike:`$false should behave like default boolean evaluation" {
+            # With -CNotLike:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object City -CNotLike:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CMatch:`$false should behave like default boolean evaluation" {
+            # With -CMatch:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CMatch:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CNotMatch:`$false should behave like default boolean evaluation" {
+            # With -CNotMatch:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CNotMatch:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CContains:`$false should behave like default boolean evaluation" {
+            # With -CContains:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CContains:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CNotContains:`$false should behave like default boolean evaluation" {
+            # With -CNotContains:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CNotContains:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CIn:`$false should behave like default boolean evaluation" {
+            # With -CIn:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CIn:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CNotIn:`$false should behave like default boolean evaluation" {
+            # With -CNotIn:$false, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -CNotIn:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-CEQ:`$false with -Value should throw an error requiring an operator" {
+            # Similar behavior for -CEQ:$false with -Value
+            { $testData | Where-Object Name -CEQ:$false -Value 'Alice' } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
+        }
+
+        It "-CGT:`$false with -Value should throw an error requiring an operator" {
+            # Similar behavior for -CGT:$false with -Value
+            { $testData | Where-Object Age -CGT:$false -Value 25 } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
+        }
+
+        It "-CLike:`$false with -Value should throw an error requiring an operator" {
+            # Similar behavior for -CLike:$false with -Value
+            { $testData | Where-Object Name -CLike:$false -Value 'A*' } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -142,4 +142,89 @@ Describe "Where-Object" -Tags "CI" {
         $Result[0] | Should -Be $dynObj
         $Result[1] | Should -Be $dynObj
     }
+
+    Context "Switch parameter explicit $false handling" {
+        BeforeAll {
+            $testData = @(
+                [PSCustomObject]@{ Name = 'Alice'; Age = 25; City = 'New York' }
+                [PSCustomObject]@{ Name = 'Bob'; Age = 30; City = 'Boston' }
+                [PSCustomObject]@{ Name = 'Charlie'; Age = 35; City = 'Chicago' }
+            )
+        }
+
+        It "-EQ:$false should behave like default boolean evaluation" {
+            # With -EQ:False, the parameter is not specified, so default boolean evaluation applies
+            # "... | Where-Object Name" is equivalent to "... | Where-Object {$true -eq $_.Name}"
+            # Non-empty strings are truthy
+            $result = $testData | Where-Object Name -EQ:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-GT:$false should behave like default boolean evaluation" {
+            # With -GT:False, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Age -GT:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-Like:$false should behave like default boolean evaluation" {
+            # With -Like:False, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object City -Like:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-Match:$false should behave like default boolean evaluation" {
+            # With -Match:False, the parameter is not specified, so default boolean evaluation applies
+            $result = $testData | Where-Object Name -Match:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-Contains:$false should behave like default boolean evaluation" {
+            # With -Contains:False, the parameter is not specified, so default boolean evaluation applies
+            # "... | Where-Object Name" checks if Name property is truthy
+            $result = $testData | Where-Object Name -Contains:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-In:$false should behave like default boolean evaluation" {
+            # With -In:False, the parameter is not specified, so default boolean evaluation applies
+            # "... | Where-Object Name" checks if Name property is truthy
+            $result = $testData | Where-Object Name -In:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-Is:$false should behave like default boolean evaluation" {
+            # With -Is:False, the parameter is not specified, so default boolean evaluation applies
+            # "... | Where-Object Name" checks if Name property is truthy
+            $result = $testData | Where-Object Name -Is:$false
+            $result | Should -HaveCount 3
+        }
+
+        It "-Not:$false should behave like default boolean evaluation" {
+            $testData2 = @(
+                [PSCustomObject]@{ Name = ''; Value = 1 }
+                [PSCustomObject]@{ Name = 'Test'; Value = 2 }
+            )
+            # With -Not:False, the parameter is not specified, so default boolean evaluation applies
+            # "... | Where-Object Name" returns objects where Name is truthy (non-empty)
+            $result = $testData2 | Where-Object Name -Not:$false
+            $result | Should -HaveCount 1
+            $result.Name | Should -Be 'Test'
+        }
+
+        It "-GT:$false with -Value should throw an error requiring an operator" {
+            # When a switch parameter is set to $false with -Value specified,
+            # it should throw an error because no valid operator is active
+            { $testData | Where-Object Age -GT:$false -Value 25 } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
+        }
+
+        It "-EQ:$false with -Value should throw an error requiring an operator" {
+            # Similar behavior for -EQ:$false with -Value
+            { $testData | Where-Object Name -EQ:$false -Value 'Alice' } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
+        }
+
+        It "-Like:$false with -Value should throw an error requiring an operator" {
+            # Similar behavior for -Like:$false with -Value
+            { $testData | Where-Object Name -Like:$false -Value 'A*' } | Should -Throw -ErrorId 'OperatorNotSpecified,Microsoft.PowerShell.Commands.WhereObjectCommand'
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -152,7 +152,7 @@ Describe "Where-Object" -Tags "CI" {
             )
         }
 
-        It "-EQ:$false should behave like default boolean evaluation" {
+        It "-EQ:`$false should behave like default boolean evaluation" {
             # With -EQ:False, the parameter is not specified, so default boolean evaluation applies
             # "... | Where-Object Name" is equivalent to "... | Where-Object {$true -eq $_.Name}"
             # Non-empty strings are truthy


### PR DESCRIPTION
## PR Summary

Fix #26480
Fix incorrect behavior when switch parameters (comparison operators) are explicitly set to `$false` in `Where-Object`.

## Breaking Change

This PR contains a breaking change categorized as **Bucket 3: Unlikely Grey Area** (ref: [breaking-change-contract.md#bucket-3](https://github.com/PowerShell/PowerShell/blob/master/docs/dev-process/breaking-change-contract.md#bucket-3-unlikely-grey-area)).

**Previous behavior:** When operator parameters (e.g., `-Not`, `-EQ`) were explicitly set to `:$false`, the cmdlet would still attempt to use that operator, leading to incorrect results.

**New behavior:** When operator parameters are explicitly set to `:$false`, the cmdlet correctly falls back to default boolean property evaluation (as if no operator was specified).

**Rationale:** This corrects behavior in a subtle corner case that has no obvious utility. The previous behavior was unintuitive and likely not depended upon by existing scripts.

## PR Context

When using `Where-Object` with explicit `:$false` on operator parameters (e.g., `-Not:$false`, `-EQ:$false`), the cmdlet should fall back to default boolean property evaluation instead of using the specified operator.

### Before this fix:
```powershell
@([pscustomobject]@{Prop=$true}, [pscustomobject]@{Prop=$false}) | Where-Object -Not:$false Prop
# Returns: Prop=$false (incorrectly applies -Not operator despite :$false)
```

### After this fix:
```powershell
@([pscustomobject]@{Prop=$true}, [pscustomobject]@{Prop=$false}) | Where-Object -Not:$false Prop
# Returns: Prop=$true (correctly falls back to boolean evaluation)

# Using operator with :$false and -Value should throw error (no operator to use)
1..5 | Where-Object -GT:$false -Property { $_ } -Value 3
# Error: An operator is required...
```

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] New and old tests pass locally