### PR TITLE
Close pipe client handles after creating the child ssh process

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1613,17 +1613,6 @@ namespace System.Management.Automation
 
             return defaultValue;
         }
-
-        internal static void SafeDispose(IDisposable disposable)
-        {
-            if (disposable is { })
-            {
-                lock (disposable)
-                {
-                    disposable.Dispose();
-                }
-            }
-        }
     }
 }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1613,6 +1613,17 @@ namespace System.Management.Automation
 
             return defaultValue;
         }
+
+        internal static void SafeDispose(IDisposable disposable)
+        {
+            if (disposable is { })
+            {
+                lock (disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+        }
     }
 }
 

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2707,9 +2707,9 @@ namespace System.Management.Automation.Runspaces
             {
                 try
                 {
-                    Utils.SafeDispose(stdInWriterVar);
-                    Utils.SafeDispose(stdOutReaderVar);
-                    Utils.SafeDispose(stdErrReaderVar);
+                    stdInWriterVar.Dispose();
+                    stdOutReaderVar.Dispose();
+                    stdErrReaderVar.Dispose();
                 }
                 catch (Exception)
                 {

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2211,11 +2211,11 @@ namespace System.Management.Automation.Runspaces
                     CommandTypes.Application,
                     SearchResolutionOptions.None,
                     CommandOrigin.Internal,
-                    context) as ApplicationInfo;
+                    context);
 
-                if (cmdInfo != null)
+                if (cmdInfo is ApplicationInfo appInfo)
                 {
-                    filePath = cmdInfo.Path;
+                    filePath = appInfo.Path;
                 }
             }
             else
@@ -2273,13 +2273,13 @@ namespace System.Management.Automation.Runspaces
             //     Subsystem powershell /usr/local/bin/pwsh -SSHServerMode -NoLogo -NoProfile
 
             // codeql[cs/microsoft/command-line-injection-shell-execution] - This is expected Poweshell behavior where user inputted paths are supported for the context of this method. The user assumes trust for the file path specified, so any file executed in the runspace would be in the user's local system/process or a system they have access to in which case restricted remoting security guidelines should be used.
