### PR TITLE
[release/v7.6] Fix PMC Repo URL for RHEL10 

### DIFF
--- a/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run/Run.ps1
+++ b/.pipelines/EV2Specs/ServiceGroupRoot/Shell/Run/Run.ps1
@@ -64,7 +64,7 @@ function Get-MappedRepositoryIds {
                     $repoIds.AddRange(([string[]]$repos.id))
                 }
                 else {
-                    Write-Failure "Could not find repo for $urlGlob"
+                    throw "Could not find repo for $urlGlob"
                 }
 
                 if ($repoIds.Count -gt 0) {

--- a/tools/packages.microsoft.com/mapping.json
+++ b/tools/packages.microsoft.com/mapping.json
@@ -22,7 +22,7 @@
           "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.rh.x86_64.rpm"
       },
       {
-          "url": "microsoft-rhel10.0-prod",
+          "url": "microsoft-rhel10-prod",
           "distribution": [
               "stable"
           ],


### PR DESCRIPTION
Backport of #27059 to release/v7.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27059$$$
-->

Triggered by @daxian-dbw on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Required tooling change: Fixes PMC repository URL mapping for RHEL10 to enable package retrieval. Without this fix, RHEL10 users would not be able to access PowerShell packages from packages.microsoft.com. Also fixes bug where missing repo URL would not throw an error in the pipeline script.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR tested by verifying PMC repository URL resolution for RHEL10. Backport verified by cherry-picking cleanly to release/v7.6 without conflicts and validating the mapping.json structure remains valid.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: Changes PMC repository URL mapping for RHEL10. Scoped to new OS version only, does not affect existing supported OS versions. The change follows established patterns for other RHEL versions. Risk is mitigated by the fact that this fixes broken package retrieval for RHEL10.
