### PR TITLE
[release/v7.4] Fix Progress Preference variable in adv functions

### DIFF
--- a/docs/community/working-group-definitions.md
+++ b/docs/community/working-group-definitions.md
@@ -30,7 +30,7 @@ The PowerShell developer experience includes the **development of modules** (in 
 as well as the experience of **hosting PowerShell and its APIs** in other applications and language runtimes.
 Special consideration should be given to topics like **backwards compatibility** with Windows PowerShell
 (e.g. with **PowerShell Standard**) and **integration with related developer tools**
-(e.g. .NET CLI or the PowerShell extension for VS Code).
+(e.g. .NET CLI or the PowerShell extension for Visual Studio Code).
 
 ### Members
 

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -341,6 +341,7 @@ namespace System.Management.Automation
             SpecialVariables.WarningPreference,
             SpecialVariables.InformationPreference,
             SpecialVariables.ConfirmPreference,
+            SpecialVariables.ProgressPreference,
         };
 
         internal static readonly Type[] PreferenceVariableTypes =
@@ -352,6 +353,7 @@ namespace System.Management.Automation
             /* WarningPreference */                       typeof(ActionPreference),
             /* InformationPreference */                   typeof(ActionPreference),
             /* ConfirmPreference */                       typeof(ConfirmImpact),
+            /* ProgressPreference */                      typeof(ActionPreference),
         };
 
         // The following variables are created in every session w/ AllScope.  We avoid creating local slots when we

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -830,6 +830,14 @@ namespace System.Management.Automation.Language
 
         static Compiler()
         {
+            Diagnostics.Assert(SpecialVariables.AutomaticVariables.Length == (int)AutomaticVariable.NumberOfAutomaticVariables
+                && SpecialVariables.AutomaticVariableTypes.Length == (int)AutomaticVariable.NumberOfAutomaticVariables,
+                "The 'AutomaticVariable' enum length does not match both 'AutomaticVariables' and 'AutomaticVariableTypes' length.");
+
+            Diagnostics.Assert(Enum.GetNames(typeof(PreferenceVariable)).Length == SpecialVariables.PreferenceVariables.Length
+                && Enum.GetNames(typeof(PreferenceVariable)).Length == SpecialVariables.PreferenceVariableTypes.Length,
+                "The 'PreferenceVariable' enum length does not match both 'PreferenceVariables' and 'PreferenceVariableTypes' length.");
+
             s_functionContext = Expression.Parameter(typeof(FunctionContext), "funcContext");
             s_executionContextParameter = Expression.Variable(typeof(ExecutionContext), "context");
 

--- a/test/powershell/Language/Scripting/CommonParameters.Tests.ps1
+++ b/test/powershell/Language/Scripting/CommonParameters.Tests.ps1
@@ -147,6 +147,44 @@ Describe "Common parameters support for script cmdlets" -Tags "CI" {
         }
     }
 
+    Context "ProgressAction" {
+        It "Ignores progress actions on advanced script function with no variables" {
+            $ps.AddScript(
+@'
+function test-function {
+    [CmdletBinding()]param()
+
+    Write-Progress "progress foo"
+}
+test-function -ProgressAction Ignore
+'@).Invoke()
+
+            $ps.Streams.Progress.Count | Should -Be 0
+            $ps.Streams.Error | ForEach-Object {
+                Write-Error -ErrorRecord $_ -ErrorAction Stop
+            }
+        }
+
+        It "Ignores progress actions on advanced script function with variables" {
+            $ps.AddScript(
+@'
+function test-function {
+    [CmdletBinding()]param([string]$path)
+
+    switch($false) { default { "echo $path" } }
+
+    Write-Progress "progress foo"
+}
+test-function -ProgressAction Ignore
+'@).Invoke()
+
+            $ps.Streams.Progress.Count | Should -Be 0
+            $ps.Streams.Error | ForEach-Object {
+                Write-Error -ErrorRecord $_ -ErrorAction Stop
+            }
+        }
+    }
+
     Context "SupportShouldprocess" {
         $script = '
                 function get-foo


### PR DESCRIPTION
Backport of #24591 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:24591$$$
-->

Triggered by @TravisEz13 on behalf of @cmkb3

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes -ProgressAction failures in advanced functions by restoring ProgressPreference entries; prevents engine errors when the common parameter is used.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Ran CommonParameters.Tests.ps1.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Scoped fix to common parameter handling with targeted tests.
