### PR TITLE
[release/v7.6] Update the macos package name for preview releases to match the previous pattern

### DIFF
--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -82,7 +82,7 @@ jobs:
   - pwsh: |
       $message = @()
       Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -filter *.pkg | ForEach-Object {
-          if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx(\.10\.12)?\-(x64|arm64)\.pkg')
+          if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx\-(x64|arm64)\.pkg')
           {
               $messageInstance = "$($_.Name) is not a valid package name"
               $message += $messageInstance

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1147,14 +1147,11 @@ function New-UnixPackage {
         }
 
         # Determine if the version is a preview version
-        $IsPreview = Test-IsPreview -Version $Version -IsLTS:$LTS
-
-        # Preview versions have preview in the name
+        # Only LTS packages get a prefix in the name
+        # Preview versions are identified by the version string itself (e.g., 7.6.0-preview.6)
+        # Rebuild versions are also identified by the version string (e.g., 7.4.13-rebuild.5)
         $Name = if($LTS) {
             "powershell-lts"
-        }
-        elseif ($IsPreview) {
-            "powershell-preview"
         }
         else {
             "powershell"

--- a/tools/packaging/releaseTests/macOSPackage.tests.ps1
+++ b/tools/packaging/releaseTests/macOSPackage.tests.ps1
@@ -74,7 +74,28 @@ Describe "Verify macOS Package" {
             $script:package | Should -Not -BeNullOrEmpty -Because "A .pkg file should be created"
             $script:package.Extension | Should -Be ".pkg"
         }
-        
+
+        It "Package name should follow correct naming convention" {
+            $script:package | Should -Not -BeNullOrEmpty
+
+            # Regex pattern for valid macOS PKG package names.
+            # This pattern matches the validation used in release-validate-packagenames.yml
+            # Valid examples:
+            # - powershell-7.4.13-osx-x64.pkg (Stable release)
+            # - powershell-7.6.0-preview.6-osx-x64.pkg (Preview version string)
+            # - powershell-7.4.13-rebuild.5-osx-arm64.pkg (Rebuild version)
+            # - powershell-lts-7.4.13-osx-arm64.pkg (LTS package)
+            $pkgPackageNamePattern = '^powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx\-(x64|arm64)\.pkg$'
+
+            $script:package.Name | Should -Match $pkgPackageNamePattern -Because "Package name should follow the standard naming convention"
+        }
+
+        It "Package name should NOT use x86_64 with underscores" {
+            $script:package | Should -Not -BeNullOrEmpty
+
+            $script:package.Name | Should -Not -Match 'x86_64' -Because "Package should use 'x64' not 'x86_64' (with underscores) for compatibility"
+        }
+
         It "Package should expand successfully" {
             $script:expandDir | Should -Exist
             Get-ChildItem -Path $script:expandDir | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
Backport of #26429 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26429$$$
-->

Triggered by @adityapatwardhan on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes GitHub Actions workflow failures in release-validate-packagenames.yml by updating deprecated package naming patterns. Updates packaging module to use consistent naming convention. Essential for proper package validation and build processes.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by running affected workflows in fork environment. Added comprehensive package name validation tests including regex patterns that match the pipeline validation. Confirmed the updated naming convention works correctly for stable, preview, rebuild, and LTS packages.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk as it affects build infrastructure and package validation, but the change is well-tested and follows established patterns. The fix prevents build failures and ensures consistent package naming across releases.

## Merge Conflicts

Simple addition conflict in tools/packaging/releaseTests/macOSPackage.tests.ps1 - added new package name validation test cases that were missing from the release branch. Applied exact changes from original PR.
