### PR TITLE
Path filters: include deleted files in changed-file detection (Fixes #26356)

### DIFF
--- a/.github/actions/infrastructure/get-changed-files/README.md
+++ b/.github/actions/infrastructure/get-changed-files/README.md
@@ -6,8 +6,8 @@ A reusable composite action that retrieves the list of files changed in a pull r
 
 - Supports both `pull_request` and `push` events
 - Optional filtering by file pattern
-- Returns files as JSON array for easy consumption
-- Filters out deleted files (only returns added, modified, or renamed files)
+-- Returns files as JSON array for easy consumption
+-- By default filters out deleted files (only returns added, modified, or renamed files). Use the `include-deleted` input to include deleted/removed files when needed.
 - Handles up to 100 changed files per request
 
 ## Usage
@@ -59,6 +59,7 @@ A reusable composite action that retrieves the list of files changed in a pull r
 |------|-------------|----------|---------|
 | `filter` | Optional filter pattern (e.g., `*.md` for markdown files, `.github/` for GitHub files) | No | `''` |
 | `event-types` | Comma-separated list of event types to support (`pull_request`, `push`) | No | `pull_request` |
+| `include-deleted` | Include deleted/removed files in the results (`true`/`false`) | No | `false` |
 
 ## Outputs
 

--- a/.github/actions/infrastructure/get-changed-files/action.yml
+++ b/.github/actions/infrastructure/get-changed-files/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Optional filter pattern (e.g., "*.md" for markdown files, ".github/" for GitHub files)'
     required: false
     default: ''
+  include-deleted:
+    description: 'Include deleted/removed files in the results (true/false)'
+    required: false
+    default: 'false'
   event-types:
     description: 'Comma-separated list of event types to support (pull_request, push)'
     required: false
@@ -26,6 +30,7 @@ runs:
         script: |
           const eventTypes = '${{ inputs.event-types }}'.split(',').map(t => t.trim());
           const filter = '${{ inputs.filter }}';
+          const includeDeleted = ('${{ inputs.include-deleted }}' || 'false').toLowerCase() === 'true';
           let changedFiles = [];
 
           if (eventTypes.includes('pull_request') && context.eventName === 'pull_request') {
@@ -55,7 +60,7 @@ runs:
             }
 
             changedFiles = allFiles
-              .filter(file => file.status === 'added' || file.status === 'modified' || file.status === 'renamed')
+              .filter(file => file.status === 'added' || file.status === 'modified' || file.status === 'renamed' || (includeDeleted && file.status === 'removed'))
               .map(file => file.filename);
 
           } else if (eventTypes.includes('push') && context.eventName === 'push') {
@@ -69,7 +74,7 @@ runs:
             });
 
             changedFiles = comparison.files
-              .filter(file => file.status === 'added' || file.status === 'modified' || file.status === 'renamed')
+              .filter(file => file.status === 'added' || file.status === 'modified' || file.status === 'renamed' || (includeDeleted && file.status === 'removed'))
               .map(file => file.filename);
 
           } else {

--- a/.github/actions/infrastructure/path-filters/action.yml
+++ b/.github/actions/infrastructure/path-filters/action.yml
@@ -36,6 +36,8 @@ runs:
       id: get-files
       if: github.event_name == 'pull_request'
       uses: "./.github/actions/infrastructure/get-changed-files"
+      with:
+        include-deleted: 'true'
 
     - name: Check if GitHubWorkflowChanges is present
       id: filter


### PR DESCRIPTION
Fixes #26356 — Adds a minimal opt-in option to the changed-files action so the path-filters composite will receive deleted files (allowing CI decisions to consider removals), while all other consumers (including the markdown link verifier) keep the existing behavior; this change is intentionally small and low-risk.