### PR TITLE
Fix UseCulture: behavior for CSV delimiter #26513

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1803,6 +1803,10 @@ namespace Microsoft.PowerShell.Commands
                         // [CultureInfo]::GetCultures("AllCultures") | % { ([CultureInfo]($_.Name)).TextInfo.ListSeparator } | ? Length -ne 1
                         delimiter = CultureInfo.CurrentCulture.TextInfo.ListSeparator[0];
                     }
+                    else
+                    {
+                        delimiter = ImportExportCSVHelper.CSVDelimiter;
+                    }
 
                     break;
                 default:


### PR DESCRIPTION
# PR Summary

Fix #26513

Fixes behavior where ConvertTo-Csv and Export-Csv incorrectly used the culture-specific delimiter even when explicitly passed -UseCulture:$false. When UseCulture is set to $false, the commands now correctly fall back to the default comma (,) delimiter.

## PR Context

-UseCulture:$false was not being treated the same as omitting -UseCulture.
This resulted in inconsistent delimiter behavior, especially in cultures that use ; as the list separator.
This PR updates ImportExportCSVHelper.SetDelimiter to ensure that UseCulture:$false properly defaults to the standard CSV delimiter.

## PR Checklist

- [ x ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ x ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ x ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ x ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ x ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ x ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
