### PR TITLE
Fix Propertyless Object not displaying after ETS introspection - Simple Fix

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -470,7 +470,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             var isRemotingPropertyName = name.Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
-                   || name.Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase);
+                   || name.Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.EventObject, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(PSObject.PSTypeNames, StringComparison.OrdinalIgnoreCase);
             return !isRemotingPropertyName;
         }
 

--- a/test/powershell/engine/Formatting/BugFix.Tests.ps1
+++ b/test/powershell/engine/Formatting/BugFix.Tests.ps1
@@ -46,6 +46,27 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
         $outstring.Trim() | Should -BeLike "*.Hidden2"
     }
 
+    It "Formatting for an object with only hidden property should use 'ToString' after a Get-Member call" {
+        class Hidden {
+            hidden $Param = 'Foo'
+            [String]ToString() { return 'MyString' }
+        }
+
+        $hiddenObjectOne = [Hidden]::new()
+        $hiddenObjectOne | Get-Member | Out-Null
+        $outstring = $hiddenObjectOne | Out-String
+        $outstring.Trim() | Should -BeExactly "MyString"
+
+        class Hidden2 {
+            hidden $Param = 'Foo'
+        }
+
+        $hiddenObjectTwo = [Hidden2]::new()
+        $hiddenObjectTwo | Get-Member | Out-Null
+        $outstring = $hiddenObjectTwo | Out-String
+        $outstring.Trim() | Should -BeLike "*.Hidden2"
+    }
+
     It 'Formatting for an object with no-hidden property should use the default view' {
         class Params {
             $Param = 'Foo'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #25832
This fix the case where a Propertyless object is rendered undisplayable after being inspected using Get-Member or any similar introspection commands.

<!-- Summarize your PR between here and the checklist. -->

## PR Context
Propertyless object are usually displayed using a fallback to their ToString() methods.
But the method currently used to evaluate the "Propertyless-ness" of an object relies on a flawed evaluation:
After inspecting the object, one new property gets dynamically attached to the object, rendering it undisplayable, because no longer regarded as Propertyless.

This PR fixes and extend the current `IsNotRemotingProperty` function in two ways: adds the currently missing `RemotingConstants.EventObject` kind (currently missing from the evaluation), and also adds the `PSObject.PSTypeNames` kind to the exclusion list to ensure introspected propertyless objects don't get misjudged as "property-full".

Also, maybe changing the `IsNotRemotingProperty` into a new name like `IsNotBlacklistedProperty` or `IsNotSkippedProperty` could be a good idea to mach this function extended purpose, but I wanted to get some feedback before any name change.

The full rational and discussion prior to making this PR can be found in my issue report :
#25832

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable (Bug-fix)
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - [X] Issue filed: <!-- Number/link of that issue here --> Issue #25832
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
  