### PR TITLE
Support file redirection to local named pipe for external applications

### DIFF
--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -281,18 +281,26 @@ namespace System.Management.Automation
                 mode = FileMode.CreateNew;
             }
 
-            if (Force && (Append || !NoClobber))
+#if UNIX
+            bool isNamedPipe = false;
+#else
+            // File.Exists and new FileInfo() will open 2 HANDLES to the file which causes problems for named pipes
+            // as it may only allow 1 client at a time. We don't need to worry about whether it exists and has the
+            // read-only attribute so just skip it altogether.
+            bool isNamedPipe = resolvedPath.StartsWith(@"\\.\pipe\", StringComparison.OrdinalIgnoreCase) ||
+                resolvedPath.StartsWith(@"\\.\mailslot\", StringComparison.OrdinalIgnoreCase);
+#endif
+
+            if (Force && (Append || !NoClobber) && !isNamedPipe)
             {
-                if (File.Exists(resolvedPath))
+                // The constructor does not fail if it does not exist, the Attributes property will just return -1.
+                FileInfo fInfo = new FileInfo(resolvedPath);
+                if ((int)fInfo.Attributes != -1 && fInfo.Attributes.HasFlag(FileAttributes.ReadOnly))
                 {
-                    FileInfo fInfo = new FileInfo(resolvedPath);
-                    if ((fInfo.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
-                    {
-                        // remember to reset the read-only attribute later
-                        readOnlyFileInfo = fInfo;
-                        // Clear the read-only attribute
-                        fInfo.Attributes &= ~(FileAttributes.ReadOnly);
-                    }
+                    // remember to reset the read-only attribute later
+                    readOnlyFileInfo = fInfo;
+                    // Clear the read-only attribute
+                    fInfo.Attributes &= ~FileAttributes.ReadOnly;
                 }
             }
 

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -1,5 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
+using namespace System.IO
+using namespace System.IO.Pipes
+using namespace System.Management.Automation
+using namespace System.Text
+using namespace System.Threading.Tasks
+
 Describe "Redirection operator now supports encoding changes" -Tags "CI" {
     BeforeAll {
         $asciiString = "abc"
@@ -237,5 +244,200 @@ Describe "Redirection and Set-Variable -append tests" -tags CI {
             }
             $observed | Should -Be $expected
         }
+    }
+}
+
+Describe "Redirection operator should work with named pipe for native commands" -tags CI {
+    BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+
+        # Named pipe logic is Windows only.
+        if (-not $IsWindows) {
+            $PSDefaultParameterValues['It:Skip'] = $true
+            return
+        }
+
+        Add-Type -TypeDefinition @'
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace RedirectionOperators.Tests;
+
+public static class NativeMethods
+{
+    [DllImport("Kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateMailslotW(
+        string lpName,
+        int nMaxMessageSize,
+        int lReadTimeout,
+        IntPtr lpSecurityAttributes);
+
+    public static FileStream CreateMailslot(string name)
+    {
+        SafeFileHandle handle = CreateMailslotW($"\\\\.\\mailslot\\{name}", 4096, -1, IntPtr.Zero);
+        if (handle.IsInvalid)
+        {
+            throw new Win32Exception();
+        }
+
+        return new FileStream(handle, FileAccess.Read, bufferSize: 4096, isAsync: true);
+    }
+}
+'@
+
+        function Invoke-WithNamedPipe {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory)]
+                [ScriptBlock]
+                $ScriptBlock,
+
+                [Parameter()]
+                [switch]
+                $UseMailslot
+            )
+
+            $pipeName = "PwshTest-$([Guid]::NewGuid())"
+
+            $pipe = $reader = $job = $null
+            try {
+                if ($UseMailslot) {
+                    $pipe = [RedirectionOperators.Tests.NativeMethods]::CreateMailslot($pipeName)
+                    $connectTask = $null
+                }
+                else {
+                    $pipe = [NamedPipeServerStream]::new(
+                        $pipeName,
+                        [PipeDirection]::In,
+                        1,
+                        [PipeTransmissionMode]::Byte,
+                        [PipeOptions]::Asynchronous)
+
+                    $connectTask = $pipe.WaitForConnectionAsync($PSCmdlet.PipelineStopToken)
+                }
+
+                $reader = [StreamReader]::new($pipe, [Encoding]::UTF8)
+
+                $job = Start-ThreadJob -ScriptBlock $ScriptBlock -ArgumentList $pipeName
+
+                if ($connectTask) {
+                    if (-not ([Task]::WaitAll([Task[]]@($connectTask), 5000, $PSCmdlet.PipelineStopToken))) {
+                        throw "Timeout waiting for pipe client to connect"
+                    }
+                    $null = $connectTask.GetAwaiter().GetResult()
+                }
+
+                $readTask = $reader.ReadLineAsync($PSCmdlet.PipelineStopToken).AsTask()
+                if (-not ([Task]::WaitAll([Task[]]@($readTask), 5000, $PSCmdlet.PipelineStopToken))) {
+                    throw "Timeout waiting for read to complete"
+                }
+                $readTask.GetAwaiter().GetResult()
+
+                $start = Get-Date
+                while ($job.State -eq 'Running') {
+                    if (((Get-Date) - $start).TotalSeconds -gt 3) {
+                        throw "Timeout waiting for the ScriptBlock to complete"
+                    }
+
+                    Start-Sleep -Milliseconds 300
+                }
+
+                $job.State | Should -Be Completed
+            }
+            catch {
+                if (-not $job) {
+                    throw
+                }
+
+                # If a ScriptBlock job was invoked, try out best to run it
+                # until the end so we can get more context behind why it failed.
+
+                if ($job.State -eq 'Running') {
+                    # We don't use Stop-Job as that will block until the stop
+                    # is complete. As we cannot guarantee the job won't block
+                    # the stop this is a best attempt to stop it.
+                    $job.StopJobAsync()
+
+                    $start = Get-Date
+                    while ($job.State -eq 'Running'){
+                        if (((Get-Date) - $start).TotalSeconds -gt 3) {
+                            break
+                        }
+
+                        Start-Sleep -Milliseconds 300
+                    }
+                }
+
+                $err = @()
+                $jobOut = $null
+                $state = $job.State
+                if ($state) {
+                    $jobOut = $job | Receive-Job -AutoRemoveJob -Wait -ErrorAction SilentlyContinue -ErrorVariable err
+                    $job = $null
+                }
+
+                $jobInfoMsg = @(
+                    "State: $state"
+
+                    "Output:"
+                    $jobOut
+
+                    ""
+
+                    "Errors:"
+                    $err | ForEach-Object {
+                        "$_`nScriptStackTrace`n$($_.ScriptStackTrace)"
+                    }
+                ) -split "\r?\n" | ForEach-Object { "`t$_" }
+
+                $msg = "$_`nScriptStackTrace`n$($_.ScriptStackTrace)`n`nScriptBlock Details`n$($jobInfoMsg -join "`n")"
+                Write-Host $msg -ForegroundColor Red
+
+                throw
+            }
+            finally {
+                ${reader}?.Dispose()
+                ${pipe}?.Dispose()
+
+                if ($job) {
+                    $job | Receive-Job -AutoRemoveJob -Wait
+                }
+            }
+        }
+    }
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+    }
+
+    It "Can redirect external application output to a named pipe" {
+        Invoke-WithNamedPipe -ScriptBlock {
+            pwsh -Command "'test output'" > "\\.\pipe\$($args[0])"
+        } | Should -BeExactly 'test output'
+    }
+
+    It "Can redirect external application output to a named pipe that is capitalised" {
+        Invoke-WithNamedPipe -ScriptBlock {
+            pwsh -Command "'test output'" > "\\.\PIPE\$($args[0])"
+        } | Should -BeExactly 'test output'
+    }
+
+    It "Can redirect external application output to an appending named pipe" {
+        Invoke-WithNamedPipe -ScriptBlock {
+            pwsh -Command "'test output'" >> "\\.\pipe\$($args[0])"
+        } | Should -BeExactly 'test output'
+    }
+
+    It "Can redirect to mailslot" {
+        Invoke-WithNamedPipe -UseMailslot -ScriptBlock {
+            pwsh -Command "'test output'" > "\\.\mailslot\$($args[0])"
+        } | Should -BeExactly 'test output'
+    }
+
+    It "Fails with expected error when pipe does not exist" {
+        $expectedMsg = "Could not find file '\\.\pipe\NonExistingPipe'"
+        { pwsh -Command "'test output'" > \\.\pipe\NonExistingPipe } | Should -Throw $expectedMsg
     }
 }

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -352,7 +352,7 @@ public static class NativeMethods
                     throw
                 }
 
-                # If a ScriptBlock job was invoked, try out best to run it
+                # If a ScriptBlock job was invoked, try our best to run it
                 # until the end so we can get more context behind why it failed.
 
                 if ($job.State -eq 'Running') {


### PR DESCRIPTION
# PR Summary
Fixes the logic when opening a file for a redirected file path to ensure only 1 HANDLE is opened for local named pipes. This allows redirection to a named pipe where there is only 1 listener.

Also optimizes the number of file HANDLES being opened from 3 to 2 for other files types.

## PR Context

Currently trying to redirect to a named pipe will result in the error

```
All pipe instances are busy. : '\\.\pipe\testpipe'.
```

This is because the redirection setup will call `CreateFileW` on the provided path 3 times with the first succeeding then the subsequent 2 fails as the named pipe no longer has an active server listener. This PR bypasses the readonly attribute tests for named pipes as they do not apply to those file types.

While this fixes redirection from an external executable, redirecting from the normal output stream to a named pipe still fails with the same error. This is because the native command processor bypasses `Out-File` to write the raw bytes directly whereas the normal file redirection goes through `Out-File -Path $redirectionPath` and the provider API `Out-File` calls will open the pipe handle as part of the `-Path` globbing matches. Maybe in the future this could also be solved but that's out of scope for this PR.

Going into a bit more detail, redirection of non-external applications end up calling [command.SessionState.Path.GetResolvedProviderPathFromPSPath(filePath, out provider)](https://github.com/PowerShell/PowerShell/blob/1f8bbe1e5332bb8fe1b39c81c366ddadbf9dd1a2/src/System.Management.Automation/utils/PathUtils.cs#L419) because `> $path` is compiled to `| Out-File -Path $path`. Something around this resolution is opening yet another HANDLE to the pipe causing the subsequent open operation later on to create the StreamWriter to fail as there are no more pipe instances to handle that. This could be solved in a few ways but as this PR is focused just on getting redirection working for external application redirection like can be done in cmd I didn't want to make it more complicated.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
