### PR TITLE
Add PSJsonSerializerV2 for ConvertTo-Json using TruncatingConverterFactory

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -15,6 +15,10 @@ namespace Microsoft.PowerShell.Commands
     /// The ConvertTo-Json command.
     /// This command converts an object to a Json string representation.
     /// </summary>
+    /// <remarks>
+    /// This class is hidden when PSJsonSerializerV2 experimental feature is enabled.
+    /// </remarks>
+    [Experimental(ExperimentalFeature.PSJsonSerializerV2, ExperimentAction.Hide)]
     [Cmdlet(VerbsData.ConvertTo, "Json", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096925", RemotingCapability = RemotingCapability.None)]
     [OutputType(typeof(string))]
     public class ConvertToJsonCommand : PSCmdlet, IDisposable

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -219,14 +219,8 @@ namespace Microsoft.PowerShell.Commands
 
                 // PSObject uses JsonConverterPSObject (Extended/Adapted properties)
                 // Raw objects use TruncatingConverterFactory (Base properties only)
-                if (objectToProcess is PSObject pso)
-                {
-                    return System.Text.Json.JsonSerializer.Serialize(pso, typeof(PSObject), options);
-                }
-                else
-                {
-                    return System.Text.Json.JsonSerializer.Serialize(objectToProcess, objectToProcess.GetType(), options);
-                }
+                Type typeToProcess = objectToProcess is PSObject ? typeof(PSObject) : objectToProcess.GetType();
+                System.Text.Json.JsonSerializer.Serialize(objectToProcess, typeToProcess, options);
             }
             catch (OperationCanceledException)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -187,7 +187,7 @@ namespace Microsoft.PowerShell.Commands
             bool enumsAsStrings,
             bool compressOutput,
             JsonStringEscapeHandling stringEscapeHandling,
-            ConvertToJsonCommandV2? cmdlet,
+            ConvertToJsonCommandV2 cmdlet,
             CancellationToken cancellationToken)
         {
             if (objectToProcess is null)
@@ -262,14 +262,14 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     internal sealed class PSJsonPSObjectConverter : System.Text.Json.Serialization.JsonConverter<PSObject>
     {
-        private readonly ConvertToJsonCommandV2? _cmdlet;
+        private readonly ConvertToJsonCommandV2 _cmdlet;
 
-        public PSJsonPSObjectConverter(ConvertToJsonCommandV2? cmdlet)
+        public PSJsonPSObjectConverter(ConvertToJsonCommandV2 cmdlet)
         {
             _cmdlet = cmdlet;
         }
 
-        private int MaxDepth => _cmdlet?.Depth ?? 2;
+        private int MaxDepth => _cmdlet.Depth;
 
         public override PSObject? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
@@ -432,7 +432,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void WriteDepthExceeded(Utf8JsonWriter writer, PSObject pso, object obj, JsonSerializerOptions options)
         {
-            _cmdlet?.WriteWarningOnce();
+            _cmdlet.WriteWarningOnce();
 
             // Pure PSObject: convert to string only (V1 behavior)
             if (pso.ImmediateBaseObjectIsEmpty)
@@ -808,14 +808,14 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     internal sealed class PSJsonCompositeConverterFactory : JsonConverterFactory
     {
-        private readonly ConvertToJsonCommandV2? _cmdlet;
+        private readonly ConvertToJsonCommandV2 _cmdlet;
 
         // Cached converter instances (one per converter type)
         private PSJsonDictionaryConverter? _dictionaryConverter;
         private PSJsonEnumerableConverter? _enumerableConverter;
         private PSJsonCompositeConverter? _compositeConverter;
 
-        public PSJsonCompositeConverterFactory(ConvertToJsonCommandV2? cmdlet)
+        public PSJsonCompositeConverterFactory(ConvertToJsonCommandV2 cmdlet)
         {
             _cmdlet = cmdlet;
         }
@@ -857,7 +857,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal void WriteWarningOnce()
         {
-            _cmdlet?.WriteWarningOnce();
+            _cmdlet.WriteWarningOnce();
         }
 
         internal void WriteDepthExceeded(Utf8JsonWriter writer, object obj)
@@ -866,7 +866,7 @@ namespace Microsoft.PowerShell.Commands
             writer.WriteStringValue(obj.ToString());
         }
 
-        internal int MaxDepth => _cmdlet?.Depth ?? 2;
+        internal int MaxDepth => _cmdlet.Depth;
     }
 
     /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -1055,6 +1055,13 @@ namespace Microsoft.PowerShell.Commands
                 return true;
             }
 
+            // System.Object has Kind=None but serializes as {} (not a scalar)
+            // See: https://source.dot.net/#System.Text.Json/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs,1337
+            if (type == typeof(object))
+            {
+                return false;
+            }
+
             // GetTypeInfo() has internal caching, no need for additional cache
             var typeInfo = JsonSerializerOptions.Default.GetTypeInfo(type);
             return typeInfo.Kind == JsonTypeInfoKind.None;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -1009,13 +1009,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 writer.WriteNullValue();
             }
-            else if (value is PSObject psoValue)
-            {
-                System.Text.Json.JsonSerializer.Serialize(writer, psoValue, typeof(PSObject), options);
-            }
             else
             {
-                System.Text.Json.JsonSerializer.Serialize(writer, value, value.GetType(), options);
+                Type typeToProcess = value is PSObject ? typeof(PSObject) : value.GetType();
+                System.Text.Json.JsonSerializer.Serialize(writer, value, typeToProcess, options);
             }
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -587,10 +587,18 @@ namespace Microsoft.PowerShell.Commands
                 var value = prop.Value;
                 writer.WritePropertyName(prop.Name);
 
-                // If maxDepth is 0 and value is non-null non-scalar, convert to string
+                // If maxDepth is 0 and value is non-null non-scalar, handle depth exceeded
                 if (MaxDepth == 0 && value is not null && !JsonSerializerHelper.IsStjNativeScalarType(value))
                 {
-                    writer.WriteStringValue(value.ToString());
+                    // PSObject may have ETS properties that need to be serialized
+                    if (value is PSObject pso)
+                    {
+                        WriteDepthExceeded(writer, pso, pso.BaseObject, options);
+                    }
+                    else
+                    {
+                        writer.WriteStringValue(value.ToString());
+                    }
                 }
                 else
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -514,7 +514,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            // Has ETS properties: serialize as {"value":[...],"prop":"..."}
+            // Has ETS properties: serialize as {"value":[...],"etsprop":"..."}
             writer.WriteStartObject();
             writer.WritePropertyName("value");
             SerializeEnumerable(writer, enumerable, options);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -1,0 +1,1030 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Management.Automation;
