### PR TITLE
Fix the DSC test by skipping `AfterAll` cleanup if the initial setup in `BeforeAll` failed

### DIFF
--- a/test/powershell/dsc/dsc.profileresource.Tests.ps1
+++ b/test/powershell/dsc/dsc.profileresource.Tests.ps1
@@ -160,8 +160,6 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
         $testProfilePathAllUsersAllHosts = $PROFILE.AllUsersAllHosts
         Copy-Item -Path $testProfilePathAllUsersAllHosts -Destination "$TestDrive/allusers-allhosts-profile.bak" -Force -ErrorAction SilentlyContinue
         New-Item -Path $testProfilePathAllUsersAllHosts -Value $testProfileContent -Force -ItemType File
-
-        $env:PATH += "$pathSeparator$PSHome"
     }
     AfterAll {
         if ($skipCleanup) {

--- a/test/powershell/dsc/dsc.profileresource.Tests.ps1
+++ b/test/powershell/dsc/dsc.profileresource.Tests.ps1
@@ -4,8 +4,10 @@
 Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
     BeforeAll {
         $DSC_ROOT = $env:DSC_ROOT
+        $skipCleanup = $false
 
         if (-not (Test-Path -Path $DSC_ROOT)) {
+            $skipCleanup = $true
             throw "DSC_ROOT environment variable is not set or path does not exist."
         }
 
@@ -40,6 +42,10 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
         New-Item -Path $testProfilePathCurrentUserAllHosts -Value $testProfileContent -Force -ItemType File
     }
     AfterAll {
+        if ($skipCleanup) {
+            return
+        }
+
         # Restore original profile
         $testProfilePathCurrentUserCurrentHost = $PROFILE.CurrentUserCurrentHost
         if (Test-Path "$TestDrive/currentuser-currenthost-profile.bak") {
@@ -118,16 +124,19 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdminOnWindows', 'RequireSudoOnUnix' {
     BeforeAll {
         $DSC_ROOT = $env:DSC_ROOT
+        $skipCleanup = $false
 
         if (-not (Test-Path -Path $DSC_ROOT)) {
+            $skipCleanup = $true
             throw "DSC_ROOT environment variable is not set or path does not exist."
         }
 
         Write-Verbose "DSC_ROOT is set to $DSC_ROOT" -Verbose
+
+        $originalPath = $env:PATH
+
         $pathSeparator = [System.IO.Path]::PathSeparator
-
         $env:PATH += "$pathSeparator$DSC_ROOT"
-
         $env:PATH += "$pathSeparator$PSHome"
 
         Write-Verbose "Updated PATH to include DSC_ROOT: $env:PATH" -Verbose
@@ -152,10 +161,13 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
         Copy-Item -Path $testProfilePathAllUsersAllHosts -Destination "$TestDrive/allusers-allhosts-profile.bak" -Force -ErrorAction SilentlyContinue
         New-Item -Path $testProfilePathAllUsersAllHosts -Value $testProfileContent -Force -ItemType File
 
-        $originalPath = $env:PATH
         $env:PATH += "$pathSeparator$PSHome"
     }
     AfterAll {
+        if ($skipCleanup) {
+            return
+        }
+
         $env:PATH = $originalPath
 
         $testProfilePathAllUsersCurrentHost = $PROFILE.AllUsersCurrentHost


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The test `dsc.profileresource.Tests.ps1` blindly restores `$env:PATH` to `$originalPath`, but `BeforeAll` throws when `DSC_ROOT` is not set and in that case the `$originalPath` is not set yet. So, `$env:PATH = $originalPath` in `AftgerAll` basically removes the PATH env variable from the current process.