### PR TITLE
[release/v7.6] Fix ConvertFrom-ClearlyDefinedCoordinates to handle API object coordinates

### DIFF
--- a/tools/clearlyDefined/src/ClearlyDefined/ClearlyDefined.psm1
+++ b/tools/clearlyDefined/src/ClearlyDefined/ClearlyDefined.psm1
@@ -40,19 +40,30 @@ function ConvertFrom-ClearlyDefinedCoordinates {
     [CmdletBinding()]
     param(
         [parameter(mandatory = $true, ValueFromPipeline = $true)]
-        [string]
+        [object]
         $Coordinates
     )
 
     Begin {}
     Process {
-        $parts = $Coordinates.Split('/')
-        [PSCustomObject]@{
-            type = $parts[0]
-            provider = $parts[1]
-            namespace = $parts[2]
-            name = $parts[3]
-            revision = $parts[4]
+        if ($Coordinates -is [string]) {
+            $parts = $Coordinates.Split('/')
+            [PSCustomObject]@{
+                type = $parts[0]
+                provider = $parts[1]
+                namespace = $parts[2]
+                name = $parts[3]
+                revision = $parts[4]
+            }
+        } else {
+            # Coordinates is already an object (e.g., from ClearlyDefined API response)
+            [PSCustomObject]@{
+                type = $Coordinates.type
+                provider = $Coordinates.provider
+                namespace = $Coordinates.namespace
+                name = $Coordinates.name
+                revision = $Coordinates.revision
+            }
         }
     }
     End {}


### PR DESCRIPTION
Backport of #26893 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26893$$$
-->

Triggered by @daxian-dbw on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes ClearlyDefined license generation tooling. The ConvertFrom-ClearlyDefinedCoordinates function only accepted string input, but Get-ClearlyDefinedData returns PSCustomObject from the API. This caused Start-ClearlyDefinedHarvest to fail. Backporting only the ClearlyDefined.psm1 fix (reverted all dependency updates).

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR tested with ClearlyDefined API responses. Backport verified by reviewing diff shows only ClearlyDefined.psm1 changes.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk - isolated change to a single tooling script used for license generation. Only affects ClearlyDefined coordinate parsing logic. Does not impact runtime or user-facing features. Change adds conditional logic to handle both input types without breaking existing string input handling.

## Merge Conflicts

6 files had conflicts (dependency version updates). Resolved by reverting all changes except ClearlyDefined.psm1 to keep only the tooling fix without pulling in dependency updates.
