### PR TITLE
[release/v7.6] Add rebuild branch support with conditional MSIX signing

### DIFF
--- a/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run/Run.ps1
+++ b/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run/Run.ps1
@@ -354,6 +354,9 @@ try {
     $skipPublish = $metadataContent.SkipPublish
     $lts = $metadataContent.LTS
 
+    # Check if this is a rebuild version (e.g., 7.4.13-rebuild.5)
+    $isRebuild = $releaseVersion -match '-rebuild\.'
+
     if ($releaseVersion.Contains('-')) {
         $channel = 'preview'
         $packageNames = @('powershell-preview')
@@ -363,7 +366,8 @@ try {
         $packageNames = @('powershell')
     }
 
-    if ($lts) {
+    # Only add LTS package if not a rebuild branch
+    if ($lts -and -not $isRebuild) {
         $packageNames += @('powershell-lts')
     }
 

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -297,9 +297,20 @@ extends:
         - template: /.pipelines/templates/SetVersionVariables.yml@self
           parameters:
             ReleaseTagVar: $(ReleaseTagVar)
+        - template: /.pipelines/templates/rebuild-branch-check.yml@self
         - powershell: |
             $metadata = Get-Content '$(Build.SourcesDirectory)/PowerShell/tools/metadata.json' -Raw | ConvertFrom-Json
-            $LTS = $metadata.LTSRelease.Package
+
+            # Use the rebuild branch check from the template
+            $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+            # Don't mark as LTS release for rebuild branches
+            $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
+
+            if ($isRebuildBranch) {
+              Write-Verbose -Message "Rebuild branch detected, not marking as LTS release" -Verbose
+            }
+
             @{ ReleaseVersion = "$(Version)"; LTSRelease = $LTS } | ConvertTo-Json | Out-File "$(Build.StagingDirectory)\release.json"
             Get-Content "$(Build.StagingDirectory)\release.json"
 

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -260,6 +260,8 @@ extends:
       dependsOn: [windows_package]
       jobs:
       - template: /.pipelines/templates/package-create-msix.yml@self
+        parameters:
+          OfficialBuild: ${{ parameters.OfficialBuild }}
 
     - stage: upload
       dependsOn: [mac_package, windows_package, linux_package, nupkg, msixbundle]

--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -2,13 +2,31 @@ steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
     $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
+    $releaseTag = '$(OutputReleaseTag.releaseTag)'
+
+    # Rebuild branches should be treated as preview builds
+    # NOTE: The following regex is duplicated from rebuild-branch-check.yml.
+    # This duplication is necessary because channelSelection.yml does not call rebuild-branch-check.yml,
+    # and is used in contexts where that check may not have run.
+    # If you update this regex, also update it in rebuild-branch-check.yml to keep them in sync.
+    $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
+
     $LTS = $metadata.LTSRelease.Latest
     $Stable = $metadata.StableRelease.Latest
-    $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'
+    $isPreview = $releaseTag -match '-'
 
-    $IsLTS = [bool]$LTS
-    $IsStable = [bool]$Stable
-    $IsPreview = [bool]$isPreview
+    # If this is a rebuild branch, force preview mode and ignore LTS metadata
+    if ($isRebuildBranch) {
+        $IsLTS = $false
+        $IsStable = $false
+        $IsPreview = $true
+        Write-Verbose -Message "Rebuild branch detected, forcing Preview channel" -Verbose
+    }
+    else {
+        $IsLTS = [bool]$LTS
+        $IsStable = [bool]$Stable
+        $IsPreview = [bool]$isPreview
+    }
 
     $channelVars = @{
         IsLTS     = $IsLTS

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -63,6 +63,8 @@ jobs:
     parameters:
       nativePathRoot: '$(Agent.TempDirectory)'
 
+  - template: rebuild-branch-check.yml@self
+
   - download: CoOrdinatedBuildPipeline
     artifact: ${{ parameters.unsignedDrop }}
     displayName: 'Download unsigned artifacts'
@@ -140,7 +142,21 @@ jobs:
       }
 
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
-      $LTS = $metadata.LTSRelease.Package
+
+      Write-Verbose -Verbose "metadata:"
+      $metadata | Out-String | Write-Verbose -Verbose
+
+      # Use the rebuild branch check from the template
+      $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+      # Don't build LTS packages for rebuild branches
+      $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
+
+      if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose
+      }
+
+      Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
         Write-Verbose -Message "LTS Release: $LTS"

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -61,6 +61,8 @@ jobs:
     parameters:
       nativePathRoot: '$(Agent.TempDirectory)'
 
+  - template: rebuild-branch-check.yml@self
+
   - download: CoOrdinatedBuildPipeline
     artifact: macosBinResults-${{ parameters.buildArchitecture }}
 
@@ -104,7 +106,21 @@ jobs:
       Get-PSOptions | Write-Verbose -Verbose
 
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
-      $LTS = $metadata.LTSRelease.Package
+
+      Write-Verbose -Verbose "metadata:"
+      $metadata | Out-String | Write-Verbose -Verbose
+
+      # Use the rebuild branch check from the template
+      $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+      # Don't build LTS packages for rebuild branches
+      $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
+
+      if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose
+      }
+
+      Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
         Write-Verbose -Message "LTS Release: $LTS"

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: OfficialBuild
+    type: boolean
+    default: false
+
 jobs:
 - job: CreateMSIXBundle
   displayName: Create .msixbundle file
@@ -49,7 +54,7 @@ jobs:
           **/*.msix
         targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
       displayName: Download windows x86 packages
-    
+
     # Finds the makeappx tool on the machine with image: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
     - pwsh: |
         $cmd = Get-Command makeappx.exe -ErrorAction Ignore
@@ -99,12 +104,13 @@ jobs:
 
     - task: onebranch.pipeline.signing@1
       displayName: Sign MsixBundle
+      condition: eq('${{ parameters.OfficialBuild }}', 'true')
       inputs:
         command: 'sign'
         signing_profile: $(MSIXProfile)
         files_to_sign: '**/*.msixbundle'
         search_root: '$(BundleDir)'
-    
+
     - pwsh: |
         $signedBundle = Get-ChildItem -Path $(BundleDir) -Filter "*.msixbundle" -File
         Write-Verbose -Verbose "Signed bundle: $signedBundle"
@@ -126,12 +132,12 @@ jobs:
         Get-ChildItem -Path $(System.DefaultWorkingDirectory) -Recurse | Select-Object -ExpandProperty FullName
         Test-Path -Path '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP-Private.xml' | Write-Verbose -Verbose
       displayName: Output Pipeline.Workspace and System.DefaultWorkingDirectory
-    
+
     - template: channelSelection.yml@self
 
     - pwsh: |
         $IsLTS = '$(ChannelSelection.IsLTS)' -eq 'true'
-        $IsStable = '$(ChannelSelection.IsStable)' -eq 'true' 
+        $IsStable = '$(ChannelSelection.IsStable)' -eq 'true'
         $IsPreview = '$(ChannelSelection.IsPreview)' -eq 'true'
 
         Write-Verbose -Verbose "Channel Selection - LTS: $IsLTS, Stable: $IsStable, Preview: $IsPreview"
@@ -161,11 +167,11 @@ jobs:
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
-          else { 
+          else {
             Write-Error "No valid channel detected"
             exit 1
           }
-                       
+
         $config = $channelConfigs[$currentChannel]
         Write-Verbose -Verbose "Selected channel: $currentChannel"
         Write-Verbose -Verbose "App Store Name: $($config.AppStoreName)"
@@ -181,7 +187,7 @@ jobs:
           # Create namespace manager for XML with default namespace
           $nsManager = New-Object System.Xml.XmlNamespaceManager($pdpXml.NameTable)
           $nsManager.AddNamespace("pd", "http://schemas.microsoft.com/appx/2012/ProductDescription")
-          
+
           $appStoreNameElement = $pdpXml.SelectSingleNode("//pd:AppStoreName", $nsManager)
           if ($appStoreNameElement) {
             $appStoreNameElement.SetAttribute("_locID", $config.AppStoreName)
@@ -218,8 +224,31 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=ServiceConnection]$($config.ServiceEndpoint)"
         Write-Host "##vso[task.setvariable variable=SBConfigPath]$($sbConfigPath)"
+
+        # These variables are used in the next tasks to determine which ServiceEndpoint to use
+        $ltsValue = $IsLTS.ToString().ToLower()
+        $stableValue = $IsStable.ToString().ToLower()
+        $previewValue = $IsPreview.ToString().ToLower()
+        
+        Write-Verbose -Verbose "About to set variables:"
+        Write-Verbose -Verbose "  LTS=$ltsValue"
+        Write-Verbose -Verbose "  STABLE=$stableValue"
+        Write-Verbose -Verbose "  PREVIEW=$previewValue"
+        
+        Write-Host "##vso[task.setvariable variable=LTS]$ltsValue"
+        Write-Host "##vso[task.setvariable variable=STABLE]$stableValue"
+        Write-Host "##vso[task.setvariable variable=PREVIEW]$previewValue"
+        
+        Write-Verbose -Verbose "Variables set successfully"
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
+
+    - pwsh: |
+        Write-Verbose -Verbose "Checking variables after UpdateConfigs:"
+        Write-Verbose -Verbose "LTS=$(LTS)"
+        Write-Verbose -Verbose "STABLE=$(STABLE)"
+        Write-Verbose -Verbose "PREVIEW=$(PREVIEW)"
+      displayName: Debug - Check Variables
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package'
@@ -242,14 +271,14 @@ jobs:
         $submissionPackageDir = "$(System.DefaultWorkingDirectory)/SBOutDir"
         $jsonFile = "$submissionPackageDir/PowerShellStorePackage.json"
         $zipFile = "$submissionPackageDir/PowerShellStorePackage.zip"
-    
+
         if ((Test-Path $jsonFile) -and (Test-Path $zipFile)) {
           Write-Verbose -Verbose "Uploading StoreBroker Package files:"
           Write-Verbose -Verbose "JSON File: $jsonFile"
           Write-Verbose -Verbose "ZIP File: $zipFile"
 
           Copy-Item -Path $submissionPackageDir -Destination "$(ob_outputDirectory)" -Verbose -Recurse
-        } 
+        }
 
         else {
           Write-Error "Required files not found in $submissionPackageDir"

--- a/.pipelines/templates/rebuild-branch-check.yml
+++ b/.pipelines/templates/rebuild-branch-check.yml
@@ -1,0 +1,17 @@
+# This template checks if the current branch is a rebuild branch
+# and sets an output variable IsRebuildBranch that can be used by other templates
+steps:
+- pwsh: |
+    # Check if this is a rebuild branch (e.g., rebuild/v7.4.13-rebuild.5)
+    $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
+
+    $value = if ($isRebuildBranch) { 'true' } else { 'false' }
+    Write-Verbose -Message "IsRebuildBranch: $value" -Verbose
+
+    if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected: $(Build.SourceBranch)" -Verbose
+    }
+
+    Write-Host "##vso[task.setvariable variable=IsRebuildBranch;isOutput=true]$value"
+  name: RebuildBranchCheck
+  displayName: Check if Rebuild Branch

--- a/.pipelines/templates/windows-package-build.yml
+++ b/.pipelines/templates/windows-package-build.yml
@@ -55,6 +55,8 @@ jobs:
     parameters:
       nativePathRoot: '$(Agent.TempDirectory)'
 
+  - template: rebuild-branch-check.yml@self
+
   - download: CoOrdinatedBuildPipeline
     artifact: drop_windows_build_windows_${{ parameters.runtime }}_release
     displayName: Download signed artifacts
@@ -134,7 +136,21 @@ jobs:
       Get-PSOptions | Write-Verbose -Verbose
 
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
-      $LTS = $metadata.LTSRelease.Package
+
+      Write-Verbose -Verbose "metadata:"
+      $metadata | Out-String | Write-Verbose -Verbose
+
+      # Use the rebuild branch check from the template
+      $isRebuildBranch = '$(RebuildBranchCheck.IsRebuildBranch)' -eq 'true'
+
+      # Don't build LTS packages for rebuild branches
+      $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
+
+      if ($isRebuildBranch) {
+        Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose
+      }
+
+      Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
         Write-Verbose -Message "LTS Release: $LTS"


### PR DESCRIPTION
Backport of #26415 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26415$$$
-->

Triggered by @adityapatwardhan on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This backports critical rebuild branch detection and handling improvements to prevent accidental LTS releases from rebuild branches. Includes conditional MSIX signing and enhanced pipeline diagnostics.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR added comprehensive rebuild branch detection across all platform build templates. Backport verified by successful cherry-pick and conflict resolution. All changes are to build/packaging pipeline templates with no runtime code changes.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Changes only affect build and packaging pipeline templates. No runtime PowerShell code is modified. The enhancements add safety checks to prevent incorrect LTS package creation and improve diagnostics through better logging.

## Merge Conflicts

Resolved conflict in .pipelines/templates/package-create-msix.yml where enhanced variable setting code with verbose logging was missing from release/v7.6 branch. Applied the complete enhancement from original PR.
