### PR TITLE
[release/v7.6] Create LTS pkg and non-LTS pkg for macOS for LTS releases

### DIFF
--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -102,6 +102,10 @@ jobs:
       Restore-PSOptions -PSOptionsPath "$psoptionsPath"
       Get-PSOptions | Write-Verbose -Verbose
 
+      if (-not (Test-Path "$repoRoot/tools/metadata.json")) {
+        throw "metadata.json not found in $repoRoot/tools"
+      }
+
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
 
       Write-Verbose -Verbose "metadata:"
@@ -120,14 +124,19 @@ jobs:
       Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
-        Write-Verbose -Message "LTS Release: $LTS"
+        Write-Verbose -Message "LTS Release: $LTS" -Verbose
       }
 
       Start-PSBootstrap -Scenario Package
 
       $macosRuntime = "osx-$buildArch"
 
-      Start-PSPackage -Type osxpkg -SkipReleaseChecks -MacOSRuntime $macosRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath -LTS:$LTS
+      Start-PSPackage -Type osxpkg -SkipReleaseChecks -MacOSRuntime $macosRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath
+
+      if ($LTS) {
+        Start-PSPackage -Type osxpkg -SkipReleaseChecks -MacOSRuntime $macosRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath -LTS
+      }
+
       $pkgNameFilter = "powershell-*$macosRuntime.pkg"
       Write-Verbose -Verbose "Looking for pkg packages with filter: $pkgNameFilter in '$(Pipeline.Workspace)' to upload..."
       $pkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $pkgNameFilter -Recurse -File


### PR DESCRIPTION
Backport of #27039 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27039$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Changes macOS packaging build pipeline to create both standard and LTS packages for LTS releases. This ensures users can distinguish between LTS and non-LTS packages on macOS, matching behavior of other platforms.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Backported from proven commits (27f04197 and ed53cf52) already in release/v7.4 branch. Build pipeline changes will be verified by CI. Original commits created both standard and LTS macOS packages as intended.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Changes affect the macOS build pipeline infrastructure, but are well-scoped to LTS package creation only. Changes have been validated in v7.4 release branch. Builds will fail early if there are issues, preventing bad packages.