+using System.Management.Automation.Internal;
+using System.Numerics;
+using System.Reflection;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Unicode;
+using System.Threading;
+
+namespace Microsoft.PowerShell.Commands
+{
+    /// <summary>
+    /// Specifies how strings are escaped when writing JSON text.
+    /// </summary>
+    /// <remarks>
+    /// The numeric values must match Newtonsoft.Json.StringEscapeHandling for backward compatibility.
+    /// Do not change these values.
+    /// </remarks>
+    public enum JsonStringEscapeHandling
+    {
+        /// <summary>
+        /// Only control characters (e.g. newline) are escaped.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// All non-ASCII and control characters are escaped.
+        /// </summary>
+        EscapeNonAscii = 1,
+
+        /// <summary>
+        /// HTML (&lt;, &gt;, &amp;, ', ") and control characters are escaped.
+        /// </summary>
+        EscapeHtml = 2,
+    }
+
+    /// <summary>
+    /// Transforms Newtonsoft.Json.StringEscapeHandling to JsonStringEscapeHandling for backward compatibility.
+    /// </summary>
+    internal sealed class StringEscapeHandlingTransformationAttribute : ArgumentTransformationAttribute
+    {
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+            => inputData is Newtonsoft.Json.StringEscapeHandling newtonsoftValue ? (JsonStringEscapeHandling)(int)newtonsoftValue : inputData;
+    }
+
+    /// <summary>
+    /// The ConvertTo-Json command.
+    /// This command converts an object to a JSON string representation.
+    /// </summary>
+    /// <remarks>
+    /// This class is shown when PSJsonSerializerV2 experimental feature is enabled.
+    /// </remarks>
+    [Experimental(ExperimentalFeature.PSJsonSerializerV2, ExperimentAction.Show)]
+    [Cmdlet(VerbsData.ConvertTo, "Json", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2096925", RemotingCapability = RemotingCapability.None)]
+    [OutputType(typeof(string))]
+    public class ConvertToJsonCommandV2 : PSCmdlet
+    {
+        /// <summary>
+        /// Gets or sets the InputObject property.
+        /// </summary>
+        [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true)]
+        [AllowNull]
+        public object? InputObject { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Depth property.
+        /// Default is 2. Maximum allowed is 100.
+        /// Use 0 to serialize only top-level properties.
+        /// </summary>
+        [Parameter]
+        [ValidateRange(0, 100)]
+        public int Depth { get; set; } = 2;
+
+        /// <summary>
+        /// Gets or sets the Compress property.
+        /// If the Compress property is set to be true, the Json string will
+        /// be output in the compressed way. Otherwise, the Json string will
+        /// be output with indentations.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Compress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the EnumsAsStrings property.
+        /// If the EnumsAsStrings property is set to true, enum values will
+        /// be converted to their string equivalent. Otherwise, enum values
+        /// will be converted to their numeric equivalent.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter EnumsAsStrings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AsArray property.
+        /// If the AsArray property is set to be true, the result JSON string will
+        /// be returned with surrounding '[', ']' chars. Otherwise,
+        /// the array symbols will occur only if there is more than one input object.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter AsArray { get; set; }
+
+        /// <summary>
+        /// Gets or sets how strings are escaped when writing JSON text.
+        /// If the EscapeHandling property is set to EscapeHtml, the result JSON string will
+        /// be returned with HTML (&lt;, &gt;, &amp;, ', ") and control characters (e.g. newline) are escaped.
+        /// </summary>
+        [Parameter]
+        [StringEscapeHandlingTransformation]
+        public JsonStringEscapeHandling EscapeHandling { get; set; } = JsonStringEscapeHandling.Default;
+
+        private readonly List<object?> _inputObjects = new();
+
+        /// <summary>
+        /// Caching the input objects for the command.
+        /// </summary>
+        protected override void ProcessRecord()
+        {
+            _inputObjects.Add(InputObject);
+        }
+
+        /// <summary>
+        /// Do the conversion to json and write output.
+        /// </summary>
+        protected override void EndProcessing()
+        {
+            if (_inputObjects.Count > 0)
+            {
+                object? objectToProcess = (_inputObjects.Count > 1 || AsArray) ? _inputObjects : _inputObjects[0];
+
+                string? output = SystemTextJsonSerializer.ConvertToJson(
+                    objectToProcess,
+                    Depth,
+                    EnumsAsStrings.IsPresent,
+                    Compress.IsPresent,
+                    EscapeHandling,
+                    this,
+                    PipelineStopToken);
+
+                // null is returned only if the pipeline is stopping (e.g. ctrl+c is signaled).
+                // in that case, we shouldn't write the null to the output pipe.
+                if (output is not null)
+                {
+                    WriteObject(output);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides JSON serialization using System.Text.Json with PowerShell-specific handling.
+    /// </summary>
+    internal static class SystemTextJsonSerializer
+    {
+        /// <summary>
+        /// Convert an object to JSON string using System.Text.Json.
+        /// </summary>
+        public static string? ConvertToJson(
+            object? objectToProcess,
+            int maxDepth,
+            bool enumsAsStrings,
+            bool compressOutput,
+            JsonStringEscapeHandling stringEscapeHandling,
+            PSCmdlet? cmdlet,
+            CancellationToken cancellationToken)
+        {
+            if (objectToProcess is null)
+            {
+                return "null";
+            }
+
+            try
+            {
+                var options = new JsonSerializerOptions()
+                {
+                    WriteIndented = !compressOutput,
+
+                    // Set high value to avoid System.Text.Json exceptions
+                    // User-specified depth is enforced by JsonConverterPSObject (max 100 via ValidateRange)
+                    MaxDepth = 1000,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+                    Encoder = GetEncoder(stringEscapeHandling),
+                };
+
+                if (enumsAsStrings)
+                {
+                    options.Converters.Add(new JsonStringEnumConverter());
+                }
+
+                // Add custom converters for PowerShell-specific types
+                if (!ExperimentalFeature.IsEnabled(ExperimentalFeature.PSSerializeJSONLongEnumAsNumber))
+                {
+                    options.Converters.Add(new JsonConverterInt64Enum());
+                }
+
+                options.Converters.Add(new JsonConverterBigInteger());
+                options.Converters.Add(new JsonConverterDouble());
+                options.Converters.Add(new JsonConverterFloat());
+                options.Converters.Add(new JsonConverterType());
+                options.Converters.Add(new JsonConverterNullString());
+                options.Converters.Add(new JsonConverterDBNull());
+                options.Converters.Add(new JsonConverterPSObject(cmdlet, maxDepth));
+                options.Converters.Add(new JsonConverterJObject());
+
+                // TruncatingConverterFactory must be last - it handles all non-primitive types
+                // that don't have dedicated converters above
+                options.Converters.Add(new TruncatingConverterFactory(cmdlet, maxDepth));
+
+                // PSObject uses JsonConverterPSObject (Extended/Adapted properties)
+                // Raw objects use TruncatingConverterFactory (Base properties only)
+                if (objectToProcess is PSObject pso)
+                {
+                    return System.Text.Json.JsonSerializer.Serialize(pso, typeof(PSObject), options);
+                }
+                else
+                {
+                    return System.Text.Json.JsonSerializer.Serialize(objectToProcess, objectToProcess.GetType(), options);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+        }
+
+        private static JavaScriptEncoder GetEncoder(JsonStringEscapeHandling escapeHandling) =>
+            escapeHandling switch
+            {
+                JsonStringEscapeHandling.Default => JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                JsonStringEscapeHandling.EscapeNonAscii => JavaScriptEncoder.Default,
+                JsonStringEscapeHandling.EscapeHtml => JavaScriptEncoder.Create(UnicodeRanges.BasicLatin),
+                _ => JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            };
+    }
+
+    /// <summary>
+    /// Custom JsonConverter for PSObject that handles PowerShell-specific serialization.
+    /// </summary>
+    internal sealed class JsonConverterPSObject : System.Text.Json.Serialization.JsonConverter<PSObject>
+    {
+        private readonly PSCmdlet? _cmdlet;
+        private readonly int _maxDepth;
+
+        private bool _warningWritten;
+
+        public JsonConverterPSObject(PSCmdlet? cmdlet, int maxDepth)
+        {
+            _cmdlet = cmdlet;
+            _maxDepth = maxDepth;
+        }
+
+        public override PSObject? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, PSObject? pso, JsonSerializerOptions options)
+        {
+            if (LanguagePrimitives.IsNull(pso))
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            object? obj = pso.BaseObject;
+
+            // Handle special types - check for null-like objects (no depth increment needed)
+            if (obj is null || obj is DBNull or System.Management.Automation.Language.NullString)
+            {
+                // Single enumeration: write properties directly as we find them
+                var etsProperties = new PSMemberInfoIntegratingCollection<PSPropertyInfo>(
+                    pso,
+                    PSObject.GetPropertyCollection(PSMemberViewTypes.Extended));
+
+                bool isNull = true;
+                foreach (var prop in etsProperties)
+                {
+                    if (JsonSerializerHelper.ShouldSkipProperty(prop))
+                    {
+                        continue;
+                    }
+
+                    if (isNull)
+                    {
+                        writer.WriteStartObject();
+                        writer.WritePropertyName("value");
+                        writer.WriteNullValue();
+                        isNull = false;
+                    }
+
+                    WriteProperty(writer, prop, options);
+                }
+
+                if (isNull)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    writer.WriteEndObject();
+                }
+
+                return;
+            }
+
+            // Handle Newtonsoft.Json.Linq.JObject by delegating to JsonConverterJObject
+            if (obj is Newtonsoft.Json.Linq.JObject jObject)
+            {
+                System.Text.Json.JsonSerializer.Serialize(writer, jObject, options);
+                return;
+            }
+
+            // If STJ natively serializes this type as scalar, use STJ directly (no depth increment)
+            if (JsonSerializerHelper.IsStjNativeScalarType(obj))
+            {
+                JsonSerializerHelper.SerializePrimitive(writer, obj, options);
+                return;
+            }
+
+            // Check depth limit for complex types only (after scalar type check)
+            if (writer.CurrentDepth > _maxDepth)
+            {
+                WriteDepthExceeded(writer, pso, obj);
+                return;
+            }
+
+            // For dictionaries, collections, and custom objects
+            if (obj is IDictionary dict)
+            {
+                SerializeDictionary(writer, pso, dict, options);
+            }
+            else if (obj is IEnumerable enumerable)
+            {
+                SerializeEnumerable(writer, enumerable, options);
+            }
+            else
+            {
+                // For custom objects, serialize as dictionary with properties
+                SerializeAsObject(writer, pso, options);
+            }
+        }
+
+        private void WriteDepthExceeded(Utf8JsonWriter writer, PSObject pso, object obj)
+        {
+            // Write warning once
+            if (!_warningWritten && _cmdlet is not null)
+            {
+                _warningWritten = true;
+                string warningMessage = string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Resulting JSON is truncated as serialization has exceeded the set depth of {0}.",
+                    _maxDepth);
+                _cmdlet.WriteWarning(warningMessage);
+            }
+
+            // Convert to string when depth exceeded
+            string stringValue = LanguagePrimitives.ConvertTo<string>(pso.ImmediateBaseObjectIsEmpty ? pso : obj);
+            writer.WriteStringValue(stringValue);
+        }
+
+        private void SerializeEnumerable(Utf8JsonWriter writer, IEnumerable enumerable, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            foreach (var item in enumerable)
+            {
+                WriteValue(writer, item, options);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private void SerializeDictionary(Utf8JsonWriter writer, PSObject pso, IDictionary dict, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            // Serialize dictionary entries
+            foreach (DictionaryEntry entry in dict)
+            {
+                string key = entry.Key?.ToString() ?? string.Empty;
+                writer.WritePropertyName(key);
+                WriteValue(writer, entry.Value, options);
+            }
+
+            // Add PSObject extended properties
+            AppendPSProperties(writer, pso, options, PSMemberViewTypes.Extended);
+
+            writer.WriteEndObject();
+        }
+
+        private void WriteValue(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
+        {
+            // Handle null values (including AutomationNull)
+            if (LanguagePrimitives.IsNull(value) || value is DBNull)
+            {
+                writer.WriteNullValue();
+            }
+            else if (value is Newtonsoft.Json.Linq.JObject jObject)
+            {
+                System.Text.Json.JsonSerializer.Serialize(writer, jObject, options);
+            }
+            else if (value is PSObject psoValue)
+            {
+                // Existing PSObject: use PSObject serialization (Extended/Adapted properties)
+                Write(writer, psoValue, options);
+            }
+            else
+            {
+                // Raw object: check if STJ natively handles this type
+                if (JsonSerializerHelper.IsStjNativeScalarType(value))
+                {
+                    // STJ handles this type natively as scalar
+                    JsonSerializerHelper.SerializePrimitive(writer, value, options);
+                }
+                else
+                {
+                    // Not a native scalar type - delegate to TruncatingConverterFactory (Base properties only)
+                    System.Text.Json.JsonSerializer.Serialize(writer, value, value.GetType(), options);
+                }
+            }
+        }
+
+        private void SerializeAsObject(Utf8JsonWriter writer, PSObject pso, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            AppendPSProperties(writer, pso, options, PSMemberViewTypes.Extended | PSMemberViewTypes.Adapted);
+
+            writer.WriteEndObject();
+        }
+
+        private void AppendPSProperties(
+            Utf8JsonWriter writer,
+            PSObject pso,
+            JsonSerializerOptions options,
+            PSMemberViewTypes memberTypes)
+        {
+            var properties = new PSMemberInfoIntegratingCollection<PSPropertyInfo>(
+                pso,
+                PSObject.GetPropertyCollection(memberTypes));
+
+            foreach (var prop in properties)
+            {
+                if (JsonSerializerHelper.ShouldSkipProperty(prop))
+                {
+                    continue;
+                }
+
+                WriteProperty(writer, prop, options);
+            }
+        }
+
+        private void WriteProperty(Utf8JsonWriter writer, PSPropertyInfo prop, JsonSerializerOptions options)
+        {
+            try
+            {
+                var value = prop.Value;
+                writer.WritePropertyName(prop.Name);
+
+                // If maxDepth is 0 and value is non-null non-scalar, convert to string
+                if (_maxDepth == 0 && value is not null && !JsonSerializerHelper.IsStjNativeScalarType(value))
+                {
+                    writer.WriteStringValue(value.ToString());
+                }
+                else
+                {
+                    WriteValue(writer, value, options);
+                }
+            }
+            catch
+            {
+                // Skip properties that throw on access - write nothing for this property
+            }
+        }
+    }
+
+    /// <summary>
+    /// JsonConverter for Int64/UInt64 enums to avoid JavaScript precision issues.
+    /// </summary>
+    internal sealed class JsonConverterInt64Enum : System.Text.Json.Serialization.JsonConverter<Enum>
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (!typeToConvert.IsEnum)
+            {
+                return false;
+            }
+
+            var underlyingType = Enum.GetUnderlyingType(typeToConvert);
+            return underlyingType == typeof(long) || underlyingType == typeof(ulong);
+        }
+
+        public override Enum? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, Enum value, JsonSerializerOptions options)
+        {
+            // Convert to string to avoid JavaScript precision issues with large integers
+            writer.WriteStringValue(value.ToString("D"));
+        }
+    }
+
+    /// <summary>
+    /// JsonConverter for NullString to serialize as null.
+    /// </summary>
+    internal sealed class JsonConverterNullString : System.Text.Json.Serialization.JsonConverter<System.Management.Automation.Language.NullString>
+    {
+        public override System.Management.Automation.Language.NullString? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, System.Management.Automation.Language.NullString value, JsonSerializerOptions options)
+        {
+            writer.WriteNullValue();
+        }
+    }
+
+    /// <summary>
+    /// JsonConverter for DBNull to serialize as null.
+    /// </summary>
+    internal sealed class JsonConverterDBNull : System.Text.Json.Serialization.JsonConverter<DBNull>
+    {
+        public override DBNull? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, DBNull value, JsonSerializerOptions options)
+        {
+            writer.WriteNullValue();
+        }
+    }
+
+    /// <summary>
+    /// JsonConverter for BigInteger to serialize as number string.
+    /// </summary>
+    internal sealed class JsonConverterBigInteger : System.Text.Json.Serialization.JsonConverter<BigInteger>
+    {
+        public override BigInteger Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, BigInteger value, JsonSerializerOptions options)
+        {
+            // Write as number string to preserve precision
+            writer.WriteRawValue(value.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// JsonConverter for double to serialize Infinity and NaN as strings for V1 compatibility.
+    /// </summary>
+    internal sealed class JsonConverterDouble : System.Text.Json.Serialization.JsonConverter<double>
+    {
+        public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+        {
+            if (double.IsPositiveInfinity(value))
+            {
+                writer.WriteStringValue("Infinity");
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                writer.WriteStringValue("-Infinity");
+            }
+            else if (double.IsNaN(value))
+            {
+                writer.WriteStringValue("NaN");
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// JsonConverter for float to serialize Infinity and NaN as strings for V1 compatibility.
+    /// </summary>
+    internal sealed class JsonConverterFloat : System.Text.Json.Serialization.JsonConverter<float>
+    {
+        public override float Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, float value, JsonSerializerOptions options)
+        {
+            if (float.IsPositiveInfinity(value))
+            {
+                writer.WriteStringValue("Infinity");
+            }
+            else if (float.IsNegativeInfinity(value))
+            {
+                writer.WriteStringValue("-Infinity");
+            }
+            else if (float.IsNaN(value))
+            {
+                writer.WriteStringValue("NaN");
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// JsonConverter for System.Type to serialize as AssemblyQualifiedName string for V1 compatibility.
+    /// </summary>
+    internal sealed class JsonConverterType : System.Text.Json.Serialization.JsonConverter<Type>
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            // Handle Type and all derived types (e.g., RuntimeType)
+            return typeof(Type).IsAssignableFrom(typeToConvert);
+        }
+
+        public override Type Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.AssemblyQualifiedName);
+        }
+    }
+
+    /// <summary>
+    /// Custom JsonConverter for Newtonsoft.Json.Linq.JObject to isolate Newtonsoft-related code.
+    /// </summary>
+    internal sealed class JsonConverterJObject : System.Text.Json.Serialization.JsonConverter<Newtonsoft.Json.Linq.JObject>
+    {
+        public override Newtonsoft.Json.Linq.JObject Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, Newtonsoft.Json.Linq.JObject jObject, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            foreach (var prop in jObject.Properties())
+            {
+                writer.WritePropertyName(prop.Name);
+                WriteJTokenValue(writer, prop.Value, options);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteJTokenValue(Utf8JsonWriter writer, Newtonsoft.Json.Linq.JToken token, JsonSerializerOptions options)
+        {
+            var value = token.Type switch
+            {
+                Newtonsoft.Json.Linq.JTokenType.String => token.ToObject<string>(),
+                Newtonsoft.Json.Linq.JTokenType.Integer => token.ToObject<long>(),
+                Newtonsoft.Json.Linq.JTokenType.Float => token.ToObject<double>(),
+                Newtonsoft.Json.Linq.JTokenType.Boolean => token.ToObject<bool>(),
+                Newtonsoft.Json.Linq.JTokenType.Null => (object?)null,
+                _ => token.ToString(),
+            };
+            System.Text.Json.JsonSerializer.Serialize(writer, value, options);
+        }
+    }
+
+    /// <summary>
+    /// JsonConverterFactory that dispatches to appropriate converters for non-primitive types.
+    /// Handles depth control and truncation for Dictionary, Enumerable, and composite objects.
+    /// </summary>
+    internal sealed class TruncatingConverterFactory : JsonConverterFactory
+    {
+        private readonly PSCmdlet? _cmdlet;
+        private readonly int _maxDepth;
+        private bool _warningWritten;
+
+        public TruncatingConverterFactory(PSCmdlet? cmdlet, int maxDepth)
+        {
+            _cmdlet = cmdlet;
+            _maxDepth = maxDepth;
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            // Don't handle PSObject - it has its own converter
+            if (typeToConvert == typeof(PSObject) || typeof(PSObject).IsAssignableFrom(typeToConvert))
+            {
+                return false;
+            }
+
+            // Don't handle types that have dedicated converters
+            if (typeToConvert == typeof(BigInteger) ||
+                typeToConvert == typeof(System.Management.Automation.Language.NullString) ||
+                typeToConvert == typeof(DBNull) ||
+                typeof(Type).IsAssignableFrom(typeToConvert) ||
+                typeToConvert == typeof(Newtonsoft.Json.Linq.JObject))
+            {
+                return false;
+            }
+
+            // Check if STJ handles this type as a scalar
+            var typeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeToConvert);
+            return typeInfo.Kind != JsonTypeInfoKind.None;
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            // Create the appropriate generic converter
+            Type converterType;
+
+            if (typeof(IDictionary).IsAssignableFrom(typeToConvert))
+            {
+                converterType = typeof(JsonConverterDictionary<>).MakeGenericType(typeToConvert);
+            }
+            else if (typeof(IEnumerable).IsAssignableFrom(typeToConvert))
+            {
+                converterType = typeof(JsonConverterEnumerable<>).MakeGenericType(typeToConvert);
+            }
+            else
+            {
+                converterType = typeof(JsonConverterComposite<>).MakeGenericType(typeToConvert);
+            }
+
+            return (JsonConverter)Activator.CreateInstance(converterType, this)!;
+        }
+
+        internal void WriteDepthExceeded(Utf8JsonWriter writer, object obj)
+        {
+            if (!_warningWritten && _cmdlet is not null)
+            {
+                _warningWritten = true;
+                string warningMessage = string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Resulting JSON is truncated as serialization has exceeded the set depth of {0}.",
+                    _maxDepth);
+                _cmdlet.WriteWarning(warningMessage);
+            }
+
+            writer.WriteStringValue(obj.ToString());
+        }
+
+        internal int MaxDepth => _maxDepth;
+    }
+
+    /// <summary>
+    /// Generic JsonConverter for Dictionary types (IDictionary).
+    /// </summary>
+#pragma warning disable CA1812 // Instantiated via Activator.CreateInstance in TruncatingConverterFactory
+    internal sealed class JsonConverterDictionary<T> : JsonConverter<T> where T : IDictionary
+    {
+        private readonly TruncatingConverterFactory _factory;
+
+        public JsonConverterDictionary(TruncatingConverterFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            // Check depth limit
+            if (writer.CurrentDepth > _factory.MaxDepth)
+            {
+                _factory.WriteDepthExceeded(writer, value);
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            foreach (DictionaryEntry entry in value)
+            {
+                string key = entry.Key?.ToString() ?? string.Empty;
+                writer.WritePropertyName(key);
+                JsonSerializerHelper.WriteValue(writer, entry.Value, options);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+
+    /// <summary>
+    /// Generic JsonConverter for Enumerable types (IEnumerable, excluding IDictionary).
+    /// </summary>
+#pragma warning disable CA1812 // Instantiated via Activator.CreateInstance in TruncatingConverterFactory
+    internal sealed class JsonConverterEnumerable<T> : JsonConverter<T> where T : IEnumerable
+    {
+        // Field kept for consistency with other converters in CreateConverter pattern
+#pragma warning disable IDE0052 // Remove unread private member
+        private readonly TruncatingConverterFactory _factory;
+#pragma warning restore IDE0052
+
+        public JsonConverterEnumerable(TruncatingConverterFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartArray();
+
+            foreach (var item in value)
+            {
+                JsonSerializerHelper.WriteValue(writer, item, options);
+            }
+
+            writer.WriteEndArray();
+        }
+    }
+
+    /// <summary>
+    /// Generic JsonConverter for composite objects (non-primitive, non-collection types).
+    /// Serializes only base .NET properties using reflection.
+    /// </summary>
+#pragma warning disable CA1812 // Instantiated via Activator.CreateInstance in TruncatingConverterFactory
+    internal sealed class JsonConverterComposite<T> : JsonConverter<T>
+    {
+        private readonly TruncatingConverterFactory _factory;
+
+        public JsonConverterComposite(TruncatingConverterFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            // Check depth limit
+            if (writer.CurrentDepth > _factory.MaxDepth)
+            {
+                _factory.WriteDepthExceeded(writer, value);
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            // Use PSObject to enumerate base properties (Adapted view, Property type only)
+            var pso = PSObject.AsPSObject(value);
+            var properties = new PSMemberInfoIntegratingCollection<PSPropertyInfo>(
+                pso,
+                PSObject.GetPropertyCollection(PSMemberViewTypes.Adapted));
+
+            foreach (var prop in properties)
+            {
+                // Filter to only Property type (excludes CodeProperty, ScriptProperty, etc.)
+                if (prop.MemberType != PSMemberTypes.Property)
+                {
+                    continue;
+                }
+
+                if (JsonSerializerHelper.ShouldSkipProperty(prop))
+                {
+                    continue;
+                }
+
+                WriteProperty(writer, prop, options);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private void WriteProperty(Utf8JsonWriter writer, PSPropertyInfo prop, JsonSerializerOptions options)
+        {
+            try
+            {
+                var value = prop.Value;
+                writer.WritePropertyName(prop.Name);
+
+                // If maxDepth is 0 and value is non-null non-scalar, convert to string
+                if (_factory.MaxDepth == 0 && value is not null && !JsonSerializerHelper.IsStjNativeScalarType(value))
+                {
+                    writer.WriteStringValue(value.ToString());
+                }
+                else
+                {
+                    JsonSerializerHelper.WriteValue(writer, value, options);
+                }
+            }
+            catch
+            {
+                // Skip properties that throw on access
+            }
+        }
+    }
+
+    /// <summary>
+    /// Shared helper methods for JSON serialization.
+    /// </summary>
+    internal static class JsonSerializerHelper
+    {
+        private static readonly ConcurrentDictionary<Type, bool> s_stjNativeScalarTypeCache = new();
+
+        /// <summary>
+        /// Determines if STJ natively serializes the type as a scalar (string, number, boolean).
+        /// Uses JsonTypeInfoKind to classify types. Results are cached per type for performance.
+        /// </summary>
+        public static bool IsStjNativeScalarType(object obj)
+        {
+            var type = obj.GetType();
+
+            // Special cases: types that need custom handling but should be treated as scalars
+            // BigInteger: STJ serializes as object, but V1 serializes as number
+            if (type == typeof(BigInteger))
+            {
+                return true;
+            }
+
+            // System.Type: STJ reports JsonTypeInfoKind.None but cannot serialize it
+            // Use JsonConverterType to serialize as AssemblyQualifiedName (V1 compatibility)
+            if (typeof(Type).IsAssignableFrom(type))
+            {
+                return true;
+            }
+
+            // Infinity/NaN: STJ throws, but V1 serializes as string
+            if (obj is double d && (double.IsInfinity(d) || double.IsNaN(d)))
+            {
+                return true;
+            }
+
+            if (obj is float f && (float.IsInfinity(f) || float.IsNaN(f)))
+            {
+                return true;
+            }
+
+            return s_stjNativeScalarTypeCache.GetOrAdd(type, static t =>
+            {
+                var typeInfo = JsonSerializerOptions.Default.GetTypeInfo(t);
+                return typeInfo.Kind == JsonTypeInfoKind.None;
+            });
+        }
+
+        public static void SerializePrimitive(Utf8JsonWriter writer, object obj, JsonSerializerOptions options)
+        {
+            // Delegate to STJ - custom converters handle special cases:
+            // - JsonConverterBigInteger: BigInteger as number string
+            // - JsonConverterDouble/Float: Infinity/NaN as string
+            // - JsonConverterType: Type as AssemblyQualifiedName
+            System.Text.Json.JsonSerializer.Serialize(writer, obj, obj.GetType(), options);
+        }
+
+        public static bool ShouldSkipProperty(PSPropertyInfo prop)
+        {
+            // Check for Hidden attribute
+            if (prop.IsHidden)
+            {
+                return true;
+            }
+
+            // Check for JsonIgnoreAttribute on the underlying member
+            if (prop is PSProperty psProperty)
+            {
+                if (psProperty.adapterData is MemberInfo memberInfo &&
+                    memberInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>() is not null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Writes a value to the JSON writer, handling null, PSObject, and raw objects.
+        /// Used by TruncatingConverterFactory converters for consistent value serialization.
+        /// </summary>
+        public static void WriteValue(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
+        {
+            if (LanguagePrimitives.IsNull(value) || value is DBNull)
+            {
+                writer.WriteNullValue();
+            }
+            else if (value is PSObject psoValue)
+            {
+                System.Text.Json.JsonSerializer.Serialize(writer, psoValue, typeof(PSObject), options);
+            }
+            else
+            {
+                System.Text.Json.JsonSerializer.Serialize(writer, value, value.GetType(), options);
+            }
+        }
+    }
+}

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -239,7 +239,7 @@ namespace Microsoft.PowerShell.Commands
     }
 
     /// <summary>
-    /// Custom JsonConverter for PSObject that handles PowerShell-specific serialization.
+    /// JSON converter for PSObject type.
     /// </summary>
     internal sealed class JsonConverterPSObject : System.Text.Json.Serialization.JsonConverter<PSObject>
     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -1078,6 +1078,13 @@ namespace Microsoft.PowerShell.Commands
             System.Text.Json.JsonSerializer.Serialize(writer, obj, obj.GetType(), options);
         }
 
+        /// <summary>
+        /// Determines if a property should be skipped during serialization.
+        /// Checks for Hidden attribute and JsonIgnoreAttribute.
+        /// Note: This is only called for PSObject-wrapped objects (via PSJsonPSObjectConverter).
+        /// Script-defined classes passed as raw objects go through PSJsonCompositeConverter,
+        /// which uses STJ's JsonTypeInfo.Properties and does not call this method.
+        /// </summary>
         public static bool ShouldSkipProperty(PSPropertyInfo prop)
         {
             // Check for Hidden attribute

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -705,21 +705,16 @@ namespace Microsoft.PowerShell.Commands
 
         public override bool CanConvert(Type typeToConvert)
         {
-            // Don't handle PSObject - it has its own converter
-            if (typeToConvert == typeof(PSObject) || typeof(PSObject).IsAssignableFrom(typeToConvert))
-            {
-                return false;
-            }
-
-            // Don't handle types that have dedicated converters
-            if (typeToConvert == typeof(BigInteger) ||
-                typeToConvert == typeof(System.Management.Automation.Language.NullString) ||
-                typeToConvert == typeof(DBNull) ||
-                typeof(Type).IsAssignableFrom(typeToConvert) ||
-                typeToConvert == typeof(Newtonsoft.Json.Linq.JObject))
-            {
-                return false;
-            }
+            // Types with dedicated converters should be handled before reaching this factory
+            Debug.Assert(
+                typeToConvert != typeof(PSObject) &&
+                !typeof(PSObject).IsAssignableFrom(typeToConvert) &&
+                typeToConvert != typeof(BigInteger) &&
+                typeToConvert != typeof(System.Management.Automation.Language.NullString) &&
+                typeToConvert != typeof(DBNull) &&
+                !typeof(Type).IsAssignableFrom(typeToConvert) &&
+                typeToConvert != typeof(Newtonsoft.Json.Linq.JObject),
+                $"Type {typeToConvert} should be handled by its dedicated converter");
 
             // Check if STJ handles this type as a scalar
             var typeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeToConvert);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommandV2.cs
@@ -1048,8 +1048,10 @@ namespace Microsoft.PowerShell.Commands
         {
             var type = obj.GetType();
 
-            // BigInteger: STJ serializes as object (Kind=Object), but V1 serializes as number
-            // Must check explicitly since Kind != None
+            // BigInteger: STJ serializes as object (Kind=Object), but V1 serializes as number.
+            // Using JsonSerializerOptions.Default returns Kind=Object; using local options with
+            // our custom PSJsonBigIntegerConverter would return Kind=None.
+            // Must check explicitly since we use Default options here.
             if (type == typeof(BigInteger))
             {
                 return true;

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -22,6 +22,7 @@ namespace System.Management.Automation
         internal const string EngineSource = "PSEngine";
         internal const string PSSerializeJSONLongEnumAsNumber = nameof(PSSerializeJSONLongEnumAsNumber);
         internal const string PSProfileDSCResource = "PSProfileDSCResource";
+        internal const string PSJsonSerializerV2 = nameof(PSJsonSerializerV2);
 
         #endregion
 
@@ -110,6 +111,10 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: PSSerializeJSONLongEnumAsNumber,
                     description: "Serialize enums based on long or ulong as an numeric value rather than the string representation when using ConvertTo-Json."
+                ),
+                new ExperimentalFeature(
+                    name: PSJsonSerializerV2,
+                    description: "Use System.Text.Json for ConvertTo-Json with V1-compatible behavior and support for non-string dictionary keys."
                 ),
                 new ExperimentalFeature(
                     name: PSProfileDSCResource,

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1056,10 +1056,12 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="obj">The object to test.</param>
         /// <returns>True if the object is null.</returns>
-        internal static bool IsNull(object obj)
+#nullable enable
+        internal static bool IsNull([NotNullWhen(false)] object? obj)
         {
-            return (obj == null || obj == AutomationNull.Value);
+            return obj is null || obj == AutomationNull.Value;
         }
+#nullable restore
 
         /// <summary>
         /// Auxiliary for the cases where we want a new PSObject or null.

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.PSJsonSerializerV2.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.PSJsonSerializerV2.Tests.ps1
@@ -47,12 +47,4 @@ Describe 'ConvertTo-Json PSJsonSerializerV2 specific behavior' -Tags "CI" {
         $json | Should -Not -Match 'Hidden'
     }
 
-    # V2 improvement: Guid is serialized consistently (V1 had inconsistency between Pipeline and InputObject)
-    It 'Should serialize Guid as string consistently' {
-        $guid = [guid]"12345678-1234-1234-1234-123456789abc"
-        $jsonPipeline = $guid | ConvertTo-Json -Compress
-        $jsonInputObject = ConvertTo-Json -InputObject $guid -Compress
-        $jsonPipeline | Should -BeExactly '"12345678-1234-1234-1234-123456789abc"'
-        $jsonInputObject | Should -BeExactly '"12345678-1234-1234-1234-123456789abc"'
-    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.PSJsonSerializerV2.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.PSJsonSerializerV2.Tests.ps1
@@ -34,17 +34,4 @@ Describe 'ConvertTo-Json PSJsonSerializerV2 specific behavior' -Tags "CI" {
         $json | Should -Match '"12345678-1234-1234-1234-123456789abc":\s*"guid-value"'
     }
 
-    It 'Should not serialize hidden properties in PowerShell class' {
-        class TestHiddenClass {
-            [string] $Visible
-            hidden [string] $Hidden
-        }
-        $obj = [TestHiddenClass]::new()
-        $obj.Visible = "yes"
-        $obj.Hidden = "no"
-        $json = $obj | ConvertTo-Json -Compress
-        $json | Should -Match 'Visible'
-        $json | Should -Not -Match 'Hidden'
-    }
-
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.PSJsonSerializerV2.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.PSJsonSerializerV2.Tests.ps1
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'ConvertTo-Json PSJsonSerializerV2 specific behavior' -Tags "CI" {
+
+    BeforeAll {
+        $skipTest = -not $EnabledExperimentalFeatures.Contains('PSJsonSerializerV2')
+
+        if ($skipTest) {
+            Write-Verbose "Test Suite Skipped. The test suite requires the experimental feature 'PSJsonSerializerV2' to be enabled." -Verbose
+            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+    }
+
+    AfterAll {
+        if ($skipTest) {
+            $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        }
+    }
+
+    It 'Should serialize dictionary with integer keys' {
+        $dict = @{ 1 = "one"; 2 = "two" }
+        $json = $dict | ConvertTo-Json -Compress
+        $json | Should -BeIn @('{"1":"one","2":"two"}', '{"2":"two","1":"one"}')
+    }
+
+    It 'Should serialize dictionary with non-string keys converting keys to strings' {
+        $dict = [System.Collections.Hashtable]::new()
+        $dict.Add(1, "one")
+        $dict.Add([guid]"12345678-1234-1234-1234-123456789abc", "guid-value")
+        $json = $dict | ConvertTo-Json -Compress
+        $json | Should -Match '"1":\s*"one"'
+        $json | Should -Match '"12345678-1234-1234-1234-123456789abc":\s*"guid-value"'
+    }
+
+    It 'Should not serialize hidden properties in PowerShell class' {
+        class TestHiddenClass {
+            [string] $Visible
+            hidden [string] $Hidden
+        }
+        $obj = [TestHiddenClass]::new()
+        $obj.Visible = "yes"
+        $obj.Hidden = "no"
+        $json = $obj | ConvertTo-Json -Compress
+        $json | Should -Match 'Visible'
+        $json | Should -Not -Match 'Hidden'
+    }
+
+    # V2 improvement: Guid is serialized consistently (V1 had inconsistency between Pipeline and InputObject)
+    It 'Should serialize Guid as string consistently' {
+        $guid = [guid]"12345678-1234-1234-1234-123456789abc"
+        $jsonPipeline = $guid | ConvertTo-Json -Compress
+        $jsonInputObject = ConvertTo-Json -InputObject $guid -Compress
+        $jsonPipeline | Should -BeExactly '"12345678-1234-1234-1234-123456789abc"'
+        $jsonInputObject | Should -BeExactly '"12345678-1234-1234-1234-123456789abc"'
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -133,11 +133,14 @@ Describe 'ConvertTo-Json' -tags "CI" {
     }
 
     It 'Should not serialize ETS properties added to DateTime' {
-        $date = "2021-06-24T15:54:06.796999-07:00"
-        $d = [DateTime]::Parse($date)
+        # Use UTC to avoid timezone conversion issues across different systems
+        $d = [DateTime]::new(2021, 6, 24, 12, 0, 0, [DateTimeKind]::Utc)
+        $d = Add-Member -InputObject $d -MemberType NoteProperty -Name ETSProp -Value 'test' -PassThru
 
-        # need to use wildcard here due to some systems may be configured with different culture setting showing time in different format
-        $d | ConvertTo-Json -Compress | Should -BeLike '"2021-06-24T*'
+        # DateTime should serialize as ISO string, not object with ETS properties
+        $json = $d | ConvertTo-Json -Compress
+        $json | Should -BeLike '"2021-06-24T12:00:00*'
+        $json | Should -Not -Match 'ETSProp'
         $d | ConvertTo-Json | ConvertFrom-Json | Should -Be $d
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -98,6 +98,13 @@ Describe 'ConvertTo-Json' -tags "CI" {
         1, $null, 2 | ConvertTo-Json -Compress | Should -Be '[1,null,2]'
     }
 
+    It "Should write null for properties that throw on access" {
+        $obj = [PSCustomObject]@{ Normal = "value" }
+        $obj | Add-Member -MemberType ScriptProperty -Name Throws -Value { throw "Error" }
+        $json = $obj | ConvertTo-Json -Compress
+        $json | Should -BeExactly '{"Normal":"value","Throws":null}'
+    }
+
     It "Should handle 'AutomationNull.Value' and 'NullString.Value' correctly" {
         [ordered]@{
             a = $null;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -150,6 +150,13 @@ Describe 'ConvertTo-Json' -tags "CI" {
         $t | ConvertTo-Json -Compress | Should -BeExactly "`"$text`""
     }
 
+    It 'Should serialize ETS properties added to Uri as object with value' {
+        # Uri is not string/DateTime, so ETS properties should be included
+        $uri = [Uri]"http://example.com"
+        $u = Add-Member -InputObject $uri -MemberType NoteProperty -Name MyProp -Value 'test' -PassThru
+        $u | ConvertTo-Json -Compress | Should -BeExactly '{"value":"http://example.com","MyProp":"test"}'
+    }
+
     It 'Should serialize BigInteger values' {
         $obj = [Ordered]@{
             Positive = 18446744073709551615n

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -232,6 +232,17 @@ Describe 'ConvertTo-Json' -tags "CI" {
         { ConvertTo-Json -InputObject @{a=1} -Depth 101 } | Should -Throw
     }
 
+    It 'Should serialize hidden properties in PowerShell class' {
+        class TestClassWithHidden {
+            [string]$Visible = 'visible'
+            hidden [string]$Hidden = 'hidden'
+        }
+        $obj = [TestClassWithHidden]::new()
+        $json = $obj | ConvertTo-Json -Compress
+        $json | Should -Match '"Visible":\s*"visible"'
+        $json | Should -Match '"Hidden":\s*"hidden"'
+    }
+
     Context 'Nested raw object serialization' {
         BeforeAll {
             class TestClassWithFileInfo {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright (c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 Describe 'ConvertTo-Json' -tags "CI" {
     BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -403,5 +403,18 @@ Describe 'ConvertTo-Json' -tags "CI" {
             $json | Should -BeExactly '{"inner":{"Name":"test","ETSProp":"ets"}}'
         }
 
+        It 'Non-pure PSObject (FileInfo) with ETS properties includes ETS when depth exceeded' {
+            $file = Get-Item $PSHOME/pwsh.exe
+            $pso = [PSObject]::new($file)
+            $pso | Add-Member -NotePropertyName CustomExt -NotePropertyValue 'extended_value'
+            $outer = [PSCustomObject]@{ File = $pso }
+
+            $result = $outer | ConvertTo-Json -Depth 0 -WarningAction SilentlyContinue
+            $parsed = $result | ConvertFrom-Json
+
+            $parsed.File.CustomExt | Should -BeExactly 'extended_value'
+            $parsed.File.value | Should -BeLike '*pwsh.exe'
+        }
+
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -348,6 +348,19 @@ Describe 'ConvertTo-Json' -tags "CI" {
             # InputObject does not include Extended properties
             $jsonInputObject | Should -Not -Match 'IPAddressToString'
         }
+
+        It 'Should serialize array with ETS properties via InputObject and comma pipeline' {
+            $arr = @(1, 2, 3)
+            $arrWithEts = Add-Member -InputObject $arr -MemberType NoteProperty -Name MyProp -Value "test" -PassThru
+
+            # -InputObject preserves PSObject wrapper with ETS
+            $jsonInputObject = ConvertTo-Json -InputObject $arrWithEts -Compress
+            $jsonInputObject | Should -BeExactly '{"value":[1,2,3],"MyProp":"test"}'
+
+            # Comma operator prevents array unwrapping, preserving PSObject wrapper
+            $jsonCommaPipeline = ,$arrWithEts | ConvertTo-Json -Compress
+            $jsonCommaPipeline | Should -BeExactly '{"value":[1,2,3],"MyProp":"test"}'
+        }
     }
 
     It 'Should output warning when depth is exceeded' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -355,6 +355,10 @@ Describe "Json Tests" -Tags "Feature" {
 			# For the ones that are datetimes, make sure they retain all of the various formats correctly
 			# for the ones that are strings just verify that they are actually strings.
 
+			# Use en-US culture to ensure consistent date format output across all environments
+			$originalCulture = [Threading.Thread]::CurrentThread.CurrentCulture
+			[Threading.Thread]::CurrentThread.CurrentCulture = [CultureInfo]::new('en-US')
+			try {
 			$json = @"
 {
 	"date-s-should-parse-as-datetime": "2008-09-22T14:01:54",
@@ -455,6 +459,9 @@ Describe "Json Tests" -Tags "Feature" {
 				$result."date-upperY-should-parse-as-string" | Should -BeOfType [String]
 				$result."date-y-should-parse-as-string" | Should -Be "September 2008"
 				$result."date-y-should-parse-as-string" | Should -BeOfType [String]
+			}
+			} finally {
+				[Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
 			}
 		}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Json.Tests.ps1
@@ -1262,8 +1262,7 @@ Describe "Validate Json serialization" -Tags "CI" {
              }
             @{
                 TestInput = 127
-                ToJson = '""'
-                ToJsonV2 = '"\u007F"'
+                ToJson = if ([ExperimentalFeature]::IsEnabled("PSJsonSerializerV2")) { '"\u007F"' } else { '""' }
                 FromJson = ''
              }
         )
@@ -1290,13 +1289,7 @@ Describe "Validate Json serialization" -Tags "CI" {
                     $result.FromJson | Should -Match $testCase.FromJson
                 }
 
-                # Use ToJsonV2 if available and PSJsonSerializerV2 is enabled
-                $expectedToJson = $testCase.ToJson
-                if ($testCase.ToJsonV2 -and (Get-ExperimentalFeature PSJsonSerializerV2).Enabled)
-                {
-                    $expectedToJson = $testCase.ToJsonV2
-                }
-                $result.ToJson | Should -Be $expectedToJson
+                $result.ToJson | Should -Be $testCase.ToJson
             }
         }
 

--- a/test/xUnit/csharp/test_ConvertToJson.cs
+++ b/test/xUnit/csharp/test_ConvertToJson.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerShell.Commands;
+using Xunit;
+
+namespace PSTests.Parallel
+{
+    public static class ConvertToJsonTests
+    {
+        /// <summary>
+        /// Verifies that JsonStringEscapeHandling enum values match Newtonsoft.Json.StringEscapeHandling
+        /// for backward compatibility. These values must not change.
+        /// </summary>
+        [Fact]
+        public static void JsonStringEscapeHandling_Values_MatchNewtonsoftStringEscapeHandling()
+        {
+            Assert.Equal((int)Newtonsoft.Json.StringEscapeHandling.Default, (int)JsonStringEscapeHandling.Default);
+            Assert.Equal((int)Newtonsoft.Json.StringEscapeHandling.EscapeNonAscii, (int)JsonStringEscapeHandling.EscapeNonAscii);
+            Assert.Equal((int)Newtonsoft.Json.StringEscapeHandling.EscapeHtml, (int)JsonStringEscapeHandling.EscapeHtml);
+        }
+    }
+}


### PR DESCRIPTION
# PR Summary

Implements `TruncatingConverterFactory` pattern for `ConvertTo-Json` V2 as discussed with @iSazonov in PR #26637.

This PR is an alternative implementation approach based on the Factory pattern, branched from `feature-convertto-json-isazonov-approach`.

Fixes #5749

# PR Context

## Background

In PR #26637, @iSazonov suggested implementing the Factory approach in a new PR to evaluate whether it provides a better architecture than the current implementation.

> "I can't say for sure which approach will be the best for us in the end. Therefore, it is better to implement the factory approach with a new PR."

Thanks to @iSazonov's guidance on the technical considerations, this implementation now works correctly.

## Solution

This implementation uses a **`TruncatingConverterFactory`** that dispatches to type-specific converters:

| Type | Converter |
|------|-----------|
| PSObject | `JsonConverterPSObject` (Extended/Adapted properties) |
| IDictionary | `JsonConverterDictionary<T>` (Base properties only) |
| IEnumerable | `JsonConverterEnumerable<T>` |
| Composite objects | `JsonConverterComposite<T>` (Base properties only) |
| Primitives | STJ default converters |

### Architecture Benefits

1. **Type-level dispatch** - STJ caches converters per type, improving performance
2. **Clear separation** - Each converter handles one concern
3. **Extensibility** - Easy to add new type-specific converters

### Key Differences from PR #26637

| Aspect | PR #26637 | This PR (Factory) |
|--------|-----------|-------------------|
| Raw object handling | `RawObjectWrapper` class | `TruncatingConverterFactory` dispatch |
| Type dispatch | Manual in `WriteValue` | Factory pattern with generic converters |
| Converter structure | Single `JsonConverterPSObject` with `_basePropertiesOnly` flag | Separate converters per type category |

# PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [x] This PR is ready to merge
- [x] **Breaking changes**: Experimental feature needed
  - Experimental feature name: `PSJsonSerializerV2`
- [ ] **User-facing changes**: Documentation needed
- [x] **Testing**: New tests added

# Changes Made

## Modified Files

### `ConvertToJsonCommandV2.cs`

- Added `TruncatingConverterFactory` - dispatches to appropriate converters based on type
- Added `JsonConverterDictionary<T>` - handles IDictionary types
- Added `JsonConverterEnumerable<T>` - handles IEnumerable types  
- Added `JsonConverterComposite<T>` - handles composite objects with Base properties only
- Removed `RawObjectWrapper` class
- Removed `_basePropertiesOnly` field and `filterToPropertyOnly` parameter from `JsonConverterPSObject`
- Added `WriteValue` helper to `JsonSerializerHelper`

### `ConvertTo-Json.PSJsonSerializerV2.Tests.ps1`

- Removed array element test that now matches V1 behavior

# Testing

## Existing Tests (ConvertTo-Json.Tests.ps1)

- **36 passed**, 1 failed, 1 pending
- The single failure is a DateTime test with timezone-dependent expectations (unrelated to this change)

## V2 Specific Tests (ConvertTo-Json.PSJsonSerializerV2.Tests.ps1)

- **4 passed**, 0 failed

# Related Work

| PR/Issue | Description |
|----------|-------------|
| #26637 | Original implementation (this PR is an alternative approach) |
| #5749 | Dictionary with non-string keys handling |

# Branch Structure

```mermaid
gitGraph
    commit id: "master"
    branch system-text-json
    commit id: "77d8a1b0c"
    commit id: "159b76387"
    branch isazonov-approach
    commit id: "e7dfff962"
    commit id: "da0c8cbfb"
    branch factory-test
    commit id: "test" type: REVERSE
    checkout isazonov-approach
    commit id: "6913cb119"
    commit id: "2ecc51e05"
    commit id: "2c549207a" tag: "PR #26637"
    branch factory-v2
    commit id: "af393269b" tag: "HEAD"
    checkout system-text-json
    commit id: "07cea1dc5" tag: "PR #26624"
```

| Branch | Base | PR | Status |
|--------|------|-----|--------|
| `system-text-json` | master | #26624 | Superseded |
| `isazonov-approach` | system-text-json | #26637 | Open |
| `factory-test` | isazonov-approach | - | Experiment (failed) |
| `factory-v2` | isazonov-approach | This PR | ✅ Success |