### PR TITLE
Support TargetObject position in ParserErrors

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1190,8 +1190,37 @@ namespace System.Management.Automation.Runspaces
                                             $highlightLine = ''
                                             if ($useTargetObject) {
                                                 $line = $_.TargetObject.LineText.Trim()
+
                                                 $offsetLength = 0
                                                 $offsetInLine = 0
+                                                $startColumn = 0
+                                                if (
+                                                    ([System.Collections.IDictionary]$_.TargetObject).Contains('StartColumn') -and
+                                                    [System.Management.Automation.LanguagePrimitives]::TryConvertTo[int]($_.TargetObject.StartColumn, [ref]$startColumn) -and
+                                                    $null -ne $startColumn -and
+                                                    $startColumn -gt 0 -and
+                                                    $startColumn -le $line.Length
+                                                ) {
+                                                    $endColumn = 0
+                                                    if (-not (
+                                                        ([System.Collections.IDictionary]$_.TargetObject).Contains('EndColumn') -and
+                                                        [System.Management.Automation.LanguagePrimitives]::TryConvertTo[int]($_.TargetObject.EndColumn, [ref]$endColumn) -and
+                                                        $null -ne $endColumn -and
+                                                        $endColumn -gt $startColumn -and
+                                                        $endColumn -le ($line.Length + 1)
+                                                    )) {
+                                                        $endColumn = $line.Length + 1
+                                                    }
+
+                                                    # Input is expected to be 1-based index to match the extent positioning
+                                                    # but we use 0-based indexing below.
+                                                    $startColumn -= 1
+                                                    $endColumn -= 1
+
+                                                    $highlightLine = "$(" " * $startColumn)$("~" * ($endColumn - $startColumn))"
+                                                    $offsetLength = $endColumn - $startColumn
+                                                    $offsetInLine = $startColumn
+                                                }
                                             }
                                             else {
                                                 $positionMessage = $myinv.PositionMessage.Split($newline)

--- a/test/powershell/engine/Formatting/ErrorView.Tests.ps1
+++ b/test/powershell/engine/Formatting/ErrorView.Tests.ps1
@@ -165,6 +165,387 @@ Describe 'Tests for $ErrorView' -Tag CI {
             $e | Out-String | Should -BeLike '*ParserError*'
         }
 
+        It 'Parser TargetObject shows Line information' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   1 | This is the line with the error"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+                            Line = 1
+                            LineText = 'This is the line with the error'
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject shows File information' {
+            $expected = (@(
+                ": MyFile.ps1"
+                "Line |"
+                "   1 | This is the line with the error"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+                            File = 'MyFile.ps1'
+                            Line = 1
+                            LineText = 'This is the line with the error'
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject has StartColumn' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   5 | This is the line with the error"
+                "     |                  ~~~~~~~~~~~~~~"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+
+                            Line = 5
+                            LineText = 'This is the line with the error'
+                            StartColumn = 18
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject has StartColumn and EndColumn' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   5 | This is the line with the error"
+                "     |                  ~~~~"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+
+                            Line = 5
+                            LineText = 'This is the line with the error'
+                            StartColumn = 18
+                            EndColumn = 22
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject has StartColumn at end of the line' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   5 | This is the line with the error"
+                "     |                               ~"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+
+                            Line = 5
+                            LineText = 'This is the line with the error'
+                            StartColumn = 31
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+
+        It 'Parser TargetObject has StartColumn at end of the line with EndColumn' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   5 | This is the line with the error"
+                "     |                               ~"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+
+                            Line = 5
+                            LineText = 'This is the line with the error'
+                            StartColumn = 31
+                            EndColumn = 32
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject ignores EndColumn if no StartColumn' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   1 | This is the line with the error"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+                            Line = 1
+                            LineText = 'This is the line with the error'
+                            EndColumn = 22
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject converts StartColumn and EndColumn from string' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   5 | This is the line with the error"
+                "     |                  ~~~~"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+
+                            Line = 5
+                            LineText = 'This is the line with the error'
+                            StartColumn = "18"
+                            EndColumn = "22"
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject ignores StartColumn if it cannot be converted' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   1 | This is the line with the error"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+                            Line = 1
+                            LineText = 'This is the line with the error'
+                            StartColumn = 'abc'
+                            EndColumn = 22
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject ignores EndColumn if it cannot be converted' {
+            $expected = (@(
+                ": "
+                "Line |"
+                "   5 | This is the line with the error"
+                "     |                  ~~~~~~~~~~~~~~"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+
+                            Line = 5
+                            LineText = 'This is the line with the error'
+                            StartColumn = 18
+                            EndColumn = 'abc'
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject ignores StartColumn with invalid value <Value>' -TestCases @(
+            @{ Value = -1 }
+            @{ Value = 0 }
+            @{ Value = 32 }  # Beyond end of line
+        ) {
+            param ($Value)
+
+            $expected = (@(
+                ": "
+                "Line |"
+                "   1 | This is the line with the error"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+                            Line = 1
+                            LineText = 'This is the line with the error'
+                            StartColumn = $Value
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
+        It 'Parser TargetObject ignores EndColumn with invalid value <Value>' -TestCases @(
+            @{ Value = -1 }
+            @{ Value = 0 }
+            @{ Value = 17 }  # Before StartColumn
+            @{ Value = 18 }  # Equal to StartColumn
+            @{ Value = 33 }  # Beyond end of line + 1
+        ) {
+            param ($Value)
+
+            $expected = (@(
+                ": "
+                "Line |"
+                "   1 | This is the line with the error"
+                "     |                  ~~~~~~~~~~~~~~"
+                "     | Test Parser Error"
+            ) -join ([Environment]::NewLine)).TrimEnd()
+            $e = {
+                [CmdletBinding()]
+                param ()
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new('Test Parser Error'),
+                        'ParserErrorText',
+                        [System.Management.Automation.ErrorCategory]::ParserError,
+                        @{
+                            Line = 1
+                            LineText = 'This is the line with the error'
+                            StartColumn = 18
+                            EndColumn = $Value
+                        }
+                    )
+                )
+            } | Should -Throw -PassThru
+
+            $actual = ($e | Out-String).TrimEnd()
+            $actual | Should -BeExactly $expected
+        }
+
         It 'Exception thrown from Enumerator.MoveNext in a pipeline shows information' {
             $e = {
                 $l = [System.Collections.Generic.List[string]] @('one', 'two')


### PR DESCRIPTION
# PR Summary
Add support for specifying the column position of a parser error when using the TargetObject IDictionary value. This allows PowerShell to provide a nicely formatted error message that shows the exact position in the line provided where the error occurs.

## PR Context
The change made in https://github.com/PowerShell/PowerShell/pull/19239 made it impossible for cmdlets to emit an ErrorRecord that PowerShell will display with the parsing extent information. A cmdlet cannot throw `ParentContainsErrorRecordException` which means the checks to use the custom parsing formatting is never used. This results in an `ErrorRecord` with the `ParsingError` to be seen as the below in the default `$ErrorView`.

```
Some-Cmdlet: Error message here
```

There exists code right now to use the `TargetObject` to provide a way to produce a more detailed error with the line and script information but doesn't have a way to provide the line position message so it looks just like

```
Some-Cmdlet: 
Line |
   1 | Some-Cmdlet -Target { param() } -Hook {}
     | Error message here
```

This PR extends the `TargetObject` functionality to also support `StartColumn` and `EndColumn` which allows the error author to provide enough information to give the line position where the failure actually is.

```
Some-Cmdlet:
Line |
   1 | Some-Cmdlet -Target { param() } -Hook {}
     |                       ~~~~~~~
     | Error message here
```

The other benefit is that on consoles that support VT sequences, the problematic position is highlighted

<img width="675" height="122" alt="image" src="https://github.com/user-attachments/assets/ff482d0e-6382-4f99-bd95-44db677ed404" />

There should be no regression here as the `StartColumn` is only used if present and in a valid format.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
