### PR TITLE
[release/v7.6] Bump actions/upload-artifact from 6 to 7

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -229,7 +229,7 @@ jobs:
         testResultsFolder: "${{ runner.workspace }}/testResults"
     - name: Upload package artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: macos-package
         path: "*.pkg"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/windows-packaging-reusable.yml
+++ b/.github/workflows/windows-packaging-reusable.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload Build Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-packaging-${{ matrix.architecture }}-${{ matrix.channel }}
           path: |

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -46,7 +46,7 @@ jobs:
           Write-Host "Completed xUnit test run."
 
       - name: Upload xUnit results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ inputs.test_results_artifact_name }}


### PR DESCRIPTION
Backport of #26914 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26914$$$
-->

Triggered by @daxian-dbw on behalf of @app/dependabot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Upgrades actions/upload-artifact from v6 to v7 across CI/CD workflows. V7 adds support for direct file uploads (unzipped) and upgrades to ESM module format.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

V7 has been tested and validated in master branch. Conflicts were straightforward version mismatches (v4 in release branch vs v7 incoming) that were resolved by taking v7. No functional changes to workflows beyond action version upgrade.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk as this is a major version upgrade (v6 → v7) of GitHub Actions upload-artifact action. New version introduces direct file upload support and ESM module format. However, changes are to CI/CD infrastructure only with no impact on production code. V7 has been stable in master branch.

## Merge Conflicts

Merge conflicts in 4 workflow files (.github/workflows/macos-ci.yml, scorecards.yml, windows-packaging-reusable.yml, xunit-tests.yml) were resolved by upgrading actions/upload-artifact from v4 to v7. The release branch had v4, incoming change was v7. Conflicts occurred due to version mismatch between branch vintages. Git rerere recorded resolutions for future use.
