### PR TITLE
[release/v7.6] Fix macOS preview package identifier detection to use version string

### DIFF
--- a/test/packaging/packaging.tests.ps1
+++ b/test/packaging/packaging.tests.ps1
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Packaging Module Functions" {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../build.psm1 -Force
+        Import-Module $PSScriptRoot/../../tools/packaging/packaging.psm1 -Force
+    }
+
+    Context "Test-IsPreview function" {
+        It "Should return True for preview versions" {
+            Test-IsPreview -Version "7.6.0-preview.6" | Should -Be $true
+            Test-IsPreview -Version "7.5.0-rc.1" | Should -Be $true
+        }
+
+        It "Should return False for stable versions" {
+            Test-IsPreview -Version "7.6.0" | Should -Be $false
+            Test-IsPreview -Version "7.5.0" | Should -Be $false
+        }
+
+        It "Should return False for LTS builds regardless of version string" {
+            Test-IsPreview -Version "7.6.0-preview.6" -IsLTS | Should -Be $false
+            Test-IsPreview -Version "7.5.0" -IsLTS | Should -Be $false
+        }
+    }
+
+    Context "Get-MacOSPackageIdentifierInfo function (New-MacOSPackage logic)" {
+        It "Should detect preview builds and return preview identifier" {
+            $result = Get-MacOSPackageIdentifierInfo -Version "7.6.0-preview.6" -LTS:$false
+            
+            $result.IsPreview | Should -Be $true
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell-preview"
+        }
+
+        It "Should detect stable builds and return stable identifier" {
+            $result = Get-MacOSPackageIdentifierInfo -Version "7.6.0" -LTS:$false
+            
+            $result.IsPreview | Should -Be $false
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell"
+        }
+
+        It "Should treat LTS builds as stable even with preview version string" {
+            $result = Get-MacOSPackageIdentifierInfo -Version "7.4.0-preview.1" -LTS:$true
+            
+            $result.IsPreview | Should -Be $false
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell"
+        }
+
+        It "Should NOT use package name for preview detection (bug fix verification)" {
+            # This test verifies the fix for issue #26673
+            # The bug was using ($Name -like '*-preview') which always returned false
+            # because preview builds use Name="powershell" not "powershell-preview"
+            
+            $Version = "7.6.0-preview.6"
+            $Name = "powershell"  # Preview builds use "powershell" not "powershell-preview"
+            
+            # The INCORRECT logic (the bug): $Name -like '*-preview'
+            $incorrectCheck = $Name -like '*-preview'
+            $incorrectCheck | Should -Be $false -Because "Package name is 'powershell' not 'powershell-preview'"
+            
+            # The CORRECT logic (the fix): uses version string
+            $result = Get-MacOSPackageIdentifierInfo -Version $Version -LTS:$false
+            $result.IsPreview | Should -Be $true -Because "Version string correctly identifies preview"
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell-preview"
+        }
+    }
+}

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1371,6 +1371,7 @@ function New-UnixPackage {
                         AppsFolder = $AppsFolder
                         HostArchitecture = $HostArchitecture
                         CurrentLocation = $CurrentLocation
+                        LTS = $LTS
                     }
 
                     try {
@@ -1515,7 +1516,12 @@ function New-MacOsDistributionPackage
 
     # Get package ID if not provided
     if (-not $PackageIdentifier) {
-        $PackageIdentifier = Get-MacOSPackageId -IsPreview:$IsPreview.IsPresent
+        if ($IsPreview.IsPresent) {
+            $PackageIdentifier = 'com.microsoft.powershell-preview'
+        }
+        else {
+            $PackageIdentifier = 'com.microsoft.powershell'
+        }
     }
 
     # Minimum OS version
@@ -1984,7 +1990,9 @@ function New-MacOSPackage
         [Parameter(Mandatory)]
         [string]$HostArchitecture,
 
-        [string]$CurrentLocation = (Get-Location)
+        [string]$CurrentLocation = (Get-Location),
+
+        [switch]$LTS
     )
 
     Write-Log "Creating macOS package using pkgbuild and productbuild..."
@@ -2059,8 +2067,10 @@ function New-MacOSPackage
             Copy-Item -Path "$AppsFolder/*" -Destination $appsInPkg -Recurse -Force
         }
 
