### PR TITLE
Fix WSManInstance COM interface with ResourceURI

### DIFF
--- a/src/Microsoft.WSMan.Management/Interop.cs
+++ b/src/Microsoft.WSMan.Management/Interop.cs
@@ -734,18 +734,19 @@ namespace Microsoft.WSMan.Management
         [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
         string ResourceUri
         {
+            // IDL: HRESULT resourceUri (BSTR value);
+            [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1212:PropertyAccessorsMustFollowOrder", Justification = "COM interface defines put_ before get_.")]
+            [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "resource")]
+            [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
+            [DispId(1)]
+            set;
+
             // IDL: HRESULT resourceUri ([out, retval] BSTR* ReturnValue);
             [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "resource")]
             [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
             [DispId(1)]
             [return: MarshalAs(UnmanagedType.BStr)]
             get;
-
-            // IDL: HRESULT resourceUri (BSTR value);
-            [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "resource")]
-            [SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
-            [DispId(1)]
-            set;
         }
 
         /// <summary><para><c>AddSelector</c> method of <c>IWSManResourceLocator</c> interface.  </para><para>Add selector to resource locator</para></summary>
@@ -818,14 +819,16 @@ namespace Microsoft.WSMan.Management
 
         int MustUnderstandOptions
         {
+            // IDL: HRESULT MustUnderstandOptions (long value);
+
+            [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1212:PropertyAccessorsMustFollowOrder", Justification = "COM interface defines put_ before get_.")]
+            [DispId(7)]
+            set;
+
             // IDL: HRESULT MustUnderstandOptions ([out, retval] long* ReturnValue);
 
             [DispId(7)]
             get;
-            // IDL: HRESULT MustUnderstandOptions (long value);
-
-            [DispId(7)]
-            set;
         }
 
         /// <summary><para><c>ClearOptions</c> method of <c>IWSManResourceLocator</c> interface.  </para><para>Clear all options</para></summary>


### PR DESCRIPTION
# PR Summary
Fixes the COM definitions of some WSMan classes that stopped Set-WSManInstance and New-WSManInstance from working. As the COM definition places the put/set method for `ResourceUri` before the get, it is important we do the same otherwise .NET will call the wrong method in the VTable throwing an exception around an invalid URI. This has been broken since v6 when the CORECLR directives changed it from an IDispatch implementation to IUnknown with the IDispatch methods in the interface. With the move to `IUnknown` the definition order is important as that is how C# sets up the VTable to invoke these methods.

You can see the header which defines the methods with `put_ResourceUri` before `get_ResourceUri` https://github.com/nihon-tc/Rtest/blob/8246e4d21323802fb84c406edc1a005991304f5a/header/Microsoft%20SDKs/Windows/v7.0A/Include/wsmandisp.h#L2426-L2430. Also fixes `MustUnderstandOptions` even though we don't use it in the codebase.

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/discussions/26647
https://github.com/ansible/ansible-documentation/issues/2709
https://github.com/MicrosoftDocs/PowerShell-Docs/issues/5687
https://stackoverflow.com/questions/73780191/set-wsmaninstance-fails-in-powershell-7

Unfortuantely I cannot write a test because `New-WSManInstance` and `Set-WSManInstance` requires WSMan to be setup which we cannot guarantee in CI. I have manually tested it with

```powershell
Set-WSManInstance -ResourceURI winrm/config -ValueSet @{
    MaxEnvelopeSizekb = (Get-WSManInstance -ResourceURI winrm/config).MaxEnvelopeSizekb
}
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
