### PR TITLE
[release/v7.6] Update the macos package name for preview releases to match the previous pattern

### DIFF
--- a/test/packaging/macos/package-validation.tests.ps1
+++ b/test/packaging/macos/package-validation.tests.ps1
@@ -82,12 +82,13 @@ Describe "Verify macOS Package" {
             $script:package | Should -Not -BeNullOrEmpty
 
             # Regex pattern for valid macOS PKG package names.
+            # This pattern matches the validation used in release-validate-packagenames.yml
             # Valid examples:
-            # - powershell-7.4.13-osx-x64.pkg (Intel x64 - note: x64 with hyphens for compatibility)
-            # - powershell-7.4.13-osx-arm64.pkg (Apple Silicon)
-            # - powershell-preview-7.6.0-preview.6-osx-x64.pkg
-            # - powershell-lts-7.4.13-osx-arm64.pkg
-            $pkgPackageNamePattern = '^powershell(-preview|-lts)?-\d+\.\d+\.\d+(-[a-z]+\.\d+)?-osx-(x64|arm64)\.pkg$'
+            # - powershell-7.4.13-osx-x64.pkg (Stable release)
+            # - powershell-7.6.0-preview.6-osx-x64.pkg (Preview version string)
+            # - powershell-7.4.13-rebuild.5-osx-arm64.pkg (Rebuild version)
+            # - powershell-lts-7.4.13-osx-arm64.pkg (LTS package)
+            $pkgPackageNamePattern = '^powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx\-(x64|arm64)\.pkg$'
 
             $script:package.Name | Should -Match $pkgPackageNamePattern -Because "Package name should follow the standard naming convention"
         }


### PR DESCRIPTION
Backport of #26429 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26429$$$
-->

Triggered by @adityapatwardhan on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes test validation for macOS package naming convention. Required to ensure tests correctly validate that preview packages use version string instead of -preview prefix.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified the regex pattern matches the validation used in .pipelines/templates/release-validate-packagenames.yml. Updated comments to reflect correct naming convention. No functional testing needed as this is a test pattern fix.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk as this only fixes a test validation pattern. Does not affect actual package building or runtime behavior, only test validation to ensure package names follow correct convention.
