### PR TITLE
[release/v7.5] Fix build to only enable ready-to-run for the Release configuration

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -193,12 +193,20 @@
   <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' ">
     <!-- If we specify Environment too, it searches that first, no matter what order we specify-->
     <AppHostDotNetSearch>Global</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <!-- Enable ready-to-run only for Release configuration -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'FxDependentDeployment' And '$(Configuration)' == 'Release' ">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' ">
     <AppHostDotNetSearch>AppLocal</AppHostDotNetSearch>
+  </PropertyGroup>
+
+  <!-- Enable ready-to-run only for Release configuration -->
+  <PropertyGroup Condition=" '$(AppDeployment)' == 'SelfContained' And '$(Configuration)' == 'Release' ">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
   </PropertyGroup>


### PR DESCRIPTION
Backport of #26290 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26290$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This fix is required for developers to be able to debug PowerShell code. Without this fix, Debug builds incorrectly enable ready-to-run which prevents proper debugging.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified that Debug builds can be debugged and Release builds correctly enable ready-to-run. Already validated in master, 7.4, and 7.6 branches.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a build configuration change that prevents ready-to-run from being enabled in Debug configuration, making debugging possible. The change has been tested in master and already backported to 7.4 and 7.6.
