### PR TITLE
[release/v7.6] Update Microsoft.PowerShell.PSResourceGet to v1.2.0-preview5

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
-    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-preview4" />
+    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-preview5" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.4.5" />
     <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   


### PR DESCRIPTION
Backport of #26589 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26589$$$
-->

Triggered by @adityapatwardhan on behalf of @alerickson

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Updates PSResourceGet module to preview5 version, improving module management functionality for PowerShell 7.6 users.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Module version update verified by build process. No additional tests needed as this is a package version bump.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk because this is a simple package version update from preview4 to preview5. PSResourceGet is a well-tested module and preview versions are expected to have incremental improvements.
