### PR TITLE
[release/v7.6] Update metadata.json to update the Latest attribute with a better name

### DIFF
--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -2,6 +2,10 @@ steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
     $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
+
+    $LTS = $metadata.LTSRelease.PublishToChannels
+    $Stable = $metadata.StableRelease.PublishToChannels
+    $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'
     $releaseTag = '$(OutputReleaseTag.releaseTag)'
 
     # Rebuild branches should be treated as preview builds
@@ -10,10 +14,6 @@ steps:
     # and is used in contexts where that check may not have run.
     # If you update this regex, also update it in rebuild-branch-check.yml to keep them in sync.
     $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
-
-    $LTS = $metadata.LTSRelease.Latest
-    $Stable = $metadata.StableRelease.Latest
-    $isPreview = $releaseTag -match '-'
 
     # If this is a rebuild branch, force preview mode and ignore LTS metadata
     if ($isRebuildBranch) {

--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -33,7 +33,7 @@ stages:
     - template: release-SetReleaseTagandContainerName.yml
       parameters:
         restorePhase: true
-    
+
     - pwsh: |
         $packageVersion = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant() -replace '^v',''
         $vstsCommandString = "vso[task.setvariable variable=packageVersion]$packageVersion"
@@ -42,7 +42,7 @@ stages:
       displayName: Set Package version
       env:
         ob_restore_phase: true
-    
+
     - pwsh: |
         $branch = 'mirror-target'
         $gitArgs = "clone",
@@ -151,7 +151,7 @@ stages:
         $metadataHash = @{}
         $skipPublishValue = '${{ parameters.skipPublish }}'
         $metadataHash["ReleaseTag"] = '$(OutputReleaseTag.ReleaseTag)'
-        $metadataHash["LTS"] = $metadata.LTSRelease.Latest
+        $metadataHash["LTS"] = $metadata.LTSRelease.PublishToChannels
         $metadataHash["ForProduction"] = $true
         $metadataHash["SkipPublish"] = [System.Convert]::ToBoolean($skipPublishValue)
 
@@ -222,7 +222,7 @@ stages:
         files_to_sign: '*.ps1'
         search_root: '$(repoRoot)/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run'
       displayName: Sign Run.ps1
-  
+
     - pwsh: |
         # folder to tar must have: Run.ps1, settings.toml, python_dl
         $srcPath = Join-Path '$(ev2ServiceGroupRootFolder)' -ChildPath 'Shell'

--- a/.pipelines/templates/release-upload-buildinfo.yml
+++ b/.pipelines/templates/release-upload-buildinfo.yml
@@ -58,8 +58,8 @@ jobs:
       $dateTime = [datetime]::new($dateTime.Ticks - ($dateTime.Ticks % [timespan]::TicksPerSecond), $dateTime.Kind)
 
       $metadata = Get-Content -LiteralPath "$toolsDirectory/metadata.json" -ErrorAction Stop | ConvertFrom-Json
-      $stableRelease = $metadata.StableRelease.Latest
-      $ltsRelease = $metadata.LTSRelease.Latest
+      $stableRelease = $metadata.StableRelease.PublishToChannels
+      $ltsRelease = $metadata.LTSRelease.PublishToChannels
 
       Write-Verbose -Verbose "Writing $jsonFile contents:"
       $buildInfoJsonContent = Get-Content $jsonFile -Encoding UTF8NoBom -Raw

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -1,10 +1,10 @@
 {
-  "StableReleaseTag": "v7.5.3",
-  "PreviewReleaseTag": "v7.6.0-preview.4",
+  "StableReleaseTag": "v7.5.4",
+  "PreviewReleaseTag": "v7.6.0-preview.5",
   "ServicingReleaseTag": "v7.0.13",
-  "ReleaseTag": "v7.5.3",
-  "LTSReleaseTag" : ["v7.4.12"],
-  "NextReleaseTag": "v7.6.0-preview.5",
-  "LTSRelease": { "Latest": false, "Package": false },
-  "StableRelease":  { "Latest": false, "Package": false }
+  "ReleaseTag": "v7.5.4",
+  "LTSReleaseTag" : ["v7.4.13"],
+  "NextReleaseTag": "v7.6.0-preview.6",
+  "LTSRelease": { "PublishToChannels": false, "Package": false },
+  "StableRelease":  { "PublishToChannels": false, "Package": false }
 }


### PR DESCRIPTION
Backport of #26380 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26380$$$
-->

Triggered by @daxian-dbw on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Build and release pipeline improvement. Updates metadata property naming from 'Latest' to 'PublishToChannels' for better clarity. This only affects internal build tooling.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The fix has been tested in the original PR. Changes can be verified by running the release pipelines and confirming they correctly read the 'PublishToChannels' property from metadata.json. All pipeline template references have been updated to use the new property name.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The changes standardize metadata property naming in build/release pipelines by renaming 'Latest' to 'PublishToChannels'. All references in pipeline templates have been updated consistently. This is internal tooling only and doesn't affect product code.

## Merge Conflicts

Merge conflict in tools/metadata.json due to version number differences between branches. Resolved by accepting the cherry-picked changes (both version updates and property rename).
