### PR TITLE
Fix Set-PSDebug -Trace to display all lines of multiline commands

### DIFF
--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4161,14 +4161,12 @@ namespace System.Management.Automation
 
         internal void TraceLine(IScriptExtent extent)
         {
-            string msg = PositionUtilities.BriefMessage(extent);
+            string[] lines = PositionUtilities.BriefMessage(extent);
             InternalHostUserInterface ui = (InternalHostUserInterface)_context.EngineHostInterface.UI;
 
             ActionPreference pref = _context.PSDebugTraceStep ?
                 ActionPreference.Inquire : ActionPreference.Continue;
 
-            // Write each line separately so each gets the DEBUG: prefix
-            string[] lines = msg.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             foreach (string line in lines)
             {
                 ui.WriteDebugLine(line, ref pref);

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4161,13 +4161,18 @@ namespace System.Management.Automation
 
         internal void TraceLine(IScriptExtent extent)
         {
-            string msg = PositionUtilities.BriefMessage(extent.StartScriptPosition);
+            string msg = PositionUtilities.BriefMessage(extent);
             InternalHostUserInterface ui = (InternalHostUserInterface)_context.EngineHostInterface.UI;
 
             ActionPreference pref = _context.PSDebugTraceStep ?
                 ActionPreference.Inquire : ActionPreference.Continue;
 
-            ui.WriteDebugLine(msg, ref pref);
+            // Write each line separately so each gets the DEBUG: prefix
+            string[] lines = msg.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            foreach (string line in lines)
+            {
+                ui.WriteDebugLine(line, ref pref);
+            }
 
             if (pref == ActionPreference.Continue)
                 _context.PSDebugTraceStep = false;

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -4168,7 +4168,7 @@ namespace System.Management.Automation
                 ActionPreference.Inquire : ActionPreference.Continue;
 
             // Write each line separately so each gets the DEBUG: prefix
-            string[] lines = msg.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            string[] lines = msg.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             foreach (string line in lines)
             {
                 ui.WriteDebugLine(line, ref pref);

--- a/src/System.Management.Automation/engine/parser/Position.cs
+++ b/src/System.Management.Automation/engine/parser/Position.cs
@@ -282,24 +282,24 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
-        /// Return a message for an extent that may span multiple lines.
-        /// For single-line extents, the format is:
+        /// Return messages for an extent that may span multiple lines.
+        /// For single-line extents, returns an array with one element:
         ///     12+  >>>> $x + $b.
-        /// For multi-line extents (e.g., line continuation with backtick), the format is:
+        /// For multi-line extents (e.g., line continuation with backtick), returns an array with one element per line:
         ///     12+  >>>> Write-Output "foo `
         ///     13+  >>>> bar"
         /// </summary>
-        internal static string BriefMessage(IScriptExtent extent)
+        internal static string[] BriefMessage(IScriptExtent extent)
         {
             // For single-line extents, delegate to the existing single-position method
             if (extent.StartLineNumber == extent.EndLineNumber)
             {
-                return BriefMessage(extent.StartScriptPosition);
+                return new[] { BriefMessage(extent.StartScriptPosition) };
             }
 
             // For multi-line extents, include all lines
-            string[] lines = extent.Text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
-            StringBuilder result = new StringBuilder();
+            string[] lines = extent.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            string[] result = new string[lines.Length];
             int lineNumber = extent.StartLineNumber;
 
             for (int i = 0; i < lines.Length; i++)
@@ -326,18 +326,11 @@ namespace System.Management.Automation.Language
                     message.Insert(0, " >>>> ");
                 }
 
-                string formattedLine = StringUtil.Format(ParserStrings.TraceScriptLineMessage, lineNumber, message.ToString());
-
-                if (i > 0)
-                {
-                    result.AppendLine();
-                }
-
-                result.Append(formattedLine);
+                result[i] = StringUtil.Format(ParserStrings.TraceScriptLineMessage, lineNumber, message.ToString());
                 lineNumber++;
             }
 
-            return result.ToString();
+            return result;
         }
 
         internal static IScriptExtent NewScriptExtent(IScriptExtent start, IScriptExtent end)

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
@@ -26,5 +26,51 @@ Describe "Set-PSDebug" -Tags "CI" {
                 [ClassWithDefaultCtor]::new()
             } | Should -Not -Throw
         }
+
+        It "Should trace all lines of a multiline command" {
+            $tempScript = Join-Path $TestDrive "multiline-trace.ps1"
+            $scriptContent = "Set-PSDebug -Trace 1`nWrite-Output `"foo ```nbar`""
+            Set-Content -Path $tempScript -Value $scriptContent -NoNewline
+
+            # Run in a separate process to capture trace output
+            $pinfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $pinfo.FileName = (Get-Process -Id $PID).Path
+            $pinfo.Arguments = "-NoProfile -File `"$tempScript`""
+            $pinfo.RedirectStandardOutput = $true
+            $pinfo.UseShellExecute = $false
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $pinfo
+            $process.Start() | Should -BeTrue
+            $output = $process.StandardOutput.ReadToEnd()
+            $process.WaitForExit()
+
+            # The debug trace for multiline commands should include all lines with DEBUG: prefix
+            $output | Should -Match 'DEBUG:.*Write-Output' -Because "debug output should contain the command with DEBUG: prefix"
+            $output | Should -Match 'DEBUG:.*bar"' -Because "debug output should contain the continuation line with DEBUG: prefix"
+        }
+
+        It "Should trace all lines of a multiline command with -Trace 2" {
+            $tempScript = Join-Path $TestDrive "multiline-trace2.ps1"
+            $scriptContent = "Set-PSDebug -Trace 2`nWrite-Output `"foo ```nbar`""
+            Set-Content -Path $tempScript -Value $scriptContent -NoNewline
+
+            # Run in a separate process to capture trace output
+            $pinfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $pinfo.FileName = (Get-Process -Id $PID).Path
+            $pinfo.Arguments = "-NoProfile -File `"$tempScript`""
+            $pinfo.RedirectStandardOutput = $true
+            $pinfo.UseShellExecute = $false
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $pinfo
+            $process.Start() | Should -BeTrue
+            $output = $process.StandardOutput.ReadToEnd()
+            $process.WaitForExit()
+
+            # The debug trace for multiline commands should include all lines with DEBUG: prefix
+            $output | Should -Match 'DEBUG:.*Write-Output' -Because "debug output should contain the command with DEBUG: prefix"
+            $output | Should -Match 'DEBUG:.*bar"' -Because "debug output should contain the continuation line with DEBUG: prefix"
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
@@ -43,7 +43,11 @@ Describe "Set-PSDebug" -Tags "CI" {
             $process.StartInfo = $pinfo
             $process.Start() | Should -BeTrue
             $output = $process.StandardOutput.ReadToEnd()
-            $process.WaitForExit()
+            $exited = $process.WaitForExit(5000)
+            if (-not $exited) {
+                $process.Kill()
+            }
+            $exited | Should -BeTrue -Because "process should exit within timeout"
 
             # The debug trace for multiline commands should include all lines with DEBUG: prefix
             $output | Should -Match 'DEBUG:.*Write-Output' -Because "debug output should contain the command with DEBUG: prefix"
@@ -66,7 +70,11 @@ Describe "Set-PSDebug" -Tags "CI" {
             $process.StartInfo = $pinfo
             $process.Start() | Should -BeTrue
             $output = $process.StandardOutput.ReadToEnd()
-            $process.WaitForExit()
+            $exited = $process.WaitForExit(5000)
+            if (-not $exited) {
+                $process.Kill()
+            }
+            $exited | Should -BeTrue -Because "process should exit within timeout"
 
             # The debug trace for multiline commands should include all lines with DEBUG: prefix
             $output | Should -Match 'DEBUG:.*Write-Output' -Because "debug output should contain the command with DEBUG: prefix"


### PR DESCRIPTION
# PR Summary

Fix `Set-PSDebug -Trace` to display all lines of multiline commands.

## PR Context

Fixes #8113

When using `Set-PSDebug -Trace 1` or `-Trace 2`, multiline commands (e.g., using backtick line continuation) only showed the first line in debug output. This made it difficult to trace and debug scripts with multiline commands.

### Before this fix:
```powershell
Set-PSDebug -Trace 1

Write-Output "foo `
bar"
```
Output:
```
DEBUG:    3+  >>>> Write-Output "foo `

foo
bar
```

### After this fix:
Output:
```
DEBUG:    3+  >>>> Write-Output "foo `
DEBUG:    4+  >>>> bar"
foo
bar
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s):
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed:
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

## Description

### Root Cause

The `TraceLine` method in the debugger was calling `PositionUtilities.BriefMessage(extent.StartScriptPosition)`, which only considers the start position of an extent. For multiline commands, this meant only the first line was displayed.

### Solution

1. Added a new overload `PositionUtilities.BriefMessage(IScriptExtent extent)` that handles multiline extents by:
   - Detecting if an extent spans multiple lines
   - For single-line extents, delegating to the existing method
   - For multiline extents, formatting each line with appropriate line numbers and markers

2. Changed `TraceLine` to call the new extent-based overload and write each line separately so each gets the `DEBUG:` prefix.

### Files Changed

- `src/System.Management.Automation/engine/debugger/debugger.cs` - Changed `TraceLine` to use extent-based `BriefMessage` and write each line separately
- `src/System.Management.Automation/engine/parser/Position.cs` - Added new `BriefMessage(IScriptExtent)` overload
- `test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1` - Added tests for multiline command tracing with `-Trace 1` and `-Trace 2`

## Testing

### Test Coverage

Added test cases that:
1. Create a script with a multiline command using backtick line continuation
2. Run it in a separate process to capture trace output
3. Verify both the first line (`Write-Output`) and continuation line (`bar"`) appear in debug output with `DEBUG:` prefix

Tests cover both `-Trace 1` and `-Trace 2` options.

### Automated Tests

All tests pass:
```
Context Tracing can be used
  [+] Should be able to go through the tracing options
  [+] Should be able to set strict
  [+] Should skip magic extents created by pwsh
  [+] Should trace all lines of a multiline command
  [+] Should trace all lines of a multiline command with -Trace 2

Tests Passed: 5, Failed: 0
```
