### PR TITLE
Add support for ITuple and Deconstruct assignment to multiple variables

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -298,10 +298,10 @@ namespace System.Management.Automation.Language
             typeof(IList).GetMethod("get_Item");
 
         internal static readonly PropertyInfo ITuple_Length =
-            typeof(System.Runtime.CompilerServices.ITuple).GetProperty(nameof(System.Runtime.CompilerServices.ITuple.Length));
+            typeof(ITuple).GetProperty(nameof(ITuple.Length));
 
         internal static readonly MethodInfo ITuple_get_Item =
-            typeof(System.Runtime.CompilerServices.ITuple).GetMethod("get_Item");
+            typeof(ITuple).GetMethod("get_Item");
 
         internal static readonly MethodInfo InterpreterError_NewInterpreterException =
             typeof(InterpreterError).GetMethod(nameof(InterpreterError.NewInterpreterException), StaticFlags);

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -126,6 +126,18 @@ namespace System.Management.Automation.Language
         internal static readonly MethodInfo EnumerableOps_GetSlice =
             typeof(EnumerableOps).GetMethod(nameof(EnumerableOps.GetSlice), StaticFlags);
 
+        internal static readonly MethodInfo EnumerableOps_GetTupleSlice =
+            typeof(EnumerableOps).GetMethod(nameof(EnumerableOps.GetTupleSlice), StaticFlags);
+
+        internal static readonly MethodInfo EnumerableOps_GetDeconstructMethod =
+            typeof(EnumerableOps).GetMethod(nameof(EnumerableOps.GetDeconstructMethod), StaticFlags);
+
+        internal static readonly MethodInfo EnumerableOps_InvokeDeconstruct =
+            typeof(EnumerableOps).GetMethod(nameof(EnumerableOps.InvokeDeconstruct), StaticFlags);
+
+        internal static readonly MethodInfo EnumerableOps_GetDeconstructSlice =
+            typeof(EnumerableOps).GetMethod(nameof(EnumerableOps.GetDeconstructSlice), StaticFlags);
+
         internal static readonly MethodInfo EnumerableOps_MethodInvoker =
             typeof(EnumerableOps).GetMethod(nameof(EnumerableOps.MethodInvoker), StaticFlags);
 
@@ -284,6 +296,12 @@ namespace System.Management.Automation.Language
 
         internal static readonly MethodInfo IList_get_Item =
             typeof(IList).GetMethod("get_Item");
+
+        internal static readonly PropertyInfo ITuple_Length =
+            typeof(System.Runtime.CompilerServices.ITuple).GetProperty(nameof(System.Runtime.CompilerServices.ITuple.Length));
+
+        internal static readonly MethodInfo ITuple_get_Item =
+            typeof(System.Runtime.CompilerServices.ITuple).GetMethod("get_Item");
 
         internal static readonly MethodInfo InterpreterError_NewInterpreterException =
             typeof(InterpreterError).GetMethod(nameof(InterpreterError.NewInterpreterException), StaticFlags);

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -1079,7 +1079,7 @@ namespace System.Management.Automation.Language
                 return (new DynamicMetaObject(
                     Expression.Block(
                         new[] { temp },
-                        Expression.Assign(temp, target.Expression.Cast(typeof(System.Runtime.CompilerServices.ITuple))),
+                        Expression.Assign(temp, target.Expression.Cast(typeof(ITuple))),
                         Expression.NewArrayInit(typeof(object), newArrayElements)),
                     restrictions)).WriteToDebugLog(this);
             }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -1033,8 +1033,7 @@ namespace System.Management.Automation.Language
                     restrictions)).WriteToDebugLog(this);
             }
 
