### PR TITLE
Refactor the module path construction code to make it more robust and easier to maintain

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1781,7 +1781,18 @@ namespace Microsoft.PowerShell
                 // since the ConsoleHostStartupException is uncaught
                 // higher in the call stack and the whole process
                 // will exit soon
-                throw new ConsoleHostStartupException(ConsoleHostStrings.ShellCannotBeStarted, e);
+                StringBuilder sb = new();
+                sb.AppendLine(e.StackTrace);
+
+                Exception inner = e.InnerException;
+                while (inner is { })
+                {
+                    sb.AppendLine("--- inner exception ---");
+                    sb.AppendLine(inner.StackTrace);
+                    inner = inner.InnerException;
+                }
+
+                throw new ConsoleHostStartupException(sb.ToString(), e);
             }
             finally
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2254,20 +2254,16 @@ namespace Microsoft.PowerShell
             }
 
             // Print the stack trace.
-            var sb = new StringBuilder(capacity: 100)
-                .AppendLine()
-                .AppendLine($"--- {e.GetType().FullName} ---")
-                .AppendLine(e.StackTrace);
+            Console.Error.WriteLine($"\n--- {e.GetType().FullName} ---");
+            Console.Error.WriteLine(e.StackTrace);
 
             Exception inner = e.InnerException;
             while (inner is { })
             {
-                sb.AppendLine($"--- inner {inner.GetType().FullName} ---");
-                sb.AppendLine(inner.StackTrace);
+                Console.Error.WriteLine($"--- inner {inner.GetType().FullName} ---");
+                Console.Error.WriteLine(inner.StackTrace);
                 inner = inner.InnerException;
             }
-
-            Console.Error.WriteLine(sb.ToString());
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2254,14 +2254,15 @@ namespace Microsoft.PowerShell
             }
 
             // Print the stack trace.
-            var sb = new StringBuilder(capacity: e.StackTrace.Length * 2)
+            var sb = new StringBuilder(capacity: 100)
                 .AppendLine()
