### PR TITLE
[release/v7.4.14] Merge the v7.6.0-preview.5 release branch back to master

### DIFF
--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -156,7 +156,7 @@ extends:
         parameters:
           jobName: "LinuxSDK"
           displayName: "Linux SDK Validation"
-          imageName: PSMMSUbuntu20.04-Secure
+          imageName: PSMMSUbuntu22.04-Secure
           poolName: $(ubuntuPool)
 
     - stage: gbltool

--- a/.pipelines/templates/channelSelection.yml
+++ b/.pipelines/templates/channelSelection.yml
@@ -2,7 +2,6 @@ steps:
 - pwsh: |
     # Determine LTS, Preview, or Stable
     $metadata = Get-Content "$(Build.SourcesDirectory)/PowerShell/tools/metadata.json" -Raw | ConvertFrom-Json
-
     $LTS = $metadata.LTSRelease.PublishToChannels
     $Stable = $metadata.StableRelease.PublishToChannels
     $isPreview = '$(OutputReleaseTag.releaseTag)' -match '-'

--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -224,49 +224,13 @@ jobs:
 
         Write-Host "##vso[task.setvariable variable=ServiceConnection]$($config.ServiceEndpoint)"
         Write-Host "##vso[task.setvariable variable=SBConfigPath]$($sbConfigPath)"
-
-        # These variables are used in the next tasks to determine which ServiceEndpoint to use
-        $ltsValue = $IsLTS.ToString().ToLower()
-        $stableValue = $IsStable.ToString().ToLower()
-        $previewValue = $IsPreview.ToString().ToLower()
-
-        Write-Verbose -Verbose "About to set variables:"
-        Write-Verbose -Verbose "  LTS=$ltsValue"
-        Write-Verbose -Verbose "  STABLE=$stableValue"
-        Write-Verbose -Verbose "  PREVIEW=$previewValue"
-
-        Write-Host "##vso[task.setvariable variable=LTS]$ltsValue"
-        Write-Host "##vso[task.setvariable variable=STABLE]$stableValue"
-        Write-Host "##vso[task.setvariable variable=PREVIEW]$previewValue"
-
-        Write-Verbose -Verbose "Variables set successfully"
       name: UpdateConfigs
       displayName: Update PDPs and SBConfig.json
 
-    - pwsh: |
-        Write-Verbose -Verbose "Checking variables after UpdateConfigs:"
-        Write-Verbose -Verbose "LTS=$(LTS)"
-        Write-Verbose -Verbose "STABLE=$(STABLE)"
-        Write-Verbose -Verbose "PREVIEW=$(PREVIEW)"
-      displayName: Debug - Check Variables
-
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
-      displayName: 'Create StoreBroker Package (Preview)'
-      condition: eq(variables['PREVIEW'], 'true')
+      displayName: 'Create StoreBroker Package'
       inputs:
-        serviceEndpoint: 'StoreAppPublish-Preview'
-        sbConfigPath: '$(SBConfigPath)'
-        sourceFolder: '$(BundleDir)'
-        contents: '*.msixBundle'
-        outSBName: 'PowerShellStorePackage'
-        pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
-        pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
-
-    - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
-      displayName: 'Create StoreBroker Package (Stable/LTS)'
-      condition: or(eq(variables['STABLE'], 'true'), eq(variables['LTS'], 'true'))
-      inputs:
-        serviceEndpoint: 'StoreAppPublish-Stable'
+        serviceEndpoint: 'StoreAppPublish-Private'
         sbConfigPath: '$(SBConfigPath)'
         sourceFolder: '$(BundleDir)'
         contents: '*.msixBundle'

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -50,7 +50,7 @@ jobs:
           $middleURL = $matches[1]
         }
 
-        $endURL = $tagString -replace '^v','' -replace '\.',''
+        $endURL = $tagString -replace '^v|\.', ''
         $message = "Changelog: https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/$middleURL.md#$endURL"
         Write-Verbose -Verbose "Release Notes for the Store:"
         Write-Verbose -Verbose "$message"
@@ -66,43 +66,32 @@ jobs:
     inputs:
       targetType: inline
       script: |
+        # Convert ADO variables to PowerShell boolean variables
         $IsLTS = '$(LTS)' -eq 'true'
         $IsStable = '$(STABLE)' -eq 'true'
         $IsPreview = '$(PREVIEW)' -eq 'true'
 
-        Write-Verbose -Verbose "Channel Selection - LTS: $(LTS), Stable: $(Stable), Preview: $(Preview)"
+        Write-Verbose -Verbose "Channel Selection - LTS: $(LTS), Stable: $(STABLE), Preview: $(PREVIEW)"
 
