### PR TITLE
New-PSSessionConfigurationFile - improve value handling

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
@@ -863,14 +863,14 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.ModulesToImport, RemotingErrorIdStrings.DISCModulesToImportComment,
-                        SessionConfigurationUtils.CombineHashTableOrStringArray(_modulesToImport, streamWriter, this), streamWriter, false));
+                        SessionConfigurationUtils.CombineHashTableOrStringArray(ConfigFileConstants.ModulesToImport, _modulesToImport, streamWriter, this), streamWriter, false));
                 }
 
                 // Visible aliases
                 if (ShouldGenerateConfigurationSnippet("VisibleAliases"))
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleAliases, RemotingErrorIdStrings.DISCVisibleAliasesComment,
-                        SessionConfigurationUtils.GetVisibilityDefault(_visibleAliases, streamWriter, this), streamWriter, _visibleAliases.Length == 0));
+                        SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleAliases, _visibleAliases, streamWriter, this), streamWriter, _visibleAliases.Length == 0));
                 }
 
                 // Visible cmdlets
@@ -885,7 +885,7 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleCmdlets, RemotingErrorIdStrings.DISCVisibleCmdletsComment,
-                        SessionConfigurationUtils.GetVisibilityDefault(_visibleCmdlets, streamWriter, this), streamWriter, false));
+                        SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleCmdlets, _visibleCmdlets, streamWriter, this), streamWriter, false));
                 }
 
                 // Visible functions
@@ -900,21 +900,21 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleFunctions, RemotingErrorIdStrings.DISCVisibleFunctionsComment,
-                        SessionConfigurationUtils.GetVisibilityDefault(_visibleFunctions, streamWriter, this), streamWriter, _visibleFunctions.Length == 0));
+                        SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleFunctions, _visibleFunctions, streamWriter, this), streamWriter, _visibleFunctions.Length == 0));
                 }
 
                 // Visible external commands (scripts, executables)
                 if (ShouldGenerateConfigurationSnippet("VisibleExternalCommands"))
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleExternalCommands, RemotingErrorIdStrings.DISCVisibleExternalCommandsComment,
-                        SessionConfigurationUtils.GetVisibilityDefault(_visibleExternalCommands, streamWriter, this), streamWriter, _visibleExternalCommands.Length == 0));
+                        SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleExternalCommands, _visibleExternalCommands, streamWriter, this), streamWriter, _visibleExternalCommands.Length == 0));
                 }
 
                 // Visible providers
                 if (ShouldGenerateConfigurationSnippet("VisibleProviders"))
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleProviders, RemotingErrorIdStrings.DISCVisibleProvidersComment,
-                        SessionConfigurationUtils.GetVisibilityDefault(_visibleProviders, streamWriter, this), streamWriter, _visibleProviders.Length == 0));
+                        SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleProviders, _visibleProviders, streamWriter, this), streamWriter, _visibleProviders.Length == 0));
                 }
 
                 // Alias definitions
@@ -1625,12 +1625,12 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.ModulesToImport, RemotingErrorIdStrings.DISCModulesToImportComment,
-                        SessionConfigurationUtils.CombineHashTableOrStringArray(_modulesToImport, streamWriter, this), streamWriter, false));
+                        SessionConfigurationUtils.CombineHashTableOrStringArray(ConfigFileConstants.ModulesToImport, _modulesToImport, streamWriter, this), streamWriter, false));
                 }
 
                 // Visible aliases
                 result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleAliases, RemotingErrorIdStrings.DISCVisibleAliasesComment,
-                    SessionConfigurationUtils.GetVisibilityDefault(_visibleAliases, streamWriter, this), streamWriter, _visibleAliases.Length == 0));
+                    SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleAliases, _visibleAliases, streamWriter, this), streamWriter, _visibleAliases.Length == 0));
 
                 // Visible cmdlets
                 if ((_visibleCmdlets == null) || (_visibleCmdlets.Length == 0))
@@ -1641,7 +1641,7 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleCmdlets, RemotingErrorIdStrings.DISCVisibleCmdletsComment,
-                        SessionConfigurationUtils.GetVisibilityDefault(_visibleCmdlets, streamWriter, this), streamWriter, false));
+                        SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleCmdlets, _visibleCmdlets, streamWriter, this), streamWriter, false));
                 }
 
                 // Visible functions
