### PR TITLE
[release/v7.4] Fix PSMethodInvocationConstraints.GetHashCode method (#24965)

### DIFF
--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -2009,7 +2009,7 @@ namespace System.Management.Automation
         }
 
         public override int GetHashCode()
-            => HashCode.Combine(MethodTargetType, ParameterTypes, GenericTypeParameters);
+            => HashCode.Combine(MethodTargetType, ParameterTypes.SequenceGetHashCode(), GenericTypeParameters.SequenceGetHashCode());
 
         public override string ToString()
         {


### PR DESCRIPTION
Backport of #24965 to release/v7.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:#24965$$$
-->

Triggered by @jshigetomi

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [x] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

This is not a regression.

## Testing

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low
