### PR TITLE
Fix the `PSNativeCommandArgumentPassing` test

### DIFF
--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -5,12 +5,7 @@ param()
 
 Describe "Behavior is specific for each platform" -tags "CI" {
     It "PSNativeCommandArgumentPassing is set to 'Windows' on Windows systems" -skip:(-not $IsWindows) {
-        if ([Version]::TryParse($PSVersiontable.PSVersion.ToString(), [ref]$null)) {
-            $PSNativeCommandArgumentPassing | Should -BeExactly "Legacy"
-        }
-        else {
-            $PSNativeCommandArgumentPassing | Should -BeExactly "Windows"
-        }
+        $PSNativeCommandArgumentPassing | Should -BeExactly "Windows"
     }
     It "PSNativeCommandArgumentPassing is set to 'Standard' on non-Windows systems" -skip:($IsWindows) {
         $PSNativeCommandArgumentPassing | Should -Be "Standard"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix the `PSNativeCommandArgumentPassing` test. This test is failing in release automation for Stable and LTS releases.
