### PR TITLE
[release/v7.6] Fix GitHub API rate limit errors in test actions

### DIFF
--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -14,6 +14,9 @@ inputs:
     required: false
     default: ctrf
     type: string
+  GITHUB_TOKEN:
+    description: 'GitHub token for API authentication'
+    required: true
 
 runs:
   using: composite
@@ -66,7 +69,10 @@ runs:
     shell: pwsh
     run: |-
       Import-Module ./.github/workflows/GHWorkflowHelper/GHWorkflowHelper.psm1
-      $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/PowerShell/Dsc/releases"
+      $headers = @{
+        Authorization = "Bearer ${{ inputs.GITHUB_TOKEN }}"
+      }
+      $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/PowerShell/Dsc/releases" -Headers $headers
       $latestRelease = $releases | Where-Object { $v = $_.name.trim("v"); $semVer = [System.Management.Automation.SemanticVersion]::new($v); if ($semVer.Major -eq 3 -and $semVer.Minor -ge 2) { $_ } } | Select-Object -First 1
       $latestVersion = $latestRelease.tag_name.TrimStart("v")
       Write-Host "Latest DSC Version: $latestVersion"
@@ -80,7 +86,7 @@ runs:
 
       $tempPath = Get-GWTempPath
 
-      Invoke-RestMethod -Uri $downloadUrl -OutFile "$tempPath/DSC.tar.gz" -Verbose
+      Invoke-RestMethod -Uri $downloadUrl -OutFile "$tempPath/DSC.tar.gz" -Verbose -Headers $headers
       New-Item -ItemType Directory -Path "$tempPath/DSC" -Force -Verbose
       tar xvf "$tempPath/DSC.tar.gz" -C "$tempPath/DSC"
       $dscRoot = "$tempPath/DSC"

--- a/.github/actions/test/windows/action.yml
+++ b/.github/actions/test/windows/action.yml
@@ -14,6 +14,9 @@ inputs:
     required: false
     default: ctrf
     type: string
+  GITHUB_TOKEN:
+    description: 'GitHub token for API authentication'
+    required: true
 
 runs:
   using: composite
@@ -49,7 +52,10 @@ runs:
     shell: pwsh
     run: |-
       Import-Module .\.github\workflows\GHWorkflowHelper\GHWorkflowHelper.psm1
-      $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/PowerShell/Dsc/releases"
+      $headers = @{
+        Authorization = "Bearer ${{ inputs.GITHUB_TOKEN }}"
+      }
+      $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/PowerShell/Dsc/releases" -Headers $headers
       $latestRelease = $releases | Where-Object { $v = $_.name.trim("v"); $semVer = [System.Management.Automation.SemanticVersion]::new($v); if ($semVer.Major -eq 3 -and $semVer.Minor -ge 2) { $_ } } | Select-Object -First 1
       $latestVersion = $latestRelease.tag_name.TrimStart("v")
       Write-Host "Latest DSC Version: $latestVersion"
@@ -57,7 +63,7 @@ runs:
       $downloadUrl = $latestRelease.assets | Where-Object { $_.name -like "DSC-*-x86_64-pc-windows-msvc.zip" } | Select-Object -First 1 | Select-Object -ExpandProperty browser_download_url
       Write-Host "Download URL: $downloadUrl"
       $tempPath = Get-GWTempPath
-      Invoke-RestMethod -Uri $downloadUrl -OutFile "$tempPath\DSC.zip"
+      Invoke-RestMethod -Uri $downloadUrl -OutFile "$tempPath\DSC.zip" -Headers $headers
 
       $null = New-Item -ItemType Directory -Path "$tempPath\DSC" -Force
       Expand-Archive -Path "$tempPath\DSC.zip" -DestinationPath "$tempPath\DSC" -Force

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           purpose: UnelevatedPesterTests
           tagSet: CI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linux_test_elevated_ci:
     name: Linux Elevated CI
     needs:
@@ -112,6 +113,7 @@ jobs:
         with:
           purpose: ElevatedPesterTests
           tagSet: CI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linux_test_unelevated_others:
     name: Linux Unelevated Others
     needs:
@@ -129,6 +131,7 @@ jobs:
         with:
           purpose: UnelevatedPesterTests
           tagSet: Others
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linux_test_elevated_others:
     name: Linux Elevated Others
     needs:
@@ -146,6 +149,7 @@ jobs:
         with:
           purpose: ElevatedPesterTests
           tagSet: Others
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   xunit_tests:
     name: xUnit Tests
     needs:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           purpose: UnelevatedPesterTests
           tagSet: CI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   macos_test_elevated_ci:
     name: macOS Elevated CI
     needs:
@@ -109,6 +110,7 @@ jobs:
         with:
           purpose: ElevatedPesterTests
           tagSet: CI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   macos_test_unelevated_others:
     name: macOS Unelevated Others
     needs:
@@ -126,6 +128,7 @@ jobs:
         with:
           purpose: UnelevatedPesterTests
           tagSet: Others
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   macos_test_elevated_others:
     name: macOS Elevated Others
     needs:
@@ -143,6 +146,7 @@ jobs:
         with:
           purpose: ElevatedPesterTests
           tagSet: Others
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   xunit_tests:
     name: xUnit Tests
     needs:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           purpose: UnelevatedPesterTests
           tagSet: CI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows_test_elevated_ci:
     name: Windows Elevated CI
     needs:
@@ -113,6 +114,7 @@ jobs:
         with:
           purpose: ElevatedPesterTests
           tagSet: CI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows_test_unelevated_others:
     name: Windows Unelevated Others
     needs:
@@ -130,6 +132,7 @@ jobs:
         with:
           purpose: UnelevatedPesterTests
           tagSet: Others
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows_test_elevated_others:
     name: Windows Elevated Others
     needs:
@@ -147,6 +150,7 @@ jobs:
         with:
           purpose: ElevatedPesterTests
           tagSet: Others
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   xunit_tests:
     name: xUnit Tests
     needs:


### PR DESCRIPTION
Backport of #26489 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26489$$$
-->

Triggered by @travisez13 on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes intermittent CI failures when multiple test jobs run concurrently and hit GitHub API rate limits (60 req/hr unauthenticated). By adding GITHUB_TOKEN authentication, test actions get 5000 req/hr limit, preventing rate limit errors when fetching DSC releases during test setup.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR verified by running affected workflows in fork and confirming CI passes. Backport tested by applying clean cherry-pick to updated release/v7.6 branch - no conflicts encountered. The fix adds GitHub token authentication to API calls in test actions, preventing rate limit errors during concurrent CI runs.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: Changes affect CI/CD test infrastructure across all platforms (Linux, macOS, Windows). However, the change is minimal (adding authentication headers), uses built-in GITHUB_TOKEN (no new secrets), and has been validated in master. Risk is isolated to test execution - does not affect production code.
