### PR TITLE
[release/v7.6] Update the WCF packages to the latest version that is compatible with v4.10.3

### DIFF
--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -23,19 +23,10 @@
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="System.IO.Packaging" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing due to NU1510 -->
-    <!-- PackageReference Include="System.Text.Encodings.Web" Version="9.0.2" /-->
-    <!--
-        the following package(s) are from https://github.com/dotnet/wcf
-        they are pinned to the version 4.10.x due to a breaking change in newer versions.
-        see https://github.com/PowerShell/PowerShell/issues/19238 for details.
-     -->
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.10.3" NoWarn="NU1605" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.10.3" NoWarn="NU1605" />
+    <!-- the following package(s) are from https://github.com/dotnet/wcf -->
+    <PackageReference Include="System.ServiceModel.Http" Version="10.0.0-rc.2.final" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.0-rc.2.final" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.0-rc.2.final" />
     <!-- the source could not be found for the following package(s) -->
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="10.0.0-rc.2.25502.107" />
   </ItemGroup>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -34,17 +34,10 @@
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing due to NU1510 -->
-    <!-- PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" /-->
     <PackageReference Include="System.DirectoryServices" Version="10.0.0-rc.2.25502.107" />
-    <!--PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" /-->
     <PackageReference Include="System.Management" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing System.Security.AccessControl as per NU1510 -->
-    <!-- PackageReference Include="System.Security.AccessControl" Version="6.0.1" /-->
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="System.Security.Permissions" Version="10.0.0-rc.2.25502.107" />
-    <!-- Removing due to NU1510 -->
-    <!-- PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.2" /-->
     <!-- the following package(s) are from the powershell org -->
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.PowerShell.Native" Version="700.0.0-preview.1" />

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -90,11 +90,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "cs/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "cs/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -160,6 +155,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "cs\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "cs\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "cs\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "cs\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "D3DCompiler_47_cor3.dll",
     "FileType": "NonProduct",
     "Architecture": [
@@ -198,11 +213,6 @@
   },
   {
     "Pattern": "de/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "de/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -272,6 +282,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "de\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "de\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "de\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "de\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "DirectWriteForwarder.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -313,11 +343,6 @@
   },
   {
     "Pattern": "es/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "es/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -387,6 +412,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "es\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "es\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "es\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "es\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "fr/Microsoft.CodeAnalysis.CSharp.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -418,11 +463,6 @@
   },
   {
     "Pattern": "fr/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "fr/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -492,6 +532,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "fr\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "fr\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "fr\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "fr\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "getfilesiginforedist.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -548,11 +608,6 @@
   },
   {
     "Pattern": "it/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "it/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -622,6 +677,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "it\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "it\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "it\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "it\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "ja/Microsoft.CodeAnalysis.CSharp.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -653,11 +728,6 @@
   },
   {
     "Pattern": "ja/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "ja/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -727,6 +797,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "ja\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ja\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ja\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ja\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "Json.More.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -773,11 +863,6 @@
   },
   {
     "Pattern": "ko/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "ko/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -843,6 +928,26 @@
   },
   {
     "Pattern": "ko/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ko\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -1112,11 +1217,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "Modules/ThreadJob/*.psd1",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "Modules\\Microsoft.PowerShell.PSResourceGet\\Microsoft.PowerShell.PSResourceGet.pdb",
     "FileType": "NonProduct",
     "Architecture": null
@@ -1153,16 +1253,6 @@
   },
   {
     "Pattern": "Modules\\PSReadLine\\.signature.p7s",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "Modules\\ThreadJob\\.signature.p7s",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "Modules\\ThreadJob\\ThreadJob.psm1",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -1247,11 +1337,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "pl/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "pl/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -1313,6 +1398,26 @@
   },
   {
     "Pattern": "pl/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pl\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -1467,11 +1572,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "pt-BR/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "pt-BR/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -1533,6 +1633,26 @@
   },
   {
     "Pattern": "pt-BR/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "pt-BR\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -2432,11 +2552,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "ru/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "ru/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -2498,6 +2613,26 @@
   },
   {
     "Pattern": "ru/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "ru\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -3317,11 +3452,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "System.Private.ServiceModel.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "System.Private.Uri.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -3603,6 +3733,11 @@
   },
   {
     "Pattern": "System.ServiceModel.Http.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "System.ServiceModel.NetFramingBase.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -3902,11 +4037,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "tr/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "tr/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -3968,6 +4098,26 @@
   },
   {
     "Pattern": "tr/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "tr\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -4047,11 +4197,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "zh-Hans/System.Private.ServiceModel.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "zh-Hans/System.Web.Services.Description.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -4117,6 +4262,26 @@
     "Architecture": null
   },
   {
+    "Pattern": "zh-Hans\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hans\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hans\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hans\\System.ServiceModel.Primitives.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "zh-Hant/Microsoft.CodeAnalysis.CSharp.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
@@ -4148,11 +4313,6 @@
   },
   {
     "Pattern": "zh-Hant/ReachFramework.resources.dll",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
-    "Pattern": "zh-Hant/System.Private.ServiceModel.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },
@@ -4218,6 +4378,26 @@
   },
   {
     "Pattern": "zh-Hant/WindowsFormsIntegration.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.Http.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.NetFramingBase.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.NetTcp.resources.dll",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
+    "Pattern": "zh-Hant\\System.ServiceModel.Primitives.resources.dll",
     "FileType": "NonProduct",
     "Architecture": null
   },


### PR DESCRIPTION
Backport of #26406 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26406$$$
-->

Triggered by @TravisEz13 on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates WCF packages from 4.10.3 to 10.0.0-rc.2.final, which is compatible with .NET 10. Fixes #19238 by removing deprecated packages (System.Private.ServiceModel, System.ServiceModel.Duplex, System.ServiceModel.Security) and updating to newer compatible versions. Also updates BOM manifest for new assembly structure and improves log file capture for GitHub Actions.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR verified that ActiveDirectory module can be correctly imported with the updated WCF packages. Changes to packaging.psm1 improve GitHub Actions compatibility without affecting existing functionality.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk as it updates core dependency packages, but these are build/packaging dependencies. The 10.0.0-rc.2.final WCF packages are backward compatible, shipping facade assemblies for removed packages. Changes were validated in master and the ActiveDirectory module functionality was verified.
