### PR TITLE
[release/v7.6] Update Microsoft.PowerShell.PSResourceGet version to 1.2.0-rc1

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
-    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-preview5" />
+    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-rc1" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.4.5" />
     <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   


### PR DESCRIPTION
Backport of #26691 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26691$$$
-->

Triggered by @daxian-dbw on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Updated Microsoft.PowerShell.PSResourceGet module from version 1.2.0-preview5 to 1.2.0-rc1. This brings in the latest release candidate with bug fixes and improvements to the PSResourceGet module.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The updated module version has been tested in the original PR. The rc1 version of PSResourceGet includes bug fixes and improvements that have gone through the module's own testing process. This can be verified by running PSResourceGet cmdlets to ensure they work correctly with the updated version.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The change only updates the PSResourceGet module version from preview5 to rc1, which is a standard dependency update to include the latest fixes and improvements. The rc1 version has been tested and is ready for release candidate status.
