### PR TITLE
[release/v7.5] Add version in description and pass store task on failure.

### DIFF
--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -57,8 +57,15 @@ jobs:
 
         $json.listings.'en-us'.baseListing.releaseNotes = $message
 
+        # Add PowerShell version to the top of the description
+        $description = $json.listings.'en-us'.baseListing.description
+        $version = "$(ReleaseTag)"
+        $updatedDescription = "Version: $version`n`n$description"
+        $json.listings.'en-us'.baseListing.description = $updatedDescription
+        Write-Verbose -Verbose "Updated description: $updatedDescription"
+
         $json | ConvertTo-Json -Depth 100 | Set-Content $jsonPath -Encoding UTF8
-    displayName: 'Update Release Notes in JSON'
+    displayName: 'Add Changelog Link and Version Number to SBJSON'
 
   - task: PowerShell@2
     inputs:
@@ -115,7 +122,8 @@ jobs:
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
     displayName: 'Publish StoreBroker Package (Stable/LTS)'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true')))
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq(variables['STABLE'], 'true'), eq(variables['LTS'], 'true')))
+    continueOnError: true
     inputs:
       serviceEndpoint: 'StoreAppPublish-Stable'
       appId: '$(AppID)'
@@ -128,7 +136,8 @@ jobs:
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
     displayName: 'Publish StoreBroker Package (Preview)'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq('$(PREVIEW)', 'true'))
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['PREVIEW'], 'true'))
+    continueOnError: true
     inputs:
       serviceEndpoint: 'StoreAppPublish-Preview'
       appId: '$(AppID)'


### PR DESCRIPTION
Backport of #26885 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26885$$$
-->

Triggered by @TravisEz13 on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Improves the v7.5 MSIX release pipeline by adding version information to app description and enabling error continuation in store publish tasks for better error handling and release visibility.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by running MSIX release pipeline on main branch. Changes to store publish tasks have been tested and confirmed to improve pipeline resilience and release note visibility without breaking existing functionality.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

This modifies critical MSIX release pipeline steps. However, the changes have been tested in main and are localized to improving store publishing error handling and release note visibility. The variable syntax update aligns with best practices.

## Merge Conflicts

One conflict in `.pipelines/templates/release-MSIX-Publish.yml` resolved by updating variable syntax from `$(VAR)` to `variables['VAR']` and adding `continueOnError: true` to both Stable/LTS and Preview store publish tasks, matching the intent of the original PR.
