### PR TITLE
[release/v7.5] Update metadata.json to update the Latest attribute with a better name

### DIFF
--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -2,6 +2,10 @@ steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
     $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
+
+    $LTS = $metadata.LTSRelease.PublishToChannels
+    $Stable = $metadata.StableRelease.PublishToChannels
+    $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'
     $releaseTag = '$(OutputReleaseTag.releaseTag)'
 
     # Rebuild branches should be treated as preview builds
@@ -10,10 +14,6 @@ steps:
     # and is used in contexts where that check may not have run.
     # If you update this regex, also update it in rebuild-branch-check.yml to keep them in sync.
     $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
-
-    $LTS = $metadata.LTSRelease.Latest
-    $Stable = $metadata.StableRelease.Latest
-    $isPreview = $releaseTag -match '-'
 
     # If this is a rebuild branch, force preview mode and ignore LTS metadata
     if ($isRebuildBranch) {

--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -33,7 +33,7 @@ stages:
     - template: release-SetReleaseTagandContainerName.yml
       parameters:
         restorePhase: true
-    
+
     - pwsh: |
         $packageVersion = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant() -replace '^v',''
         $vstsCommandString = "vso[task.setvariable variable=packageVersion]$packageVersion"
@@ -42,7 +42,7 @@ stages:
       displayName: Set Package version
       env:
         ob_restore_phase: true
-    
+
     - pwsh: |
         $branch = 'mirror-target'
         $gitArgs = "clone",
@@ -151,7 +151,7 @@ stages:
         $metadataHash = @{}
         $skipPublishValue = '${{ parameters.skipPublish }}'
         $metadataHash["ReleaseTag"] = '$(OutputReleaseTag.ReleaseTag)'
-        $metadataHash["LTS"] = $metadata.LTSRelease.Latest
+        $metadataHash["LTS"] = $metadata.LTSRelease.PublishToChannels
         $metadataHash["ForProduction"] = $true
         $metadataHash["SkipPublish"] = [System.Convert]::ToBoolean($skipPublishValue)
 
@@ -222,7 +222,7 @@ stages:
         files_to_sign: '*.ps1'
         search_root: '$(repoRoot)/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run'
       displayName: Sign Run.ps1
-  
+
     - pwsh: |
         # folder to tar must have: Run.ps1, settings.toml, python_dl
         $srcPath = Join-Path '$(ev2ServiceGroupRootFolder)' -ChildPath 'Shell'

--- a/.pipelines/templates/release-upload-buildinfo.yml
+++ b/.pipelines/templates/release-upload-buildinfo.yml
@@ -16,7 +16,7 @@ jobs:
   variables:
   - name: NugetSecurityAnalysisWarningLevel
     value: none
-  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  - name: DOTNET_NOLOGO
     value: 1
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
@@ -39,7 +39,7 @@ jobs:
   - template: release-SetReleaseTagandContainerName.yml
 
   - pwsh: |
-      Get-ChildItem Env:
+      Get-ChildItem Env: | Out-String -width 9999 -Stream | write-Verbose -Verbose
     displayName: 'Capture Environment Variables'
 
   - download: PSPackagesOfficial
@@ -57,6 +57,10 @@ jobs:
 
       $metadata = Get-Content -LiteralPath "$toolsDirectory/metadata.json" -ErrorAction Stop | ConvertFrom-Json
       $stableReleaseTag = $metadata.StableReleaseTag -Replace 'v',''
+
+      $currentReleaseTag = $buildInfo.ReleaseTag -Replace 'v',''
+      $stableRelease = $metadata.StableRelease.PublishToChannels
+      $ltsRelease = $metadata.LTSRelease.PublishToChannels
 
       Write-Verbose -Verbose "Writing $jsonFile contents:"
       $buildInfoJsonContent = Get-Content $jsonFile -Encoding UTF8NoBom -Raw

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -2,9 +2,9 @@
   "StableReleaseTag": "v7.4.4",
   "PreviewReleaseTag": "v7.5.0-preview.3",
   "ServicingReleaseTag": "v7.0.13",
-  "ReleaseTag": "v7.4.4",
-  "LTSReleaseTag" : ["v7.2.22", "v7.4.4"],
-  "NextReleaseTag": "v7.5.0-preview.4",
-  "LTSRelease": { "Latest": false, "Package": false },
-  "StableRelease":  { "Latest": true, "Package": true }
+  "ReleaseTag": "v7.5.4",
+  "LTSReleaseTag" : ["v7.4.13"],
+  "NextReleaseTag": "v7.6.0-preview.6",
+  "LTSRelease": { "PublishToChannels": false, "Package": false },
+  "StableRelease":  { "PublishToChannels": false, "Package": false }
 }


### PR DESCRIPTION
Backport of #26380 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26380$$$
-->

Triggered by @daxian-dbw on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates release pipeline templates to use standardized 'PublishToChannels' property instead of 'Latest' in metadata.json. Required for proper release channel selection in LTS and Stable releases.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated through existing CI/CD pipeline tests. The metadata property rename from 'Latest' to 'PublishToChannels' is referenced in pipeline templates and will be exercised during release pipeline execution.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a metadata property rename to standardize naming conventions. The change is isolated to release pipeline templates and metadata configuration files. No runtime code changes.

## Merge Conflicts

Resolved conflicts in .pipelines/templates/release-upload-buildinfo.yml and tools/metadata.json due to version-specific differences in the release branch.