+        # Determine the current channel for logging purposes
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
-          else { 
+          else {
             Write-Error "No valid channel detected"
             exit 1
           }
 
-        # Assign AppID for Store-Publish Task
-        $appID = $null
-        if ($IsLTS) {
-          $appID = '$(AppID-LTS)'
-        }
-        elseif ($IsStable) {
-          $appID = '$(AppID-Stable)'
-        }
-        else {
-          $appID = '$(AppID-Preview)'
-        }
-
-        Write-Host "##vso[task.setvariable variable=AppID]$appID"
         Write-Verbose -Verbose "Selected channel: $currentChannel"
         Write-Verbose -Verbose "Conditional tasks will handle the publishing based on channel variables"
     displayName: 'Validate Channel Selection'
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
-    displayName: 'Publish StoreBroker Package (Stable/LTS)'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), or(eq(variables['STABLE'], 'true'), eq(variables['LTS'], 'true')))
+    displayName: 'Publish LTS StoreBroker Package'
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['LTS'], 'true'))
     inputs:
-      serviceEndpoint: 'StoreAppPublish-Stable'
-      appId: '$(AppID)'
+      serviceEndpoint: 'StoreAppPublish-Private'
+      appId: '$(AppID-LTS)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
       zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'
@@ -111,14 +100,32 @@ jobs:
       targetPublishMode: 'Immediate'
 
   - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
-    displayName: 'Publish StoreBroker Package (Preview)'
-    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['PREVIEW'], 'true'))
+    displayName: 'Publish Stable StoreBroker Package'
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['STABLE'], 'true'))
     inputs:
-      serviceEndpoint: 'StoreAppPublish-Preview'
-      appId: '$(AppID)'
+      serviceEndpoint: 'StoreAppPublish-Private'
+      appId: '$(AppID-Stable)'
       inputMethod: JsonAndZip
       jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
       zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'
       numberOfPackagesToKeep: 2
       jsonZipUpdateMetadata: true
       targetPublishMode: 'Immediate'
+
+  - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
+    displayName: 'Publish Preview StoreBroker Package'
+    condition: and(ne('${{ parameters.skipMSIXPublish }}', 'true'), eq(variables['PREVIEW'], 'true'))
+    inputs:
+      serviceEndpoint: 'StoreAppPublish-Private'
+      appId: '$(AppID-Preview)'
+      inputMethod: JsonAndZip
+      jsonPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.json'
+      zipPath: '$(Pipeline.Workspace)\SBOutDir\PowerShellStorePackage.zip'
+      numberOfPackagesToKeep: 2
+      jsonZipUpdateMetadata: true
+      targetPublishMode: 'Immediate'
+
+  - pwsh: |
+      Get-Content -Path "$(System.DefaultWorkingDirectory)/SBLog.txt" -ErrorAction SilentlyContinue
+    displayName: Upload Store Failure Log
+    condition: failed()

--- a/.pipelines/templates/release-githubNuget.yml
+++ b/.pipelines/templates/release-githubNuget.yml
@@ -121,13 +121,13 @@ jobs:
         $middleURL = ''
         $tagString = "$(ReleaseTag)"
         Write-Verbose -Verbose "Use the following command to push the tag:"
-        if ($tagString -match '-') {
+        if ($tagString -match '-preview') {
           $middleURL = "preview"
         }
         elseif ($tagString -match '(\d+\.\d+)') {
           $middleURL = $matches[1]
         }
-        $endURL = $tagString -replace '[v\.]',''
+        $endURL = $tagString -replace '^v|\.', ''
         $message = "https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/$middleURL.md#$endURL"
         Write-Verbose -Verbose "git tag -a $(ReleaseTag) $env:BUILD_SOURCEVERSION -m $message"
     displayName: Git Push Tag Command

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -43,6 +43,9 @@ jobs:
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"
 
+        Import-Module "$repoRoot/build.psm1" -Force -Verbose
+        Start-PSBootstrap -Scenario Dotnet
+
         $toolPath = New-Item -ItemType Directory "$(System.DefaultWorkingDirectory)/toolPath" | Select-Object -ExpandProperty FullName
 
         Write-Verbose -Verbose "dotnet tool list -g"
@@ -75,6 +78,9 @@ jobs:
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"
         Import-Module "$repoRoot/build.psm1" -Force
+
+        Import-Module "$repoRoot/build.psm1" -Force -Verbose
+        Start-PSBootstrap -Scenario Dotnet
 
         $exeName = if ($IsWindows) { "pwsh.exe" } else { "pwsh" }
 

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -51,7 +51,11 @@ jobs:
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)"
 
+        Import-Module "$repoRoot/build.psm1" -Force -Verbose
+        Start-PSBootstrap -Scenario Dotnet
+
         $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+        $env:DOTNET_NOLOGO=1
 
         $localLocation = "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg"
         $xmlElement = @"


### PR DESCRIPTION
Backport of #26920 to release/v7.4.14

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26920$$$
-->

Triggered by @adityapatwardhan on behalf of @TravisEz13

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates Azure Pipelines templates for MSIX store publishing (3-task split architecture), global tools validation (added bootstrap), SDK validation (added bootstrap and DOTNET_NOLOGO), and improved regex patterns for changelog URL generation.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-picked cleanly with no conflicts. Validated YAML syntax for all modified pipeline files.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

This backport includes architectural changes to Azure Pipelines store publishing automation and updates to SDK validation. While changes are from the tested v7.6.0-preview.5 release branch, they modify critical build and release infrastructure.
