### PR TITLE
Refactor platform checks to use OperatingSystem class

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Clipboard.cs
@@ -68,18 +68,18 @@ namespace Microsoft.PowerShell.Commands.Internal
 
             string tool = string.Empty;
             string args = string.Empty;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 string clipboardText = string.Empty;
                 ExecuteOnStaThread(() => GetTextImpl(out clipboardText));
                 return clipboardText;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (OperatingSystem.IsLinux())
             {
                 tool = "xclip";
                 args = "-selection clipboard -out";
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            else if (OperatingSystem.IsMacOS())
             {
                 tool = "pbpaste";
             }
@@ -102,12 +102,12 @@ namespace Microsoft.PowerShell.Commands.Internal
 
             string tool = string.Empty;
             string args = string.Empty;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 ExecuteOnStaThread(() => SetClipboardData(Tuple.Create(text, CF_UNICODETEXT)));
                 return;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (OperatingSystem.IsLinux())
             {
                 tool = "xclip";
                 if (string.IsNullOrEmpty(text))
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.Commands.Internal
                     args = "-selection clipboard -in";
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            else if (OperatingSystem.IsMacOS())
             {
                 tool = "pbcopy";
             }
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         public static void SetRtf(string plainText, string rtfText)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!OperatingSystem.IsWindows())
             {
                 return;
             }

--- a/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
+++ b/src/Microsoft.PowerShell.GlobalTool.Shim/GlobalToolShim.cs
@@ -27,9 +27,7 @@ namespace Microsoft.PowerShell.GlobalTool.Shim
         public static int Main(string[] args)
         {
             var currentPath = new FileInfo(System.Reflection.Assembly.GetEntryAssembly().Location).Directory.FullName;
-            var isWindows = OperatingSystem.IsWindows();
-
-            string platformFolder = isWindows ? WinFolderName : UnixFolderName;
+            string platformFolder = OperatingSystem.IsWindows() ? WinFolderName : UnixFolderName;
 
             var arguments = new List<string>(args.Length + 1);
             var pwshPath = Path.Combine(currentPath, platformFolder, PwshDllName);

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -28,7 +28,7 @@ namespace System.Management.Automation
         private static bool HostSupportUnicode()
         {
             // Reference: https://github.com/zkat/supports-unicode/blob/main/src/lib.rs
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return Environment.GetEnvironmentVariable("WT_SESSION") is not null ||
                     Environment.GetEnvironmentVariable("TERM_PROGRAM") is "vscode" ||

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -139,7 +139,7 @@ namespace TestExe
         private static void EchoCmdLine()
         {
             string rawCmdLine = "N/A";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 nint cmdLinePtr = Interop.GetCommandLineW();
                 rawCmdLine = Marshal.PtrToStringUni(cmdLinePtr);


### PR DESCRIPTION
[`OperatingSystem.IsWindows`](https://learn.microsoft.com/dotnet/api/system.operatingsystem.iswindows) and similar are available since .NET 5.
