### PR TITLE
[release/v7.6] Fix a regression in the API `CompletionCompleters.CompleteFilename()` that causes null reference exception

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4580,8 +4580,8 @@ namespace System.Management.Automation
                     return CommandCompletion.EmptyCompletionResult;
                 }
 
-                var lastAst = context.RelatedAsts[^1];
-                if (lastAst.Parent is UsingStatementAst usingStatement
+                var lastAst = context.RelatedAsts?[^1];
+                if (lastAst?.Parent is UsingStatementAst usingStatement
                     && usingStatement.UsingStatementKind is UsingStatementKind.Module or UsingStatementKind.Assembly
                     && lastAst.Extent.File is not null)
                 {

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -126,4 +126,27 @@ Describe "Tab completion bug fix" -Tags "CI" {
             $Runspace.Dispose()
         }
     }
+
+    It "Issue#26277 - [CompletionCompleters]::CompleteFilename('') should work" {
+        $testDir = Join-Path $TestDrive "TempTestDir"
+        $file1 = Join-Path $testDir "abc.ps1"
+        $file2 = Join-Path $testDir "def.py"
+
+        New-Item -ItemType Directory -Path $testDir > $null
+        New-Item -ItemType File -Path $file1 > $null
+        New-Item -ItemType File -Path $file2 > $null
+
+        try {
+            Push-Location -Path $testDir
+            $result = [System.Management.Automation.CompletionCompleters]::CompleteFilename("")
+            $result | Should -Not -Be $null
+            $result | Measure-Object | ForEach-Object -MemberName Count | Should -Be 2
+
+            $item1, $item2 = @($result)
+            $item1.ListItemText | Should -BeExactly 'abc.ps1'
+            $item2.ListItemText | Should -BeExactly 'def.py'
+        } finally {
+            Pop-Location
+        }
+    }
 }


### PR DESCRIPTION
Backport of #26291 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26291$$$
-->

Triggered by @TravisEz13 on behalf of @daxian-dbw

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [x] Customer reported
- [ ] Found internally

Fixes #26277. Customers using the CompletionCompleters.CompleteFilename() API directly encounter NullReferenceException because the RelatedAsts value is null when calling this method directly. This is a regression affecting users who consume this public API programmatically.

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

Regression was introduced when the API started expecting RelatedAsts to be non-null, but this parameter is null when the API is called directly (not through tab completion pipeline).

## Testing

Original PR added unit test in test/powershell/Host/TabCompletion/BugFix.Tests.ps1 that verifies the API handles null RelatedAsts value correctly. Backport verified by running the added test on release/v7.6 branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk. This is a targeted fix for a specific regression in the public API CompletionCompleters.CompleteFilename(). The fix adds a null check for the RelatedAsts parameter which was causing NullReferenceException when the API was called directly. The change is minimal (2 lines), well-tested, and only affects the error handling path of this specific API method.
