### PR TITLE
[release/v7.6] Move package validation to package pipeline

### DIFF
--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -265,3 +265,9 @@ extends:
       dependsOn: [mac_package, windows_package, linux_package, nupkg, msixbundle]
       jobs:
       - template: /.pipelines/templates/uploadToAzure.yml@self
+
+    - stage: validatePackages
+      displayName: 'Validate Packages'
+      dependsOn: [upload]
+      jobs:
+      - template: /.pipelines/templates/release-validate-packagenames.yml@self

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -216,12 +216,6 @@ extends:
           arm64: 'yes'
           enableCredScan: false
 
-    - stage: validatePackages
-      displayName: 'Validate Packages'
-      dependsOn: []
-      jobs:
-      - template: /.pipelines/templates/release-validate-packagenames.yml@self
-
     - stage: ManualValidation
       dependsOn: []
       displayName: Manual Validation
@@ -272,7 +266,6 @@ extends:
       dependsOn:
         - ManualValidation
         - ReleaseAutomation
-        - validatePackages
         - fxdpackages
         - gbltool
         - validateSdk
@@ -365,7 +358,7 @@ extends:
             This is typically done by the community 1-2 days after the release.
 
     - stage: PublishMsix
-      dependsOn: 
+      dependsOn:
         - setReleaseTagAndChangelog
         - PushGitTagAndMakeDraftPublic
       displayName: Publish MSIX to store


### PR DESCRIPTION
Backport of #26414 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26414$$$
-->

Triggered by @adityapatwardhan on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This change moves package validation from the release pipeline to the package pipeline, improving sequencing and ensuring validation occurs earlier in the process. This is required to maintain proper build pipeline functionality on the release branch.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR was validated through CI pipeline testing. Change affects build/release automation and has been running successfully on main branch. Backport verified by cherry-pick success and will be validated through CI on the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk because this changes CI/CD pipeline structure, but the change is well-tested on main branch and is necessary to maintain pipeline consistency across branches. The risk is mitigated by the fact that this only moves validation to an earlier stage, reducing overall complexity.
