### PR TITLE
Hardcode Official templates

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -29,11 +29,8 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: bins-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: bins-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 resources:
   repositories:
@@ -91,8 +88,6 @@ variables:
       value: true
     ${{ else }}:
       value: false
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   # Fix for BinSkim ICU package error in Linux containers
   - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
     value: true
@@ -100,10 +95,10 @@ variables:
   - name: ob_sdl_binskim_enabled
     value: false
   - name: ps_official_build
-    value: ${{ parameters.OfficialBuild }}
+    value: true
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     customTags: 'ES365AIMigrationTooling'
     featureFlags:

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -289,7 +289,7 @@ extends:
       jobs:
       - template: /.pipelines/templates/package-create-msix.yml@self
         parameters:
-          OfficialBuild: ${{ parameters.OfficialBuild }}
+          OfficialBuild: true
 
     - stage: upload
       displayName: 'Upload'

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -24,14 +24,11 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
   - name: disableNetworkIsolation
     type: boolean
     default: false
 
-name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -67,8 +64,6 @@ variables:
   - name: branchCounter
     value: $[counter(variables['branchCounterKey'], 1)]
   - group: MSIXSigningProfile
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   - name: disableNetworkIsolation
     value: ${{ parameters.disableNetworkIsolation }}
 
@@ -89,7 +84,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     cloudvault:
       enabled: false

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -13,11 +13,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: ev2-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: ev2-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -49,8 +46,6 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/azurelinux/build:3.0
   - group: PoolNames
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
 
 resources:
   repositories:
@@ -72,7 +67,7 @@ resources:
             - releases/*
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     featureFlags:
       WindowsHostVersion:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -29,11 +29,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip MSIX Publish
     type: boolean
     default: false
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: release-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: release-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -65,10 +62,8 @@ variables:
   - name: ReleaseTagVar
     value: ${{ parameters.ReleaseTagVar }}
   - group: PoolNames
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   - name: releaseEnvironment
-    value: ${{ iif ( parameters.OfficialBuild, 'Production', 'Test' ) }}
+    value: 'Production'
   # Fix for BinSkim ICU package error in Linux containers
   - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
     value: true
@@ -97,7 +92,7 @@ resources:
             - releases/*
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     release:
       category: NonAzure

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -1,9 +1,6 @@
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
-- name: OfficialBuild
-  type: boolean
-  default: true
 - name: 'createVPack'
   displayName: 'Create and Submit VPack'
   type: boolean
@@ -33,7 +30,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     - Netlock
   default: "R1"
 
-name: vPack_$(Build.SourceBranchName)_Prod.${{ parameters.OfficialBuild }}_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
+name: vPack_$(Build.SourceBranchName)_Prod.true_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -58,8 +55,6 @@ variables:
     value: ${{ parameters.ReleaseTagVar }}
   - group: Azure Blob variable group
   - group: certificate_logical_to_actual # used within signing task
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/Microsoft.Official.yml@onebranchTemplates', 'v2/Microsoft.NonOfficial.yml@onebranchTemplates' ) }}
   - group: DotNetPrivateBuildAccess
   - group: certificate_logical_to_actual
   - name: netiso
@@ -75,7 +70,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/Microsoft.Official.yml@onebranchTemplates
   parameters:
     platform:
       name: 'windows_undocked' # windows undocked


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request simplifies and standardizes the build pipeline YAML files by removing the `OfficialBuild` parameter and related conditional logic. All pipelines are now hardcoded to use the "official" build templates and settings, reducing complexity and potential for misconfiguration between official and non-official builds.

Key changes include:

**Pipeline Parameter and Variable Simplification**
- Removed the `OfficialBuild` parameter from all relevant pipeline YAML files, eliminating conditional logic that switched between official and non-official templates and settings. Pipeline names and variables that previously referenced `OfficialBuild` are now hardcoded to use `true` or official values. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL32-R33) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L27-R31) [[3]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL16-R17) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL32-R33) [[5]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L4-L6) [[6]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L36-R33)

**Template Usage Standardization**
- All pipelines now directly reference the official OneBranch templates (e.g., `v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates`, `v2/Microsoft.Official.yml@onebranchTemplates`) instead of selecting a template based on the `OfficialBuild` parameter or a variable. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL94-R101) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L70-L71) [[3]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L92-R87) [[4]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL52-L53) [[5]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL75-R70) [[6]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL68-R66) [[7]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL100-R95) [[8]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L61-L62) [[9]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L78-R73)

**Consistent Build Naming**
- Pipeline and build names that previously included the value of `OfficialBuild` now use `true` directly, ensuring consistent naming conventions across all official builds. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL32-R33) [[2]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859L27-R31) [[3]](diffhunk://#diff-833ec5d61fd962c7836671be40b8e348827c747cb057ec119bb5bcf0dfd9463eL16-R17) [[4]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL32-R33) [[5]](diffhunk://#diff-55564e33e0a79a6148af9c5c4f5d87d4f1702b094953d6e9898bba8d9ccee1b4L36-R33)

**Environment and Variable Hardcoding**
- Variables that previously depended on `OfficialBuild` (e.g., `ps_official_build`, `releaseEnvironment`) are now set to their official values unconditionally, further reducing conditional complexity. [[1]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aL94-R101) [[2]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdL68-R66)

These changes make the build pipelines easier to maintain by enforcing a single, official build path and removing unnecessary parameters and branching logic.

## PR Context

This is necessary to comply with 1ES Drift Management policy.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
