### PR TITLE
[release/v7.6] Add Delimiter parameter to Get-Clipboard

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetClipboardCommand.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Management.Automation.Language;
 using Microsoft.PowerShell.Commands.Internal;
 
 namespace Microsoft.PowerShell.Commands
@@ -33,6 +35,13 @@ namespace Microsoft.PowerShell.Commands
                 _raw = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets the delimiters to use when splitting the clipboard content.
+        /// </summary>
+        [Parameter]
+        [ArgumentCompleter(typeof(DelimiterCompleter))]
+        public string[] Delimiter { get; set; } = [Environment.NewLine];
 
         private bool _raw;
 
@@ -68,11 +77,40 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                string[] splitSymbol = { Environment.NewLine };
-                result.AddRange(textContent.Split(splitSymbol, StringSplitOptions.None));
+                result.AddRange(textContent.Split(Delimiter, StringSplitOptions.None));
             }
 
             return result;
+        }
+    }
+
+    /// <summary>
+    /// Provides argument completion for the Delimiter parameter.
+    /// </summary>
+    public sealed class DelimiterCompleter : IArgumentCompleter
+    {
+        /// <summary>
+        /// Provides argument completion for the Delimiter parameter.
+        /// </summary>
+        /// <param name="commandName">The name of the command that is being completed.</param>
+        /// <param name="parameterName">The name of the parameter that is being completed.</param>
+        /// <param name="wordToComplete">The input text to filter the results by.</param>
+        /// <param name="commandAst">The ast of the command that triggered the completion.</param>
+        /// <param name="fakeBoundParameters">The parameters bound to the command.</param>
+        /// <returns>Completion results.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            wordToComplete ??= string.Empty;
+            var pattern = new WildcardPattern(wordToComplete + '*', WildcardOptions.IgnoreCase);
+            if (pattern.IsMatch("CRLF") || pattern.IsMatch("Windows"))
+            {
+                yield return new CompletionResult("\"`r`n\"", "CRLF", CompletionResultType.ParameterValue, "Windows (CRLF)");
+            }
+
+            if (pattern.IsMatch("LF") || pattern.IsMatch("Unix") || pattern.IsMatch("Linux"))
+            {
+                yield return new CompletionResult("\"`n\"", "LF", CompletionResultType.ParameterValue, "UNIX (LF)");
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clipboard.Tests.ps1
@@ -36,6 +36,13 @@ Describe 'Clipboard cmdlet tests' -Tag CI {
             Get-Clipboard -Raw | Should -BeExactly "1$([Environment]::NewLine)2"
         }
 
+        It 'Get-Clipboard -Delimiter should return items based on the delimiter' {
+            Set-Clipboard -Value "Line1`r`nLine2`nLine3"
+            $result = Get-Clipboard -Delimiter "`r`n", "`n"
+            $result.Count | Should -Be 3
+            $result | ForEach-Object -Process {$_.Length | Should -Be "LineX".Length}
+        }
+
         It 'Set-Clipboard -Append will add text' {
             'hello' | Set-Clipboard
             'world' | Set-Clipboard -Append


### PR DESCRIPTION
Backport of #26134 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26134$$$
-->

Triggered by @adityapatwardhan on behalf of @MartinGC94

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Adds new Delimiter parameter to Get-Clipboard cmdlet allowing users to customize delimiters for splitting clipboard content. This enhances functionality for handling different line endings across platforms.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

New tests added in Clipboard.Tests.ps1 to verify the new Delimiter parameter functionality. The backport preserves all existing functionality while adding the new parameter capability.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Feature addition with backwards compatibility, isolated to Get-Clipboard cmdlet with comprehensive test coverage. No breaking changes or core engine modifications.
