### PR TITLE
Set-Content: avoid double confirmation by using CmdletProviderContext…

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/SetContentCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/SetContentCommand.cs
@@ -29,7 +29,14 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentNullException(nameof(paths));
             }
 
-            CmdletProviderContext context = new(GetCurrentContext());
+            // Use a context that does not carry the current cmdlet reference
+            // to avoid a second ShouldProcess prompt from the provider.
+            CmdletProviderContext currentContext = GetCurrentContext();
+            CmdletProviderContext context = new(currentContext.ExecutionContext, CommandOrigin.Internal)
+            {
+                SuppressWildcardExpansion = currentContext.SuppressWildcardExpansion,
+                Filter = currentContext.Filter
+            };
 
             foreach (string path in paths)
             {


### PR DESCRIPTION
…(ExecutionContext, CommandOrigin.Internal); add WhatIf test to assert single message (fixes #24434)

# PR Summary

Fixes: double confirmation prompts for Set-Content when -Confirm is used (issue #24434).
Cause: Provider-level ClearContent calls ShouldProcess while cmdlet-level Set-Content also calls ShouldProcess, and the provider context was inheriting the current cmdlet reference.
Result: Only one confirmation prompt is shown for Set-Content.
