### PR TITLE
[release/v7.5] Refactor analyze job to reusable workflow and enable on Windows CI

### DIFF
--- a/.github/workflows/analyze-reusable.yml
+++ b/.github/workflows/analyze-reusable.yml
@@ -1,0 +1,76 @@
+name: CodeQL Analysis (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      runner_os:
+        description: 'Runner OS for CodeQL analysis'
+        type: string
+        required: false
+        default: ubuntu-latest
+
+permissions:
+  actions: read  # for github/codeql-action/init to get workflow details
+  contents: read  # for actions/checkout to fetch code
+  security-events: write  # for github/codeql-action/analyze to upload SARIF results
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: 1
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+  __SuppressAnsiEscapeSequences: 1
+  nugetMultiFeedWarnLevel: none
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{ inputs.runner_os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: ['csharp']
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        fetch-depth: '0'
+
+    - uses: actions/setup-dotnet@v5
+      with:
+        global-json-file: ./global.json
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v3.29.5
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    - run: |
+        Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
+      name: Capture Environment
+      shell: pwsh
+
+    - run: |
+        Import-Module .\tools\ci.psm1
+        Invoke-CIInstall -SkipUser
+      name: Bootstrap
+      shell: pwsh
+
+    - run: |
+        Import-Module .\tools\ci.psm1
+        Invoke-CIBuild -Configuration 'StaticAnalysis'
+      name: Build
+      shell: pwsh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v3.29.5

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -155,7 +155,6 @@ jobs:
       runner_os: ubuntu-latest
       test_results_artifact_name: testResults-xunit
 
-
   analyze:
     name: CodeQL Analysis
     needs: changes
@@ -167,8 +166,6 @@ jobs:
       security-events: write
     with:
       runner_os: ubuntu-latest
-
->>>>>>> 5e5e17766 (Refactor analyze job to reusable workflow and enable on Windows CI (#26322))
 
   ready_to_merge:
     name: Linux ready to merge

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -157,63 +157,18 @@ jobs:
 
 
   analyze:
-    permissions:
-      actions: read  # for github/codeql-action/init to get workflow details
-      contents: read  # for actions/checkout to fetch code
-      security-events: write  # for github/codeql-action/analyze to upload SARIF results
-    name: Analyze
-    runs-on: ubuntu-latest
+    name: CodeQL Analysis
     needs: changes
     if: ${{ needs.changes.outputs.source == 'true' }}
+    uses: ./.github/workflows/analyze-reusable.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    with:
+      runner_os: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['csharp']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        fetch-depth: '0'
-
-    - uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: ./global.json
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    - run: |
-        Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
-      name: Capture Environment
-      shell: pwsh
-
-    - run: |
-        Import-Module .\tools\ci.psm1
-        Invoke-CIInstall -SkipUser
-      name: Bootstrap
-      shell: pwsh
-
-    - run: |
-        Import-Module .\tools\ci.psm1
-        Invoke-CIBuild
-      name: Build
-      shell: pwsh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
+>>>>>>> 5e5e17766 (Refactor analyze job to reusable workflow and enable on Windows CI (#26322))
 
   ready_to_merge:
     name: Linux ready to merge

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -165,10 +165,6 @@ jobs:
       security-events: write
     with:
       runner_os: windows-latest
-
-      security-events: write
-    with:
-      runner_os: windows-latest
   windows_packaging:
     name: Windows Packaging
     needs:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -169,7 +169,6 @@ jobs:
       security-events: write
     with:
       runner_os: windows-latest
->>>>>>> 5e5e17766 (Refactor analyze job to reusable workflow and enable on Windows CI (#26322))
   windows_packaging:
     name: Windows Packaging
     needs:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -154,7 +154,22 @@ jobs:
     with:
       runner_os: windows-latest
       test_results_artifact_name: testResults-xunit
+  analyze:
+    name: CodeQL Analysis
+    needs: changes
+    if: ${{ needs.changes.outputs.source == 'true' }}
+    uses: ./.github/workflows/analyze-reusable.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    with:
+      runner_os: windows-latest
 
+      security-events: write
+    with:
+      runner_os: windows-latest
+>>>>>>> 5e5e17766 (Refactor analyze job to reusable workflow and enable on Windows CI (#26322))
   windows_packaging:
     name: Windows Packaging
     needs:
@@ -169,6 +184,7 @@ jobs:
       - windows_test_elevated_others
       - windows_test_unelevated_ci
       - windows_test_unelevated_others
+      - analyze
       - windows_packaging
     if: always()
     uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@v1.0.0

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -101,6 +101,11 @@ function Invoke-CIFull
 # Implements the CI 'build_script' step
 function Invoke-CIBuild
 {
+    param(
+        [ValidateSet('Debug', 'Release', 'CodeCoverage', 'StaticAnalysis')]
+        [string]$Configuration = 'Release'
+    )
+
     $releaseTag = Get-ReleaseTag
     # check to be sure our test tags are correct
     $result = Get-PesterTag
@@ -115,7 +120,7 @@ function Invoke-CIBuild
         Start-PSBuild -Configuration 'CodeCoverage' -PSModuleRestore -CI -ReleaseTag $releaseTag
     }
 
-    Start-PSBuild -PSModuleRestore -Configuration 'Release' -CI -ReleaseTag $releaseTag -UseNuGetOrg
+    Start-PSBuild -PSModuleRestore -Configuration $Configuration -CI -ReleaseTag $releaseTag -UseNuGetOrg
     Save-PSOptions
 
     $options = (Get-PSOptions)


### PR DESCRIPTION
Backport of #26322 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26322$$$
-->

Triggered by @daxian-dbw on behalf of @app/copilot-swe-agent

Original CL Label: CL-Tools

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

This change improves CI/CD infrastructure by making CodeQL analysis reusable and enabling security scanning on Windows builds.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified that CodeQL analysis runs correctly on both Linux and Windows CI workflows using the reusable workflow. Already validated in master, 7.4, and 7.6 branches.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This refactors the CodeQL analysis job to a reusable workflow and enables it on Windows CI. The change improves security coverage and maintainability. Already validated in master, 7.4, and 7.6 branches.

## Merge Conflicts

Resolved conflicts in linux-ci.yml and windows-ci.yml: replaced inline analyze job with reusable workflow call and added analyze job to windows-ci.yml.
