### PR TITLE
[release/v7.6] Convert Azure DevOps Linux Packaging pipeline to GitHub Actions workflow

### DIFF
--- a/.github/actions/test/linux-packaging/action.yml
+++ b/.github/actions/test/linux-packaging/action.yml
@@ -1,12 +1,5 @@
 name: linux_packaging
-description: 'Test very basic Linux packaging'
-
-# This isn't working yet
-# It fails with
-
-# ERROR:  While executing gem ... (Gem::FilePermissionError)
-# You don't have write permissions for the /var/lib/gems/2.7.0 directory.
-#   WARNING: Installation of gem dotenv 2.8.1 failed! Must resolve manually.
+description: 'Linux packaging for PowerShell'
 
 runs:
   using: composite
@@ -15,58 +8,64 @@ runs:
     if: success() || failure()
     run: 'Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose'
     shell: pwsh
+
+  - uses: actions/setup-dotnet@v5
+    with:
+      global-json-file: ./global.json
+
   - name: Download Build Artifacts
     uses: actions/download-artifact@v4
     with:
-      path: "${{ github.workspace }}"
+      name: build
+      path: "${{ runner.workspace }}/build"
+
   - name: Capture Artifacts Directory
     continue-on-error: true
-    run: Get-ChildItem "${{ github.workspace }}/build/*" -Recurse
+    run: Get-ChildItem "${{ runner.workspace }}/build/*" -Recurse
     shell: pwsh
 
   - name: Bootstrap
     run: |-
       Import-Module ./build.psm1
       Start-PSBootstrap -Scenario Package
+      Write-Verbose -Verbose "Start Sync-PSTags"
+      Sync-PSTags -AddRemoteIfMissing
+      Write-Verbose -Verbose "End Sync-PSTags"
     shell: pwsh
-  - name: Capture Artifacts Directory
-    continue-on-error: true
-    run: Import-Module ./build.psm1
+
+  - name: Extract Build ZIP
+    run: |-
+      $destinationFolder = "${{ runner.workspace }}/bins"
+      $archiveFile = "${{ runner.workspace }}/build/build.zip"
+
+      Write-Verbose "Extracting $archiveFile to $destinationFolder" -Verbose
+      New-Item -ItemType Directory -Path $destinationFolder -Force | Out-Null
+      Expand-Archive -Path $archiveFile -DestinationPath $destinationFolder -Force
     shell: pwsh
-  - name: Extract Files
-    uses: actions/github-script@v7.0.0
-    env:
-      DESTINATION_FOLDER: "${{ github.workspace }}/bins"
-      ARCHIVE_FILE_PATTERNS: "${{ github.workspace }}/build/build.zip"
-    with:
-      script: |-
-        const fs = require('fs').promises
-        const path = require('path')
-        const target = path.resolve(process.env.DESTINATION_FOLDER)
-        const patterns = process.env.ARCHIVE_FILE_PATTERNS
-        const globber = await glob.create(patterns)
-        await io.mkdirP(path.dirname(target))
-        for await (const file of globber.globGenerator()) {
-          if ((await fs.lstat(file)).isDirectory()) continue
-          await exec.exec(`7z x ${file} -o${target} -aoa`)
-        }
+
   - name: Fix permissions
     continue-on-error: true
     run: |-
-      find "${{ github.workspace }}/bins" -type d -exec chmod +rwx {} \;
-      find "${{ github.workspace }}/bins" -type f -exec chmod +rw {} \;
+      find "${{ runner.workspace }}/bins" -type d -exec chmod +rwx {} \;
+      find "${{ runner.workspace }}/bins" -type f -exec chmod +rw {} \;
     shell: bash
+
   - name: Capture Extracted Build ZIP
     continue-on-error: true
-    run: Get-ChildItem "${{ github.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
+    run: Get-ChildItem "${{ runner.workspace }}/bins/*" -Recurse -ErrorAction SilentlyContinue
     shell: pwsh
-  - name: Packaging Tests
-    if: success()
+
+  - name: Create Packages
+    env:
+      BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.workspace }}/packages
     run: |-
+      # Create the artifacts staging directory
+      New-Item -ItemType Directory -Path "$env:BUILD_ARTIFACTSTAGINGDIRECTORY" -Force | Out-Null
+
       Import-Module ./tools/ci.psm1
-      Restore-PSOptions -PSOptionsPath '${{ github.workspace }}/build/psoptions.json'
+      Restore-PSOptions -PSOptionsPath '${{ runner.workspace }}/build/psoptions.json'
       $options = (Get-PSOptions)
-      $rootPath = '${{ github.workspace }}/bins'
+      $rootPath = '${{ runner.workspace }}/bins'
       $originalRootPath = Split-Path -path $options.Output
       $path = Join-Path -path $rootPath -ChildPath (split-path -leaf -path $originalRootPath)
       $pwshPath = Join-Path -path $path -ChildPath 'pwsh'
@@ -75,21 +74,24 @@ runs:
       Set-PSOptions $options
       Invoke-CIFinish
     shell: pwsh
