### PR TITLE
[release/v7.6] Fix the container image for vPack, MSIX vPack and Package pipelines

### DIFF
--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -22,7 +22,7 @@ variables:
   BuildSolution: $(Build.SourcesDirectory)\dirs.proj
   ReleaseTagVar: ${{ parameters.ReleaseTagVar }}
   BuildConfiguration: Release
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
   Codeql.Enabled: false  #  pipeline is not building artifacts; it repackages existing artifacts into a vpack
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
@@ -46,6 +46,9 @@ resources:
 extends:
   template: v2/Microsoft.Official.yml@onebranchTemplates
   parameters:
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
     platform:
       name: 'windows_undocked' # windows undocked
 

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -68,7 +68,7 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/azurelinux/build:3.0
   - name: WindowsContainerImage
-    value: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
+    value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)]
   - name: ReleaseTagVar
@@ -105,6 +105,7 @@ extends:
       LinuxHostVersion:
           Network: KS3
       WindowsHostVersion:
+          Version: 2022
           Network: KS3
       incrementalSDLBinaryAnalysis: true
     globalSdl:

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -41,7 +41,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: WindowsContainerImage
-    value: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+    value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
   - name: Codeql.Enabled
     value: false  #  pipeline is not building artifacts; it repackages existing artifacts into a vpack
   - name: DOTNET_CLI_TELEMETRY_OPTOUT


### PR DESCRIPTION
### PR Summary

Updates the pipeline configuration files to use newer Windows container images and sets the Windows host version to 2022 for improved compatibility and support.

Backported from #27015