### PR TITLE
Add comprehensive array and dictionary tests for ConvertTo-Json

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -631,121 +631,158 @@ Describe 'ConvertTo-Json' -tags "CI" {
             $jsonInputObject | Should -BeExactly '[10,20,30]'
         }
 
-        It 'Should serialize array with single null element correctly' {
+        It 'Should serialize array with single null element correctly via Pipeline and InputObject' {
             $arr = @($null)
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[null]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[null]'
+            $jsonInputObject | Should -BeExactly '[null]'
         }
 
-        It 'Should serialize array with multiple null elements correctly' {
+        It 'Should serialize array with multiple null elements correctly via Pipeline and InputObject' {
             $arr = @($null, $null, $null)
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[null,null,null]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[null,null,null]'
+            $jsonInputObject | Should -BeExactly '[null,null,null]'
         }
     }
 
     Context 'Nested arrays' {
-        It 'Should serialize 2D array correctly via InputObject' {
+        It 'Should serialize 2D array correctly via Pipeline and InputObject' {
             $arr = @(@(1, 2), @(3, 4))
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[[1,2],[3,4]]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[[1,2],[3,4]]'
+            $jsonInputObject | Should -BeExactly '[[1,2],[3,4]]'
         }
 
-        It 'Should serialize 3D array correctly via InputObject' {
+        It 'Should serialize 3D array correctly via Pipeline and InputObject' {
             $arr = @(@(@(1, 2), @(3, 4)), @(@(5, 6), @(7, 8)))
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[[[1,2],[3,4]],[[5,6],[7,8]]]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[[[1,2],[3,4]],[[5,6],[7,8]]]'
+            $jsonInputObject | Should -BeExactly '[[[1,2],[3,4]],[[5,6],[7,8]]]'
         }
 
-        It 'Should serialize jagged array correctly via InputObject' {
+        It 'Should serialize jagged array correctly via Pipeline and InputObject' {
             $arr = @(@(1), @(2, 3), @(4, 5, 6))
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[[1],[2,3],[4,5,6]]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[[1],[2,3],[4,5,6]]'
+            $jsonInputObject | Should -BeExactly '[[1],[2,3],[4,5,6]]'
         }
 
-        It 'Should serialize array containing empty arrays correctly' {
+        It 'Should serialize array containing empty arrays correctly via Pipeline and InputObject' {
             $arr = @(@(), @(1), @())
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[[],[1],[]]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[[],[1],[]]'
+            $jsonInputObject | Should -BeExactly '[[],[1],[]]'
         }
 
-        It 'Should serialize deeply nested array with Depth limit using ToString' {
+        It 'Should serialize deeply nested array with Depth limit using ToString via Pipeline and InputObject' {
             $ip = [System.Net.IPAddress]::Parse('192.168.1.1')
             $arr = ,(,(,(,($ip))))
-            $json = ConvertTo-Json -InputObject $arr -Compress -Depth 2
-            $json | Should -BeExactly '[[["192.168.1.1"]]]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress -Depth 2
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress -Depth 2
+            $jsonPipeline | Should -BeExactly '[[["192.168.1.1"]]]'
+            $jsonInputObject | Should -BeExactly '[[["192.168.1.1"]]]'
         }
 
-        It 'Should serialize deeply nested array with sufficient Depth as full object' {
+        It 'Should serialize deeply nested array with sufficient Depth as full object via Pipeline and InputObject' {
             $ip = [System.Net.IPAddress]::Parse('192.168.1.1')
             $arr = ,(,(,(,($ip))))
-            $json = ConvertTo-Json -InputObject $arr -Compress -Depth 10
-            $json | Should -BeExactly '[[[[{"AddressFamily":2,"ScopeId":null,"IsIPv6Multicast":false,"IsIPv6LinkLocal":false,"IsIPv6SiteLocal":false,"IsIPv6Teredo":false,"IsIPv6UniqueLocal":false,"IsIPv4MappedToIPv6":false,"Address":16885952}]]]]'
+            $expected = '[[[[{"AddressFamily":2,"ScopeId":null,"IsIPv6Multicast":false,"IsIPv6LinkLocal":false,"IsIPv6SiteLocal":false,"IsIPv6Teredo":false,"IsIPv6UniqueLocal":false,"IsIPv4MappedToIPv6":false,"Address":16885952}]]]]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress -Depth 10
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress -Depth 10
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
     }
 
     Context 'Array with mixed content types' {
-        It 'Should serialize array with mixed scalars correctly' {
+        It 'Should serialize array with mixed scalars correctly via Pipeline and InputObject' {
             $arr = @(1, 'two', 3.14, $true, $null)
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[1,"two",3.14,true,null]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[1,"two",3.14,true,null]'
+            $jsonInputObject | Should -BeExactly '[1,"two",3.14,true,null]'
         }
 
-        It 'Should serialize array with nested array and scalars correctly' {
+        It 'Should serialize array with nested array and scalars correctly via Pipeline and InputObject' {
             $arr = @(1, @(2, 3), 4)
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[1,[2,3],4]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[1,[2,3],4]'
+            $jsonInputObject | Should -BeExactly '[1,[2,3],4]'
         }
 
-        It 'Should serialize array with PSCustomObject elements correctly' {
+        It 'Should serialize array with PSCustomObject elements correctly via Pipeline and InputObject' {
             $arr = @([PSCustomObject]@{x = 1}, [PSCustomObject]@{y = 2})
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[{"x":1},{"y":2}]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[{"x":1},{"y":2}]'
+            $jsonInputObject | Should -BeExactly '[{"x":1},{"y":2}]'
         }
 
-        It 'Should serialize array with DateTime elements correctly' {
+        It 'Should serialize array with DateTime elements correctly via Pipeline and InputObject' {
             $date1 = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc)
             $date2 = [DateTime]::new(2024, 12, 25, 0, 0, 0, [DateTimeKind]::Utc)
             $arr = @($date1, $date2)
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '["2024-06-15T10:30:00Z","2024-12-25T00:00:00Z"]'
+            $expected = '["2024-06-15T10:30:00Z","2024-12-25T00:00:00Z"]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
 
-        It 'Should serialize array with Guid elements correctly' {
+        It 'Should serialize array with Guid elements correctly via Pipeline and InputObject' {
             $guid1 = [Guid]'12345678-1234-1234-1234-123456789abc'
             $guid2 = [Guid]'87654321-4321-4321-4321-cba987654321'
             $arr = @($guid1, $guid2)
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '["12345678-1234-1234-1234-123456789abc","87654321-4321-4321-4321-cba987654321"]'
+            $expected = '["12345678-1234-1234-1234-123456789abc","87654321-4321-4321-4321-cba987654321"]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
 
-        It 'Should serialize array with enum elements correctly' {
+        It 'Should serialize array with enum elements correctly via Pipeline and InputObject' {
             $arr = @([DayOfWeek]::Monday, [DayOfWeek]::Friday)
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[1,5]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[1,5]'
+            $jsonInputObject | Should -BeExactly '[1,5]'
         }
 
-        It 'Should serialize array with enum as string correctly' {
+        It 'Should serialize array with enum as string correctly via Pipeline and InputObject' {
             $arr = @([DayOfWeek]::Monday, [DayOfWeek]::Friday)
-            $json = ConvertTo-Json -InputObject $arr -Compress -EnumsAsStrings
-            $json | Should -BeExactly '["Monday","Friday"]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress -EnumsAsStrings
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress -EnumsAsStrings
+            $jsonPipeline | Should -BeExactly '["Monday","Friday"]'
+            $jsonInputObject | Should -BeExactly '["Monday","Friday"]'
         }
     }
 
     Context 'Array ETS properties' {
-        It 'Should include ETS properties on array via InputObject' {
+        It 'Should include ETS properties on array via Pipeline and InputObject' {
             $arr = @(1, 2, 3)
             $arr = Add-Member -InputObject $arr -MemberType NoteProperty -Name ArrayName -Value 'MyArray' -PassThru
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '{"value":[1,2,3],"ArrayName":"MyArray"}'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '{"value":[1,2,3],"ArrayName":"MyArray"}'
+            $jsonInputObject | Should -BeExactly '{"value":[1,2,3],"ArrayName":"MyArray"}'
         }
 
-        It 'Should include multiple ETS properties on array via InputObject' {
+        It 'Should include multiple ETS properties on array via Pipeline and InputObject' {
             $arr = @('a', 'b')
             $arr = Add-Member -InputObject $arr -MemberType NoteProperty -Name Prop1 -Value 'val1' -PassThru
             $arr = Add-Member -InputObject $arr -MemberType NoteProperty -Name Prop2 -Value 'val2' -PassThru
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '{"value":["a","b"],"Prop1":"val1","Prop2":"val2"}'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '{"value":["a","b"],"Prop1":"val1","Prop2":"val2"}'
+            $jsonInputObject | Should -BeExactly '{"value":["a","b"],"Prop1":"val1","Prop2":"val2"}'
         }
     }
 
@@ -766,21 +803,26 @@ Describe 'ConvertTo-Json' -tags "CI" {
             $jsonInputObject | Should -BeExactly '{"key":"value"}'
         }
 
-        It 'Should serialize hashtable with null value correctly' {
+        It 'Should serialize hashtable with null value correctly via Pipeline and InputObject' {
             $hash = @{ nullKey = $null }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"nullKey":null}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"nullKey":null}'
+            $jsonInputObject | Should -BeExactly '{"nullKey":null}'
         }
 
-        It 'Should serialize hashtable with various scalar types correctly' {
+        It 'Should serialize hashtable with various scalar types correctly via Pipeline and InputObject' {
             $hash = [ordered]@{
                 intKey = 42
                 strKey = 'hello'
                 boolKey = $true
                 doubleKey = 3.14
             }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"intKey":42,"strKey":"hello","boolKey":true,"doubleKey":3.14}'
+            $expected = '{"intKey":42,"strKey":"hello","boolKey":true,"doubleKey":3.14}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
     }
 
@@ -798,26 +840,31 @@ Describe 'ConvertTo-Json' -tags "CI" {
             $jsonInputObject | Should -BeExactly $expected
         }
 
-        It 'Should serialize large OrderedDictionary preserving order' {
+        It 'Should serialize large OrderedDictionary preserving order via Pipeline and InputObject' {
             $ordered = [ordered]@{}
             1..5 | ForEach-Object { $ordered["key$_"] = $_ }
-            $json = $ordered | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"key1":1,"key2":2,"key3":3,"key4":4,"key5":5}'
+            $expected = '{"key1":1,"key2":2,"key3":3,"key4":4,"key5":5}'
+            $jsonPipeline = $ordered | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $ordered -Compress
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
     }
 
     Context 'Nested dictionaries' {
-        It 'Should serialize nested hashtable correctly' {
+        It 'Should serialize nested hashtable correctly via Pipeline and InputObject' {
             $hash = @{
                 outer = @{
                     inner = 'value'
                 }
             }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"outer":{"inner":"value"}}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"outer":{"inner":"value"}}'
+            $jsonInputObject | Should -BeExactly '{"outer":{"inner":"value"}}'
         }
 
-        It 'Should serialize deeply nested hashtable correctly' {
+        It 'Should serialize deeply nested hashtable correctly via Pipeline and InputObject' {
             $hash = @{
                 level1 = @{
                     level2 = @{
@@ -825,11 +872,13 @@ Describe 'ConvertTo-Json' -tags "CI" {
                     }
                 }
             }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"level1":{"level2":{"level3":"deep"}}}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"level1":{"level2":{"level3":"deep"}}}'
+            $jsonInputObject | Should -BeExactly '{"level1":{"level2":{"level3":"deep"}}}'
         }
 
-        It 'Should serialize nested hashtable with Depth limit' {
+        It 'Should serialize nested hashtable with Depth limit via Pipeline and InputObject' {
             $hash = @{
                 level1 = @{
                     level2 = @{
@@ -837,165 +886,211 @@ Describe 'ConvertTo-Json' -tags "CI" {
                     }
                 }
             }
-            $json = $hash | ConvertTo-Json -Compress -Depth 1
-            $json | Should -BeExactly '{"level1":{"level2":"System.Collections.Hashtable"}}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress -Depth 1
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress -Depth 1
+            $jsonPipeline | Should -BeExactly '{"level1":{"level2":"System.Collections.Hashtable"}}'
+            $jsonInputObject | Should -BeExactly '{"level1":{"level2":"System.Collections.Hashtable"}}'
         }
 
-        It 'Should serialize hashtable with array value correctly' {
+        It 'Should serialize hashtable with array value correctly via Pipeline and InputObject' {
             $hash = @{ arr = @(1, 2, 3) }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"arr":[1,2,3]}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"arr":[1,2,3]}'
+            $jsonInputObject | Should -BeExactly '{"arr":[1,2,3]}'
         }
 
-        It 'Should serialize hashtable with nested array of hashtables correctly' {
+        It 'Should serialize hashtable with nested array of hashtables correctly via Pipeline and InputObject' {
             $hash = @{
                 items = @(
                     @{ id = 1 },
                     @{ id = 2 }
                 )
             }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"items":[{"id":1},{"id":2}]}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"items":[{"id":1},{"id":2}]}'
+            $jsonInputObject | Should -BeExactly '{"items":[{"id":1},{"id":2}]}'
         }
     }
 
     Context 'Dictionary key types' {
-        It 'Should serialize hashtable with string keys correctly' {
+        It 'Should serialize hashtable with string keys correctly via Pipeline and InputObject' {
             $hash = @{ 'string-key' = 'value' }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"string-key":"value"}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"string-key":"value"}'
+            $jsonInputObject | Should -BeExactly '{"string-key":"value"}'
         }
 
-        It 'Should serialize hashtable with special character keys correctly' {
+        It 'Should serialize hashtable with special character keys correctly via Pipeline and InputObject' {
             $hash = [ordered]@{
                 'key with space' = 1
                 'key-with-dash' = 2
                 'key_with_underscore' = 3
             }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"key with space":1,"key-with-dash":2,"key_with_underscore":3}'
+            $expected = '{"key with space":1,"key-with-dash":2,"key_with_underscore":3}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
 
-        It 'Should serialize hashtable with unicode keys correctly' {
+        It 'Should serialize hashtable with unicode keys correctly via Pipeline and InputObject' {
             $hash = @{ "`u{65E5}`u{672C}`u{8A9E}" = 'Japanese' }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly "{`"`u{65E5}`u{672C}`u{8A9E}`":`"Japanese`"}"
+            $expected = "{`"`u{65E5}`u{672C}`u{8A9E}`":`"Japanese`"}"
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
 
-        It 'Should serialize hashtable with empty string key correctly' {
+        It 'Should serialize hashtable with empty string key correctly via Pipeline and InputObject' {
             $hash = @{ '' = 'empty key' }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"":"empty key"}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"":"empty key"}'
+            $jsonInputObject | Should -BeExactly '{"":"empty key"}'
         }
     }
 
     Context 'Dictionary with complex values' {
-        It 'Should serialize hashtable with DateTime value correctly' {
+        It 'Should serialize hashtable with DateTime value correctly via Pipeline and InputObject' {
             $hash = @{ date = [DateTime]::new(2024, 6, 15, 10, 30, 0, [DateTimeKind]::Utc) }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"date":"2024-06-15T10:30:00Z"}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"date":"2024-06-15T10:30:00Z"}'
+            $jsonInputObject | Should -BeExactly '{"date":"2024-06-15T10:30:00Z"}'
         }
 
-        It 'Should serialize hashtable with Guid value correctly' {
+        It 'Should serialize hashtable with Guid value correctly via Pipeline and InputObject' {
             $hash = @{ guid = [Guid]'12345678-1234-1234-1234-123456789abc' }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"guid":"12345678-1234-1234-1234-123456789abc"}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"guid":"12345678-1234-1234-1234-123456789abc"}'
+            $jsonInputObject | Should -BeExactly '{"guid":"12345678-1234-1234-1234-123456789abc"}'
         }
 
-        It 'Should serialize hashtable with enum value correctly' {
+        It 'Should serialize hashtable with enum value correctly via Pipeline and InputObject' {
             $hash = @{ day = [DayOfWeek]::Monday }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"day":1}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"day":1}'
+            $jsonInputObject | Should -BeExactly '{"day":1}'
         }
 
-        It 'Should serialize hashtable with enum as string correctly' {
+        It 'Should serialize hashtable with enum as string correctly via Pipeline and InputObject' {
             $hash = @{ day = [DayOfWeek]::Monday }
-            $json = $hash | ConvertTo-Json -Compress -EnumsAsStrings
-            $json | Should -BeExactly '{"day":"Monday"}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress -EnumsAsStrings
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress -EnumsAsStrings
+            $jsonPipeline | Should -BeExactly '{"day":"Monday"}'
+            $jsonInputObject | Should -BeExactly '{"day":"Monday"}'
         }
 
-        It 'Should serialize hashtable with PSCustomObject value correctly' {
+        It 'Should serialize hashtable with PSCustomObject value correctly via Pipeline and InputObject' {
             $hash = @{ obj = [PSCustomObject]@{ prop = 'value' } }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"obj":{"prop":"value"}}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"obj":{"prop":"value"}}'
+            $jsonInputObject | Should -BeExactly '{"obj":{"prop":"value"}}'
         }
     }
 
     Context 'Dictionary ETS properties' {
-        It 'Should include ETS properties on hashtable via InputObject' {
+        It 'Should include ETS properties on hashtable via Pipeline and InputObject' {
             $hash = @{ a = 1 }
             $hash = Add-Member -InputObject $hash -MemberType NoteProperty -Name ETSProp -Value 'ets' -PassThru
-            $json = ConvertTo-Json -InputObject $hash -Compress
-            $json | Should -BeExactly '{"a":1,"ETSProp":"ets"}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"a":1,"ETSProp":"ets"}'
+            $jsonInputObject | Should -BeExactly '{"a":1,"ETSProp":"ets"}'
         }
 
-        It 'Should include ETS properties on OrderedDictionary via InputObject' {
+        It 'Should include ETS properties on OrderedDictionary via Pipeline and InputObject' {
             $ordered = [ordered]@{ a = 1 }
             $ordered = Add-Member -InputObject $ordered -MemberType NoteProperty -Name ETSProp -Value 'ets' -PassThru
-            $json = ConvertTo-Json -InputObject $ordered -Compress
-            $json | Should -BeExactly '{"a":1,"ETSProp":"ets"}'
+            $jsonPipeline = $ordered | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $ordered -Compress
+            $jsonPipeline | Should -BeExactly '{"a":1,"ETSProp":"ets"}'
+            $jsonInputObject | Should -BeExactly '{"a":1,"ETSProp":"ets"}'
         }
     }
 
     Context 'Generic Dictionary types' {
-        It 'Should serialize Generic Dictionary correctly' {
+        It 'Should serialize Generic Dictionary correctly via Pipeline and InputObject' {
             $dict = [System.Collections.Generic.Dictionary[string,int]]::new()
             $dict['one'] = 1
             $dict['two'] = 2
-            $json = $dict | ConvertTo-Json -Compress
-            $json | Should -Match '"one":1'
-            $json | Should -Match '"two":2'
+            $jsonPipeline = $dict | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $dict -Compress
+            $jsonPipeline | Should -Match '"one":1'
+            $jsonPipeline | Should -Match '"two":2'
+            $jsonInputObject | Should -Match '"one":1'
+            $jsonInputObject | Should -Match '"two":2'
         }
 
-        It 'Should serialize SortedDictionary correctly' {
+        It 'Should serialize SortedDictionary correctly via Pipeline and InputObject' {
             $dict = [System.Collections.Generic.SortedDictionary[string,int]]::new()
             $dict['b'] = 2
             $dict['a'] = 1
             $dict['c'] = 3
-            $json = $dict | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"a":1,"b":2,"c":3}'
+            $jsonPipeline = $dict | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $dict -Compress
+            $jsonPipeline | Should -BeExactly '{"a":1,"b":2,"c":3}'
+            $jsonInputObject | Should -BeExactly '{"a":1,"b":2,"c":3}'
         }
     }
 
     Context 'Array of dictionaries' {
-        It 'Should serialize array of hashtables correctly via Pipeline' {
-            $arr = @{ a = 1 }, @{ b = 2 }, @{ c = 3 }
-            $json = $arr | ConvertTo-Json -Compress
-            $json | Should -BeExactly '[{"a":1},{"b":2},{"c":3}]'
+        It 'Should serialize array of hashtables correctly via Pipeline and InputObject' {
+            $arr = @(@{ a = 1 }, @{ b = 2 }, @{ c = 3 })
+            $jsonPipeline = $arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[{"a":1},{"b":2},{"c":3}]'
+            $jsonInputObject | Should -BeExactly '[{"a":1},{"b":2},{"c":3}]'
         }
 
-        It 'Should serialize array of ordered dictionaries correctly via InputObject' {
+        It 'Should serialize array of ordered dictionaries correctly via Pipeline and InputObject' {
             $arr = @(
                 [ordered]@{ x = 1; y = 2 },
                 [ordered]@{ x = 3; y = 4 }
             )
-            $json = ConvertTo-Json -InputObject $arr -Compress
-            $json | Should -BeExactly '[{"x":1,"y":2},{"x":3,"y":4}]'
+            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
+            $jsonPipeline | Should -BeExactly '[{"x":1,"y":2},{"x":3,"y":4}]'
+            $jsonInputObject | Should -BeExactly '[{"x":1,"y":2},{"x":3,"y":4}]'
         }
     }
 
     Context 'Dictionary with array values' {
-        It 'Should serialize dictionary with array values correctly' {
+        It 'Should serialize dictionary with array values correctly via Pipeline and InputObject' {
             $hash = [ordered]@{
                 numbers = @(1, 2, 3)
                 strings = @('a', 'b', 'c')
             }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"numbers":[1,2,3],"strings":["a","b","c"]}'
+            $expected = '{"numbers":[1,2,3],"strings":["a","b","c"]}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly $expected
+            $jsonInputObject | Should -BeExactly $expected
         }
 
-        It 'Should serialize dictionary with nested array values correctly' {
+        It 'Should serialize dictionary with nested array values correctly via Pipeline and InputObject' {
             $hash = @{
                 matrix = @(@(1, 2), @(3, 4))
             }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"matrix":[[1,2],[3,4]]}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"matrix":[[1,2],[3,4]]}'
+            $jsonInputObject | Should -BeExactly '{"matrix":[[1,2],[3,4]]}'
         }
 
-        It 'Should serialize dictionary with empty array value correctly' {
+        It 'Should serialize dictionary with empty array value correctly via Pipeline and InputObject' {
             $hash = @{ empty = @() }
-            $json = $hash | ConvertTo-Json -Compress
-            $json | Should -BeExactly '{"empty":[]}'
+            $jsonPipeline = $hash | ConvertTo-Json -Compress
+            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
+            $jsonPipeline | Should -BeExactly '{"empty":[]}'
+            $jsonInputObject | Should -BeExactly '{"empty":[]}'
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -1041,58 +1041,5 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
     }
 
-    Context 'Array of dictionaries' {
-        It 'Should serialize array of hashtables correctly via Pipeline and InputObject' {
-            $arr = @(@{ a = 1 }, @{ b = 2 }, @{ c = 3 })
-            $jsonPipeline = $arr | ConvertTo-Json -Compress
-            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
-            $jsonPipeline | Should -BeExactly '[{"a":1},{"b":2},{"c":3}]'
-            $jsonInputObject | Should -BeExactly '[{"a":1},{"b":2},{"c":3}]'
-        }
-
-        It 'Should serialize array of ordered dictionaries correctly via Pipeline and InputObject' {
-            $arr = @(
-                [ordered]@{ x = 1; y = 2 },
-                [ordered]@{ x = 3; y = 4 }
-            )
-            $jsonPipeline = ,$arr | ConvertTo-Json -Compress
-            $jsonInputObject = ConvertTo-Json -InputObject $arr -Compress
-            $jsonPipeline | Should -BeExactly '[{"x":1,"y":2},{"x":3,"y":4}]'
-            $jsonInputObject | Should -BeExactly '[{"x":1,"y":2},{"x":3,"y":4}]'
-        }
-    }
-
-    Context 'Dictionary with array values' {
-        It 'Should serialize dictionary with array values correctly via Pipeline and InputObject' {
-            $hash = [ordered]@{
-                numbers = @(1, 2, 3)
-                strings = @('a', 'b', 'c')
-            }
-            $expected = '{"numbers":[1,2,3],"strings":["a","b","c"]}'
-            $jsonPipeline = $hash | ConvertTo-Json -Compress
-            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
-            $jsonPipeline | Should -BeExactly $expected
-            $jsonInputObject | Should -BeExactly $expected
-        }
-
-        It 'Should serialize dictionary with nested array values correctly via Pipeline and InputObject' {
-            $hash = @{
-                matrix = @(@(1, 2), @(3, 4))
-            }
-            $jsonPipeline = $hash | ConvertTo-Json -Compress
-            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
-            $jsonPipeline | Should -BeExactly '{"matrix":[[1,2],[3,4]]}'
-            $jsonInputObject | Should -BeExactly '{"matrix":[[1,2],[3,4]]}'
-        }
-
-        It 'Should serialize dictionary with empty array value correctly via Pipeline and InputObject' {
-            $hash = @{ empty = @() }
-            $jsonPipeline = $hash | ConvertTo-Json -Compress
-            $jsonInputObject = ConvertTo-Json -InputObject $hash -Compress
-            $jsonPipeline | Should -BeExactly '{"empty":[]}'
-            $jsonInputObject | Should -BeExactly '{"empty":[]}'
-        }
-    }
-
     #endregion Comprehensive Array and Dictionary Tests (Phase 2)
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -677,11 +677,10 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should serialize deeply nested array with sufficient Depth as full object' {
-            $ip = [System.Net.IPAddress]::Parse('10.0.0.1')
+            $ip = [System.Net.IPAddress]::Parse('192.168.1.1')
             $arr = ,(,(,(,($ip))))
             $json = ConvertTo-Json -InputObject $arr -Compress -Depth 10
-            $json | Should -BeLike '*AddressFamily*'
-            $json | Should -Not -BeExactly '[[[["10.0.0.1"]]]]'
+            $json | Should -BeExactly '[[[[{"AddressFamily":2,"ScopeId":null,"IsIPv6Multicast":false,"IsIPv6LinkLocal":false,"IsIPv6SiteLocal":false,"IsIPv6Teredo":false,"IsIPv6UniqueLocal":false,"IsIPv4MappedToIPv6":false,"Address":16885952}]]]]'
         }
     }
 


### PR DESCRIPTION
# PR Summary

Add comprehensive array and dictionary tests for `ConvertTo-Json` (Phase 2).

## PR Context

This is a follow-up to #26736. Per @iSazonov's suggestion in #26639, comprehensive tests are being submitted as separate PRs for each phase.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] These changes were tested
- [x] Test added (test-only PR)

## Tests Added

The following array and dictionary tests are added to `ConvertTo-Json.Tests.ps1`:

| Context | Tests | Description |
|---------|-------|-------------|
| Array basic serialization | 7 | empty, single, multi-element, string, typed, null elements |
| Nested arrays | 6 | 2D, 3D, jagged, empty nested, depth limit |
| Array with mixed content types | 4 | mixed scalars, nested, hashtable/PSCustomObject elements |
| Array ETS properties | 2 | single and multiple ETS properties |
| Hashtable basic serialization | 4 | empty, single key, null value, various scalar types |
| OrderedDictionary serialization | 2 | order preservation, large dictionary |
| Nested dictionaries | 5 | nested, deeply nested, depth limit, array values |
| Dictionary key types | 4 | string, special chars, unicode, empty string keys |
| Dictionary with complex values | 5 | DateTime, Guid, enum, PSCustomObject values |
| Dictionary ETS properties | 2 | hashtable and OrderedDictionary ETS |
| Generic Dictionary types | 2 | Dictionary<string,int>, SortedDictionary |
| Array of dictionaries | 2 | via Pipeline and InputObject |
| Dictionary with array values | 3 | array values, nested arrays, empty arrays |

**Total: 48 new tests**