### PR TITLE
[release/v7.5] Hardcode Official templates

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -25,11 +25,8 @@ parameters:
     displayName: Enable MSBuild Binary Logs
     type: boolean
     default: false
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: bins-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: bins-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 resources:
   repositories:
@@ -77,9 +74,8 @@ variables:
   - group: mscodehub-feed-read-general
   - group: mscodehub-feed-read-akv
   - name: ENABLE_MSBUILD_BINLOGS
+  - name: ENABLE_MSBUILD_BINLOGS
     value: ${{ parameters.ENABLE_MSBUILD_BINLOGS }}
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   # Fix for BinSkim ICU package error in Linux containers
   - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
     value: true
@@ -87,10 +83,10 @@ variables:
   - name: ob_sdl_binskim_enabled
     value: false
   - name: ps_official_build
-    value: ${{ parameters.OfficialBuild }}
+    value: true
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     customTags: 'ES365AIMigrationTooling'
     featureFlags:

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -24,14 +24,11 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
   - name: disableNetworkIsolation
     type: boolean
     default: false
 
-name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -67,8 +64,6 @@ variables:
   - name: branchCounter
     value: $[counter(variables['branchCounterKey'], 1)]
   - group: MSIXSigningProfile
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   - name: disableNetworkIsolation
     value: ${{ parameters.disableNetworkIsolation }}
 
@@ -89,7 +84,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     cloudvault:
       enabled: false
@@ -294,7 +289,7 @@ extends:
       jobs:
       - template: /.pipelines/templates/package-create-msix.yml@self
         parameters:
-          OfficialBuild: ${{ parameters.OfficialBuild }}
+          OfficialBuild: true
 
     - stage: upload
       displayName: 'Upload'

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -13,11 +13,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: ev2-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: ev2-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -49,8 +46,6 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/azurelinux/build:3.0
   - group: PoolNames
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
 
 resources:
   repositories:
@@ -72,7 +67,7 @@ resources:
             - releases/*
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     featureFlags:
       WindowsHostVersion:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -29,11 +29,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip MSIX Publish
     type: boolean
     default: false
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: release-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: release-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -65,10 +62,8 @@ variables:
   - name: ReleaseTagVar
     value: ${{ parameters.ReleaseTagVar }}
   - group: PoolNames
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   - name: releaseEnvironment
-    value: ${{ iif ( parameters.OfficialBuild, 'Production', 'Test' ) }}
+    value: 'Production'
   # Fix for BinSkim ICU package error in Linux containers
   - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
     value: true
@@ -97,7 +92,7 @@ resources:
             - releases/*
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     release:
       category: NonAzure

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -1,9 +1,6 @@
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
-- name: OfficialBuild
-  type: boolean
-  default: true
 - name: 'createVPack'
   displayName: 'Create and Submit VPack'
   type: boolean
@@ -33,7 +30,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     - Netlock
   default: "R1"
 
-name: vPack_$(Build.SourceBranchName)_Prod.${{ parameters.OfficialBuild }}_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
+name: vPack_$(Build.SourceBranchName)_Prod.true_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -58,8 +55,6 @@ variables:
     value: ${{ parameters.ReleaseTagVar }}
   - group: Azure Blob variable group
   - group: certificate_logical_to_actual # used within signing task
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/Microsoft.Official.yml@onebranchTemplates', 'v2/Microsoft.NonOfficial.yml@onebranchTemplates' ) }}
   - group: DotNetPrivateBuildAccess
   - group: certificate_logical_to_actual
   - name: netiso
@@ -75,7 +70,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/Microsoft.Official.yml@onebranchTemplates
   parameters:
     platform:
       name: 'windows_undocked' # windows undocked


### PR DESCRIPTION
Backport of #26928 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26928$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Removes OfficialBuild parameter from pipeline YAML files and hardcodes official OneBranch templates to comply with 1ES Drift Management policy.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Build pipeline YAML changes only — verified by pipeline execution. No functional code changes.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Removes conditional OfficialBuild parameter logic and hardcodes official templates. This aligns with 1ES Drift Management policy compliance. Same change was already successfully backported to release/v7.4.

## Merge Conflicts

Conflict in .pipelines/PowerShell-Coordinated_Packages-Official.yml: The release/v7.5 branch had a templateFile variable (referencing OfficialBuild) where master had CodeQL variables. Resolved by removing the templateFile variable (the intent of the PR) without adding the CodeQL variables (which were pre-existing context on master, not part of this PR's changes).