-            var iTuple = target.Value as System.Runtime.CompilerServices.ITuple;
-            if (iTuple is not null)
+            if (target.Value is ITuple iTuple)
             {
                 // Handle ITuple types (System.Tuple, System.ValueTuple, etc.)
                 // 3 possibilities - too few, exact, or too many elements.
@@ -1047,7 +1046,7 @@ namespace System.Management.Automation.Language
 
                 int i;
                 Expression[] newArrayElements = new Expression[_elements];
-                var temp = Expression.Variable(typeof(System.Runtime.CompilerServices.ITuple));
+                var temp = Expression.Variable(typeof(ITuple));
                 if (iTuple.Length <= _elements)
                 {
                     // Too few or exact, create an array with the correct number assigned, fill in null for the extras

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -1039,7 +1039,7 @@ namespace System.Management.Automation.Language
                 // Handle ITuple types (System.Tuple, System.ValueTuple, etc.)
                 // 3 possibilities - too few, exact, or too many elements.
 
-                var getTupleLengthExpr = Expression.Property(target.Expression.Cast(typeof(System.Runtime.CompilerServices.ITuple)), CachedReflectionInfo.ITuple_Length);
+                var getTupleLengthExpr = Expression.Property(target.Expression.Cast(typeof(ITuple)), CachedReflectionInfo.ITuple_Length);
 
                 var restrictions = target.PSGetTypeRestriction().Merge(
                     BindingRestrictions.GetExpressionRestriction(Expression.Equal(getTupleLengthExpr,

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3684,17 +3684,7 @@ namespace System.Management.Automation
                     continue;
                 }
 
-                bool allOut = true;
-                foreach (var param in parameters)
-                {
-                    if (!param.IsOut)
-                    {
-                        allOut = false;
-                        break;
-                    }
-                }
-
-                if (allOut)
+                if (parameters.All(param => param.IsOut))
                 {
                     return method;
                 }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3648,7 +3648,7 @@ namespace System.Management.Automation
         /// <param name="tuple">The tuple to slice.</param>
         /// <param name="startIndex">The starting index.</param>
         /// <returns>An array containing the remaining elements.</returns>
-        internal static object[] GetTupleSlice(System.Runtime.CompilerServices.ITuple tuple, int startIndex)
+        internal static object[] GetTupleSlice(ITuple tuple, int startIndex)
         {
             int countElements = tuple.Length - startIndex;
             object[] result = new object[countElements];

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3640,6 +3640,103 @@ namespace System.Management.Automation
 
             return result;
         }
+
+        /// <summary>
+        /// Gets a slice of elements from an ITuple starting at the specified index.
+        /// Used for array assignment when there are more tuple elements than variables.
+        /// </summary>
+        /// <param name="tuple">The tuple to slice.</param>
+        /// <param name="startIndex">The starting index.</param>
+        /// <returns>An array containing the remaining elements.</returns>
+        internal static object[] GetTupleSlice(System.Runtime.CompilerServices.ITuple tuple, int startIndex)
+        {
+            int countElements = tuple.Length - startIndex;
+            object[] result = new object[countElements];
+
+            int i = startIndex;
+            int j = 0;
+            while (j < countElements)
+            {
+                result[j++] = tuple[i++];
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Attempts to find a Deconstruct method on the given type.
+        /// </summary>
+        /// <param name="type">The type to search.</param>
+        /// <returns>The Deconstruct method info, or null if not found.</returns>
+        internal static MethodInfo GetDeconstructMethod(Type type)
+        {
+            // Look for a public instance method named "Deconstruct" with all out parameters
+            foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (method.Name != "Deconstruct" || method.ReturnType != typeof(void))
+                {
+                    continue;
+                }
+
+                var parameters = method.GetParameters();
+                if (parameters.Length == 0)
+                {
+                    continue;
+                }
+
+                bool allOut = true;
+                foreach (var param in parameters)
+                {
+                    if (!param.IsOut)
+                    {
+                        allOut = false;
+                        break;
+                    }
+                }
+
+                if (allOut)
+                {
+                    return method;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Invokes the Deconstruct method on the given object and returns the deconstructed values.
+        /// </summary>
+        /// <param name="obj">The object to deconstruct.</param>
+        /// <param name="method">The Deconstruct method to invoke.</param>
+        /// <returns>An array containing the deconstructed values.</returns>
+        internal static object[] InvokeDeconstruct(object obj, MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+            var args = new object[parameters.Length];
+            method.Invoke(obj, args);
+            return args;
+        }
+
+        /// <summary>
+        /// Gets a slice of values starting at the specified index.
+        /// Used for array assignment when there are more deconstructed values than variables.
+        /// This method takes the already-deconstructed array to avoid calling Deconstruct() multiple times.
+        /// </summary>
+        /// <param name="allValues">The array of all deconstructed values.</param>
+        /// <param name="startIndex">The starting index.</param>
+        /// <returns>An array containing the remaining values.</returns>
+        internal static object[] GetDeconstructSlice(object[] allValues, int startIndex)
+        {
+            int countElements = allValues.Length - startIndex;
+            object[] result = new object[countElements];
+
+            for (int i = 0; i < countElements; i++)
+            {
+                result[i] = allValues[startIndex + i];
+            }
+
+            return result;
+        }
     }
 
     internal static class MemberInvocationLoggingOps

--- a/test/powershell/Language/Scripting/Indexer.Tests.ps1
+++ b/test/powershell/Language/Scripting/Indexer.Tests.ps1
@@ -40,4 +40,140 @@ Describe 'Tests for indexers' -Tags "CI" {
         $tuple = [Tuple]::Create(10, 'Hello')
         $tuple[-1] | Should -BeExactly 'Hello'
     }
+
+    It 'ITuple can be assigned to multiple variables with exact element count' {
+        $tuple = [Tuple]::Create(1, 2)
+        $a, $b = $tuple
+        $a | Should -Be 1
+        $b | Should -Be 2
+    }
+
+    It 'Single element Tuple can be assigned to multiple variables' {
+        $tuple = [Tuple]::Create(1)
+        $a, $b = $tuple
+        $a | Should -Be 1
+        $b | Should -BeNullOrEmpty
+    }
+
+    It 'Tuple with 7 elements can be assigned to multiple variables' {
+        $tuple = [Tuple]::Create(1, 2, 3, 4, 5, 6, 7)
+        $a, $b, $c, $d, $e, $f, $g = $tuple
+        $a | Should -Be 1
+        $b | Should -Be 2
+        $c | Should -Be 3
+        $d | Should -Be 4
+        $e | Should -Be 5
+        $f | Should -Be 6
+        $g | Should -Be 7
+    }
+
+    It 'Tuple with 8 elements can be assigned to multiple variables' {
+        $tuple = [Tuple]::Create(1, 2, 3, 4, 5, 6, 7, 8)
+        $a, $b, $c, $d, $e, $f, $g, $h = $tuple
+        $a | Should -Be 1
+        $b | Should -Be 2
+        $c | Should -Be 3
+        $d | Should -Be 4
+        $e | Should -Be 5
+        $f | Should -Be 6
+        $g | Should -Be 7
+        $h | Should -Be 8
+    }
+
+    It 'ValueTuple can be assigned to multiple variables' {
+        $vtuple = [ValueTuple]::Create("x", "y", "z")
+        $a, $b, $c = $vtuple
+        $a | Should -BeExactly "x"
+        $b | Should -BeExactly "y"
+        $c | Should -BeExactly "z"
+    }
+
+    It 'ITuple with more elements than variables assigns remaining to last variable' {
+        $tuple = [Tuple]::Create(10, 20, 30)
+        $first, $rest = $tuple
+        $first | Should -Be 10
+        $rest | Should -Be @(20, 30)
+    }
+
+    It 'ITuple with fewer elements than variables assigns null to extras' {
+        $tuple = [Tuple]::Create(100, 200)
+        $x, $y, $z = $tuple
+        $x | Should -Be 100
+        $y | Should -Be 200
+        $z | Should -BeNullOrEmpty
+    }
+
+    It 'Math.DivRem result can be assigned to multiple variables' {
+        $quotient, $remainder = [Math]::DivRem(17, 5)
+        $quotient | Should -Be 3
+        $remainder | Should -Be 2
+    }
+
+    It 'DictionaryEntry can be assigned to multiple variables' {
+        $de = [System.Collections.DictionaryEntry]::new("testKey", "testValue")
+        $key, $value = $de
+        $key | Should -BeExactly "testKey"
+        $value | Should -BeExactly "testValue"
+    }
+
+    It 'KeyValuePair can be assigned to multiple variables' {
+        $kvp = [System.Collections.Generic.KeyValuePair[string, int]]::new("count", 42)
+        $k, $v = $kvp
+        $k | Should -BeExactly "count"
+        $v | Should -Be 42
+    }
+
+    It 'DictionaryEntry with more variables than elements assigns null to extras' {
+        $de = [System.Collections.DictionaryEntry]::new("key", "value")
+        $a, $b, $c = $de
+        $a | Should -BeExactly "key"
+        $b | Should -BeExactly "value"
+        $c | Should -BeNullOrEmpty
+    }
+
+    It 'Hashtable enumeration produces deconstructable DictionaryEntry' {
+        $ht = @{ name = "test" }
+        foreach ($entry in $ht.GetEnumerator()) {
+            $k, $v = $entry
+            $k | Should -BeExactly "name"
+            $v | Should -BeExactly "test"
+        }
+    }
+
+    It 'Deconstruct method should only be called once during array assignment' {
+        Add-Type -TypeDefinition @'
+        public class DeconstructCounter
+        {
+            public static int CallCount = 0;
+            public string A { get; set; }
+            public string B { get; set; }
+            public string C { get; set; }
+
+            public DeconstructCounter(string a, string b, string c)
+            {
+                A = a;
+                B = b;
+                C = c;
+            }
+
+            public void Deconstruct(out string a, out string b, out string c)
+            {
+                CallCount++;
+                a = A;
+                b = B;
+                c = C;
+            }
+        }
+'@
+        [DeconstructCounter]::CallCount = 0
+        $obj = [DeconstructCounter]::new("x", "y", "z")
+
+        # This assignment should call Deconstruct only once
+        # even though there are more deconstructed values (3) than variables (2)
+        $first, $rest = $obj
+
+        $first | Should -BeExactly "x"
+        $rest | Should -Be @("y", "z")
+        [DeconstructCounter]::CallCount | Should -Be 1 -Because "Deconstruct should only be called once"
+    }
 }


### PR DESCRIPTION
## PR Summary

Adds support for assigning `ITuple` types (`System.Tuple`, `System.ValueTuple`) and types with `Deconstruct` methods (`DictionaryEntry`, `KeyValuePair<,>`, etc.) to multiple variables using array assignment syntax.

Fixes #7471

## PR Context

### Problem
When assigning a `Tuple`, `ValueTuple`, `DictionaryEntry`, or `KeyValuePair` to multiple variables, PowerShell previously assigned the entire object to the first variable instead of deconstructing it:

```powershell
$tuple = [Tuple]::Create(1, 2)
$a, $b = $tuple
# Result: $a contains the entire tuple, $b is $null

$de = [System.Collections.DictionaryEntry]::new("key", "value")
$k, $v = $de
# Result: $k contains the entire DictionaryEntry, $v is $null
```

This prevented convenient use of APIs that return tuples (like `[Math]::DivRem()`) and made hashtable enumeration cumbersome.

### Solution
Added special handling in `PSGetMemberBinder` for two cases:

1. **ITuple types** - Detected via `System.Runtime.CompilerServices.ITuple` interface, elements extracted using the indexer
2. **Deconstruct methods** - Types with a public `Deconstruct` method with all `out` parameters (like `DictionaryEntry` and `KeyValuePair<,>`)

Both handle three scenarios: exact match, fewer elements than variables (fills with null), more elements than variables (remaining go to last variable as array).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- TODO: File documentation issue after PR is merged -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

## Changes Made

### 1. `Compiler.cs` (+18 lines)
- Added cached reflection references for `ITuple.Length` property and `ITuple.get_Item` method
- Added references for `EnumerableOps.GetTupleSlice`, `GetDeconstructMethod`, `InvokeDeconstruct`, and `GetDeconstructSlice` methods

### 2. `Binders.cs` (+120 lines)
- Added `ITuple` detection and handling in `PSGetMemberBinder.FallbackGetMember`
- Added `Deconstruct` method detection and handling
- Implemented three-case logic for both: exact element count, fewer elements, more elements

### 3. `MiscOps.cs` (+97 lines)
- Added `GetTupleSlice` - extracts remaining elements from ITuple
- Added `GetDeconstructMethod` - finds Deconstruct method on a type
- Added `InvokeDeconstruct` - invokes Deconstruct and returns values
- Added `GetDeconstructSlice` - extracts remaining values from already-deconstructed array (avoids calling Deconstruct multiple times)

### 4. `Indexer.Tests.ps1` (+136 lines)
- Added 13 comprehensive tests covering ITuple and Deconstruct scenarios

**Total: 4 files changed, 371 insertions(+)**

## Behavior Examples

### Tuple assignment
```powershell
$tuple = [Tuple]::Create(1, 2)
$a, $b = $tuple
```
| | $a | $b |
|--|----|----|
| Before | `(1, 2)` tuple object | `$null` |
| After | `1` | `2` |

### DictionaryEntry assignment
```powershell
$de = [System.Collections.DictionaryEntry]::new("key", "value")
$k, $v = $de
```
| | $k | $v |
|--|----|----|
| Before | `DictionaryEntry` object | `$null` |
| After | `"key"` | `"value"` |

### KeyValuePair assignment
```powershell
$kvp = [System.Collections.Generic.KeyValuePair[string,int]]::new("count", 42)
$k, $v = $kvp
```
| | $k | $v |
|--|----|----|
| Before | `KeyValuePair` object | `$null` |
| After | `"count"` | `42` |

### Hashtable enumeration
```powershell
$ht = @{ name = "test" }
foreach ($entry in $ht.GetEnumerator()) {
    $key, $value = $entry
}
```
| | $key | $value |
|--|------|--------|
| Before | `DictionaryEntry` object | `$null` |
| After | `"name"` | `"test"` |

### Math.DivRem
```powershell
$quotient, $remainder = [Math]::DivRem(17, 5)
```
| | $quotient | $remainder |
|--|-----------|------------|
| Before | `(3, 2)` ValueTuple object | `$null` |
| After | `3` | `2` |

## Testing

### Test Cases (13 new tests)

**ITuple tests:**
1. Tuple with exact element count (2 elements)
2. Single element Tuple (1 element) - boundary
3. Tuple with 7 elements - boundary (max without nesting)
4. Tuple with 8 elements - boundary (uses internal Rest nesting)
5. ValueTuple with 3 elements
6. More elements than variables (overflow to last)
7. Fewer elements than variables (null for extras)
8. Math.DivRem practical example

**Deconstruct tests:**
9. DictionaryEntry assignment
10. KeyValuePair assignment
11. DictionaryEntry with more variables than elements
12. Hashtable enumeration practical example
13. Deconstruct method called only once (verifies no redundant calls)

### Test Results

| Environment | Passed | Failed | Status |
|-------------|--------|--------|--------|
| Local build | 20/20 | 0 | ✅ All pass |

## Implementation Details

### Supported Types

**Via ITuple interface:**
- `System.Tuple<>` (1-8 elements)
- `System.ValueTuple<>` (1-8 elements)
- Any type implementing `System.Runtime.CompilerServices.ITuple`

**Via Deconstruct method:**
- `System.Collections.DictionaryEntry`
- `System.Collections.Generic.KeyValuePair<,>`
- Any type with a public `Deconstruct(out T1, out T2, ...)` method

### Design Decisions

1. **ITuple first, then Deconstruct** - ITuple is checked first as it's more specific; Deconstruct is a fallback for types like DictionaryEntry
2. **Length-based restriction for ITuple** - Dynamic binding includes tuple length in restrictions for correct caching
3. **Instance Deconstruct only** - Extension methods are not supported (consistent with PowerShell's general behavior)
4. **Consistent overflow/underflow behavior** - Follows same patterns as array/IList assignment
5. **Single Deconstruct invocation** - GetDeconstructSlice takes the already-deconstructed array to avoid calling Deconstruct() multiple times