### PR TITLE
[release/v7.6] Hardcode Official templates

### DIFF
--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -29,11 +29,8 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: bins-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: bins-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 resources:
   repositories:
@@ -91,8 +88,6 @@ variables:
       value: true
     ${{ else }}:
       value: false
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   # Fix for BinSkim ICU package error in Linux containers
   - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
     value: true
@@ -100,10 +95,10 @@ variables:
   - name: ob_sdl_binskim_enabled
     value: false
   - name: ps_official_build
-    value: ${{ parameters.OfficialBuild }}
+    value: true
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     customTags: 'ES365AIMigrationTooling'
     featureFlags:

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -24,14 +24,11 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
   - name: disableNetworkIsolation
     type: boolean
     default: false
 
-name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -67,8 +64,6 @@ variables:
   - name: branchCounter
     value: $[counter(variables['branchCounterKey'], 1)]
   - group: MSIXSigningProfile
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   - name: disableNetworkIsolation
     value: ${{ parameters.disableNetworkIsolation }}
 
@@ -89,7 +84,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     cloudvault:
       enabled: false
@@ -294,7 +289,7 @@ extends:
       jobs:
       - template: /.pipelines/templates/package-create-msix.yml@self
         parameters:
-          OfficialBuild: ${{ parameters.OfficialBuild }}
+          OfficialBuild: true
 
     - stage: upload
       displayName: 'Upload'

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -13,11 +13,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip Signing
     type: string
     default: 'NO'
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: ev2-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: ev2-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -49,8 +46,6 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/azurelinux/build:3.0
   - group: PoolNames
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
 
 resources:
   repositories:
@@ -72,7 +67,7 @@ resources:
             - releases/*
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     featureFlags:
       WindowsHostVersion:

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -29,11 +29,8 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip MSIX Publish
     type: boolean
     default: false
-  - name: OfficialBuild
-    type: boolean
-    default: false
 
-name: release-$(BUILD.SOURCEBRANCHNAME)-prod.${{ parameters.OfficialBuild }}-$(Build.BuildId)
+name: release-$(BUILD.SOURCEBRANCHNAME)-prod.true-$(Build.BuildId)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -65,10 +62,8 @@ variables:
   - name: ReleaseTagVar
     value: ${{ parameters.ReleaseTagVar }}
   - group: PoolNames
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates', 'v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates' ) }}
   - name: releaseEnvironment
-    value: ${{ iif ( parameters.OfficialBuild, 'Production', 'Test' ) }}
+    value: 'Production'
   # Fix for BinSkim ICU package error in Linux containers
   - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
     value: true
@@ -97,7 +92,7 @@ resources:
             - releases/*
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     release:
       category: NonAzure

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -1,9 +1,6 @@
 trigger: none
 
 parameters: # parameters are shown up in ADO UI in a build queue time
-- name: OfficialBuild
-  type: boolean
-  default: true
 - name: 'createVPack'
   displayName: 'Create and Submit VPack'
   type: boolean
@@ -32,7 +29,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     - Netlock
   default: "R1"
 
-name: vPack_$(Build.SourceBranchName)_Prod.${{ parameters.OfficialBuild }}_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
+name: vPack_$(Build.SourceBranchName)_Prod.true_Create.${{ parameters.createVPack }}_Name.${{ parameters.vPackName}}_$(date:yyyyMMdd).$(rev:rr)
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -57,8 +54,6 @@ variables:
     value: ${{ parameters.ReleaseTagVar }}
   - group: Azure Blob variable group
   - group: certificate_logical_to_actual # used within signing task
-  - name: templateFile
-    value: ${{ iif ( parameters.OfficialBuild, 'v2/Microsoft.Official.yml@onebranchTemplates', 'v2/Microsoft.NonOfficial.yml@onebranchTemplates' ) }}
   - group: DotNetPrivateBuildAccess
   - group: certificate_logical_to_actual
   - name: netiso
@@ -74,7 +69,7 @@ resources:
       ref: refs/heads/main
 
 extends:
-  template: ${{ variables.templateFile }}
+  template: v2/Microsoft.Official.yml@onebranchTemplates
   parameters:
     platform:
       name: 'windows_undocked' # windows undocked


### PR DESCRIPTION
Backport of #26928 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26928$$$
-->

Triggered by @daxian-dbw on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Enforces 1ES Drift Management policy compliance by hardcoding official OneBranch templates in all build pipelines. Removes OfficialBuild parameter and conditional logic, simplifying pipeline configuration and preventing misconfigurations.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Successfully backported to v7.4 and merged. Changes validated through CI/CD pipeline runs in official build environment. v7.5 backport (#26968) currently in testing.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk as it modifies core build pipeline infrastructure by hardcoding official OneBranch templates. However, this is necessary for 1ES Drift Management policy compliance. Changes have been validated in v7.4 (merged successfully) and stabilization is in progress for v7.5. Not taking this change creates policy compliance risks.
