### PR TITLE
[release/v7.5] Fix build to only enable ready-to-run for the Release configuration

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -188,13 +188,35 @@
     <AppHostDotNetSearch>EnvironmentVariable;Global</AppHostDotNetSearch>
   </PropertyGroup>
 
+
   <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' ">
     <!-- If we specify Environment too, it searches that first, no matter what order we specify-->
     <AppHostDotNetSearch>Global</AppHostDotNetSearch>
   </PropertyGroup>
 
+  <!-- Enable ready-to-run only for Release configuration -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' And '$(Configuration)' == 'Release' ">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' ">
     <AppHostDotNetSearch>AppLocal</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <!-- Enable ready-to-run only for Release configuration -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' And '$(Configuration)' == 'Release' ">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
+  </PropertyGroup>
+
+  </PropertyGroup>
+
+  <!-- Enable ready-to-run only for Release configuration -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' And '$(Configuration)' == 'Release' ">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
+>>>>>>> b0507ca4c (Fix build to only enable ready-to-run for the Release configuration (#26290))
   </PropertyGroup>
 
   <!-- Define all OS, release configuration properties -->


### PR DESCRIPTION
Backport of #26290 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26290$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Issue found internally during development - ready-to-run was being enabled even for Debug configuration, making it impossible to debug code.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The fix was tested by building PowerShell in Debug configuration and verifying that ready-to-run is not enabled, allowing proper debugging. Release builds continue to have ready-to-run enabled.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This change adds proper configuration conditions to only enable ready-to-run for Release builds, while leaving Debug builds unchanged. This makes debugging possible again without affecting release builds.

## Merge Conflicts

Resolved conflict in PowerShell.Common.props by accepting the new structure that conditionally enables ready-to-run only for Release configuration.
