### PR TITLE
[release/v7.4] Skip the flaky `Update-Help` test for the `PackageManagement` module

### DIFF
--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -215,7 +215,7 @@ function RunUpdateHelpTests
 
             It ('Validate Update-Help for module ''{0}'' in {1}' -F $moduleName, [PSCustomObject] $updateScope) -Skip:(!(Test-CanWriteToPsHome) -and $userscope -eq $false) {
 
-                if ($markAsPending) {
+                if ($markAsPending -or ($IsLinux -and $moduleName -eq "PackageManagement")) {
                     Set-ItResult -Pending -Because "Update-Help from the web has intermittent connectivity issues. See issues #2807 and #6541."
                     return
                 }
@@ -333,9 +333,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module." -Tags @(
         $ProgressPreference = $SavedProgressPreference
     }
 
-    ## Update-Help from the web has intermittent connectivity issues that cause CI failures.
-    ## Tests are marked as Pending to unblock work. See issues #2807 and #6541.
-    RunUpdateHelpTests -Tag "CI" -MarkAsPending
+    RunUpdateHelpTests -Tag "CI"
 }
 
 Describe "Validate Update-Help from the Web for one PowerShell module for user scope." -Tags @('CI', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {
@@ -347,9 +345,7 @@ Describe "Validate Update-Help from the Web for one PowerShell module for user s
         $ProgressPreference = $SavedProgressPreference
     }
 
-    ## Update-Help from the web has intermittent connectivity issues that cause CI failures.
-    ## Tests are marked as Pending to unblock work. See issues #2807 and #6541.
-    RunUpdateHelpTests -Tag "CI" -UserScope -MarkAsPending
+    RunUpdateHelpTests -Tag "CI" -UserScope
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell modules." -Tags @('Feature', 'RequireAdminOnWindows', 'RequireSudoOnUnix') {


### PR DESCRIPTION
Backport of #26845 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26845$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Fixes CI failures by skipping flaky Update-Help tests for PackageManagement module on Linux. This prevents false negatives in CI runs on release branches.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified with successful CI run (linked in original PR) showing tests now pass properly by correctly skipping the problematic PackageManagement tests on Linux

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Only changes test files to skip flaky tests. No production code changes, minimal risk of unintended side effects. Improves CI reliability.
