### PR TITLE
Fix Set-Location failure with special characters when switching drives

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -307,15 +307,12 @@ namespace System.Management.Automation
                     // not a slash-terminated path to the root of a drive,
                     // set the path to the current working directory of that drive.
                     string colonTerminatedVolume = CurrentDrive.Name + ':';
-                    if (path.Length == colonTerminatedVolume.Length)
+                    if (path.Length == colonTerminatedVolume.Length && CurrentDrive.VolumeSeparatedByColon)
                     {
-                        if (CurrentDrive.VolumeSeparatedByColon)
-                        {
-                            // The restored path should be treated as a literal path to avoid
-                            // wildcard expansion issues with special characters (e.g., brackets)
-                            pathRestoredFromDrive = true;
-                            path = Path.Combine(colonTerminatedVolume + Path.DirectorySeparatorChar, CurrentDrive.CurrentLocation);
-                        }
+                        // The restored path should be treated as a literal path to avoid
+                        // wildcard expansion issues with special characters (e.g., brackets)
+                        pathRestoredFromDrive = true;
+                        path = Path.Combine(colonTerminatedVolume + Path.DirectorySeparatorChar, CurrentDrive.CurrentLocation);
                     }
 
                     // Now that the current working drive is set,

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -128,8 +128,6 @@ Describe "Set-Location" -Tags "CI" {
         }
     }
 
-
-    # Issue #25282: Set-Location fails for paths with special characters when switching drives
     Context "Set-Location with special characters in path" {
 
         BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -128,6 +128,224 @@ Describe "Set-Location" -Tags "CI" {
         }
     }
 
