### PR TITLE
Respect $VerbosePreference in ShouldProcess

### DIFF
--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -1559,7 +1559,7 @@ namespace System.Management.Automation
 
             if (this.CanShouldProcessAutoConfirm())
             {
-                if (this.Verbose)
+                if (IsWriteVerboseEnabled())
                 {
                     // 2005/05/24 908827
                     // WriteDebug/WriteVerbose/WriteProgress/WriteWarning should only be callable from the main thread
@@ -1639,7 +1639,7 @@ namespace System.Management.Automation
 
             if (this.CanShouldProcessAutoConfirm())
             {
-                if (this.Verbose)
+                if (IsWriteVerboseEnabled())
                 {
                     return ShouldProcessPossibleOptimization.AutoYes_CanCallShouldProcessAsynchronously;
                 }

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -576,6 +576,33 @@ namespace System.Management.Automation
             => WriteHelper_ShouldWrite(VerbosePreference, lastVerboseContinueStatus);
 
         /// <summary>
+        /// Check if verbose should be emitted from ShouldProcess.
+        /// This method only considers -Verbose parameter and $VerbosePreference variable,
+        /// excluding the effect of -Debug parameter.
+        /// </summary>
+        private bool ShouldEmitVerboseFromShouldProcess()
+        {
+            // If -Verbose is explicitly set, use that value
+            if (IsVerboseFlagSet)
+            {
+                return Verbose;
+            }
+
+            // Otherwise, check $VerbosePreference variable only (excluding -Debug effect)
+            if (!_isVerbosePreferenceCached)
+            {
+                bool defaultUsed = false;
+                _verbosePreference = Context.GetEnumPreference(
+                    SpecialVariables.VerbosePreferenceVarPath,
+                    _verbosePreference,
+                    out defaultUsed);
+            }
+
+            return _verbosePreference != ActionPreference.Ignore &&
+                   _verbosePreference != ActionPreference.SilentlyContinue;
+        }
+
+        /// <summary>
         /// Display verbose information.
         /// </summary>
         internal void WriteVerbose(VerboseRecord record, bool overrideInquire = false)
@@ -1559,7 +1586,7 @@ namespace System.Management.Automation
 
             if (this.CanShouldProcessAutoConfirm())
             {
-                if (IsWriteVerboseEnabled())
+                if (ShouldEmitVerboseFromShouldProcess())
                 {
                     // 2005/05/24 908827
                     // WriteDebug/WriteVerbose/WriteProgress/WriteWarning should only be callable from the main thread
@@ -1639,7 +1666,7 @@ namespace System.Management.Automation
 
             if (this.CanShouldProcessAutoConfirm())
             {
-                if (IsWriteVerboseEnabled())
+                if (ShouldEmitVerboseFromShouldProcess())
                 {
                     return ShouldProcessPossibleOptimization.AutoYes_CanCallShouldProcessAsynchronously;
                 }

--- a/test/powershell/Language/Scripting/ShouldProcess.Tests.ps1
+++ b/test/powershell/Language/Scripting/ShouldProcess.Tests.ps1
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "ShouldProcess respects VerbosePreference" -Tags "CI","Feature" {
+    
+    BeforeAll {
+        function Test-ShouldProcess {
+            [CmdletBinding(SupportsShouldProcess)]
+            param($Target = "TestTarget", $Action = "TestAction")
+            if ($PSCmdlet.ShouldProcess($Target, $Action)) { "OK" }
+        }
+    }
+
+    Context "VerbosePreference variable" {
+        It "Emits verbose output when VerbosePreference is Continue" {
+            $VerbosePreference = 'Continue'
+            $output = Test-ShouldProcess 4>&1
+            $VerbosePreference = 'SilentlyContinue'
+            
+            $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
+            $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+            $verboseOutput | Should -Not -BeNullOrEmpty
+            $verboseOutput.Message | Should -Match "TestAction.*TestTarget"
+        }
+
+        It "Does not emit verbose output when VerbosePreference is SilentlyContinue" {
+            $VerbosePreference = 'SilentlyContinue'
+            $output = Test-ShouldProcess 4>&1
+            
+            $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
+            $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+            $verboseOutput | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Verbose parameter" {
+        It "Emits verbose output when -Verbose is specified" {
+            $output = Test-ShouldProcess -Verbose 4>&1
+            
+            $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
+            $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+            $verboseOutput | Should -Not -BeNullOrEmpty
+            $verboseOutput.Message | Should -Match "TestAction.*TestTarget"
+        }
+    }
+}

--- a/test/powershell/Language/Scripting/ShouldProcess.Tests.ps1
+++ b/test/powershell/Language/Scripting/ShouldProcess.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 Describe "ShouldProcess respects VerbosePreference" -Tags "CI","Feature" {
-    
+
     BeforeAll {
         function Test-ShouldProcess {
             [CmdletBinding(SupportsShouldProcess)]
@@ -13,34 +13,60 @@ Describe "ShouldProcess respects VerbosePreference" -Tags "CI","Feature" {
 
     Context "VerbosePreference variable" {
         It "Emits verbose output when VerbosePreference is Continue" {
-            $VerbosePreference = 'Continue'
-            $output = Test-ShouldProcess 4>&1
-            $VerbosePreference = 'SilentlyContinue'
-            
-            $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
-            $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
-            $verboseOutput | Should -Not -BeNullOrEmpty
-            $verboseOutput.Message | Should -Match "TestAction.*TestTarget"
+            $originalVerbosePreference = $VerbosePreference
+            try {
+                $VerbosePreference = 'Continue'
+                $output = Test-ShouldProcess 4>&1
+
+                $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
+                $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+                $verboseOutput | Should -Not -BeNullOrEmpty
+                $verboseOutput.Message | Should -Match "TestAction.*TestTarget"
+            }
+            finally {
+                $VerbosePreference = $originalVerbosePreference
+            }
         }
 
         It "Does not emit verbose output when VerbosePreference is SilentlyContinue" {
-            $VerbosePreference = 'SilentlyContinue'
-            $output = Test-ShouldProcess 4>&1
-            
-            $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
-            $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
-            $verboseOutput | Should -BeNullOrEmpty
+            $originalVerbosePreference = $VerbosePreference
+            try {
+                $VerbosePreference = 'SilentlyContinue'
+                $output = Test-ShouldProcess 4>&1
+
+                $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
+                $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+                $verboseOutput | Should -BeNullOrEmpty
+            }
+            finally {
+                $VerbosePreference = $originalVerbosePreference
+            }
         }
     }
 
     Context "Verbose parameter" {
         It "Emits verbose output when -Verbose is specified" {
             $output = Test-ShouldProcess -Verbose 4>&1
-            
+
             $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
             $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
             $verboseOutput | Should -Not -BeNullOrEmpty
             $verboseOutput.Message | Should -Match "TestAction.*TestTarget"
+        }
+
+        It "Does not emit verbose output when -Verbose:`$false is specified even if VerbosePreference is Continue" {
+            $originalVerbosePreference = $VerbosePreference
+            try {
+                $VerbosePreference = 'Continue'
+                $output = Test-ShouldProcess -Verbose:$false 4>&1
+
+                $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
+                $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+                $verboseOutput | Should -BeNullOrEmpty
+            }
+            finally {
+                $VerbosePreference = $originalVerbosePreference
+            }
         }
     }
 }

--- a/test/powershell/Language/Scripting/ShouldProcess.Tests.ps1
+++ b/test/powershell/Language/Scripting/ShouldProcess.Tests.ps1
@@ -69,4 +69,18 @@ Describe "ShouldProcess respects VerbosePreference" -Tags "CI","Feature" {
             }
         }
     }
+
+    Context "Debug switch" {
+        It "Does not emit verbose output when only -Debug is specified" {
+            # -Debug must not imply verbose for ShouldProcess: the effect of -Debug
+            # on the VerbosePreference property getter is intentionally excluded.
+            # -Confirm:$false keeps ShouldProcess on the auto-confirm path (which is
+            # where the verbose decision is made) and avoids an interactive prompt.
+            $output = Test-ShouldProcess -Debug -Confirm:$false 4>&1 5>&1
+
+            $output | Where-Object { $_ -eq "OK" } | Should -Not -BeNullOrEmpty
+            $verboseOutput = $output | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+            $verboseOutput | Should -BeNullOrEmpty
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -141,8 +141,9 @@ Describe "History cmdlet test cases" -Tags "CI" {
             $ps.Streams.Information).Count
         $ps.Dispose()
 
-        ## Twice per stream - once for the original invocation, and once for the re-invocation
-        $outputCount | Should -Be 12
+        ## Twice per stream - once for the original invocation, and once for the re-invocation.
+        ## Plus one additional verbose output from Invoke-History's ShouldProcess when $VerbosePreference is 'Continue'.
+        $outputCount | Should -Be 13
     }
 
     It "Tests Invoke-History on a private command" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix `ShouldProcess` to respect `$VerbosePreference` variable in addition to `-Verbose` parameter.

## PR Context

Fixes #12148

`$PSCmdlet.ShouldProcess()` was only emitting verbose output when the `-Verbose` parameter was explicitly specified, completely ignoring the `$VerbosePreference` variable setting. This is inconsistent with how other cmdlets handle verbose output.

The issue occurred because `DoShouldProcess()` and `CalculatePossibleShouldProcessOptimization()` were checking `this.Verbose` (which only tracks the `-Verbose` parameter flag) instead of calling `IsWriteVerboseEnabled()` (which properly checks both `-Verbose` parameter and `$VerbosePreference` variable).

**Changes:**
- Modified `MshCommandRuntime.cs` to use `IsWriteVerboseEnabled()` instead of `this.Verbose` in two locations
- Added comprehensive tests to verify the fix

**Before:**
```powershell
function Test-SP {
    [CmdletBinding(SupportsShouldProcess)]
    param($Target = "TestTarget", $Action = "TestAction")
    if ($PSCmdlet.ShouldProcess($Target, $Action)) { "OK" }
}
$VerbosePreference = 'Continue'
Test-SP  # No verbose output (bug)
```

**After:**
```powershell
function Test-SP {
    [CmdletBinding(SupportsShouldProcess)]
    param($Target = "TestTarget", $Action = "TestAction")
    if ($PSCmdlet.ShouldProcess($Target, $Action)) { "OK" }
}
$VerbosePreference = 'Continue'
Test-SP  # VERBOSE: Performing the operation "TestAction" on target "TestTarget". (fixed!)
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- This is a bug fix that makes behavior consistent with documentation, no additional docs needed -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
