### PR TITLE
[release/v7.6] Fetch latest ICU release version dynamically

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2152,7 +2152,7 @@ function Get-PackageDependencies
         #   than the build version and we know that older versions just works.
         #
         $MinICUVersion = 60                    # runtime minimum supported
-        $BuildICUVersion = 76                  # current build version
+        $BuildICUVersion = Get-IcuLatestRelease
         $MaxICUVersion = $BuildICUVersion + 30 # headroom
 
         if ($Distribution -eq 'deb') {
@@ -5811,4 +5811,16 @@ function Test-IsProductFile {
     }
 
     return $false
+}
+
+# Get major version from latest ICU release (latest: stable version)
+function Get-IcuLatestRelease {
+    $response = Invoke-WebRequest -Uri "https://github.com/unicode-org/icu/releases/latest"
+    $tagUrl = ($response.Links | Where-Object href -like "*releases/tag/release-*")[0].href
+
+    if ($tagUrl -match 'release-(\d+)\.') {
+       return [int]$Matches[1]
+    }
+
+    throw "Unable to determine the latest ICU release version."
 }


### PR DESCRIPTION
Backport of #26827 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26827$$$
-->

Triggered by @daxian-dbw on behalf of @kasperk81

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates build system to dynamically fetch the latest ICU release version from GitHub instead of using hardcoded values. This simplifies build maintenance and ensures latest ICU versions are used.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by running build process to confirm ICU version is fetched correctly from GitHub releases API. No changes to runtime behavior or test requirements.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk as it changes build system behavior for ICU version detection. The change makes builds more maintainable by fetching latest ICU releases dynamically rather than hardcoding versions. Limited scope to build-time operations only.
