### PR TITLE
[release/v7.6] Update the `Update-Help` tests to use `-Force` to remove read-only files

### DIFF
--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -215,7 +215,7 @@ function RunUpdateHelpTests
             It ('Validate Update-Help for module ''{0}'' in {1}' -F $moduleName, [PSCustomObject] $updateScope) -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
                 # Delete the whole help directory
-                Remove-Item ($moduleHelpPath) -Recurse
+                Remove-Item ($moduleHelpPath) -Recurse -Force -ErrorAction SilentlyContinue
 
                 [hashtable] $UICultureParam = $(if ((Get-UICulture).Name -ne $myUICulture) { @{ UICulture = $myUICulture } } else { @{} })
                 [hashtable] $sourcePathParam = $(if ($useSourcePath) { @{ SourcePath = Join-Path $PSScriptRoot assets } } else { @{} })


### PR DESCRIPTION
Backport of #26780 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26780$$$
-->

Triggered by @TravisEz13 on behalf of @daxian-dbw

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This fixes CI test infrastructure failures caused by inability to remove read-only files in help content folders during test cleanup. Without this fix, Update-Help tests produce numerous non-terminating errors that clutter test output and could mask real test failures.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The fix modifies test cleanup code to use -Force parameter when removing help content directories. This allows tests to remove read-only files that were previously causing non-terminating errors. The tests themselves verify the Update-Help cmdlet functionality works correctly after cleanup.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk as this only modifies test code, not production code. The change improves test reliability by properly cleaning up read-only files during test execution. No impact to end users or runtime behavior.