-  - name: Upload packages
-    run: |-
-      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.deb" -Recurse | ForEach-Object {
-        $packagePath = $_.FullName
-        Write-Host "Uploading $packagePath"
-        Write-Host "##vso[artifact.upload containerfolder=deb;artifactname=deb]$packagePath"
-      }
-      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.rpm" -Recurse | ForEach-Object {
-        $packagePath = $_.FullName
-        Write-Host "Uploading $packagePath"
-        Write-Host "##vso[artifact.upload containerfolder=rpm;artifactname=rpm]$packagePath"
-      }
-      Get-ChildItem "${env:BUILD_ARTIFACTSTAGINGDIRECTORY}/*.tar.gz" -Recurse | ForEach-Object {
-        $packagePath = $_.FullName
-        Write-Host "Uploading $packagePath"
-        Write-Host "##vso[artifact.upload containerfolder=rpm;artifactname=rpm]$packagePath"
-      }
-    shell: pwsh
+
+  - name: Upload deb packages
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-deb
+      path: ${{ runner.workspace }}/packages/*.deb
+      if-no-files-found: ignore
+
+  - name: Upload rpm packages
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-rpm
+      path: ${{ runner.workspace }}/packages/*.rpm
+      if-no-files-found: ignore
+
+  - name: Upload tar.gz packages
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-tar
+      path: ${{ runner.workspace }}/packages/*.tar.gz
+      if-no-files-found: ignore

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -225,24 +225,22 @@ jobs:
       - linux_test_unelevated_ci
       - linux_test_unelevated_others
       # - analyze
+      - linux_packaging
     if: always()
     uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@v1.0.0
     with:
       needs_context: ${{ toJson(needs) }}
-  # TODO: Enable this when we have a Linux packaging workflow
-
-  # ERROR:  While executing gem ... (Gem::FilePermissionError)
-  # You don't have write permissions for the /var/lib/gems/2.7.0 directory.
-  #   WARNING: Installation of gem dotenv 2.8.1 failed! Must resolve manually.
-
-  # linux_packaging:
-  #   name: Attempt Linux Packaging
-  #   needs: ci_build
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v5
-  #       with:
-  #         fetch-depth: 1000
-  #     - name: Verify xUnit test results
-  #       uses: "./.github/actions/test/linux-packaging"
+  linux_packaging:
+    name: Linux Packaging
+    needs:
+      - ci_build
+      - changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Linux Packaging
+        uses: "./.github/actions/test/linux-packaging"

--- a/build.psm1
+++ b/build.psm1
@@ -2252,7 +2252,7 @@ function Install-GlobalGem {
         # We cannot guess if the user wants to run gem install as root on linux and windows,
         # but macOs usually requires sudo
         $gemsudo = ''
-        if($environment.IsMacOS -or $env:TF_BUILD) {
+        if($environment.IsMacOS -or $env:TF_BUILD -or $env:GITHUB_ACTIONS) {
             $gemsudo = $sudo
         }
 


### PR DESCRIPTION
Backport of #26225 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26225$$$
-->

Triggered by @TravisEz13 on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This is a critical tooling change required for Linux packaging infrastructure. Converts the Azure DevOps Linux Packaging pipeline to GitHub Actions workflow, including:
- Updated `.github/actions/test/linux-packaging/action.yml` composite action to use GitHub Actions artifact handling
- Enabled `linux_packaging` job in `.github/workflows/linux-ci.yml`
- Fixed gem installation permissions for GitHub Actions environment in `build.psm1`
Without this change, Linux packaging cannot function in GitHub Actions.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR validated with GitHub Actions workflows in master branch. Verified:
1. YAML syntax and structure validation
2. Composite action updates to use GitHub Actions equivalents for Azure DevOps tasks
3. Fixed gem permission errors by detecting GitHub Actions environment
4. Fixed git describe errors with deep checkout (fetch-depth: 0) and Sync-PSTags
5. Successfully integrated with existing CI workflow structure

Backport verified by successful cherry-pick with conflict resolution maintaining release branch patterns.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk as it modifies build infrastructure (CI/CD pipelines, packaging composite action, bootstrap script). However, this change is necessary to maintain Linux packaging functionality after migration to GitHub Actions. The changes have been validated in master branch since October 17, 2025 (over one month). Not taking this change would prevent Linux package creation on release/v7.6 branch in GitHub Actions environment.

## Merge Conflicts

Conflict occurred in `.github/workflows/linux-ci.yml` in the `ready_to_merge` job dependencies.

**Cause**: The original PR added two dependencies to `ready_to_merge`:
1. `- analyze` (uncommented the CodeQL analysis dependency)
2. `- linux_packaging` (added the new packaging job)

However, release/v7.6 has the CodeQL `analyze` job intentionally commented out with note: "Temporarily disable the CodeQL analysis on Linux as it doesn't work for .NET SDK 10-rc.2."

**Resolution**: Kept release branch pattern by maintaining `# - analyze` as commented out, while adding only `- linux_packaging` dependency which is the actual fix from PR #26225. This preserves the intentional CodeQL disablement on release/v7.6 while enabling the Linux packaging functionality.

**Files modified during resolution**:
- `.github/workflows/linux-ci.yml`: Line ~228 in ready_to_merge.needs list
