### PR TITLE
[release/v7.4] Remove unused runCodesignValidationInjection variable from pipeline templates

### DIFF
--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -4,8 +4,6 @@
 jobs:
   - job: APIScan
     variables:
-      - name: runCodesignValidationInjection
-        value : false
       - name: NugetSecurityAnalysisWarningLevel
         value: none
       - name: ReleaseTagVar

--- a/.pipelines/templates/compliance/generateNotice.yml
+++ b/.pipelines/templates/compliance/generateNotice.yml
@@ -10,8 +10,6 @@ parameters:
 jobs:
 - job: generateNotice
   variables:
-  - name: runCodesignValidationInjection
-    value : false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - name: ob_outputDirectory

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -13,8 +13,6 @@ jobs:
     type: linux
 
   variables:
-    - name: runCodesignValidationInjection
-      value: false
     - name: nugetMultiFeedWarnLevel
       value: none
     - name: NugetSecurityAnalysisWarningLevel

--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -10,8 +10,6 @@ jobs:
   pool:
     type: linux
   variables:
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
@@ -137,8 +135,6 @@ jobs:
   pool:
     type: windows
   variables:
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -15,8 +15,6 @@ jobs:
   variables:
     - name: HOMEBREW_NO_ANALYTICS
       value: 1
-    - name: runCodesignValidationInjection
-      value: false
     - name: nugetMultiFeedWarnLevel
       value: none
     - name: NugetSecurityAnalysisWarningLevel

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -13,8 +13,6 @@ jobs:
   variables:
   - name: HOMEBREW_NO_ANALYTICS
     value: 1
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - group: DotNetPrivateBuildAccess

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -6,8 +6,6 @@ jobs:
     type: windows
 
   variables:
-    - name: runCodesignValidationInjection
-      value: false
     - name: nugetMultiFeedWarnLevel
       value: none
     - name: NugetSecurityAnalysisWarningLevel

--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -9,8 +9,6 @@ jobs:
     type: windows
 
   variables:
-    - name: runCodesignValidationInjection
-      value: false
     - name: ob_sdl_codeSignValidation_enabled
       value: false  # Skip signing validation in build-only stage
     - name: ob_signing_setup_enabled

--- a/.pipelines/templates/release-symbols.yml
+++ b/.pipelines/templates/release-symbols.yml
@@ -10,8 +10,6 @@ jobs:
   pool:
     type: windows
   variables:
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/.pipelines/templates/release-upload-buildinfo.yml
+++ b/.pipelines/templates/release-upload-buildinfo.yml
@@ -14,8 +14,6 @@ jobs:
     demands:
     - ImageOverride -equals PSMMS2019-Secure
   variables:
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -1,8 +1,6 @@
 jobs:
 - job: build_testartifacts_win
   variables:
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - group: DotNetPrivateBuildAccess
@@ -73,8 +71,6 @@ jobs:
 
 - job: build_testartifacts_nonwin
   variables:
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - group: DotNetPrivateBuildAccess

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -7,8 +7,6 @@ jobs:
   variables:
   - name: ob_sdl_sbom_enabled
     value: true
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/.pipelines/templates/variable/release-shared.yml
+++ b/.pipelines/templates/variable/release-shared.yml
@@ -17,9 +17,9 @@ variables:
     value: false
   - name: ob_sdl_sbom_enabled
     value: ${{ parameters.SBOM }}
-  - name: runCodesignValidationInjection
-    value: false
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+    value: 1
+  - name: DOTNET_NOLOGO
     value: 1
   - group: 'mscodehub-code-read-akv'
   - group: 'Azure Blob variable group'

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -10,8 +10,6 @@ jobs:
   pool:
     type: windows
   variables:
-  - name: runCodesignValidationInjection
-    value: false
   - name: NugetSecurityAnalysisWarningLevel
     value: none
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE


### PR DESCRIPTION
Backport of #26412 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26412$$$
-->

Triggered by @TravisEz13 on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Removes unused pipeline variable declarations; no functional change.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Not run locally; change is a variable cleanup in pipeline templates.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Deletion of unused variables in templates only.

## Merge Conflicts

Conflict in .pipelines/templates/variable/release-shared.yml due to variable list mismatch. Removed runCodesignValidationInjection per PR and kept DOTNET_SKIP_FIRST_TIME_EXPERIENCE alongside DOTNET_NOLOGO.