+
+    # Issue #25282: Set-Location fails for paths with special characters when switching drives
+    Context "Set-Location with special characters in path" {
+
+        BeforeAll {
+            # Find an available drive letter for subst
+            $script:availableDrive = $null
+            foreach ($letter in 'T','U','V','W','X','Y','Z') {
+                if (-not (Test-Path "${letter}:\")) {
+                    $script:availableDrive = $letter
+                    break
+                }
+            }
+
+            if (-not $script:availableDrive) {
+                throw "No available drive letter found for subst"
+            }
+
+            $script:oldLocation = Get-Location
+            # Create a temporary directory for subst (physical drive)
+            $script:tempRoot = New-Item -Path "$env:TEMP\TestDrive_$([guid]::NewGuid())" -ItemType Directory -Force
+            # Create a subst drive (physical Windows drive)
+            & subst "${script:availableDrive}:" $script:tempRoot.FullName
+            Start-Sleep -Milliseconds 200
+
+            # Create directories with special characters on both drives
+            # Physical drive with brackets
+            $script:testDirPhysical = New-Item -Path "${script:availableDrive}:\Test [Folder] physical" -ItemType Directory -Force
+            # C: drive with brackets
+            $script:testDirC = New-Item -Path "$env:TEMP\Test [Folder] c" -ItemType Directory -Force
+
+            # Create a PSDrive that points to a path with special characters
+            $script:psDrivePath = New-Item -Path "$env:TEMP\PSDrive [Root]" -ItemType Directory -Force
+            $script:testDirPSDrive = New-Item -Path "$($script:psDrivePath.FullName)\Test [Folder] psdrive" -ItemType Directory -Force
+            New-PSDrive -Name 'TestPS' -PSProvider FileSystem -Root $script:psDrivePath.FullName -Scope Global | Out-Null
+        }
+
+        AfterAll {
+            Set-Location C:\
+            if ($script:availableDrive) {
+                & subst "${script:availableDrive}:" /D 2>$null
+                Start-Sleep -Milliseconds 200
+            }
+            if (Get-PSDrive -Name 'TestPS' -ErrorAction SilentlyContinue) {
+                Remove-PSDrive -Name 'TestPS' -Force -ErrorAction SilentlyContinue
+            }
+            if ($script:tempRoot -and (Test-Path $script:tempRoot)) {
+                Remove-Item $script:tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+            if ($script:testDirC -and (Test-Path $script:testDirC)) {
+                Remove-Item $script:testDirC -Recurse -Force -ErrorAction SilentlyContinue
+            }
+            if ($script:psDrivePath -and (Test-Path $script:psDrivePath)) {
+                Remove-Item $script:psDrivePath -Recurse -Force -ErrorAction SilentlyContinue
+            }
+            if ($script:oldLocation) {
+                Set-Location $script:oldLocation
+            }
+        }
+
+        It "Should navigate to directory with brackets using escaped path" {
+            # Reproduce the exact issue: navigate using escaped brackets
+            $escapedPath = "${script:availableDrive}:\Test ``[Folder``] physical"
+            Set-Location $escapedPath
+            $expectedPath = $script:testDirPhysical.FullName
+            (Get-Location).Path | Should -BeExactly $expectedPath
+        }
+
+        It "Should restore path with brackets when switching from physical drive to C: and back" {
+            # Step 1: Navigate to physical drive directory with brackets (using escaped path)
+            $escapedPath = "${script:availableDrive}:\Test ``[Folder``] physical"
+            Set-Location $escapedPath
+            $expectedPath = (Get-Location).Path
+
+            # Step 2: Switch to C: drive
+            Set-Location 'C:\'
+
+            # Step 3: Switch back using drive letter only - this is where the bug occurred
+            Set-Location "${script:availableDrive}:"
+
+            # Verify we're back in the directory with brackets
+            (Get-Location).Path | Should -BeExactly $expectedPath
+        }
+
+        It "Should restore path with brackets when switching from C: to physical drive and back" {
+            # Step 1: Navigate to C: directory with brackets (using escaped path)
+            $escapedPath = "$env:TEMP\Test ``[Folder``] c"
+            Set-Location $escapedPath
+            $expectedPathC = (Get-Location).Path
+
+            # Step 2: Switch to physical drive
+            Set-Location "${script:availableDrive}:\"
+
+            # Step 3: Switch back to C: using drive letter only
+            Set-Location 'C:'
+
+            # Verify we're back in the C: directory with brackets
+            (Get-Location).Path | Should -BeExactly $expectedPathC
+        }
+
+        It "Should handle multiple round-trips between drives with special characters" {
+            # Navigate to physical drive directory
+            $escapedPathPhysical = "${script:availableDrive}:\Test ``[Folder``] physical"
+            Set-Location $escapedPathPhysical
+            $expectedPathPhysical = (Get-Location).Path
+
+            # Navigate to C: directory
+            $escapedPathC = "$env:TEMP\Test ``[Folder``] c"
+            Set-Location $escapedPathC
+            $expectedPathC = (Get-Location).Path
+
+            # Round-trip 1: C: -> Physical -> C:
+            Set-Location "${script:availableDrive}:"
+            (Get-Location).Path | Should -BeExactly $expectedPathPhysical
+
+            Set-Location 'C:'
+            (Get-Location).Path | Should -BeExactly $expectedPathC
+
+            # Round-trip 2: C: -> Physical -> C:
+            Set-Location "${script:availableDrive}:"
+            (Get-Location).Path | Should -BeExactly $expectedPathPhysical
+
+            Set-Location 'C:'
+            (Get-Location).Path | Should -BeExactly $expectedPathC
+        }
+
+        It "Should restore path with brackets when switching from PSDrive to C: and back" {
+            # Step 1: Navigate to PSDrive directory with brackets
+            $escapedPath = "TestPS:\Test ``[Folder``] psdrive"
+            Set-Location $escapedPath
+            $expectedPath = (Get-Location).Path
+
+            # Step 2: Switch to C: drive
+            Set-Location 'C:\'
+
+            # Step 3: Switch back to PSDrive using drive letter only
+            Set-Location 'TestPS:'
+
+            # Verify we're back in the PSDrive directory with brackets
+            (Get-Location).Path | Should -BeExactly $expectedPath
+        }
+
+        It "Should restore path with brackets when switching from C: to PSDrive and back" {
+            # Step 1: Navigate to C: directory with brackets
+            $escapedPathC = "$env:TEMP\Test ``[Folder``] c"
+            Set-Location $escapedPathC
+            $expectedPathC = (Get-Location).Path
+
+            # Step 2: Switch to PSDrive
+            Set-Location 'TestPS:\'
+
+            # Step 3: Switch back to C: using drive letter only
+            Set-Location 'C:'
+
+            # Verify we're back in the C: directory with brackets
+            (Get-Location).Path | Should -BeExactly $expectedPathC
+        }
+
+        It "Should handle multiple round-trips between PSDrive and C: with special characters" {
+            # Navigate to PSDrive directory
+            $escapedPathPS = "TestPS:\Test ``[Folder``] psdrive"
+            Set-Location $escapedPathPS
+            $expectedPathPS = (Get-Location).Path
+
+            # Navigate to C: directory
+            $escapedPathC = "$env:TEMP\Test ``[Folder``] c"
+            Set-Location $escapedPathC
+            $expectedPathC = (Get-Location).Path
+
+            # Round-trip 1: C: -> PSDrive -> C:
+            Set-Location 'TestPS:'
+            (Get-Location).Path | Should -BeExactly $expectedPathPS
+
+            Set-Location 'C:'
+            (Get-Location).Path | Should -BeExactly $expectedPathC
+
+            # Round-trip 2: C: -> PSDrive -> C:
+            Set-Location 'TestPS:'
+            (Get-Location).Path | Should -BeExactly $expectedPathPS
+
+            Set-Location 'C:'
+            (Get-Location).Path | Should -BeExactly $expectedPathC
+        }
+
+        It "Should not change location when using same-drive syntax on current drive" {
+            # Navigate to a path with brackets
+            $escapedPath = "${script:availableDrive}:\Test ``[Folder``] physical"
+            Set-Location $escapedPath
+            $currentPath = (Get-Location).Path
+
+            # Use same-drive syntax - should stay in same location
+            Set-Location "${script:availableDrive}:"
+            (Get-Location).Path | Should -BeExactly $currentPath
+        }
+
+        It "Should not change location when using same-drive syntax on C: drive" {
+            # Navigate to C: directory with brackets
+            $escapedPath = "$env:TEMP\Test ``[Folder``] c"
+            Set-Location $escapedPath
+            $currentPath = (Get-Location).Path
+
+            # Use same-drive syntax - should stay in same location
+            Set-Location 'C:'
+            (Get-Location).Path | Should -BeExactly $currentPath
+        }
+
+        It "Should not change location when using same-drive syntax on PSDrive" {
+            # Navigate to PSDrive directory with brackets
+            $escapedPath = "TestPS:\Test ``[Folder``] psdrive"
+            Set-Location $escapedPath
+            $currentPath = (Get-Location).Path
+
+            # Use same-drive syntax - should stay in same location
+            Set-Location 'TestPS:'
+            (Get-Location).Path | Should -BeExactly $currentPath
+        }
+    }
+
     Context 'Set-Location with last location history' {
 
         It 'Should go to last location when specifying minus as a path' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -134,8 +134,8 @@ Describe "Set-Location" -Tags "CI" {
             $oldLocation = Get-Location
 
             # Create temporary directories for PSDrives
-            $tempRoot1 = New-Item -Path "$env:TEMP\TestPSDrive1_$([guid]::NewGuid())" -ItemType Directory -Force
-            $tempRoot2 = New-Item -Path "$env:TEMP\TestPSDrive2_$([guid]::NewGuid())" -ItemType Directory -Force
+            $tempRoot1 = New-Item -Path (Join-Path ([System.IO.Path]::GetTempPath()) "TestPSDrive1_$([guid]::NewGuid())") -ItemType Directory -Force
+            $tempRoot2 = New-Item -Path (Join-Path ([System.IO.Path]::GetTempPath()) "TestPSDrive2_$([guid]::NewGuid())") -ItemType Directory -Force
 
             # Create nested directories with special characters (brackets)
             # Structure: TestPS1:\Parent [Folder]\Child [Folder]

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -151,7 +151,7 @@ Describe "Set-Location" -Tags "CI" {
         }
 
         AfterAll {
-            Set-Location C:\
+            Set-Location $(if ($IsWindows) { 'C:\' } else { '/' })
 
             if (Get-PSDrive -Name 'TestPS1' -ErrorAction SilentlyContinue) {
                 Remove-PSDrive -Name 'TestPS1' -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## PR Summary

Fix `Set-Location` failure when switching drives to restore paths containing special characters like brackets.

## PR Context

Fixes #25282

When switching drives using drive-letter-only syntax (e.g., `E:`), PowerShell attempts to restore the previous location on that drive from `CurrentLocation`. However, if the path contains special characters like brackets, wildcard expansion incorrectly interprets them as wildcard patterns, causing `Set-Location` to fail with "Cannot find path" error.

### Before this fix:
```powershell
# Navigate to a directory with brackets
md "E:\Test [Folder] with brackets"
cd 'E:\Test `[Folder`] with brackets'

# Switch to another drive
C:

# Try to switch back - FAILS
E:
# Error: Set-Location: Cannot find path 'E:\Test [Folder] with brackets' because it does not exist.
```

### After this fix:
```powershell
# Navigate to a directory with brackets
md "E:\Test [Folder] with brackets"
cd 'E:\Test `[Folder`] with brackets'

# Switch to another drive
C:

# Switch back - WORKS
E:
# Successfully restored to: E:\Test [Folder] with brackets
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress)
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- [x] New and old tests pass locally

## Description

### Root Cause

When switching drives with syntax like `E:`, PowerShell restores the drive's current location by combining the drive letter with the path stored in `CurrentDrive.CurrentLocation`. This restored path is then processed through the normal path resolution logic, which performs wildcard expansion on special characters.

For paths containing brackets (e.g., `E:\Test [Folder]`), the brackets are interpreted as wildcard character classes, causing path resolution to fail.

### Solution

This PR treats paths restored from drive's `CurrentLocation` as literal paths by suppressing wildcard expansion, similar to how `-LiteralPath` parameter works.

**Implementation:**
1. Added `pathRestoredFromDrive` flag to track when a path is restored from a drive's `CurrentLocation`
2. Set `context.SuppressWildcardExpansion = true` when `pathRestoredFromDrive` is true
3. This ensures special characters in restored paths are treated literally, not as wildcard patterns

### Files Changed

- `src/System.Management.Automation/engine/SessionStateLocationAPIs.cs` - Added path restoration tracking and wildcard suppression
- `test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1` - Added comprehensive test coverage

## Testing

### Test Coverage

Added 10 comprehensive test cases covering:

1. **Basic navigation with escaped brackets**
   - Verifies that escaped paths work for initial navigation

2. **Physical drive ↔ C: drive switching** (3 tests)
   - Physical drive → C: → Physical drive restoration
   - C: → Physical drive → C: restoration
   - Multiple round-trips between drives

3. **PSDrive ↔ C: drive switching** (3 tests)
   - PSDrive → C: → PSDrive restoration
   - C: → PSDrive → C: restoration
   - Multiple round-trips between PSDrive and C:

4. **Same-drive navigation** (3 tests)
   - Physical drive same-drive cd (e.g., `T:` when already on T:)
   - C: drive same-drive cd (e.g., `C:` when already on C:)
   - PSDrive same-drive cd (e.g., `TestPS:` when already on TestPS:)

### Test Environment

- **Physical drives**: Uses `subst` command to create temporary physical drives (1-character names: T, U, V, etc.)
- **PSDrive**: Uses `New-PSDrive` to create drives with multi-character names (e.g., "TestPS")
- **Special characters**: Tests focus on brackets `[]` as the primary problematic characters

### Manual Testing

```powershell
# Test 1: Physical drive with brackets
subst T: $env:TEMP
md "T:\Test [Folder]"
cd 'T:\Test `[Folder`]'
C:
T:  # Should restore to T:\Test [Folder]
(Get-Location).Path  # Should be: T:\Test [Folder]

# Test 2: PSDrive with brackets
New-PSDrive -Name MyDrive -PSProvider FileSystem -Root $env:TEMP
md "$env:TEMP\Test [Folder]"
cd 'MyDrive:\Test `[Folder`]'
C:
MyDrive:  # Should restore to MyDrive:\Test [Folder]
(Get-Location).Path  # Should include: Test [Folder]

# Test 3: Same-drive navigation
cd 'C:\Temp\Test `[Folder`]'
C:  # Should stay in C:\Temp\Test [Folder]
(Get-Location).Path  # Should be: C:\Temp\Test [Folder]
```

### Automated Tests

All 10 tests pass successfully:
```
Context Set-Location with special characters in path
  [+] Should navigate to directory with brackets using escaped path
  [+] Should restore path with brackets when switching from physical drive to C: and back
  [+] Should restore path with brackets when switching from C: to physical drive and back
  [+] Should handle multiple round-trips between drives with special characters
  [+] Should restore path with brackets when switching from PSDrive to C: and back
  [+] Should restore path with brackets when switching from C: to PSDrive and back
  [+] Should handle multiple round-trips between PSDrive and C: with special characters
  [+] Should not change location when using same-drive syntax on current drive
  [+] Should not change location when using same-drive syntax on C: drive
  [+] Should not change location when using same-drive syntax on PSDrive

Tests Passed: 31, Failed: 0
```

## Additional Notes

- This fix does not affect normal path operations or `-LiteralPath` usage
- Only paths automatically restored from drive's `CurrentLocation` are affected
- The behavior now matches user expectations: drive switching should preserve the exact path, regardless of special characters
- No breaking changes - this fix only corrects previously broken behavior