### PR TITLE
[release/v7.6] Exclude .exe packages from publishing to GitHub

### DIFF
--- a/.pipelines/templates/release-githubNuget.yml
+++ b/.pipelines/templates/release-githubNuget.yml
@@ -35,6 +35,14 @@ jobs:
       targetType: inline
       script: |
         $Path = "$(Pipeline.Workspace)/GitHubPackages"
+
+        # The .exe packages are for Windows Update only and should not be uploaded to GitHub release.
+        $exefiles = Get-ChildItem -Path $Path -Filter *.exe
+        if ($exefiles) {
+            Write-Verbose -Verbose "Remove .exe packages:"
+            $exefiles | Remove-Item -Force -Verbose
+        }
+
         $OutputPath = Join-Path $Path 'hashes.sha256'
         $packages  = Get-ChildItem -Path $Path -Include * -Recurse -File
         $checksums = $packages |


### PR DESCRIPTION
Backport of #26859 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26859$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

This change affects only the release packaging process. Customers will no longer see .exe packages in GitHub releases as they are intended for Windows Update only.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified the backport cherry-picked cleanly with no conflicts. The change is a simple addition to the release pipeline that removes .exe files after downloading artifacts and before uploading to GitHub.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This change only removes .exe packages from GitHub releases before upload. The .exe packages are still created and intended for Windows Update only. No functional changes to PowerShell itself.
