### PR TITLE
[release/v7.6] Update PowerShell Profile DSC resource manifests to allow null for content

### DIFF
--- a/dsc/pwsh.profile.dsc.resource.json
+++ b/dsc/pwsh.profile.dsc.resource.json
@@ -90,7 +90,7 @@
                 "content": {
                     "title": "Content",
                     "description": "Defines the content of the profile. If you don't specify this property, the resource doesn't manage the file contents. If you specify this property as an empty string, the resource removes all content from the file. If you specify this property as a non-empty string, the resource sets the file contents to the specified string. The resources retains newlines from this property without any modification.",
-                    "type": "string"
+                    "type": [ "string", "null" ]
                 },
                 "_exist": {
                     "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/exist.json"


### PR DESCRIPTION
Backport of #26929 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26929$$$
-->

Triggered by @daxian-dbw on behalf of @adityapatwardhan

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Improves DSC resource schema flexibility by allowing null values for content property, enabling scenarios where content may be intentionally omitted.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Schema change validated to ensure it accepts both string and null values as intended. No functional code changes or test additions needed for schema-only modifications.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk as this only updates the DSC resource manifest schema to allow null values for the content property. The change improves schema flexibility without affecting existing functionality or breaking current usage patterns.
