### PR TITLE
[release/v7.5] Update the macos package name for preview releases to match the previous pattern

### DIFF
--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -82,7 +82,7 @@ jobs:
   - pwsh: |
       $message = @()
       Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -filter *.pkg | ForEach-Object {
-          if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx(\.10\.12)?\-(x64|arm64)\.pkg')
+          if($_.Name -notmatch 'powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx\-(x64|arm64)\.pkg')
           {
               $messageInstance = "$($_.Name) is not a valid package name"
               $message += $messageInstance

--- a/test/packaging/macos/package-validation.tests.ps1
+++ b/test/packaging/macos/package-validation.tests.ps1
@@ -82,12 +82,13 @@ Describe "Verify macOS Package" {
             $script:package | Should -Not -BeNullOrEmpty
 
             # Regex pattern for valid macOS PKG package names.
+            # This pattern matches the validation used in release-validate-packagenames.yml
             # Valid examples:
-            # - powershell-7.4.13-osx-x64.pkg (Intel x64 - note: x64 with hyphens for compatibility)
-            # - powershell-7.4.13-osx-arm64.pkg (Apple Silicon)
-            # - powershell-preview-7.6.0-preview.6-osx-x64.pkg
-            # - powershell-lts-7.4.13-osx-arm64.pkg
-            $pkgPackageNamePattern = '^powershell(-preview|-lts)?-\d+\.\d+\.\d+(-[a-z]+\.\d+)?-osx-(x64|arm64)\.pkg$'
+            # - powershell-7.4.13-osx-x64.pkg (Stable release)
+            # - powershell-7.6.0-preview.6-osx-x64.pkg (Preview version string)
+            # - powershell-7.4.13-rebuild.5-osx-arm64.pkg (Rebuild version)
+            # - powershell-lts-7.4.13-osx-arm64.pkg (LTS package)
+            $pkgPackageNamePattern = '^powershell-(lts-)?\d+\.\d+\.\d+\-([a-z]*.\d+\-)?osx\-(x64|arm64)\.pkg$'
 
             $script:package.Name | Should -Match $pkgPackageNamePattern -Because "Package name should follow the standard naming convention"
         }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1147,14 +1147,11 @@ function New-UnixPackage {
         }
 
         # Determine if the version is a preview version
-        $IsPreview = Test-IsPreview -Version $Version -IsLTS:$LTS
-
-        # Preview versions have preview in the name
+        # Only LTS packages get a prefix in the name
+        # Preview versions are identified by the version string itself (e.g., 7.6.0-preview.6)
+        # Rebuild versions are also identified by the version string (e.g., 7.4.13-rebuild.5)
         $Name = if($LTS) {
             "powershell-lts"
-        }
-        elseif ($IsPreview) {
-            "powershell-preview"
         }
         else {
             "powershell"


### PR DESCRIPTION
Backport of #26429 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26429$$$
-->

Triggered by @daxian-dbw on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates macOS preview package naming to match previous pattern

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Fix validated in 7.4 and 7.6 releases. Ensures consistent package naming across releases.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Updates macOS package naming for preview releases to match historical pattern. Successfully backported to 7.4 and 7.6 branches.
