### PR TITLE
Centralize ExcludeProperty filter application in ViewGenerator base class

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -351,9 +351,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private List<MshResolvedExpressionParameterAssociation> _activeAssociationList;
 
         /// <summary>
-        /// Gets the current active association list for read-only access.
+        /// Gets the current active association list.
         /// </summary>
-        protected IReadOnlyList<MshResolvedExpressionParameterAssociation> ActiveAssociationList => _activeAssociationList;
+        protected List<MshResolvedExpressionParameterAssociation> ActiveAssociationList => _activeAssociationList;
 
         /// <summary>
         /// Builds the raw association list for the given object.

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -360,8 +360,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// Subclasses override this to provide cmdlet-specific property expansion logic.
         /// </summary>
         /// <param name="so">The object to build the association list for.</param>
+        /// <param name="propertyList">The list of properties specified by the user, or null if not specified.</param>
         /// <returns>The raw association list, or null if not applicable.</returns>
-        protected virtual List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so)
+        protected virtual List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so, List<MshParameter> propertyList)
         {
             return null;
         }
@@ -376,8 +377,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             if (_activeAssociationList is null)
             {
-                var rawList = BuildRawAssociationList(so);
-                _activeAssociationList = ApplyExcludeFilter(rawList);
+                var propertyList = parameters?.mshParameterList;
+                var excludeFilter = parameters?.excludePropertyFilter;
+                var rawList = BuildRawAssociationList(so, propertyList);
+                _activeAssociationList = ApplyExcludeFilter(rawList, excludeFilter);
             }
 
             return _activeAssociationList;
@@ -409,17 +412,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return associationList
                 .Where(item => !excludeFilter.IsMatch(item.ResolvedExpression))
                 .ToList();
-        }
-
-        /// <summary>
-        /// Applies the ExcludeProperty filter to the given association list.
-        /// </summary>
-        /// <param name="associationList">The list to filter.</param>
-        /// <returns>The filtered list, or the original list if no filter is specified.</returns>
-        private List<MshResolvedExpressionParameterAssociation> ApplyExcludeFilter(
-            List<MshResolvedExpressionParameterAssociation> associationList)
-        {
-            return ApplyExcludeFilter(associationList, parameters?.excludePropertyFilter);
         }
 
         protected string GetExpressionDisplayValue(PSObject so, int enumerationLimit, PSPropertyExpression ex,

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -348,13 +348,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         protected DataBaseInfo dataBaseInfo = new DataBaseInfo();
 
-        private List<MshResolvedExpressionParameterAssociation> _activeAssociationList;
-
-        /// <summary>
-        /// Gets the current active association list.
-        /// </summary>
-        protected List<MshResolvedExpressionParameterAssociation> ActiveAssociationList => _activeAssociationList;
-
         /// <summary>
         /// Builds the raw association list for the given object.
         /// Subclasses override this to provide cmdlet-specific property expansion logic.
@@ -368,30 +361,16 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// Gets the active association list for the given object, with ExcludeProperty filter applied.
-        /// If the list is not yet built, it will be built using BuildRawAssociationList.
+        /// Builds the active association list for the given object, with ExcludeProperty filter applied.
         /// </summary>
-        /// <param name="so">The object to get the association list for.</param>
+        /// <param name="so">The object to build the association list for.</param>
         /// <returns>The filtered association list.</returns>
-        protected List<MshResolvedExpressionParameterAssociation> GetActiveAssociationList(PSObject so)
+        protected List<MshResolvedExpressionParameterAssociation> BuildActiveAssociationList(PSObject so)
         {
-            if (_activeAssociationList is null)
-            {
-                var propertyList = parameters?.mshParameterList;
-                var excludeFilter = parameters?.excludePropertyFilter;
-                var rawList = BuildRawAssociationList(so, propertyList);
-                _activeAssociationList = ApplyExcludeFilter(rawList, excludeFilter);
-            }
-
-            return _activeAssociationList;
-        }
-
-        /// <summary>
-        /// Resets the active association list, forcing it to be rebuilt on next access.
-        /// </summary>
-        protected void ResetActiveAssociationList()
-        {
-            _activeAssociationList = null;
+            var propertyList = parameters?.mshParameterList;
+            var excludeFilter = parameters?.excludePropertyFilter;
+            var rawList = BuildRawAssociationList(so, propertyList);
+            return ApplyExcludeFilter(rawList, excludeFilter);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
@@ -514,13 +513,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             List<MshResolvedExpressionParameterAssociation> activeAssociationList =
                         AssociationManager.SetupActiveProperties(parameterList, so, _expressionFactory);
 
-            // Apply ExcludeProperty filter if specified
-            if (_parameters != null && _parameters.excludePropertyFilter != null)
-            {
-                activeAssociationList = activeAssociationList
-                    .Where(item => !_parameters.excludePropertyFilter.IsMatch(item.ResolvedExpression))
-                    .ToList();
-            }
+            // Apply ExcludeProperty filter using the centralized method
+            activeAssociationList = ViewGenerator.ApplyExcludeFilter(activeAssociationList, _parameters?.excludePropertyFilter);
 
             // create a format entry
             FormatEntry fe = new FormatEntry();

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
@@ -183,8 +183,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private ListViewEntry GenerateListViewEntryFromProperties(PSObject so, int enumerationLimit)
         {
-            // Get active association list (with ExcludeProperty filter applied)
-            var associationList = GetActiveAssociationList(so);
+            // Build active association list (with ExcludeProperty filter applied)
+            var associationList = BuildActiveAssociationList(so);
 
             ListViewEntry lve = new ListViewEntry();
 
@@ -220,8 +220,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 lvf.formatPropertyField.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, a.ResolvedExpression, directive);
                 lve.listViewFieldList.Add(lvf);
             }
-
-            ResetActiveAssociationList();
             return lve;
         }
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
@@ -35,10 +35,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Builds the raw association list for list formatting.
         /// </summary>