-            System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo(filePath);
+            ProcessStartInfo startInfo = new(filePath);
 
             // pass "-i identity_file" command line argument to ssh if KeyFilePath is set
             // if KeyFilePath is not set, then ssh will use IdentityFile / IdentityAgent from ssh_config if defined else none by default
             if (!string.IsNullOrEmpty(this.KeyFilePath))
             {
-                if (!System.IO.File.Exists(this.KeyFilePath))
+                if (!File.Exists(this.KeyFilePath))
                 {
                     throw new FileNotFoundException(
                         StringUtil.Format(RemotingErrorIdStrings.KeyFileNotFound, this.KeyFilePath));
@@ -2326,7 +2326,7 @@ namespace System.Management.Automation.Runspaces
             // note that ssh expects IPv6 addresses to not be enclosed in square brackets so trim them if present
             startInfo.ArgumentList.Add(string.Create(CultureInfo.InvariantCulture, $@"-s {this.ComputerName.TrimStart('[').TrimEnd(']')} {this.Subsystem}"));
 
-            startInfo.WorkingDirectory = System.IO.Path.GetDirectoryName(filePath);
+            startInfo.WorkingDirectory = Path.GetDirectoryName(filePath);
             startInfo.CreateNoWindow = true;
             startInfo.UseShellExecute = false;
 
@@ -2580,7 +2580,7 @@ namespace System.Management.Automation.Runspaces
             // Allocate the unmanaged array to hold each string pointer.
             // It needs to have an extra element to null terminate the array.
             arrPtr = (byte**)Marshal.AllocHGlobal(sizeof(IntPtr) * arrLength);
-            System.Diagnostics.Debug.Assert(arrPtr != null, "Invalid array ptr");
+            Debug.Assert(arrPtr != null, "Invalid array ptr");
 
             // Zero the memory so that if any of the individual string allocations fails,
             // we can loop through the array to free any that succeeded.
@@ -2597,7 +2597,7 @@ namespace System.Management.Automation.Runspaces
                 byte[] byteArr = System.Text.Encoding.UTF8.GetBytes(arr[i]);
 
                 arrPtr[i] = (byte*)Marshal.AllocHGlobal(byteArr.Length + 1); // +1 for null termination
-                System.Diagnostics.Debug.Assert(arrPtr[i] != null, "Invalid array ptr");
+                Debug.Assert(arrPtr[i] != null, "Invalid array ptr");
 
                 Marshal.Copy(byteArr, 0, (IntPtr)arrPtr[i], byteArr.Length); // copy over the data from the managed byte array
                 arrPtr[i][byteArr.Length] = (byte)'\0'; // null terminate
@@ -2641,13 +2641,13 @@ namespace System.Management.Automation.Runspaces
         /// P-Invoking native APIs.
         /// </summary>
         private static int StartSSHProcessImpl(
-            System.Diagnostics.ProcessStartInfo startInfo,
-            out StreamWriter stdInWriterVar,
-            out StreamReader stdOutReaderVar,
-            out StreamReader stdErrReaderVar)
+            ProcessStartInfo startInfo,
+            out StreamWriter stdInWriter,
+            out StreamReader stdOutReader,
+            out StreamReader stdErrReader)
         {
             Exception ex = null;
-            System.Diagnostics.Process sshProcess = null;
+            Process sshProcess = null;
             //
             // These std pipe handles are bound to managed Reader/Writer objects and returned to the transport
             // manager object, which uses them for PSRP communication.  The lifetime of these handles are then
@@ -2668,7 +2668,7 @@ namespace System.Management.Automation.Runspaces
             catch (InvalidOperationException e) { ex = e; }
             catch (ArgumentException e) { ex = e; }
             catch (FileNotFoundException e) { ex = e; }
-            catch (System.ComponentModel.Win32Exception e) { ex = e; }
+            catch (Win32Exception e) { ex = e; }
 
             if ((ex != null) ||
                 (sshProcess == null) ||
@@ -2680,9 +2680,9 @@ namespace System.Management.Automation.Runspaces
             }
 
             // Create the std in writer/readers needed for communication with ssh.exe.
-            stdInWriterVar = null;
-            stdOutReaderVar = null;
-            stdErrReaderVar = null;
+            StreamWriter stdInWriterVar = null;
+            StreamReader stdOutReaderVar = null;
+            StreamReader stdErrReaderVar = null;
             try
             {
                 stdInWriterVar = new StreamWriter(new NamedPipeServerStream(PipeDirection.Out, true, true, stdInPipeServer));
@@ -2693,19 +2693,40 @@ namespace System.Management.Automation.Runspaces
             {
                 if (stdInWriterVar != null) { stdInWriterVar.Dispose(); } else { stdInPipeServer.Dispose(); }
 
-                if (stdOutReaderVar != null) { stdInWriterVar.Dispose(); } else { stdOutPipeServer.Dispose(); }
+                if (stdOutReaderVar != null) { stdOutReaderVar.Dispose(); } else { stdOutPipeServer.Dispose(); }
 
-                if (stdErrReaderVar != null) { stdInWriterVar.Dispose(); } else { stdErrPipeServer.Dispose(); }
+                if (stdErrReaderVar != null) { stdErrReaderVar.Dispose(); } else { stdErrPipeServer.Dispose(); }
 
                 throw;
             }
+
+            // On Windows, the ssh process may exit upon error but leave the pipes open, which could result in a hang.
+            // So, we close the pipe handles when the ssh process exits to avoid this situation.
+            sshProcess.EnableRaisingEvents = true;
+            sshProcess.Exited += (sender, args) =>
+            {
+                try
+                {
+                    Utils.SafeDispose(stdInWriterVar);
+                    Utils.SafeDispose(stdOutReaderVar);
+                    Utils.SafeDispose(stdErrReaderVar);
+                }
+                catch
+                {
+                    // Ignore all exceptions in the event handler.
+                }
+            };
+
+            stdInWriter = stdInWriterVar;
+            stdOutReader = stdOutReaderVar;
+            stdErrReader = stdErrReaderVar;
 
             return sshProcess.Id;
         }
 
         private static void KillSSHProcessImpl(int pid)
         {
-            using (var sshProcess = System.Diagnostics.Process.GetProcessById(pid))
+            using (var sshProcess = Process.GetProcessById(pid))
             {
                 if ((sshProcess != null) && (sshProcess.Handle != IntPtr.Zero) && !sshProcess.HasExited)
                 {
@@ -2736,7 +2757,7 @@ namespace System.Management.Automation.Runspaces
             SafeFileHandle stdInPipeClient = null;
             SafeFileHandle stdOutPipeClient = null;
             SafeFileHandle stdErrPipeClient = null;
-            string randomName = System.IO.Path.GetFileNameWithoutExtension(System.IO.Path.GetRandomFileName());
+            string randomName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
 
             try
             {

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2836,10 +2836,8 @@ namespace System.Management.Automation.Runspaces
             }
             finally
             {
+                lpStartupInfo.Dispose();
                 lpProcessInformation.Dispose();
-                stdInPipeClient?.Dispose();
-                stdOutPipeClient?.Dispose();
-                stdErrPipeClient?.Dispose();
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2711,9 +2711,9 @@ namespace System.Management.Automation.Runspaces
                     Utils.SafeDispose(stdOutReaderVar);
                     Utils.SafeDispose(stdErrReaderVar);
                 }
-                catch
+                catch (Exception)
                 {
-                    // Ignore all exceptions in the event handler.
+                    // Ignore all non-critical exceptions in the event handler.
                 }
             };
 

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1781,17 +1781,14 @@ namespace System.Management.Automation.Remoting.Client
             var connectionTimer = Interlocked.Exchange(ref _connectionTimer, null);
             connectionTimer?.Dispose();
 
-            // On Windows, the stdIn, stdOut, stdErr writer/readers are also disposed in the 'Exited' event of the ssh process.
-            // In that case, the 'Dispose' method could be called in parallel on them, which might result in a race condition.
-            // So, we handle their disposal here in a thread-safe manner.
             var stdInWriter = Interlocked.Exchange(ref _stdInWriter, null);
-            Utils.SafeDispose(stdInWriter);
+            stdInWriter?.Dispose();
 
             var stdOutReader = Interlocked.Exchange(ref _stdOutReader, null);
-            Utils.SafeDispose(stdOutReader);
+            stdOutReader?.Dispose();
 
             var stdErrReader = Interlocked.Exchange(ref _stdErrReader, null);
-            Utils.SafeDispose(stdErrReader);
+            stdErrReader?.Dispose();
 
             // The CloseConnection() method can be called multiple times from multiple places.
             // Set the _sshProcessId to zero here so that we go through the work of finding

--- a/test/powershell/engine/Remoting/SSHRemotingCmdlets.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingCmdlets.Tests.ps1
@@ -71,7 +71,7 @@ Describe "SSHConnection parameter hashtable type conversions" -Tags 'Feature', '
     }
 }
 
-Describe "No hangs when host doesn't exist" -Tag "CI" {
+Describe "No hangs when host doesn't exist" -Tags "CI" {
     $testCases = @(
         @{
             Name = 'Verifies no hang for New-PSSession with non-existing host name'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #25203
Fix https://github.com/PowerShell/PowerShell/issues/26228

**Symptom**

Running the following commands on Windows will hang indefinitely today.

- `Invoke-Command -HostName "test" -UserName "test" -ScriptBlock { 1 }`
- `New-PSSession -HostName "test" -UserName "test"`

The reported hang happens on Windows only. On Linux and macOS, both commands return to the prompt with an error written out.

**Root Cause**

What happens on Windows is -- the `ssh.exe` process already exited, but the `stdin` writer and `stdout/stderr` readers were not closed as expected. That led to the hang, as both the output and error reader threads were still blocked on the `reader.ReadLine` call.

This is because when creating the `ssh.exe` using the Win32 function `CreateProcess`, we don't close the client handles of the pipes (_`stdInPipeClient`, `stdOutPipeClient`, and `stdErrPipeClient`_) after they get inherited by the child process ([see code](https://github.com/PowerShell/PowerShell/blob/6928efb4c5224805c9d6f9fef5a20e26a20fd89c/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs#L2776-L2843)).

When inherited by a child process, the parent side of those handles remain valid and unchanged. Windows duplicates that handle into the child process's handle table.

- The parent keeps its original handle.
- The child gets a new handle value (_different numeric value_) that refers to the same underlying kernel object.
- Both processes now have separate references to that object, each with its own handle entry.

So, when the child process `ssh.exe` exits, the pipe client handles in the child process are automatically closed. However, the pipe client handles in the parent process `powershell` are still open, so the pipes will remain functional and thus the pipe server handles (_i.e. the readers used in the stdout/stderr reading threads_) are still open. Therefore, the hang happens.

**Fix Changes**

To fix the issue, we need to close the parent side pipe client handles right after creating the `ssh.exe` process, so, only the `ssh.exe` process holds the handles of client side of the pipes. Then later, when `ssh.exe` exits, the client side of the pipe will be closed, which will, as expected, lead the server side of the pipes to be closed too.

The main changes of the fix are:

- Close the client pipe handles after creating the child process (by adding `lpStartupInfo.Dispose()` in the finally block).
- A bit cleanup of the redundant namespace-qualified usages of types (e.g., `System.Diagnostics.Process`, `System.IO.Path`, etc.)
- Added new tests to verify that PowerShell does not hang when attempting SSH connections to non-existent hosts.

### PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)