### PR TITLE
Fix the CLR internal error and null ref exception when running `show-command` with PowerShell API

### DIFF
--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -679,7 +679,7 @@ Function PSGetSerializedShowCommandInfo
         /// <returns>The host window, if it is present or null if it is not.</returns>
         internal static Window GetHostWindow(PSCmdlet cmdlet)
         {
-            // The 'PrivateData' property may have null value for the default host or custom host.
+            // The value of 'PrivateData' property may be null for the default host or a custom host.
             PSPropertyInfo windowProperty = cmdlet.Host.PrivateData?.Properties["Window"];
             if (windowProperty == null)
             {

--- a/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.Management.UI.Internal/commandHelpers/ShowCommandHelper.cs
@@ -679,7 +679,8 @@ Function PSGetSerializedShowCommandInfo
         /// <returns>The host window, if it is present or null if it is not.</returns>
         internal static Window GetHostWindow(PSCmdlet cmdlet)
         {
-            PSPropertyInfo windowProperty = cmdlet.Host.PrivateData.Properties["Window"];
+            // The 'PrivateData' property may have null value for the default host or custom host.
+            PSPropertyInfo windowProperty = cmdlet.Host.PrivateData?.Properties["Window"];
             if (windowProperty == null)
             {
                 return null;

--- a/src/System.Management.Automation/resources/HelpErrors.resx
+++ b/src/System.Management.Automation/resources/HelpErrors.resx
@@ -179,7 +179,7 @@
 To update these Help topics, start PowerShell by using the "Run as Administrator" command, and try running Update-Help again.</value>
   </data>
   <data name="GraphicalHostAssemblyIsNotFound" xml:space="preserve">
-    <value>To use the {0}, install Windows PowerShell ISE by using Server Manager, and then restart this application. ({1})</value>
+    <value>To use the {0}, make sure your application uses 'Microsoft.NET.Sdk.WindowsDesktop' as the project SDK and the corresponding assembly 'Microsoft.PowerShell.GraphicalHost' is available. ({1})</value>
   </data>
   <data name="RemotingNotSupportedForFeature" xml:space="preserve">
     <value>{0} does not work in a remote session.</value>

--- a/src/System.Management.Automation/utils/GraphicalHostReflectionWrapper.cs
+++ b/src/System.Management.Automation/utils/GraphicalHostReflectionWrapper.cs
@@ -55,7 +55,7 @@ namespace System.Management.Automation.Internal
         /// <exception cref="RuntimeException">When it was not possible to load Microsoft.PowerShell.GraphicalHost.dlly.</exception>
         internal static GraphicalHostReflectionWrapper GetGraphicalHostReflectionWrapper(PSCmdlet parentCmdlet, string graphicalHostHelperTypeName)
         {
-            return GraphicalHostReflectionWrapper.GetGraphicalHostReflectionWrapper(parentCmdlet, graphicalHostHelperTypeName, parentCmdlet.CommandInfo.Name);
+            return GetGraphicalHostReflectionWrapper(parentCmdlet, graphicalHostHelperTypeName, parentCmdlet.CommandInfo.Name);
         }
 
         /// <summary>
@@ -73,9 +73,9 @@ namespace System.Management.Automation.Internal
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Assembly.Load has been found to throw unadvertised exceptions")]
         internal static GraphicalHostReflectionWrapper GetGraphicalHostReflectionWrapper(PSCmdlet parentCmdlet, string graphicalHostHelperTypeName, string featureName)
         {
-            GraphicalHostReflectionWrapper returnValue = new GraphicalHostReflectionWrapper();
+            GraphicalHostReflectionWrapper returnValue = new();
 
-            if (GraphicalHostReflectionWrapper.IsInputFromRemoting(parentCmdlet))
+            if (IsInputFromRemoting(parentCmdlet))
             {
                 ErrorRecord error = new ErrorRecord(
                     new NotSupportedException(StringUtil.Format(HelpErrors.RemotingNotSupportedForFeature, featureName)),
@@ -87,9 +87,10 @@ namespace System.Management.Automation.Internal
             }
 
             // Prepare the full assembly name.
-            AssemblyName graphicalHostAssemblyName = new AssemblyName();
+            AssemblyName smaAssemblyName = typeof(PSObject).Assembly.GetName();
+            AssemblyName graphicalHostAssemblyName = new();
             graphicalHostAssemblyName.Name = "Microsoft.PowerShell.GraphicalHost";
-            graphicalHostAssemblyName.Version = new Version(3, 0, 0, 0);
+            graphicalHostAssemblyName.Version = smaAssemblyName.Version;
             graphicalHostAssemblyName.CultureInfo = new CultureInfo(string.Empty); // Neutral culture
             graphicalHostAssemblyName.SetPublicKeyToken(new byte[] { 0x31, 0xbf, 0x38, 0x56, 0xad, 0x36, 0x4e, 0x35 });
 
@@ -124,7 +125,7 @@ namespace System.Management.Automation.Internal
 
             returnValue._graphicalHostHelperType = returnValue._graphicalHostAssembly.GetType(graphicalHostHelperTypeName);
 
-            Diagnostics.Assert(returnValue._graphicalHostHelperType != null, "the type exists in Microsoft.PowerShell.GraphicalHost");
+            Diagnostics.Assert(returnValue._graphicalHostHelperType != null, "the type should exist in Microsoft.PowerShell.GraphicalHost");
             ConstructorInfo constructor = returnValue._graphicalHostHelperType.GetConstructor(
                 BindingFlags.NonPublic | BindingFlags.Instance,
                 null,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #26665

Two issues are addressed in this PR:
1. `GraphicalHostReflectionWrapper` always tries to load `Microsoft.PowerShell.GraphicalHost` with the assembly version v3.0.0.0, which is the version of the Windows PowerShell 5.1 assemblies.
    https://github.com/PowerShell/PowerShell/blob/4838a8d5f6c95339d4b44c8b402165e69e6ff929/src/System.Management.Automation/utils/GraphicalHostReflectionWrapper.cs#L89-L94

    I believe this is the cause of the reported CLR internal error, because even though the SDK package doesn't contain the `Microsoft.PowerShell.GraphicalHost` assembly, the v3.0.0.0 version of the assembly is available in GAC (as part of Windows PS v5.1), and PowerShell engine does look for assembly in GAC as the last resort. So, in your case, the assembly gets loaded from GAC, which targets .NET Framework and causes the CLR internal error.

    - **The fix is to use the correct version corresponding to the S.M.A.dll that is currently running.**

2. `Show-Command` fails when running it in PowerShell API from within PowerShell:
    ```
    PS> ($ps=[powershell]::Create()).AddScript('Show-Command').Invoke(); $ps.Streams.Error
    Show-Command: Object reference not set to an instance of an object.
    PS> $ps.Streams.Error[0].Exception
    
    TargetSite     : System.Windows.Window
                     GetHostWindow(System.Management.Automation.PSCmdlet)
    Message        : Object reference not set to an instance of an object.
    Data           : {}
    InnerException :
    HelpLink       :
    Source         : Microsoft.PowerShell.GraphicalHost
    HResult        : -2147467261
    StackTrace     :    at Microsoft.PowerShell.Commands.ShowCommandInternal.ShowCommandHel
                     per.GetHostWindow(PSCmdlet cmdlet)
                        at Microsoft.PowerShell.Commands.ShowCommandInternal.ShowCommandHel
                     per.CallShowDialog(PSCmdlet cmdlet)
                        at System.RuntimeMethodHandle.InvokeMethod(Object target, Void**
                     arguments, Signature sig, Boolean isConstructor)
                        at System.Reflection.MethodBaseInvoker.InvokeWithManyArgs(Object
                     obj, BindingFlags invokeAttr, Binder binder, Object[] parameters,
                     CultureInfo culture)
    ```

    When running in a PowerShell object created by `PowerShell.Create()` the default host is in use. The value of `cmdlet.Host.PrivateData` is null for the default host and it also could be null for a custom host.

    - **The fix is to handle the null check.**

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
