### PR TITLE
[release/v7.6] Add PMC packages for debian13 and rhel10

### DIFF
--- a/tools/packages.microsoft.com/mapping.json
+++ b/tools/packages.microsoft.com/mapping.json
@@ -22,6 +22,13 @@
           "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.rh.x86_64.rpm"
       },
       {
+          "url": "microsoft-rhel10.0-prod",
+          "distribution": [
+              "stable"
+          ],
+          "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.rh.x86_64.rpm"
+      },
+      {
         "url": "cbl-mariner-2.0-prod-Microsoft-aarch64",
         "distribution": [
             "bionic"
@@ -100,6 +107,27 @@
           "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
       },
       {
+          "url": "microsoft-debian-bullseye-prod",
+          "distribution": [
+              "bullseye"
+          ],
+          "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
+      },
+      {
+          "url": "microsoft-debian-bookworm-prod",
+          "distribution": [
+              "bookworm"
+          ],
+          "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
+      },
+      {
+          "url": "microsoft-debian-trixie-prod",
+          "distribution": [
+              "trixie"
+          ],
+          "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
+      },
+      {
           "url": "microsoft-ubuntu-bionic-prod",
           "distribution": [
               "bionic"
@@ -133,20 +161,6 @@
             "xenial"
         ],
         "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
-    },
-    {
-        "url": "microsoft-debian-bullseye-prod",
-        "distribution": [
-            "bullseye"
-        ],
-        "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
-    },
-    {
-      "url": "microsoft-debian-bookworm-prod",
-      "distribution": [
-          "bookworm"
-      ],
-      "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
     }
   ]
 }


### PR DESCRIPTION
Backport of #26912 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26912$$$
-->

Triggered by @daxian-dbw on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds PMC (packages.microsoft.com) package mappings for Debian 13 and RHEL 10 support, enabling these distributions to receive PowerShell packages through the Microsoft package repository.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Author verified that the current .deb package is supported on Debian 13 and the current rh.x86_64.rpm package is supported on RHEL 10 (Ubi10). The change only updates JSON mapping configuration without code changes.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk - adds new OS distribution mappings to PMC configuration. This is a configuration-only change that doesn't affect existing distribution support. The packages were manually verified to work on the new OS versions before mapping was added. Low impact to existing users as it only enables new distributions.
