### PR TITLE
[release/v7.5] Bring Release Changes from v7.6.0-preview.6

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -2548,19 +2548,21 @@ function Start-PSBootstrap {
             Write-LogGroupEnd -Title "Install Windows Dependencies"
         }
 
-        if ($Scenario -in 'All', 'Tools') {
-            Write-LogGroupStart -Title "Install .NET Global Tools"
-            Write-Log -message "Installing .NET global tools"
+        # Ensure dotnet is available
+        Find-Dotnet
 
-            # Ensure dotnet is available
-            Find-Dotnet
+        if (-not $env:TF_BUILD) {
+            if ($Scenario -in 'All', 'Tools') {
+                Write-LogGroupStart -Title "Install .NET Global Tools"
+                Write-Log -message "Installing .NET global tools"
 
-            # Install dotnet-format
-            Write-Verbose -Verbose "Installing dotnet-format global tool"
-            Start-NativeExecution {
-                dotnet tool install --global dotnet-format
+                # Install dotnet-format
+                Write-Verbose -Verbose "Installing dotnet-format global tool"
+                Start-NativeExecution {
+                    dotnet tool install --global dotnet-format
+                }
+                Write-LogGroupEnd -Title "Install .NET Global Tools"
             }
-            Write-LogGroupEnd -Title "Install .NET Global Tools"
         }
 
         if ($env:TF_BUILD) {


### PR DESCRIPTION
Backport of #26627 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26627$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Modifies Start-PSBootstrap in build.psm1 to skip installing dotnet-format global tool in CI (TF_BUILD) environments and moves Find-Dotnet call outside the conditional block.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

N/A - Build infrastructure change. Can only be verified interactively or during CI runs. Original PR was tested in CI.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Only changes dotnet tool installation logic in build.psm1 to skip installing dotnet-format in CI environments. No runtime or product code changes.

## Merge Conflicts

Conflict in .pipelines/templates/release-MSIX-Publish.yml resolved by keeping the existing release/v7.5 version. The YAML condition syntax fix (from '$(VAR)' to variables['VAR']) was already present in release/v7.5. Only the build.psm1 changes apply.
