### PR TITLE
Add SubjectAlternativeName property to Get-AuthenticodeSignature

### DIFF
--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -815,6 +815,7 @@ namespace System.Management.Automation.Internal
         // The OID arc 1.3.6.1.4.1.311.80 is assigned to PowerShell. If we need
         // new OIDs, we can assign them under this branch.
         internal const string DocumentEncryptionOid = "1.3.6.1.4.1.311.80.1";
+        internal const string SubjectAlternativeNameOid = "2.5.29.17";
     }
 }
 

--- a/test/powershell/engine/Security/FileSignature.Tests.ps1
+++ b/test/powershell/engine/Security/FileSignature.Tests.ps1
@@ -19,6 +19,12 @@ Describe "Windows platform file signatures" -Tags 'Feature' {
         $signature.Status | Should -BeExactly 'Valid'
         $signature.SignatureType | Should -BeExactly 'Catalog'
     }
+
+    It "Verifies SubjectAlternativeName property exists on signed file" -Skip:(!$IsWindows) {
+        $filePath = Join-Path -Path $env:windir -ChildPath 'System32\ntdll.dll'
+        $signature = Get-AuthenticodeSignature -FilePath $filePath
+        $signature.PSObject.Properties.Name | Should -Contain 'SubjectAlternativeName'
+    }
 }
 
 Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWindows') {
@@ -185,5 +191,96 @@ Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWin
         $actual = Get-AuthenticodeSignature -Content $fileBytes -SourcePathOrExtension .ps1
         $actual.SignerCertificate.Thumbprint | Should -Be $certificate.Thumbprint
         $actual.Status | Should -Be 'Valid'
