### PR TITLE
[release/v7.6] Correct the package name for .deb and .rpm packages

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -54,6 +54,7 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
       buildModuleChanged: ${{ steps.filter.outputs.buildModuleChanged }}
+      packagingChanged: ${{ steps.filter.outputs.packagingChanged }}
     steps:
       - name: checkout
         uses: actions/checkout@v5
@@ -161,7 +162,7 @@ jobs:
     name: macOS packaging and testing
     needs:
       - changes
-    if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.buildModuleChanged == 'true' }}
+    if: ${{ needs.changes.outputs.packagingChanged == 'true' }}
     runs-on:
       - macos-15-large
     steps:

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1159,11 +1159,15 @@ function New-UnixPackage {
         }
 
         # Determine if the version is a preview version
-        # Only LTS packages get a prefix in the name
-        # Preview versions are identified by the version string itself (e.g., 7.6.0-preview.6)
-        # Rebuild versions are also identified by the version string (e.g., 7.4.13-rebuild.5)
+        $IsPreview = Test-IsPreview -Version $Version -IsLTS:$LTS
+
+        # For deb/rpm packages, use the '-lts' and '-preview' channel suffix variants to match existing names on packages.microsoft.com.
+        # For osxpkg package, only LTS packages get a channel suffix in the name.
         $Name = if($LTS) {
             "powershell-lts"
+        }
+        elseif ($IsPreview -and $Type -ne "osxpkg") {
+            "powershell-preview"
         }
         else {
             "powershell"


### PR DESCRIPTION
Backport of #26877 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26877$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Ensures that users installing .deb and .rpm packages get correctly named packages.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Backport can be validated by building .deb and .rpm packages and verifying the package names are correct.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This change only corrects package naming for .deb and .rpm packages. It does not modify functionality or runtime behavior.
