### PR TITLE
[release/v7.5] Fix ConvertFrom-ClearlyDefinedCoordinates to handle API object coordinates

### DIFF
--- a/tools/clearlyDefined/src/ClearlyDefined/ClearlyDefined.psm1
+++ b/tools/clearlyDefined/src/ClearlyDefined/ClearlyDefined.psm1
@@ -40,19 +40,30 @@ function ConvertFrom-ClearlyDefinedCoordinates {
     [CmdletBinding()]
     param(
         [parameter(mandatory = $true, ValueFromPipeline = $true)]
-        [string]
+        [object]
         $Coordinates
     )
 
     Begin {}
     Process {
-        $parts = $Coordinates.Split('/')
-        [PSCustomObject]@{
-            type = $parts[0]
-            provider = $parts[1]
-            namespace = $parts[2]
-            name = $parts[3]
-            revision = $parts[4]
+        if ($Coordinates -is [string]) {
+            $parts = $Coordinates.Split('/')
+            [PSCustomObject]@{
+                type = $parts[0]
+                provider = $parts[1]
+                namespace = $parts[2]
+                name = $parts[3]
+                revision = $parts[4]
+            }
+        } else {
+            # Coordinates is already an object (e.g., from ClearlyDefined API response)
+            [PSCustomObject]@{
+                type = $Coordinates.type
+                provider = $Coordinates.provider
+                namespace = $Coordinates.namespace
+                name = $Coordinates.name
+                revision = $Coordinates.revision
+            }
         }
     }
     End {}


### PR DESCRIPTION
Backport of #26893 to release/v7.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26893$$$
-->

Triggered by @adityapatwardhan on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes ConvertFrom-ClearlyDefinedCoordinates to handle both string and PSCustomObject coordinate inputs from the ClearlyDefined API, preventing Start-ClearlyDefinedHarvest from failing ValidateSet on PackageType.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR was tested by the author. The cherry-picked change applies cleanly to the ClearlyDefined.psm1 file. The only conflicts were in unrelated version files which were resolved by keeping the target branch versions.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The change only affects the ClearlyDefined tooling module used during build/packaging. It adds handling for PSCustomObject input alongside the existing string input path. No runtime or engine code is modified.

## Merge Conflicts

7 files had conflicts (DotnetRuntimeMetadata.json, 4 .csproj files, cgmanifest.json) — all were package version bumps from the .NET 11 upgrade on master, unrelated to the actual fix. Resolved by keeping the release/v7.5 (ours) versions.
