### PR TITLE
[release/v7.4] Update metadata.json to update the Latest attribute with a better name

### DIFF
--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -2,6 +2,10 @@ steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
     $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
+
+    $LTS = $metadata.LTSRelease.PublishToChannels
+    $Stable = $metadata.StableRelease.PublishToChannels
+    $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'
     $releaseTag = '$(OutputReleaseTag.releaseTag)'
 
     # Rebuild branches should be treated as preview builds
@@ -10,10 +14,6 @@ steps:
     # and is used in contexts where that check may not have run.
     # If you update this regex, also update it in rebuild-branch-check.yml to keep them in sync.
     $isRebuildBranch = '$(Build.SourceBranch)' -match 'refs/heads/rebuild/.*-rebuild\.'
-
-    $LTS = $metadata.LTSRelease.Latest
-    $Stable = $metadata.StableRelease.Latest
-    $isPreview = $releaseTag -match '-'
 
     # If this is a rebuild branch, force preview mode and ignore LTS metadata
     if ($isRebuildBranch) {

--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -33,7 +33,7 @@ stages:
     - template: release-SetReleaseTagandContainerName.yml
       parameters:
         restorePhase: true
-    
+
     - pwsh: |
         $packageVersion = '$(OutputReleaseTag.ReleaseTag)'.ToLowerInvariant() -replace '^v',''
         $vstsCommandString = "vso[task.setvariable variable=packageVersion]$packageVersion"
@@ -42,7 +42,7 @@ stages:
       displayName: Set Package version
       env:
         ob_restore_phase: true
-    
+
     - pwsh: |
         $branch = 'mirror-target'
         $gitArgs = "clone",
@@ -151,7 +151,7 @@ stages:
         $metadataHash = @{}
         $skipPublishValue = '${{ parameters.skipPublish }}'
         $metadataHash["ReleaseTag"] = '$(OutputReleaseTag.ReleaseTag)'
-        $metadataHash["LTS"] = $metadata.LTSRelease.Latest
+        $metadataHash["LTS"] = $metadata.LTSRelease.PublishToChannels
         $metadataHash["ForProduction"] = $true
         $metadataHash["SkipPublish"] = [System.Convert]::ToBoolean($skipPublishValue)
 
@@ -222,7 +222,7 @@ stages:
         files_to_sign: '*.ps1'
         search_root: '$(repoRoot)/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run'
       displayName: Sign Run.ps1
-  
+
     - pwsh: |
         # folder to tar must have: Run.ps1, settings.toml, python_dl
         $srcPath = Join-Path '$(ev2ServiceGroupRootFolder)' -ChildPath 'Shell'

--- a/.pipelines/templates/release-upload-buildinfo.yml
+++ b/.pipelines/templates/release-upload-buildinfo.yml
@@ -57,7 +57,6 @@ jobs:
 
       $metadata = Get-Content -LiteralPath "$toolsDirectory/metadata.json" -ErrorAction Stop | ConvertFrom-Json
       $stableReleaseTag = $metadata.StableReleaseTag -Replace 'v',''
-      
       $stableRelease = $metadata.StableRelease.PublishToChannels
       $ltsRelease = $metadata.LTSRelease.PublishToChannels
 

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -5,6 +5,6 @@
   "ReleaseTag": "v7.4.0",
   "LTSReleaseTag" : ["v7.2.13"],
   "NextReleaseTag": "v7.4.0-preview.5",
-  "LTSRelease": { "Latest": true, "Package": true },
-  "StableRelease":  { "Latest": false, "Package": true }
+  "LTSRelease": { "PublishToChannels": true, "Package": true },
+  "StableRelease":  { "PublishToChannels": false, "Package": true }
 }


### PR DESCRIPTION
Backport of #26380 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26380$$$
-->

Triggered by @TravisEz13 on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Pipeline metadata standardization for release channel selection; required for release automation.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Tested in previous release.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Release pipeline metadata changes; scoped and already exercised in a prior release.

## Merge Conflicts

Resolved conflicts in .pipelines/templates/release-upload-buildinfo.yml and tools/metadata.json to preserve release/v7.4 values while switching to PublishToChannels.
