### PR TITLE
Exclude .exe packages from publishing to GitHub

### DIFF
--- a/.pipelines/templates/release-githubNuget.yml
+++ b/.pipelines/templates/release-githubNuget.yml
@@ -35,6 +35,14 @@ jobs:
       targetType: inline
       script: |
         $Path = "$(Pipeline.Workspace)/GitHubPackages"
+
+        # The .exe packages are for Windows Update only and should not be uploaded to GitHub release.
+        $exefiles = Get-ChildItem -Path $Path -Filter *.exe
+        if ($exefiles) {
+            Write-Verbose -Verbose "Remove .exe packages:"
+            $exefiles | Remove-Item -Force -Verbose
+        }
+
         $OutputPath = Join-Path $Path 'hashes.sha256'
         $packages  = Get-ChildItem -Path $Path -Include * -Recurse -File
         $checksums = $packages |


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The .exe packages are for Windows Update only and should not be uploaded to GitHub release.
This PR removes them after downloading all package artifacts before moving forward.