### PR TITLE
[release/v7.4] Bring Release Changes from v7.6.0-preview.6

### DIFF
--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -99,7 +99,7 @@ jobs:
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
     displayName: 'Publish StoreBroker Package (Stable/LTS)'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq('$(STABLE)', 'true'), eq('$(LTS)', 'true')))
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq(variables['STABLE'], 'true'), eq(variables['LTS'], 'true')))
     inputs:
       serviceEndpoint: 'StoreAppPublish-Stable'
       appId: '$(AppID)'
@@ -112,7 +112,7 @@ jobs:
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
     displayName: 'Publish StoreBroker Package (Preview)'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq('$(PREVIEW)', 'true'))
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['PREVIEW'], 'true'))
     inputs:
       serviceEndpoint: 'StoreAppPublish-Preview'
       appId: '$(AppID)'

--- a/build.psm1
+++ b/build.psm1
@@ -2530,6 +2530,24 @@ function Start-PSBootstrap {
             Write-LogGroupEnd -Title "Install Windows Dependencies"
         }
 
+        # Ensure dotnet is available
+        Find-Dotnet
+
+        if (-not $env:TF_BUILD) {
+            if ($Scenario -in 'All', 'Tools') {
+                Write-LogGroupStart -Title "Install .NET Global Tools"
+                Write-Log -message "Installing .NET global tools"
+
+                # Install dotnet-format
+                Write-Verbose -Verbose "Installing dotnet-format global tool"
+                Start-NativeExecution {
+                    dotnet tool install --global dotnet-format
+                }
+                Write-LogGroupEnd -Title "Install .NET Global Tools"
+            }
+        }
+
+>>>>>>> 9ef5ec473 (Bring release changes from the v7.6.0-preview.6 release branch (#26627))
         if ($env:TF_BUILD) {
             Write-LogGroupStart -Title "Capture NuGet Sources"
             Write-Verbose -Verbose "--- Start - Capturing nuget sources"

--- a/build.psm1
+++ b/build.psm1
@@ -2547,7 +2547,6 @@ function Start-PSBootstrap {
             }
         }
 
->>>>>>> 9ef5ec473 (Bring release changes from the v7.6.0-preview.6 release branch (#26627))
         if ($env:TF_BUILD) {
             Write-LogGroupStart -Title "Capture NuGet Sources"
             Write-Verbose -Verbose "--- Start - Capturing nuget sources"


### PR DESCRIPTION
Backport of #26627 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26627$$$
-->

Triggered by @TravisEz13 on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates build module (build.psm1) to skip dotnet-format installation in CI/CD (Azure DevOps) environments. Updates MSIX pipeline template with corrected Azure Pipeline variable references (using variables['NAME'] syntax instead of string interpolation). These changes prevent unnecessary tool installations in CI and ensure more reliable pipeline condition evaluation.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified cherry-pick completed successfully with conflict resolution. Changes are isolated to build scripts and CI/CD templates. The dotnet-format installation logic is now properly gated behind TF_BUILD environment variable check.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: Build system changes affecting CI/CD pipelines and dotnet tool installation, but changes are isolated and well-scoped. The dotnet-format installation is now properly skipped in CI environments (TF_BUILD), and MSIX pipeline conditions are fixed for better variable reference handling. No runtime impact on user-facing functionality.

## Merge Conflicts

build.psm1 had one conflict due to missing dotnet-format installation code in release/v7.4. This was resolved by accepting the incoming change from the PR, which adds the Find-Dotnet call and wraps the dotnet-format installation in a TF_BUILD environment check to skip installation in CI environments.
