### PR TITLE
Add comprehensive PSCustomObject tests for ConvertTo-Json

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -1058,7 +1058,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should serialize PSCustomObject with multiple properties via Pipeline and InputObject' {
-            $obj = [PSCustomObject]@{
+            $obj = [PSCustomObject][ordered]@{
                 Name = 'Test'
                 Value = 42
                 Active = $true
@@ -1071,7 +1071,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should preserve property order in PSCustomObject via Pipeline and InputObject' {
-            $obj = [PSCustomObject]@{
+            $obj = [PSCustomObject][ordered]@{
                 Zebra = 1
                 Alpha = 2
                 Middle = 3
@@ -1094,7 +1094,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
     Context 'PSCustomObject with various property types' {
         It 'Should serialize PSCustomObject with scalar properties via Pipeline and InputObject' {
-            $obj = [PSCustomObject]@{
+            $obj = [PSCustomObject][ordered]@{
                 IntVal = 42
                 DoubleVal = 3.14
                 StringVal = 'hello'
@@ -1209,7 +1209,7 @@ Describe 'ConvertTo-Json' -tags "CI" {
         }
 
         It 'Should serialize PSCustomObject with mixed nested types via Pipeline and InputObject' {
-            $obj = [PSCustomObject]@{
+            $obj = [PSCustomObject][ordered]@{
                 Child = [PSCustomObject]@{ Name = 'child' }
                 Items = @(1, 2, 3)
                 Config = @{ Key = 'Value' }
@@ -1258,8 +1258,8 @@ Describe 'ConvertTo-Json' -tags "CI" {
     Context 'Array of PSCustomObject' {
         It 'Should serialize array of PSCustomObject via Pipeline and InputObject' {
             $arr = @(
-                [PSCustomObject]@{ Id = 1; Name = 'First' }
-                [PSCustomObject]@{ Id = 2; Name = 'Second' }
+                [PSCustomObject][ordered]@{ Id = 1; Name = 'First' }
+                [PSCustomObject][ordered]@{ Id = 2; Name = 'Second' }
             )
             $expected = '[{"Id":1,"Name":"First"},{"Id":2,"Name":"Second"}]'
             $jsonPipeline = $arr | ConvertTo-Json -Compress


### PR DESCRIPTION
# PR Summary

Add comprehensive PSCustomObject tests for `ConvertTo-Json` (Phase 3).

## PR Context

This is a follow-up to #26742. Per @iSazonov's suggestion in #26639, comprehensive tests are being submitted as separate PRs for each phase.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] These changes were tested
- [x] Test added (test-only PR)

## Tests Added

The following PSCustomObject tests are added to `ConvertTo-Json.Tests.ps1`:

| Context | Tests | Description |
|---------|-------|-------------|
| PSCustomObject basic serialization | 4 | single/multiple properties, property order, null property |
| PSCustomObject with various property types | 7 | scalar, DateTime, Guid, enum, array, hashtable properties |
| Nested PSCustomObject | 4 | nested, deeply nested, depth limit, mixed nested types |
| PSCustomObject ETS properties | 3 | NoteProperty, ScriptProperty, multiple ETS |
| Array of PSCustomObject | 3 | array serialization, single without -AsArray, single with -AsArray |

**Total: 21 new tests**