-        # Build the component package using pkgbuild
-        $pkgIdentifier = Get-MacOSPackageId -IsPreview:($Name -like '*-preview')
+        # Get package identifier info based on version and LTS flag
+        $packageInfo = Get-MacOSPackageIdentifierInfo -Version $Version -LTS:$LTS
+        $IsPreview = $packageInfo.IsPreview
+        $pkgIdentifier = $packageInfo.PackageIdentifier
 
         if ($PSCmdlet.ShouldProcess("Build component package with pkgbuild")) {
             Write-Log "Running pkgbuild to create component package..."
@@ -2085,7 +2095,7 @@ function New-MacOSPackage
             -OutputDirectory $CurrentLocation `
             -HostArchitecture $HostArchitecture `
             -PackageIdentifier $pkgIdentifier `
-            -IsPreview:($Name -like '*-preview')
+            -IsPreview:$IsPreview
 
         return $distributionPackage
     }
@@ -2292,20 +2302,44 @@ function New-ManGzip
     }
 }
 
-# Returns the macOS Package Identifier
-function Get-MacOSPackageId
+<#
+    .SYNOPSIS
+        Determines the package identifier and preview status for macOS packages.
+    .DESCRIPTION
+        This function determines if a package is a preview build based on the version string
+        and LTS flag, then returns the appropriate package identifier.
+    .PARAMETER Version
+        The version string (e.g., "7.6.0-preview.6" or "7.6.0")
+    .PARAMETER LTS
+        Whether this is an LTS build
+    .OUTPUTS
+        Hashtable with IsPreview (boolean) and PackageIdentifier (string) properties
+    .EXAMPLE
+        Get-MacOSPackageIdentifierInfo -Version "7.6.0-preview.6" -LTS:$false
+        Returns @{ IsPreview = $true; PackageIdentifier = "com.microsoft.powershell-preview" }
+#>
+function Get-MacOSPackageIdentifierInfo
 {
     param(
-        [switch]
-        $IsPreview
+        [Parameter(Mandatory)]
+        [string]$Version,
+        
+        [switch]$LTS
     )
-    if ($IsPreview.IsPresent)
-    {
-        return 'com.microsoft.powershell-preview'
+    
+    $IsPreview = Test-IsPreview -Version $Version -IsLTS:$LTS
+    
+    # Determine package identifier based on preview status
+    if ($IsPreview) {
+        $PackageIdentifier = 'com.microsoft.powershell-preview'
     }
-    else
-    {
-        return 'com.microsoft.powershell'
+    else {
+        $PackageIdentifier = 'com.microsoft.powershell'
+    }
+    
+    return @{
+        IsPreview = $IsPreview
+        PackageIdentifier = $PackageIdentifier
     }
 }
 
@@ -2319,8 +2353,9 @@ function New-MacOSLauncher
         [switch]$LTS
     )
 
-    $IsPreview = Test-IsPreview -Version $Version -IsLTS:$LTS
-    $packageId = Get-MacOSPackageId -IsPreview:$IsPreview
+    $packageInfo = Get-MacOSPackageIdentifierInfo -Version $Version -LTS:$LTS
+    $IsPreview = $packageInfo.IsPreview
+    $packageId = $packageInfo.PackageIdentifier
 
     # Define folder for launcher application.
     $suffix = if ($IsPreview) { "-preview" } elseif ($LTS) { "-lts" }


### PR DESCRIPTION
Backport of #26690 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26690$$$
-->

Triggered by @daxian-dbw on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [x] Customer reported
- [ ] Found internally

macOS preview packages were incorrectly installing to the stable location (/usr/local/microsoft/powershell/7/) instead of the preview location (/usr/local/microsoft/powershell/7-preview/). This prevented users from having both stable and preview versions installed simultaneously. The bug was introduced when native macOS packaging tools replaced fpm.

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

Introduced in PR #26268 (merged October 28, 2025) when native macOS packaging tools replaced fpm. The New-MacOSPackage function incorrectly detected preview builds by checking the package name ($Name -like '*-preview') instead of the version string. Since preview builds use the package name 'powershell' (not 'powershell-preview'), the check always returned false, causing preview packages to use the stable identifier.

## Testing

The fix has been tested in the original PR with 7 unit tests covering all scenarios (preview, stable, LTS). Tests verify the Get-MacOSPackageIdentifierInfo function correctly identifies preview builds based on version string. A specific test documents the bug fix for issue #26673. The fix can be verified by building a macOS preview package and confirming it uses the com.microsoft.powershell-preview identifier and installs to the preview location.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The fix corrects preview detection logic in macOS package creation to use version string instead of package name. The change centralizes logic in a testable function and includes comprehensive unit tests. This only affects macOS packaging and restores the correct behavior that existed before the regression.
