### PR TITLE
Improve error message from Start-NativeExecution

### DIFF
--- a/tools/buildCommon/startNativeExecution.ps1
+++ b/tools/buildCommon/startNativeExecution.ps1
@@ -16,6 +16,8 @@ function script:Start-NativeExecution {
     $ErrorActionPreference = "Continue"
     Write-Verbose "Executing: $ScriptBlock"
     try {
+	$cwd = Get-Location
+
         if ($VerboseOutputOnError.IsPresent) {
             $output = & $ScriptBlock 2>&1
         } else {
@@ -36,10 +38,10 @@ function script:Start-NativeExecution {
                 $callerFile = $callerLocationParts[0]
                 $callerLine = $callerLocationParts[1]
 
-                $errorMessage = "Execution of {$ScriptBlock} by ${callerFile}: line $callerLine failed with exit code $LASTEXITCODE"
+                $errorMessage = "Execution of {$ScriptBlock} in '$cwd' by ${callerFile}: line $callerLine failed with exit code $LASTEXITCODE"
                 throw $errorMessage
             }
-            throw "Execution of {$ScriptBlock} failed with exit code $LASTEXITCODE"
+            throw "Execution of {$ScriptBlock} in '$cwd' failed with exit code $LASTEXITCODE"
         }
     } finally {
         $ErrorActionPreference = $backupEAP

--- a/tools/buildCommon/startNativeExecution.ps1
+++ b/tools/buildCommon/startNativeExecution.ps1
@@ -16,7 +16,7 @@ function script:Start-NativeExecution {
     $ErrorActionPreference = "Continue"
     Write-Verbose "Executing: $ScriptBlock"
     try {
-	$cwd = Get-Location
+        $cwd = Get-Location
 
         if ($VerboseOutputOnError.IsPresent) {
             $output = & $ScriptBlock 2>&1


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the `Start-NativeExecution` cmdlet that is part of the build infrastructure to report the directory in which the script block was executed, in the event of an error.

## PR Context

I ran `Start-PSBuild`, and it failed with an error during the ResGen phase:

```
PS /code/PowerShell> Start-PSBuild                                  
VERBOSE: Using default feeds which are Microsoft, use -UseNuGetOrg to switch to Public feeds
WARNING: The 'dotnet' in the current path can't find SDK version 10.0.100, prepending /home/logiclrd/.dotnet to PATH.
VERBOSE: In Find-DotNet
VERBOSE: Executing:  dotnet --list-sdks 
VERBOSE: Find-DotNet: dotnetCLIInstalledVersion = 10.0.100; chosenDotNetVersion = 10.0.100
VERBOSE: Using configuration 'Debug'
VERBOSE: Using framework 'net10.0'
VERBOSE: Using runtime 'linux-x64'
VERBOSE: Top project directory is /code/PowerShell/src/powershell-unix
=== BEGIN: Restore NuGet Packages ===
==== END: Restore NuGet Packages ====
Run ResGen (generating C# bindings for resx files)

The build failed. Fix the build errors and run again.
Exception: /code/PowerShell/tools/buildCommon/startNativeExecution.ps1:42
Line |
  42 |                  throw $errorMessage
     |                  ~~~~~~~~~~~~~~~~~~~
     | Execution of { dotnet run } by build.psm1: line 2666 failed with exit code 1
PS /code/PowerShell> 
```

This error message told me _what_ went wrong: `dotnet run`

It told me in general terms what was happening when it went wrong: `Run ResGen`

But this information alone wasn't enough to diagnose the problem. `dotnet run` in the root obviously doesn't do anything and isn't connected with the error at all. I had to open up `build.psm1` and find out what exactly was on line 2666:

```
function Start-ResGen
{
    [CmdletBinding()]
    param()

    # Add .NET CLI tools to PATH
    Find-Dotnet

    Push-Location "$PSScriptRoot/src/ResGen"
    try {
        Start-NativeExecution { dotnet run } | Write-Verbose
    } finally {
        Pop-Location
    }
}
```

_Ahh._ It's doing it inside `./src/ResGen`.

So, this PR updates the error message so that obtaining this context doesn't require peeking into `build.psm1` directly:

```
Exception: /code/PowerShell/tools/buildCommon/startNativeExecution.ps1:42
Line |
  42 |                  throw $errorMessage
     |                  ~~~~~~~~~~~~~~~~~~~
     | Execution of { dotnet run } in '/code/PowerShell/src/ResGen' by build.psm1: line 2666 failed with exit code 1
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