-        protected override List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so)
+        protected override List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so, List<MshParameter> propertyList)
         {
-            List<MshParameter> mshParameterList = this.parameters?.mshParameterList;
-            return AssociationManager.SetupActiveProperties(mshParameterList, so, this.expressionFactory);
+            return AssociationManager.SetupActiveProperties(propertyList, so, this.expressionFactory);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -41,14 +41,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Builds the raw association list for table formatting.
         /// </summary>
-        protected override List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so)
+        protected override List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so, List<MshParameter> propertyList)
         {
-            List<MshParameter> rawMshParameterList = this.parameters?.mshParameterList;
-
             // check if we received properties from the command line
-            if (rawMshParameterList is not null && rawMshParameterList.Count > 0)
+            if (propertyList is not null && propertyList.Count > 0)
             {
-                return AssociationManager.ExpandTableParameters(rawMshParameterList, so);
+                return AssociationManager.ExpandTableParameters(propertyList, so);
             }
 
             // we did not get any properties:

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -16,11 +16,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private List<MshResolvedExpressionParameterAssociation> _activeAssociationList;
 
-        /// <summary>
-        /// Gets the cached active association list.
-        /// </summary>
-        private List<MshResolvedExpressionParameterAssociation> ActiveAssociationList => _activeAssociationList;
-
         internal override void Initialize(TerminatingErrorContext terminatingErrorContext, PSPropertyExpressionFactory mshExpressionFactory, TypeInfoDataBase db, ViewDefinition view, FormattingCommandLineParameters formatParameters)
         {
             base.Initialize(terminatingErrorContext, mshExpressionFactory, db, view, formatParameters);
@@ -231,9 +226,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             thi.hideHeader = this.HideHeaders;
             thi.repeatHeader = this.RepeatHeader;
 
-            for (int k = 0; k < this.ActiveAssociationList.Count; k++)
+            for (int k = 0; k < _activeAssociationList.Count; k++)
             {
-                MshResolvedExpressionParameterAssociation a = this.ActiveAssociationList[k];
+                MshResolvedExpressionParameterAssociation a = _activeAssociationList[k];
                 TableColumnInfo ci = new TableColumnInfo();
 
                 // set the label of the column
@@ -244,7 +239,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         ci.propertyName = (string)key;
                 }
 
-                ci.propertyName ??= this.ActiveAssociationList[k].ResolvedExpression.ToString();
+                ci.propertyName ??= _activeAssociationList[k].ResolvedExpression.ToString();
 
                 // set the width of the table
                 if (a.OriginatingParameter != null)
@@ -476,13 +471,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private TableRowEntry GenerateTableRowEntryFromFromProperties(PSObject so, int enumerationLimit)
         {
             TableRowEntry tre = new TableRowEntry();
-            for (int k = 0; k < this.ActiveAssociationList.Count; k++)
+            for (int k = 0; k < _activeAssociationList.Count; k++)
             {
                 FormatPropertyField fpf = new FormatPropertyField();
                 FieldFormattingDirective directive = null;
-                if (ActiveAssociationList[k].OriginatingParameter != null)
+                if (_activeAssociationList[k].OriginatingParameter != null)
                 {
-                    directive = ActiveAssociationList[k].OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
+                    directive = _activeAssociationList[k].OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
                 }
 
                 if (directive is null)
@@ -491,7 +486,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     directive.isTable = true;
                 }
 
-                fpf.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, this.ActiveAssociationList[k].ResolvedExpression, directive);
+                fpf.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, _activeAssociationList[k].ResolvedExpression, directive);
                 tre.formatPropertyFieldList.Add(fpf);
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -14,6 +14,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         // tableBody to use for this instance of the ViewGenerator;
         private TableControlBody _tableBody;
 
+        private List<MshResolvedExpressionParameterAssociation> _activeAssociationList;
+
+        /// <summary>
+        /// Gets the cached active association list.
+        /// </summary>
+        private List<MshResolvedExpressionParameterAssociation> ActiveAssociationList => _activeAssociationList;
+
         internal override void Initialize(TerminatingErrorContext terminatingErrorContext, PSPropertyExpressionFactory mshExpressionFactory, TypeInfoDataBase db, ViewDefinition view, FormattingCommandLineParameters formatParameters)
         {
             base.Initialize(terminatingErrorContext, mshExpressionFactory, db, view, formatParameters);
@@ -35,7 +42,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             // Build the active association list (with ExcludeProperty filter applied)
-            _ = GetActiveAssociationList(so);
+            _activeAssociationList = BuildActiveAssociationList(so);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
@@ -18,14 +18,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Builds the raw association list for wide formatting.
         /// </summary>
-        protected override List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so)
+        protected override List<MshResolvedExpressionParameterAssociation> BuildRawAssociationList(PSObject so, List<MshParameter> propertyList)
         {
-            List<MshParameter> rawMshParameterList = this.parameters?.mshParameterList;
-
             // check if we received properties from the command line
-            if (rawMshParameterList is not null && rawMshParameterList.Count > 0)
+            if (propertyList is not null && propertyList.Count > 0)
             {
-                return AssociationManager.ExpandParameters(rawMshParameterList, so);
+                return AssociationManager.ExpandParameters(propertyList, so);
             }
 
             // we did not get any properties:

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
@@ -163,8 +163,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private WideViewEntry GenerateWideViewEntryFromProperties(PSObject so, int enumerationLimit)
         {
-            // Get active association list (with ExcludeProperty filter applied)
-            var associationList = GetActiveAssociationList(so);
+            // Build active association list (with ExcludeProperty filter applied)
+            var associationList = BuildActiveAssociationList(so);
 
             WideViewEntry wve = new WideViewEntry();
             FormatPropertyField fpf = new FormatPropertyField();
@@ -182,8 +182,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                 fpf.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, a.ResolvedExpression, directive);
             }
-
-            ResetActiveAssociationList();
             return wve;
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR centralizes the `ExcludeProperty` filter application logic in the `ViewGenerator` base class, addressing the enhancement requested in #26568.

## Changes

**ViewGenerator base class:**
- Changed `activeAssociationList` from `protected` field to `private` field (`_activeAssociationList`)
- Added `ActiveAssociationList` read-only property (returns `IReadOnlyList<>` for safety)
- Added `BuildRawAssociationList(PSObject so, List<MshParameter> propertyList)` virtual method for subclasses to override
- Added `GetActiveAssociationList()` template method that extracts both `propertyList` and `excludeFilter` from `parameters` and passes them explicitly to the respective methods
- Added `ResetActiveAssociationList()` method for List/Wide per-object processing
- Added `internal static ApplyExcludeFilter()` for reuse in ComplexViewObjectBrowser

**Table/List/Wide ViewGenerators:**
- Refactored to use the template method pattern
- Override `BuildRawAssociationList(PSObject so, List<MshParameter> propertyList)` to provide cmdlet-specific property expansion
- Subclasses no longer access `parameters` field directly; they receive `propertyList` as a method parameter
- Filter application is now structurally guaranteed (cannot be forgotten)

**Complex ViewGenerator:**
- Replaced inline filtering logic with `ViewGenerator.ApplyExcludeFilter()` call
- Removed `using System.Linq;` (no longer needed)

## PR Context

PR #26514 added the `-ExcludeProperty` parameter to Format-* cmdlets. However, each ViewGenerator subclass had to manually call `ApplyExcludePropertyFilter()` after building the association list. This approach had two issues:

1. **Future implementations**: New ViewGenerator subclasses could forget to apply the filter
2. **Discoverability**: The base class didn't make this requirement obvious

This PR addresses these concerns by:
- Making `_activeAssociationList` private so subclasses cannot directly assign to it
- Providing `GetActiveAssociationList()` which automatically applies the filter
- Establishing a clear contract via `BuildRawAssociationList()` that subclasses override

**Note:** `ComplexViewGenerator` uses a recursive architecture with `ComplexViewObjectBrowser` (a separate class), so it cannot fully adopt the template method pattern. However, code duplication is eliminated by reusing `ViewGenerator.ApplyExcludeFilter()`.

## Design Decision: Explicit Parameter Passing

The template method `GetActiveAssociationList()` extracts both `propertyList` and `excludeFilter` from the `parameters` field at the same level, then passes them explicitly to the respective methods:

```csharp
protected List<MshResolvedExpressionParameterAssociation> GetActiveAssociationList(PSObject so)
{
    if (_activeAssociationList is null)
    {
        var propertyList = parameters?.mshParameterList;
        var excludeFilter = parameters?.excludePropertyFilter;
        var rawList = BuildRawAssociationList(so, propertyList);
        _activeAssociationList = ApplyExcludeFilter(rawList, excludeFilter);
    }

    return _activeAssociationList;
}
```

This design ensures:
- **Symmetry**: Both `propertyList` and `excludeFilter` are retrieved at the same abstraction level
- **Explicit data flow**: Subclasses receive `propertyList` as a parameter instead of accessing `parameters` directly
- **Separation of concerns**: `BuildRawAssociationList()` handles property expansion; `ApplyExcludeFilter()` handles filtering

## Design Decision: Lazy Initialization vs Constructor

The `ViewGenerator` class uses an `Initialize()` method pattern rather than a constructor, which is an existing design in this codebase. Within this pattern, the association list is built lazily via `GetActiveAssociationList()` rather than eagerly in `Initialize()` because different subclasses have different timing requirements:

| ViewGenerator | When to build | Reason |
|---------------|---------------|--------|
| **Table** | Once in `Initialize()` | Header columns are determined by the first object and remain fixed |
| **List** | Each object, then reset | Different objects may have different property sets |
| **Wide** | Each object, then reset | Different objects may have different property sets |

The lazy initialization pattern with `GetActiveAssociationList()` and `ResetActiveAssociationList()` provides flexibility for subclasses to call these methods at the appropriate time for their specific formatting needs.

## Design Decision: `virtual` vs `abstract` for `BuildRawAssociationList()`

Here is the mapping of cmdlets to ViewGenerator classes and their template method adoption:

| Cmdlet | ViewGenerator Class | Uses Template Method | Notes |
|--------|---------------------|---------------------|-------|
| `Format-Table` | `TableViewGenerator` | ✅ Yes | Overrides `BuildRawAssociationList()` |
| `Format-List` | `ListViewGenerator` | ✅ Yes | Overrides `BuildRawAssociationList()` |
| `Format-Wide` | `WideViewGenerator` | ✅ Yes | Overrides `BuildRawAssociationList()` |
| `Format-Custom` | `ComplexViewGenerator` | ❌ No | Does not override `BuildRawAssociationList()`; uses recursive architecture |

The general pattern is that subclasses **must** implement `BuildRawAssociationList()`. `ComplexViewGenerator` (used by `Format-Custom`) is the exception because it delegates to a separate class for recursive object traversal.

Currently, `BuildRawAssociationList()` is declared as `virtual` with a default implementation that returns `null`. I'd like feedback on whether this should be `abstract` instead.

| Approach | Pros | Cons |
|----------|------|------|
| `virtual` (current) | No changes needed for `ComplexViewGenerator` | New subclasses could forget to override; would result in `NullReferenceException` at runtime |
| `abstract` | Compile-time enforcement; impossible to forget | Requires `ComplexViewGenerator` to have an explicit opt-out implementation (e.g., `BuildRawAssociationList()` returns `null` or throws `NotSupportedException`) |

If `abstract` is preferred, I can update the PR.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)