### PR TITLE
Add `ValidateNotNullOrEmpty` attribute to the `-Property` of `Format-Table/List/Custom`

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/Format-Object.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PowerShell.Commands
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]
+        [ValidateNotNullOrEmpty]
         public object[] Property
         {
             get { return _props; }

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -727,6 +727,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]
+        [ValidateNotNullOrEmpty]
         public object[] Property { get; set; }
 
         #endregion

--- a/test/powershell/engine/Formatting/BugFix.Tests.ps1
+++ b/test/powershell/engine/Formatting/BugFix.Tests.ps1
@@ -63,3 +63,17 @@ Describe "Hidden properties should not be returned by the 'FirstOrDefault' primi
         $outstring.Trim() | Should -BeExactly "Param$([System.Environment]::NewLine)-----$([System.Environment]::NewLine)Foo"
     }
 }
+
+Describe "'Format-Table/List/Custom -Property' should not throw NullRef exception" -Tag CI {
+
+    It "'<Command> -Property' requires value to be not null and not empty" -TestCases @(
+        @{ Command = "Format-Table"; NameInErrorId = "FormatTableCommand" }
+        @{ Command = "Format-List"; NameInErrorId = "FormatListCommand" }
+        @{ Command = "Format-Custom"; NameInErrorId = "FormatCustomCommand" }
+    ) {
+        param($Command, $NameInErrorId)
+
+        { Get-Process -Id $PID | & $Command -Property @() } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.$NameInErrorId"
+        { Get-Process -Id $PID | & $Command -Property $null } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.$NameInErrorId"
+    }
+}


### PR DESCRIPTION
## PR Summary

Fix #26543 

Add the `ValidateNotNullOrEmpty` attribute to the parameter `-Property` for `Format-Table`, `Format-List`, and `Format-Custom`.
This is to fix the null reference exception when using an empty array as the argument for `-Property`.

**Breaking Change**

It's a breaking change as today you can use `$null` as the argument for `Format-List/Table/Custom`, which behaves the same as `-Property` is not specified. By adding the `ValidateNotNullOrEmpty` attribute, `-Property $null` will fail. But this may fall in the bucket 3 (grey area) though.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
