### PR TITLE
Add automatic variable for current process path

### DIFF
--- a/src/System.Management.Automation/engine/SessionState.cs
+++ b/src/System.Management.Automation/engine/SessionState.cs
@@ -376,6 +376,13 @@ namespace System.Management.Automation
                                ScopedItemOptions.Constant | ScopedItemOptions.AllScope,
                                RunspaceInit.EnabledExperimentalFeatures);
             this.GlobalScope.SetVariable(v.Name, v, asValue: false, force: true, this, CommandOrigin.Internal, fastPath: true);
+
+            // $PSProcessPath
+            v = new PSVariable(SpecialVariables.PSProcessPath,
+                               Environment.ProcessPath,
+                               ScopedItemOptions.Constant | ScopedItemOptions.AllScope,
+                               RunspaceInit.PSProcessPathDescription);
+            this.GlobalScope.SetVariable(v.Name, v, asValue: false, force: true, this, CommandOrigin.Internal, fastPath: true);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -306,6 +306,7 @@ namespace System.Management.Automation
         internal const string PSEdition = "PSEdition";
         internal const string ShellId = "ShellId";
         internal const string EnabledExperimentalFeatures = "EnabledExperimentalFeatures";
+        internal const string PSProcessPath = "PSProcessPath";
 
         #endregion AllScope variables created in every session
 
@@ -378,7 +379,8 @@ namespace System.Management.Automation
             { PSEdition, typeof(string) },
             { ShellId, typeof(string) },
             { True, typeof(bool) },
-            { EnabledExperimentalFeatures, typeof(ReadOnlyBag<string>) }
+            { EnabledExperimentalFeatures, typeof(ReadOnlyBag<string>) },
+            { PSProcessPath, typeof(string) }
         };
 
         private static readonly HashSet<string> s_classMethodsAccessibleVariables = new HashSet<string>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -228,4 +228,7 @@
   <data name="PSEditionDescription" xml:space="preserve">
     <value>Edition information for the current PowerShell session</value>
   </data>
+  <data name="PSProcessPathDescription" xml:space="preserve">
+    <value>Full path to the current PowerShell process executable</value>
+  </data>
 </root>

--- a/test/powershell/Language/Parser/AutomaticVariables.Tests.ps1
+++ b/test/powershell/Language/Parser/AutomaticVariables.Tests.ps1
@@ -20,3 +20,30 @@ Describe 'Automatic variable $input' -Tags "CI" {
         & { [cmdletbinding()]param() end { @($input).Count } } | Should -Be 0
     }
 }
+
+Describe 'Automatic variable $PSProcessPath' -Tags "CI" {
+    It '$PSProcessPath should return a non-empty string' {
+        $PSProcessPath | Should -Not -BeNullOrEmpty
+    }
+
+    It '$PSProcessPath should be a string' {
+        $PSProcessPath | Should -BeOfType [string]
+    }
+
+    It '$PSProcessPath should point to an existing file' {
+        Test-Path -LiteralPath $PSProcessPath -PathType Leaf | Should -BeTrue
+    }
+
+    It '$PSProcessPath should be a constant variable' {
+        $var = Get-Variable -Name PSProcessPath
+        $var.Options | Should -Match 'Constant'
+    }
+
+    It '$PSProcessPath should be read-only (cannot be overwritten)' {
+        { $PSProcessPath = 'something' } | Should -Throw
+    }
+
+    It '$PSProcessPath should match the current process path' {
+        $PSProcessPath | Should -Be ([System.Environment]::ProcessPath)
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add's Automatic Vairiable for Current Process Path `$PSProcessPath`
fixes #26950

## PR Context

Removes need to use .NET method for this mimicing current `$PID` automatic variable


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed: <!-- Number/link of that issue here --> https://github.com/MicrosoftDocs/PowerShell-Docs/issues/12835
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
