### PR TITLE
[release/v7.4] Fix macOS preview package identifier detection to use version string

### DIFF
--- a/test/packaging/packaging.tests.ps1
+++ b/test/packaging/packaging.tests.ps1
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Packaging Module Functions" {
+    BeforeAll {
+        Import-Module $PSScriptRoot/../../build.psm1 -Force
+        Import-Module $PSScriptRoot/../../tools/packaging/packaging.psm1 -Force
+    }
+
+    Context "Test-IsPreview function" {
+        It "Should return True for preview versions" {
+            Test-IsPreview -Version "7.6.0-preview.6" | Should -Be $true
+            Test-IsPreview -Version "7.5.0-rc.1" | Should -Be $true
+        }
+
+        It "Should return False for stable versions" {
+            Test-IsPreview -Version "7.6.0" | Should -Be $false
+            Test-IsPreview -Version "7.5.0" | Should -Be $false
+        }
+
+        It "Should return False for LTS builds regardless of version string" {
+            Test-IsPreview -Version "7.6.0-preview.6" -IsLTS | Should -Be $false
+            Test-IsPreview -Version "7.5.0" -IsLTS | Should -Be $false
+        }
+    }
+
+    Context "Get-MacOSPackageIdentifierInfo function (New-MacOSPackage logic)" {
+        It "Should detect preview builds and return preview identifier" {
+            $result = Get-MacOSPackageIdentifierInfo -Version "7.6.0-preview.6" -LTS:$false
+            
+            $result.IsPreview | Should -Be $true
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell-preview"
+        }
+
+        It "Should detect stable builds and return stable identifier" {
+            $result = Get-MacOSPackageIdentifierInfo -Version "7.6.0" -LTS:$false
+            
+            $result.IsPreview | Should -Be $false
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell"
+        }
+
+        It "Should treat LTS builds as stable even with preview version string" {
+            $result = Get-MacOSPackageIdentifierInfo -Version "7.4.0-preview.1" -LTS:$true
+            
+            $result.IsPreview | Should -Be $false
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell"
+        }
+
+        It "Should NOT use package name for preview detection (bug fix verification)" {
+            # This test verifies the fix for issue #26673
+            # The bug was using ($Name -like '*-preview') which always returned false
+            # because preview builds use Name="powershell" not "powershell-preview"
+            
+            $Version = "7.6.0-preview.6"
+            $Name = "powershell"  # Preview builds use "powershell" not "powershell-preview"
+            
+            # The INCORRECT logic (the bug): $Name -like '*-preview'
+            $incorrectCheck = $Name -like '*-preview'
+            $incorrectCheck | Should -Be $false -Because "Package name is 'powershell' not 'powershell-preview'"
+            
+            # The CORRECT logic (the fix): uses version string
+            $result = Get-MacOSPackageIdentifierInfo -Version $Version -LTS:$false
+            $result.IsPreview | Should -Be $true -Because "Version string correctly identifies preview"
+            $result.PackageIdentifier | Should -Be "com.microsoft.powershell-preview"
+        }
+    }
+}


### PR DESCRIPTION
Backport of #26690 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26690$$$
-->

Triggered by @TravisEz13 on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates macOS packaging identifier detection so preview packages install to the correct preview location.

### Customer Impact

- [x] Customer reported
- [ ] Found internally

Fixes #26673 where preview packages installed to the stable path; expected preview installs to /usr/local/microsoft/powershell/7-preview.

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

Regression introduced in PR #26268 when native macOS packaging tools replaced fpm.

## Testing

Original PR added/updated unit tests in test/packaging/packaging.tests.ps1 covering preview, stable, and LTS scenarios, including the reported bug case.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Scoped change to macOS packaging identifier logic with unit test coverage, but it affects install paths for preview packages.
