### PR TITLE
Explain `-UseNuGetOrg` in build documentation

### DIFF
--- a/docs/building/linux.md
+++ b/docs/building/linux.md
@@ -64,6 +64,8 @@ Import-Module ./build.psm1
 Start-PSBuild -UseNuGetOrg
 ```
 
+> The PowerShell project by default references packages from the private Azure Artifacts feed, which requires authentication. The `-UseNuGetOrg` flag reconfigures the build to use the public NuGet.org feed instead.
+
 Congratulations! If everything went right, PowerShell is now built.
 The `Start-PSBuild` script will output the location of the executable:
 

--- a/docs/building/macos.md
+++ b/docs/building/macos.md
@@ -37,3 +37,5 @@ We cannot do this for you in the build module due to #[847][].
 Start a PowerShell session by running `pwsh`, and then use `Start-PSBuild -UseNuGetOrg` from the module.
 
 After building, PowerShell will be at `./src/powershell-unix/bin/Debug/net6.0/osx-x64/publish/pwsh`.
+
+> The PowerShell project by default references packages from the private Azure Artifacts feed, which requires authentication. The `-UseNuGetOrg` flag reconfigures the build to use the public NuGet.org feed instead.

--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -61,6 +61,8 @@ Import-Module ./build.psm1
 Start-PSBuild -Clean -PSModuleRestore -UseNuGetOrg
 ```
 
+> The PowerShell project by default references packages from the private Azure Artifacts feed, which requires authentication. The `-UseNuGetOrg` flag reconfigures the build to use the public NuGet.org feed instead.
+
 Congratulations! If everything went right, PowerShell is now built and executable as `./src/powershell-win-core/bin/Debug/net6.0/win7-x64/publish/pwsh.exe`.
 
 This location is of the form `./[project]/bin/[configuration]/[framework]/[rid]/publish/[binary name]`,


### PR DESCRIPTION
# PR Summary

Add a brief explanation of the `-UseNuGetOrg` switch shown in `Start-PSBuild` invocations in build documentation.

## PR Context

The documentation for building PowerShell demonstrates the use of `Start-PSBuild` and includes the `-UseNuGetOrg` flag in each example. But, it doesn't explain the importance of this flag. If you don't already know what's going on, it's not obvious why it's needed. As a result, I carelessly ran `Start-PSBuild` without it, only to encounter errors because I'm not authenticated with Azure DevOps to access the private Azure Artifacts feed.

This PR adds an additional line specifically for people going through the process for the first time so that they know from the outset why `-UseNuGetOrg` is important (and that they almost certainly need it).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
