### PR TITLE
[release/v7.6] Fix buildinfo.json uploading for preview, LTS, and stable releases

### DIFF
--- a/.pipelines/templates/release-upload-buildinfo.yml
+++ b/.pipelines/templates/release-upload-buildinfo.yml
@@ -58,8 +58,7 @@ jobs:
       $dateTime = [datetime]::new($dateTime.Ticks - ($dateTime.Ticks % [timespan]::TicksPerSecond), $dateTime.Kind)
 
       $metadata = Get-Content -LiteralPath "$toolsDirectory/metadata.json" -ErrorAction Stop | ConvertFrom-Json
-      $stableRelease = $metadata.StableRelease.Latest
-      $ltsRelease = $metadata.LTSRelease.Latest
+      $stableReleaseTag = $metadata.StableReleaseTag -Replace 'v',''
 
       Write-Verbose -Verbose "Writing $jsonFile contents:"
       $buildInfoJsonContent = Get-Content $jsonFile -Encoding UTF8NoBom -Raw
@@ -67,40 +66,46 @@ jobs:
 
       $buildInfo =  $buildInfoJsonContent | ConvertFrom-Json
       $buildInfo.ReleaseDate = $dateTime
+      $currentReleaseTag = $buildInfo.ReleaseTag -Replace 'v',''
+      $stableRelease = $metadata.StableRelease.Latest
+      $ltsRelease = $metadata.LTSRelease.Latest
 
       $targetFile = "$ENV:PIPELINE_WORKSPACE/$fileName"
       ConvertTo-Json -InputObject $buildInfo | Out-File $targetFile -Encoding ascii
 
