### PR TITLE
[release/v7.5] Fix $PSDefaultParameterValues leak causing tests to skip unexpectedly

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
@@ -7,6 +7,7 @@ $DefaultResultValue = 0
 try
 {
     # set up for testing
+    $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
     $PSDefaultParameterValues["it:skip"] = ! $IsWindows
     Enable-Testhook -testhookName $RenameTesthook
     # we also set TestStopComputer
@@ -73,7 +74,7 @@ try
 }
 finally
 {
-    $PSDefaultParameterValues.Remove("it:skip")
+    $global:PSDefaultParameterValues = $originalDefaultParameterValues
     Disable-Testhook -testhookName $RenameTestHook
     Disable-Testhook -testhookName TestStopComputer
     Set-TesthookResult -testhookName $RenameResultName -value 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -3,6 +3,7 @@
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
     Context "Windows ACL test" {
         BeforeAll {
+            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
             $PSDefaultParameterValues["It:Skip"] = -not $IsWindows
         }
 
@@ -103,7 +104,7 @@ Describe "Acl cmdlets are available and operate properly" -Tag CI {
         }
 
         AfterAll {
-            $PSDefaultParameterValues.Remove("It:Skip")
+            $global:PSDefaultParameterValues = $originalDefaultParameterValues
         }
     }
 }

--- a/test/powershell/engine/ETS/CimAdapter.Tests.ps1
+++ b/test/powershell/engine/ETS/CimAdapter.Tests.ps1
@@ -3,6 +3,8 @@
 
 Describe "CIM Objects are adapted properly" -Tag @("CI") {
     BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        
         function getIndex
         {
             param([string[]]$strings,[string]$pattern)
@@ -32,7 +34,7 @@ Describe "CIM Objects are adapted properly" -Tag @("CI") {
         }
     }
     AfterAll {
-        $PSDefaultParameterValues.Remove("it:pending")
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
     It "Namespace-qualified Win32_Process is present" -Skip:(!$IsWindows) {

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -83,9 +83,7 @@ Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnW
     AfterAll {
         if ($skipTest) {
             Pop-DefaultParameterValueStack
-            return
         }
-        Pop-DefaultParameterValueStack
     }
 
     It "Configuration name should be in the transcript header" {

--- a/test/powershell/engine/Remoting/SessionOption.Tests.ps1
+++ b/test/powershell/engine/Remoting/SessionOption.Tests.ps1
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 try {
+    $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
     if ( ! $IsWindows ) {
         $PSDefaultParameterValues['it:skip'] = $true
     }
@@ -52,5 +53,5 @@ try {
     }
 }
 finally {
-    $PSDefaultParameterValues.remove("it:skip")
+    $global:PSDefaultParameterValues = $originalDefaultParameterValues
 }

--- a/test/powershell/engine/Security/FileSignature.Tests.ps1
+++ b/test/powershell/engine/Security/FileSignature.Tests.ps1
@@ -89,6 +89,7 @@ Describe "Windows file content signatures" -Tags @('Feature', 'RequireAdminOnWin
 
     AfterAll {
         if ($shouldSkip) {
+            Pop-DefaultParameterValueStack
             return
         }
 


### PR DESCRIPTION
Backport of #26602 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26602$$$
-->

Triggered by @daxian-dbw on behalf of @app/copilot-swe-agent

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes $PSDefaultParameterValues leaks in test files causing unexpected test skipping

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Fixes issue #26601. Tests now properly isolate $PSDefaultParameterValues changes. Validated in 7.6 release.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Fixes test infrastructure issue where tests were incorrectly skipped on Linux. Changes only affect test files. Successfully backported to 7.6 branch.