+                .AppendLine($"--- {e.GetType().FullName} ---")
                 .AppendLine(e.StackTrace);
 
             Exception inner = e.InnerException;
             while (inner is { })
             {
-                sb.AppendLine("--- inner exception ---");
+                sb.AppendLine($"--- inner {inner.GetType().FullName} ---");
                 sb.AppendLine(inner.StackTrace);
                 inner = inner.InnerException;
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1086,7 +1086,7 @@ namespace System.Management.Automation
         /// Adds paths to a 'combined path' string (like %Path% or %PSModulePath%) if they are not already there.
         /// </summary>
         /// <param name="basePath">Path string (like %Path% or %PSModulePath%).</param>
-        /// <param name="pathToAdd">Collection of individual paths to add.</param>
+        /// <param name="pathToAdd">An individual path to add, or multiple paths separated by the path separator character.</param>
         /// <param name="insertPosition">-1 to append to the end; 0 to insert in the beginning of the string; etc...</param>
         /// <returns>Result string.</returns>
         private static string UpdatePath(string basePath, string pathToAdd, ref int insertPosition)

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1272,11 +1272,14 @@ namespace System.Management.Automation
 
         private static string UpdatePath(string path, string pathToAdd, ref int insertIndex)
         {
-            Console.WriteLine("---- UpdatePath ----");
-            Console.WriteLine("path: " + path);
-            Console.WriteLine("pathToAdd: " + pathToAdd);
-            Console.WriteLine("insertIndex: " + insertIndex);
-            Console.WriteLine("-------- END --------");
+            if (Environment.GetEnvironmentVariable("_debug_me_") is string)
+            {
+                Console.WriteLine("---- UpdatePath ----");
+                Console.WriteLine("path: " + path);
+                Console.WriteLine("pathToAdd: " + pathToAdd);
+                Console.WriteLine("insertIndex: " + insertIndex);
+                Console.WriteLine("-------- END --------");
+            }
 
             if (!string.IsNullOrEmpty(pathToAdd))
             {

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1106,7 +1106,7 @@ namespace System.Management.Automation
                 return basePath;
             }
 
-            var result = new StringBuilder(basePath);
+            var result = new StringBuilder(basePath, capacity: basePath.Length + pathToAdd.Length + newPaths.Length);
             var addedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             string[] initialPaths = basePath.Split(
                 Path.PathSeparator,
@@ -1116,14 +1116,14 @@ namespace System.Management.Automation
             {
                 // Remove the trailing directory separators.
                 // Trailing white spaces were already removed by 'StringSplitOptions.TrimEntries'.
-                addedPaths.Add(NormalizePath(p));
+                addedPaths.Add(Path.TrimEndingDirectorySeparator(p));
             }
 
             foreach (string subPathToAdd in newPaths)
             {
                 // Remove the trailing directory separators.
                 // Trailing white spaces were already removed by 'StringSplitOptions.TrimEntries'.
-                string normalizedPath = NormalizePath(subPathToAdd);
+                string normalizedPath = Path.TrimEndingDirectorySeparator(subPathToAdd);
                 if (addedPaths.Contains(normalizedPath))
                 {
                     // The normalized sub path was already added - skip it.
@@ -1159,19 +1159,6 @@ namespace System.Management.Automation
             }
 
             return result.ToString();
-
-            // Local function to normalize a path by removing trailing directory separators.
-            static string NormalizePath(string path)
-            {
-                string normalizedPath = path.TrimEnd(Path.DirectorySeparatorChar);
-                if (normalizedPath.Length is 0)
-                {
-                    // If the 'path' is '\' or '/' only, we need to keep the ending directory separator.
-                    normalizedPath = Path.DirectorySeparatorChar.ToString();
-                }
-
-                return normalizedPath;
-            }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1272,6 +1272,12 @@ namespace System.Management.Automation
 
         private static string UpdatePath(string path, string pathToAdd, ref int insertIndex)
         {
+            Console.WriteLine("---- UpdatePath ----");
+            Console.WriteLine("path: " + path);
+            Console.WriteLine("pathToAdd: " + pathToAdd);
+            Console.WriteLine("insertIndex: " + insertIndex);
+            Console.WriteLine("-------- END --------");
+
             if (!string.IsNullOrEmpty(pathToAdd))
             {
                 path = AddToPath(path, pathToAdd, insertIndex);

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -403,7 +403,11 @@ export $envVarName='$guid'
             $psModulePath = & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command '$env:PSModulePath'
 
             ## $mPath1 already exists in the value of env PSModulePath, so it won't be added again.
-            $psModulePath.Contains("${mPath1}${pathSep}", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
+            $index = $psModulePath.IndexOf("${mPath1}${pathSep}", [System.StringComparison]::OrdinalIgnoreCase)
+            $index | Should -BeGreaterThan 0
+            $index += $mPath1.Length
+            $psModulePath.IndexOf($mPath1, $index, [System.StringComparison]::OrdinalIgnoreCase) | Should -BeExactly -1
+
             ## $mPath2 should be added at the index position 0.
             $psModulePath.StartsWith("${mPath2}${pathSep}", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
         }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -392,9 +392,10 @@ export $envVarName='$guid'
             $CustomSettingsFile = Join-Path -Path $TestDrive -ChildPath 'powershell.test.json'
             $mPath1 = Join-Path $PSHOME 'Modules'
             $mPath2 = Join-Path $TestDrive 'NonExist'
+            $pathSep = [System.IO.Path]::PathSeparator
 
             ## Use multiple paths in the setting.
-            $ModulePath = "$mPath1;$mPath2".Replace('\', "\\")
+            $ModulePath = "${mPath1}${pathSep}${mPath2}".Replace('\', "\\")
             Set-Content -Path $CustomSettingsfile -Value "{`"Microsoft.PowerShell:ExecutionPolicy`":`"Unrestricted`", `"PSModulePath`": `"$ModulePath`" }" -ErrorAction Stop
         }
 
@@ -402,9 +403,9 @@ export $envVarName='$guid'
             $psModulePath = & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command '$env:PSModulePath'
 
             ## $mPath1 already exists in the value of env PSModulePath, so it won't be added again.
-            $psModulePath.Contains("$mPath1;", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
+            $psModulePath.Contains("${mPath1}${pathSep}", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
             ## $mPath2 should be added at the index position 0.
-            $psModulePath.StartsWith("$mPath2;", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
+            $psModulePath.StartsWith("${mPath2}${pathSep}", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
         }
     }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -386,6 +386,28 @@ export $envVarName='$guid'
         }
     }
 
+    Context "-SettingsFile Commandline switch set 'PSModulePath'" {
+
+        BeforeAll {
+            $CustomSettingsFile = Join-Path -Path $TestDrive -ChildPath 'powershell.test.json'
+            $mPath1 = Join-Path $PSHOME 'Modules'
+            $mPath2 = Join-Path $TestDrive 'NonExist'
+
+            ## Use multiple paths in the setting.
+            $ModulePath = "$mPath1;$mPath2".Replace('\', "\\")
+            Set-Content -Path $CustomSettingsfile -Value "{`"Microsoft.PowerShell:ExecutionPolicy`":`"Unrestricted`", `"PSModulePath`": `"$ModulePath`" }" -ErrorAction Stop
+        }
+
+        It "Verify PowerShell PSModulePath should contain paths from config file" {
+            $psModulePath = & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command '$env:PSModulePath'
+
+            ## $mPath1 already exists in the value of env PSModulePath, so it won't be added again.
+            $psModulePath.Contains("$mPath1;", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
+            ## $mPath2 should be added at the index position 0.
+            $psModulePath.StartsWith("$mPath2;", [System.StringComparison]::OrdinalIgnoreCase) | Should -BeTrue
+        }
+    }
+
     Context "Pipe to/from powershell" {
         BeforeAll {
             if ($null -ne $PSStyle) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #26536

There are 2 issues surfaced from #26536 that we need to address:
1. The error reporting in the method `ReportExceptionFallback(Exception e, string header)` does not write out stack trace of the exception, which makes it hard to diagnose failures like `ShellCannotBeStarted`.
2. The `UpdatePath` method used in module path construction doesn't handle the case where `personalModulePathToUse` may contain multiple paths separated by the `PathSperator` (user can define `PSModulePath` in `powershell.config.json` with such a value).

The fixes are:
1. Write out stack trace of the exception in `ReportExceptionFallback(Exception e, string header)`, at the end.
2. Refactored the module path construction code to make it more robust and easier to maintain
    - Removed the old existing `UpdatePath` method.
    - Removed the old `PathContainsSubstring` method. Change to a difference approach that is much more efficient.
    - Refactored the `AddPath` method and rename it to be `UpdatePath`
    - Updated `SetModulePath()` to not blindly add a path separator when the environment variable `PSModulePath` is initially not set in all scopes.
    - Call `SetModulePath()` in the static constructor of `ModuleIntrinsics` instead of the instance constructor. So, we only need to construct the module path once per process (instead of once per a new Runspace).

With the changes, PowerShell won't crash even if the personal module path is like `C:\Users\marcv\OneDrive - company &amp; name namepart2\Dokumente\PowerShell\Modules` as reported in the issue.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
