### PR TITLE
[release/v7.6] Properly Expand Aliases to their actual ResolvedCommand

### DIFF
--- a/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs
@@ -565,9 +565,7 @@ namespace System.Management.Automation.Runspaces
                 typeName,
                 new PSScriptProperty(
                     @"DisplayName",
-                    GetScriptBlock(@"if ($this.Name.IndexOf('-') -lt 0)
-          {
-          if ($null -ne $this.ResolvedCommand)
+                    GetScriptBlock(@"if ($null -ne $this.ResolvedCommand)
           {
           $this.Name + "" -> "" + $this.ResolvedCommand.Name
           }
@@ -575,11 +573,7 @@ namespace System.Management.Automation.Runspaces
           {
           $this.Name + "" -> "" + $this.Definition
           }
-          }
-          else
-          {
-          $this.Name
-          }"),
+          "),
                     setterScript: null,
                     shouldCloneOnAccess: true),
                 typeMembers,

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -155,6 +155,16 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
             $returnObject[$i].Definition | Should -Be 'Get-Command'
         }
     }
+
+    It "Get-Alias DisplayName should always show AliasName -> ResolvedCommand for all aliases" {
+        Set-Alias -Name Test-MyAlias -Value Get-Command -Force
+        Set-Alias -Name tma -Value Test-MyAlias -force
+        $aliases = Get-Alias Test-MyAlias, tma
+        $aliases | ForEach-Object {
+            $_.DisplayName | Should -Be "$($_.Name) -> Get-Command"
+        }
+        $aliases.Name.foreach{Remove-Item Alias:$_ -ErrorAction SilentlyContinue}
+    }
 }
 
 Describe "Get-Alias" -Tags "CI" {


### PR DESCRIPTION
Backport of #25763 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:25763$$$
-->

Triggered by @adityapatwardhan on behalf of @kilasuit

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

This fixes a long-standing quirk in how aliased commands display their resolved command names. The change improves user experience by consistently showing alias -> resolved command mapping for better discoverability. This is an engine improvement that affects how Get-Alias displays command information.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR added comprehensive tests in Get-Alias.Tests.ps1 to verify that DisplayName always shows the correct "AliasName -> ResolvedCommand" format for all aliases. The fix was verified to resolve issue #25616.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a display/formatting improvement in the engine's alias system with comprehensive test coverage. The change is isolated to the DisplayName script property logic and doesn't affect core command execution or critical functionality.