@@ -1653,16 +1653,16 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleFunctions, RemotingErrorIdStrings.DISCVisibleFunctionsComment,
-                        SessionConfigurationUtils.GetVisibilityDefault(_visibleFunctions, streamWriter, this), streamWriter, _visibleFunctions.Length == 0));
+                        SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleFunctions, _visibleFunctions, streamWriter, this), streamWriter, _visibleFunctions.Length == 0));
                 }
 
                 // Visible external commands (scripts, executables)
                 result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleExternalCommands, RemotingErrorIdStrings.DISCVisibleExternalCommandsComment,
-                    SessionConfigurationUtils.GetVisibilityDefault(_visibleExternalCommands, streamWriter, this), streamWriter, _visibleExternalCommands.Length == 0));
+                    SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleExternalCommands, _visibleExternalCommands, streamWriter, this), streamWriter, _visibleExternalCommands.Length == 0));
 
                 // Visible providers
                 result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.VisibleProviders, RemotingErrorIdStrings.DISCVisibleProvidersComment,
-                    SessionConfigurationUtils.GetVisibilityDefault(_visibleProviders, streamWriter, this), streamWriter, _visibleProviders.Length == 0));
+                    SessionConfigurationUtils.GetVisibilityDefault(ConfigFileConstants.VisibleProviders, _visibleProviders, streamWriter, this), streamWriter, _visibleProviders.Length == 0));
 
                 // Scripts to process
                 string resultData = (_scriptsToProcess.Length > 0) ? SessionConfigurationUtils.CombineStringArray(_scriptsToProcess) : "'C:\\ConfigData\\InitScript1.ps1', 'C:\\ConfigData\\InitScript2.ps1'";
@@ -1922,11 +1922,11 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets the visibility default value.
         /// </summary>
