### PR TITLE
[release/v7.6] Skip the flaky `Update-Help` test for the `PackageManagement` module

### DIFF
--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -215,7 +215,7 @@ function RunUpdateHelpTests
 
             It ('Validate Update-Help for module ''{0}'' in {1}' -F $moduleName, [PSCustomObject] $updateScope) -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
-                if ($markAsPending) {
+                if ($markAsPending -or ($IsLinux -and $moduleName -eq "PackageManagement")) {
                     Set-ItResult -Pending -Because "Update-Help from the web has intermittent connectivity issues. See issues #2807 and #6541."
                     return
                 }
@@ -333,9 +333,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    ## Update-Help from the web has intermittent connectivity issues that cause CI failures.
-    ## Tests are marked as Pending to unblock work. See issues #2807 and #6541.
-    RunUpdateHelpTests -Tag "CI" -MarkAsPending
+    RunUpdateHelpTests -Tag "CI"
 }
 
 Describe "Validate Update-Help from the Web for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -347,9 +345,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    ## Update-Help from the web has intermittent connectivity issues that cause CI failures.
-    ## Tests are marked as Pending to unblock work. See issues #2807 and #6541.
-    RunUpdateHelpTests -Tag "CI" -UserScope -MarkAsPending
+    RunUpdateHelpTests -Tag "CI" -UserScope
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {


### PR DESCRIPTION
Backport of #26845 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26845$$$
-->

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low