+    }
+
+    It "Verifies SubjectAlternativeName is null when certificate has no SAN" {
+        Set-Content -Path testdrive:\test.ps1 -Value 'Write-Output "Test No SAN"' -Encoding UTF8NoBOM
+
+        $scriptPath = Join-Path $TestDrive test.ps1
+        $status = Set-AuthenticodeSignature -FilePath $scriptPath -Certificate $certificate
+        $status.Status | Should -Be 'Valid'
+
+        $actual = Get-AuthenticodeSignature -FilePath $scriptPath
+        $actual.SubjectAlternativeName | Should -BeNullOrEmpty
+    }
+
+    It "Verifies SubjectAlternativeName is populated for certificate with SAN" {
+        $session = New-PSSession -UseWindowsPowerShell
+        try {
+            $sanThumbprint = Invoke-Command -Session $session -ScriptBlock {
+                $testPrefix = 'SelfSignedTestSAN'
+
+                $enhancedKeyUsage = [Security.Cryptography.OidCollection]::new()
+                $null = $enhancedKeyUsage.Add('1.3.6.1.5.5.7.3.3')
+
+                $caParams = @{
+                    Extension         = @(
+                        [Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new($true, $false, 0, $true),
+                        [Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new('KeyCertSign', $false),
+                        [Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]::new($enhancedKeyUsage, $false)
+                    )
+                    CertStoreLocation = 'Cert:\CurrentUser\My'
+                    NotAfter          = (Get-Date).AddDays(1)
+                    Type              = 'Custom'
+                }
+                $sanCA = PKI\New-SelfSignedCertificate @caParams -Subject "CN=$testPrefix-CA"
+
+                $rootStore = Get-Item -Path Cert:\LocalMachine\Root
+                $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+                try {
+                    $rootStore.Add([System.Security.Cryptography.X509Certificates.X509Certificate2]::new($sanCA.RawData))
+                } finally {
+                    $rootStore.Close()
+                }
+
+                $certParams = @{
+                    CertStoreLocation = 'Cert:\CurrentUser\My'
+                    KeyUsage          = 'DigitalSignature'
+                    TextExtension     = @(
+                        "2.5.29.37={text}1.3.6.1.5.5.7.3.3",
+                        "2.5.29.19={text}",
+                        "2.5.29.17={text}DNS=test.example.com&DNS=*.example.com"
+                    )
+                    Type              = 'Custom'
+                }
+                $sanCert = PKI\New-SelfSignedCertificate @certParams -Subject "CN=$testPrefix-Signed" -Signer $sanCA
+
+                $publisherStore = Get-Item -Path Cert:\LocalMachine\TrustedPublisher
+                $publisherStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+                try {
+                    $publisherStore.Add([System.Security.Cryptography.X509Certificates.X509Certificate2]::new($sanCert.RawData))
+                } finally {
+                    $publisherStore.Close()
+                }
+
+                $sanCA | Remove-Item
+                $sanCA.Thumbprint, $sanCert.Thumbprint
+            }
+        } finally {
+            $session | Remove-PSSession
+        }
+
+        $sanCARootThumbprint = $sanThumbprint[0]
+        $sanCertThumbprint = $sanThumbprint[1]
+        $sanCertificate = Get-Item -Path Cert:\CurrentUser\My\$sanCertThumbprint
+
+        try {
+            Set-Content -Path testdrive:\test.ps1 -Value 'Write-Output "Test SAN"' -Encoding UTF8NoBOM
+
+            $scriptPath = Join-Path $TestDrive test.ps1
+            $status = Set-AuthenticodeSignature -FilePath $scriptPath -Certificate $sanCertificate
+            $status.Status | Should -Be 'Valid'
+
+            $actual = Get-AuthenticodeSignature -FilePath $scriptPath
+            $actual.SubjectAlternativeName | Should -Not -BeNullOrEmpty
+            $actual.SubjectAlternativeName | Should -BeOfType [string]
+            $actual.SubjectAlternativeName.Count | Should -Be 2
+            $actual.SubjectAlternativeName | Should -Contain 'DNS Name=test.example.com'
+            $actual.SubjectAlternativeName | Should -Contain 'DNS Name=*.example.com'
+        } finally {
+            Remove-Item -Path "Cert:\LocalMachine\Root\$sanCARootThumbprint" -Force -ErrorAction Ignore
+            Remove-Item -Path "Cert:\LocalMachine\TrustedPublisher\$sanCertThumbprint" -Force -ErrorAction Ignore
+            Remove-Item -Path "Cert:\CurrentUser\My\$sanCertThumbprint" -Force -ErrorAction Ignore
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

Adds a `SubjectAlternativeName` property to the `Signature` class returned by `Get-AuthenticodeSignature`, exposing the Subject Alternative Name (SAN) extension from the signer certificate as a `string[]`.

Fixes #14006

## PR Context

### Problem
The Subject Alternative Name extension contains important security data including DNS names, email addresses, IP addresses, and directory names associated with a certificate. As noted by the [Security Working Group](https://github.com/PowerShell/PowerShell/issues/14006#issuecomment-761987758), this information is valuable for making informed trust decisions. Previously, accessing SAN data required manually inspecting certificate extensions:

```powershell
$sig = Get-AuthenticodeSignature -FilePath $path
$sanExt = $sig.SignerCertificate.Extensions | Where-Object { $_.Oid.FriendlyName -match "subject alternative name" }
$sanStr = $sanExt.Format($true)
```

### Solution
Added a `SubjectAlternativeName` property directly to the `Signature` class that automatically extracts and parses the SAN extension (OID 2.5.29.17) from the signer certificate:

```powershell
$sig = Get-AuthenticodeSignature -FilePath $path
$sig.SubjectAlternativeName
# DNS Name=example.com
# DNS Name=*.example.com
```

> **Note:** There is a prior PR #26252 from copilot-swe-agent for this same issue, but it has had a compile error (type mismatch in `GetSubjectAlternativeName`) for over 100 days with no activity.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed: #14006
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

## Changes Made

### 1. `SecuritySupport.cs` (+1 line)
- Added `SubjectAlternativeNameOid` constant (`"2.5.29.17"`) to `CertificateFilterInfo`

### 2. `MshSignature.cs` (+28 lines)
- Added `public string[] SubjectAlternativeName` property
- Added `GetSubjectAlternativeName` helper method that extracts the SAN extension, formats it as multiline text, and splits into individual entries
- Called from `Init` when a signer certificate is present

### 3. `FileSignature.Tests.ps1` (+97 lines)
- Verifies `SubjectAlternativeName` property exists on catalog-signed system files
- Verifies `SubjectAlternativeName` is null for certificates without SAN
- Verifies `SubjectAlternativeName` contains correct DNS entries for certificates with SAN

**Total: 3 files changed, 127 insertions(+)**

## Behavior Examples

### Signed system file
```powershell
$sig = Get-AuthenticodeSignature -FilePath 'C:\Windows\System32\ntdll.dll'
$sig.SubjectAlternativeName
```
```
Directory Address:
SERIALNUMBER="229879+505326"
OU=Microsoft Corporation
```

### Certificate without SAN
```powershell
$sig = Get-AuthenticodeSignature -FilePath $scriptSignedWithoutSAN
$sig.SubjectAlternativeName  # returns $null
```

### Certificate with DNS SAN
```powershell
$sig = Get-AuthenticodeSignature -FilePath $scriptSignedWithSAN
$sig.SubjectAlternativeName
```
```
DNS Name=test.example.com
DNS Name=*.example.com
```

## Testing

### Test Cases (3 new tests)

1. **SubjectAlternativeName property exists** on catalog-signed system file (ntdll.dll)
2. **SubjectAlternativeName is null** for certificate without SAN extension
3. **SubjectAlternativeName is populated** with correct DNS entries for certificate with SAN

### Implementation Notes

- Returns `null` when the certificate has no SAN extension (not an empty array)
- Uses `extension.Format(multiLine: true)` and splits by newline, consistent with how other certificate extension formatters work in .NET
- Each entry is trimmed via `StringSplitOptions.TrimEntries`
- OID constant is defined alongside existing OID constants in `CertificateFilterInfo`
