### PR TITLE
[release/v7.6] Add version in description and pass store task on failure.

### DIFF
--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -59,8 +59,15 @@ jobs:
 
         $json.listings.'en-us'.baseListing.releaseNotes = $message
 
+        # Add PowerShell version to the top of the description
+        $description = $json.listings.'en-us'.baseListing.description
+        $version = "$(ReleaseTag)"
+        $updatedDescription = "Version: $version`n`n$description"
+        $json.listings.'en-us'.baseListing.description = $updatedDescription
+        Write-Verbose -Verbose "Updated description: $updatedDescription"
+
         $json | ConvertTo-Json -Depth 100 | Set-Content $jsonPath -Encoding UTF8
-    displayName: 'Update Release Notes in JSON'
+    displayName: 'Add Changelog Link and Version Number to SBJSON'
 
   - task: PowerShell@2
     inputs:
@@ -101,6 +108,7 @@ jobs:
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
     displayName: 'Publish StoreBroker Package (Stable/LTS)'
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq(variables['STABLE'], 'true'), eq(variables['LTS'], 'true')))
+    continueOnError: true
     inputs:
       serviceEndpoint: 'StoreAppPublish-Stable'
       appId: '$(AppID)'
@@ -114,6 +122,7 @@ jobs:
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
     displayName: 'Publish StoreBroker Package (Preview)'
     condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['PREVIEW'], 'true'))
+    continueOnError: true
     inputs:
       serviceEndpoint: 'StoreAppPublish-Preview'
       appId: '$(AppID)'


### PR DESCRIPTION
Backport of #26885 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26885$$$
-->

Triggered by @daxian-dbw on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Required for release pipeline reliability. Prevents store publish task failures from blocking the entire release pipeline.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Tested via MSIX release pipeline. Changes only affect store publishing metadata and error handling.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Changes only affect store publishing process. Adding version to description is a metadata-only change. continueOnError ensures pipeline doesn't fail on known store publishing issues.