-        internal static string GetVisibilityDefault(object[] values, StreamWriter writer, PSCmdlet caller)
+        internal static string GetVisibilityDefault(string configKey, object[] values, StreamWriter writer, PSCmdlet caller)
         {
             if ((values != null) && (values.Length > 0))
             {
-                return CombineHashTableOrStringArray(values, writer, caller);
+                return CombineHashTableOrStringArray(configKey, values, writer, caller);
             }
 
             // Default Visibility is Empty which gets commented
@@ -2103,28 +2103,26 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Combines an array of strings or hashtables into a single string block.
         /// </summary>
-        internal static string CombineHashTableOrStringArray(object[] values, StreamWriter writer, PSCmdlet caller)
+        internal static string CombineHashTableOrStringArray(string configKey, object[] values, StreamWriter writer, PSCmdlet caller)
         {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < values.Length; i++)
             {
-                string strVal = values[i] as string;
-                if (!string.IsNullOrEmpty(strVal))
+                object value = PSObject.Base(values[i]);
+                if (value is string strVal && !string.IsNullOrEmpty(strVal))
                 {
                     sb.Append(QuoteName(strVal));
                 }
+                else if (value is IDictionary dictVal)
+                {
+                    sb.Append(CombineHashtable(dictVal, writer));
+                }
                 else
                 {
-                    Hashtable hashVal = values[i] as Hashtable;
-                    if (hashVal == null)
-                    {
-                        string message = StringUtil.Format(RemotingErrorIdStrings.DISCTypeMustBeStringOrHashtableArray,
-                                                           ConfigFileConstants.ModulesToImport);
-                        PSArgumentException e = new PSArgumentException(message);
-                        caller.ThrowTerminatingError(e.ErrorRecord);
-                    }
-
-                    sb.Append(CombineHashtable(hashVal, writer));
+                    string message = StringUtil.Format(RemotingErrorIdStrings.DISCTypeMustBeStringOrHashtableArray,
+                                                        configKey);
+                    PSArgumentException e = new PSArgumentException(message);
+                    caller.ThrowTerminatingError(e.ErrorRecord);
                 }
 
                 if (i < (values.Length - 1))

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -603,6 +603,37 @@ namespace PowershellTestConfigNamespace
             # following keys which we are validating below.
             $resultContent.ContainsKey("SessionType") -and $resultContent.ContainsKey("SchemaVersion") -and $resultContent.ContainsKey("Guid") -and $resultContent.ContainsKey("Author") | Should -BeTrue
         }
+
+        It "Handles PSObject wrapped strings inside hashtable or string parameter value" {
+            New-PSSessionConfigurationFile -Path TestDrive:/test.pssc -VisibleCmdlets @(('Get-Help' | Write-Output))
+            $content = Get-Content -Path TestDrive:/test.pssc -Raw
+            $content | Should -Match "VisibleCmdlets = 'Get-Help'"
+        }
+
+        It "Handles dictionary types in hashtable or string parameter value" {
+            $dict = [Ordered]@{
+                Name = 'Get-Service'
+                Parameters = @(
+                    @{ Name = 'Name'; ValidateSet = @('WinRM', 'Netlogon') }
+                    @{ Name = 'DependentServices' }
+                )
+            }
+
+            New-PSSessionConfigurationFile -Path TestDrive:/test.pssc -VisibleCmdlets @('Get-Help', $dict)
+            $config = Import-PowerShellDataFile -Path TestDrive:/test.pssc
+            $config.VisibleCmdlets.Count | Should -Be 2
+            $config.VisibleCmdlets[0] | Should -Be Get-Help
+            $config.VisibleCmdlets[1].Name | Should -Be 'Get-Service'
+            $config.VisibleCmdlets[1].Parameters.Count | Should -Be 2
+            $config.VisibleCmdlets[1].Parameters[0].Name | Should -Be 'Name'
+            $config.VisibleCmdlets[1].Parameters[0].ValidateSet | Should -Be @('WinRM', 'Netlogon')
+            $config.VisibleCmdlets[1].Parameters[1].Name | Should -Be 'DependentServices'
+        }
+
+        It "Emits error with correct member names when invalid parameters are provided to New-PSSessionConfigurationFile" {
+             $err = { New-PSSessionConfigurationFile -Path TestDrive:/test.pssc -VisibleCmdlets @(1) -ErrorAction Stop } | Should -Throw -PassThru
+             ([string]$err) | Should -Be 'The member 'VisibleCmdlets' must be an array consisting of either string or hashtable elements.'
+        }
     }
 
     Describe "Feature tests for New-PSSessionConfigurationFile Cmdlet" -Tags @("Feature", 'RequireAdminOnWindows') {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -632,7 +632,7 @@ namespace PowershellTestConfigNamespace
 
         It "Emits error with correct member names when invalid parameters are provided to New-PSSessionConfigurationFile" {
              $err = { New-PSSessionConfigurationFile -Path TestDrive:/test.pssc -VisibleCmdlets @(1) -ErrorAction Stop } | Should -Throw -PassThru
-             ([string]$err) | Should -Be 'The member 'VisibleCmdlets' must be an array consisting of either string or hashtable elements.'
+             ([string]$err) | Should -Be "The member 'VisibleCmdlets' must be an array consisting of either string or hashtable elements."
         }
     }
 


### PR DESCRIPTION
# PR Summary

Improves the parameter handling to properly unwrap PSObject wrapped string or Hashtable values when encountered in object[] based parameters. The existing code just checked for the string or Hashtable types without considering whether they were wrapped by a PSObject.

This also improves the error message to include the correct member name on an error as before it was hardcoded to `ModulesToImport`.

## PR Context

The existing cmdlet fails to deal with a string that might be wrapped as a `PSObject` for any parameters that are typed as `object[]`. This includes the parameters `ModulesToImport`, `VisibleCmdlets`, and `VisibleFunctions`. For example running the following results in an error

```powershell
New-PSSessionConfigurationFile -Path test.pssc -VisibleCmdlets @(
    ('Get-Help' | Write-Output)
)

# New-PSSessionConfigurationFile: The member 'ModulesToImport' must be an array consisting of either string or hashtable elements.
```

Not only is this a string and should be valid but the error points to the wrong member `ModulesToImport` rather than `VisibleCmdlets`.

This PR fixes the logic to unwrap and `PSObject` value but also fixes the error message to contain the correct member. 

There is most likely other improvements that could be done to handle nested values as the checks for string vs hashtable/IDictionary are not really consistent but that can be done in follow up PRs if required.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