-      if ($stableRelease -or $fileName -eq "preview.json") {
-        Set-BuildVariable -Name CopyMainBuildInfo -Value YES
+      if ($fileName -eq "preview.json") {
+        Set-BuildVariable -Name UploadPreview -Value YES
       } else {
-        Set-BuildVariable -Name CopyMainBuildInfo -Value NO
+        Set-BuildVariable -Name UploadPreview -Value NO
       }
 
-      Set-BuildVariable -Name BuildInfoJsonFile -Value $targetFile
+      Set-BuildVariable -Name PreviewBuildInfoFile -Value $targetFile
 
-      ## Create 'lts.json' if it's the latest stable and also a LTS release.
-
+      ## Create 'lts.json' if marked as a LTS release.
       if ($fileName -eq "stable.json") {
+        [System.Management.Automation.SemanticVersion] $stableVersion = $stableReleaseTag
+        [System.Management.Automation.SemanticVersion] $currentVersion = $currentReleaseTag
         if ($ltsRelease) {
           $ltsFile = "$ENV:PIPELINE_WORKSPACE/lts.json"
           Copy-Item -Path $targetFile -Destination $ltsFile -Force
-          Set-BuildVariable -Name LtsBuildInfoJsonFile -Value $ltsFile
-          Set-BuildVariable -Name CopyLTSBuildInfo -Value YES
+          Set-BuildVariable -Name LTSBuildInfoFile -Value $ltsFile
+          Set-BuildVariable -Name UploadLTS -Value YES
         } else {
-          Set-BuildVariable -Name CopyLTSBuildInfo -Value NO
+          Set-BuildVariable -Name UploadLTS -Value NO
         }
 
-        $releaseTag = $buildInfo.ReleaseTag
-        $version = $releaseTag -replace '^v'
-        $semVersion = [System.Management.Automation.SemanticVersion] $version
+        ## Only update the stable.json if the current version is greater than the stable version.
+        if ($currentVersion -gt $stableVersion) {
+          $versionFile = "$ENV:PIPELINE_WORKSPACE/$($currentVersion.Major)-$($currentVersion.Minor).json"
+          Copy-Item -Path $targetFile -Destination $versionFile -Force
+          Set-BuildVariable -Name StableBuildInfoFile -Value $versionFile
+          Set-BuildVariable -Name UploadStable -Value YES
+        } else {
+          Set-BuildVariable -Name UploadStable -Value NO
+        }
 
-        $versionFile = "$ENV:PIPELINE_WORKSPACE/$($semVersion.Major)-$($semVersion.Minor).json"
-        Copy-Item -Path $targetFile -Destination $versionFile -Force
-        Set-BuildVariable -Name VersionBuildInfoJsonFile -Value $versionFile
-        Set-BuildVariable -Name CopyVersionBuildInfo -Value YES
       } else {
-        Set-BuildVariable -Name CopyVersionBuildInfo -Value NO
+        Set-BuildVariable -Name UploadStable -Value NO
       }
     displayName: Create json files
 
@@ -118,24 +123,27 @@ jobs:
 
         $storageContext = New-AzStorageContext -StorageAccountName $storageAccount -UseConnectedAccount
 
-        if ($env:CopyMainBuildInfo -eq 'YES') {
-          $jsonFile = "$env:BuildInfoJsonFile"
+        #preview
+        if ($env:UploadPreview -eq 'YES') {
+          $jsonFile = "$env:PreviewBuildInfoFile"
           $blobName = Get-Item $jsonFile | Split-Path -Leaf
           Write-Verbose -Verbose "Uploading $jsonFile to $containerName/$prefix/$blobName"
           Set-AzStorageBlobContent -File $jsonFile -Container $containerName -Blob "$prefix/$blobName" -Context $storageContext -Force
         }
 
-        if ($env:CopyLTSBuildInfo -eq 'YES') {
-          $jsonFile = "$env:LtsBuildInfoJsonFile"
+        #LTS
+        if ($env:UploadLTS -eq 'YES') {
+          $jsonFile = "$env:LTSBuildInfoFile"
           $blobName = Get-Item $jsonFile | Split-Path -Leaf
           Write-Verbose -Verbose "Uploading $jsonFile to $containerName/$prefix/$blobName"
           Set-AzStorageBlobContent -File $jsonFile -Container $containerName -Blob "$prefix/$blobName" -Context $storageContext -Force
         }
 
-        if ($env:CopyVersionBuildInfo -eq 'YES') {
-          $jsonFile = "$env:VersionBuildInfoJsonFile"
+        #stable
+        if ($env:UploadStable -eq 'YES') {
+          $jsonFile = "$env:StableBuildInfoFile"
           $blobName = Get-Item $jsonFile | Split-Path -Leaf
           Write-Verbose -Verbose "Uploading $jsonFile to $containerName/$prefix/$blobName"
           Set-AzStorageBlobContent -File $jsonFile -Container $containerName -Blob "$prefix/$blobName" -Context $storageContext -Force
         }
-    condition: and(succeeded(), eq(variables['CopyMainBuildInfo'], 'YES'))
+    condition: and(succeeded(), or(eq(variables['UploadPreview'], 'YES'), eq(variables['UploadLTS'], 'YES'), eq(variables['UploadStable'], 'YES')))


### PR DESCRIPTION
Backport of #25571 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:25571$$$
-->

Triggered by @daxian-dbw on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

This fixes an issue in the release pipeline where buildinfo.json files for preview, LTS, and stable releases were not being uploaded correctly. This ensures proper metadata is available for PowerShell releases.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The changes have been adapted for the v7.6 branch by using the `Latest` property instead of `PublishToChannels` to match the existing metadata.json structure in v7.6. The logic for creating and uploading preview, LTS, and stable JSON files remains functionally equivalent to the original PR.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a backport of a build/packaging improvement that has already been tested and merged to master. The only modification is adapting property names to match v7.6's metadata.json structure. The logic and functionality remain the same.

## Merge Conflicts

Resolved merge conflicts in `.pipelines/templates/release-upload-buildinfo.yml` by adapting the property references from `PublishToChannels` to `Latest` to match the v7.6 branch's metadata.json structure. All other changes from the original PR were applied without modification.
