### PR TITLE
Fix `Import-Module.Tests.ps1` to handle Arm32 platform

### DIFF
--- a/test/powershell/Language/Scripting/Requires.Tests.ps1
+++ b/test/powershell/Language/Scripting/Requires.Tests.ps1
@@ -41,7 +41,7 @@ Describe "Requires tests" -Tags "CI" {
         BeforeAll {
             $currentVersion = $PSVersionTable.PSVersion
 
-            $powerShellVersions = "1.0", "2.0", "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6"
+            $powerShellVersions = "1.0", "2.0", "3.0", "4.0", "5.0", "5.1", "6.0", "6.1", "6.2", "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6", "7.7"
             $latestVersion = [version]($powerShellVersions | Sort-Object -Descending -Top 1)
             $nonExistingMinor = "$($latestVersion.Major).$($latestVersion.Minor + 1)"
             $nonExistingMajor = "$($latestVersion.Major + 1).0"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -62,6 +62,7 @@ Describe "Import-Module" -Tags "CI" {
             'X86' { 'x86' }
             'X64' { 'amd64' }
             'Arm64' { 'arm' }
+            'Arm' { 'arm' }
             default { throw "Unknown processor architecture" }
         }
         New-ModuleManifest -Path "$TestDrive\TestModule.psd1" -ProcessorArchitecture $currentProcessorArchitecture


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix `Import-Module.Tests.ps1` to handle Arm32 platform. This fixes a test failure in our release automation runs.
