### PR TITLE
[release/v7.5] Move package validation to package pipeline

### DIFF
--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -265,3 +265,9 @@ extends:
       dependsOn: [mac_package, windows_package, linux_package, nupkg, msixbundle]
       jobs:
       - template: /.pipelines/templates/uploadToAzure.yml@self
+
+    - stage: validatePackages
+      displayName: 'Validate Packages'
+      dependsOn: [upload]
+      jobs:
+      - template: /.pipelines/templates/release-validate-packagenames.yml@self

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -216,12 +216,6 @@ extends:
           arm64: 'yes'
           enableCredScan: false
 
-    - stage: validatePackages
-      displayName: 'Validate Packages'
-      dependsOn: []
-      jobs:
-      - template: /.pipelines/templates/release-validate-packagenames.yml@self
-
     - stage: ManualValidation
       dependsOn: []
       displayName: Manual Validation
@@ -272,7 +266,6 @@ extends:
       dependsOn:
         - ManualValidation
         - ReleaseAutomation
-        - validatePackages
         - fxdpackages
         - gbltool
         - validateSdk
@@ -365,10 +358,12 @@ extends:
             This is typically done by the community 1-2 days after the release.
 
     - stage: PublishMsix
-      dependsOn: PushGitTagAndMakeDraftPublic
+      dependsOn:
+        - setReleaseTagAndChangelog
+        - PushGitTagAndMakeDraftPublic
       displayName: Publish MSIX to store
       variables:
-        ob_release_environment: Production
+        ob_release_environment: ${{ variables.releaseEnvironment }}
       jobs:
       - template: /.pipelines/templates/release-MSIX-Publish.yml@self
         parameters:


### PR DESCRIPTION
Backport of #26414 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26414$$$
-->

Triggered by @daxian-dbw on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Moves package validation stage from release to package pipeline for better workflow

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Successfully tested in 7.4 and 7.6 releases. Validation now occurs immediately after package build stage.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Moves package validation stage from release pipeline to package pipeline for earlier validation. Successfully backported to 7.4 and 7.6 branches.

## Merge Conflicts

Conflict in PowerShell-Release-Official.yml resolved - stage dependency differences
