### PR TITLE
[release/v7.6] Bump actions/dependency-review-action from 4.8.3 to 4.9.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,4 +19,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0


### PR DESCRIPTION
Backport of #26938 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26938$$$
-->

Triggered by @daxian-dbw on behalf of @app/dependabot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Updates dependency-review-action to v4.9.0, bringing improvements to dependency vulnerability scanning and reporting.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Automated dependabot update validated in master branch. No functional changes to workflows, only dependency version update. The conflict was auto-resolved using git rerere from previous successful backports to v7.4 and v7.5.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk as this is a minor version bump of a GitHub Actions dependency (4.8.3 to 4.9.0). The update includes improvements to purl matching, scorecard fetching optimization, and patched version display. No breaking changes or significant behavior modifications.

## Merge Conflicts

Merge conflict in .github/workflows/dependency-review.yml was auto-resolved by git rerere using a previous resolution.
