### PR TITLE
[release/v7.6] Update Microsoft.PowerShell.PSResourceGet version to 1.2.0

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
-    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0-rc3" />
+    <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0" />
     <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
     <PackageReference Include="PSReadLine" Version="2.4.5" />
     <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -1217,6 +1217,11 @@
     "Architecture": null
   },
   {
+    "Pattern": "Modules\\Microsoft.PowerShell.PSResourceGet\\.signature.p7s",
+    "FileType": "NonProduct",
+    "Architecture": null
+  },
+  {
     "Pattern": "Modules\\Microsoft.PowerShell.PSResourceGet\\Microsoft.PowerShell.PSResourceGet.pdb",
     "FileType": "NonProduct",
     "Architecture": null


### PR DESCRIPTION
Backport of #27003 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27003$$$
-->

Triggered by @daxian-dbw on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates PSGalleryModules.csproj to package PSResourceGet 1.2.0

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Customers will receive the updated PSResourceGet 1.2.0 module with improved functionality and bug fixes

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

PSResourceGet 1.2.0 has been tested by the PSResourceGet team. Backport verification: Module loads correctly, packaging includes correct version. BOM file updated to reflect new version for compliance tracking.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk as it updates a user-facing module that customers depend on for package management. However, this is a tested stable release (1.2.0) from the PSResourceGet team. The change is limited to version references in packaging files with no code changes to PowerShell itself.
