### PR TITLE
[release/v7.4] Fix a preview detection test for the packaging script

### DIFF
--- a/test/packaging/packaging.tests.ps1
+++ b/test/packaging/packaging.tests.ps1
@@ -46,18 +46,15 @@ Describe "Packaging Module Functions" {
             $result.PackageIdentifier | Should -Be "com.microsoft.powershell"
         }
 
-        It "Should NOT use package name for preview detection (bug fix verification)" {
+        It "Should NOT use package name for preview detection (bug fix verification) - <Name>" -TestCases @(
+            @{ Version = "7.6.0-preview.6"; Name = "Preview" }
+            @{ Version = "7.6.0-rc.1"; Name = "RC" }
+        ) {
             # This test verifies the fix for issue #26673
             # The bug was using ($Name -like '*-preview') which always returned false
             # because preview builds use Name="powershell" not "powershell-preview"
-            
-            $Version = "7.6.0-preview.6"
-            $Name = "powershell"  # Preview builds use "powershell" not "powershell-preview"
-            
-            # The INCORRECT logic (the bug): $Name -like '*-preview'
-            $incorrectCheck = $Name -like '*-preview'
-            $incorrectCheck | Should -Be $false -Because "Package name is 'powershell' not 'powershell-preview'"
-            
+            param($Version)
+
             # The CORRECT logic (the fix): uses version string
             $result = Get-MacOSPackageIdentifierInfo -Version $Version -LTS:$false
             $result.IsPreview | Should -Be $true -Because "Version string correctly identifies preview"


### PR DESCRIPTION
Backport of #26882 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26882$$$
-->

Triggered by @TravisEz13 on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes a preview detection test in the packaging script that is needed for correct package release validation.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Test verified by running packaging script on release/v7.4 branch. Confirming preview detection works correctly in test suite.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a test fix for the packaging script. Tests do not execute in production, and the change is localized to test validation. Risk is minimal.
