### PR TITLE
Fix generic List conversion from Boolean scalar - Issue #17731

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -3901,7 +3901,11 @@ namespace System.Management.Automation
 
                 if (IsScalar)
                 {
-                    resultAsList.Add(valueToConvert);
+                    // Fix for Issue #17731: Convert scalar to element type before adding to list
+                    // Previously, this directly added the value without conversion, which failed for
+                    // types like bool where the value's runtime type differs from the expected type
+                    object convertedValue = LanguagePrimitives.ConvertTo(valueToConvert, ElementType, formatProvider);
+                    resultAsList.Add(convertedValue);
                 }
                 else if (array == null)
                 {

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -223,4 +223,32 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $convertedValue = [System.Management.Automation.LanguagePrimitives]::ConvertTo($formattedNumber, [bigint])
         $convertedValue | Should -Be 1
     }
+
+    # Issue #17731 - Generic List conversion from scalar
+    It 'Converts Boolean scalar to Generic List[bool]' {
+        $result = [System.Collections.Generic.List[bool]]$true
+        $result | Should -BeOfType [System.Collections.Generic.List[bool]]
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be $true
+    }
+
+    It 'Converts Boolean `$false to Generic List[bool]' {
+        $result = [System.Collections.Generic.List[bool]]$false
+        $result | Should -BeOfType [System.Collections.Generic.List[bool]]
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be $false
+    }
+
+    It 'Converts Boolean variable to Generic List[bool]' {
+        $boolVar = $true
+        $result = [System.Collections.Generic.List[bool]]$boolVar
+        $result[0] | Should -Be $true
+    }
+
+    It 'Converts PSObject to Generic List[psobject]' {
+        $result = [System.Collections.Generic.List[psobject]]$true
+        $result | Should -BeOfType [System.Collections.Generic.List[psobject]]
+        $result.Count | Should -Be 1
+        $result[0] | Should -Be $true
+    }
 }


### PR DESCRIPTION
## Summary

Fixes Issue #17731 - Cannot directly construct a generic list from a Boolean scalar

## Problem

The following statements return an error:
\\\powershell
[System.Collections.Generic.List[bool]]$False
[System.Collections.Generic.List[bool]]$True
[System.Collections.Generic.List[psobject]]$True
\\\

While these statements work fine:
\\\powershell
[System.Collections.Generic.List[int]]3
[System.Collections.Generic.List[string]]'Test'
[Array]$True
\\\

## Root Cause

The \ConvertViaIEnumerableConstructor.Convert\ method was directly adding the scalar value to the list without converting it to the element type first. This worked for types like \int\ where the value's runtime type matches the expected element type, but failed for \ool\ because the PowerShell Boolean wrapper type differs from \System.Boolean\.

## Fix

Use \LanguagePrimitives.ConvertTo\ to convert the scalar value to the element type before adding to the list, similar to how non-scalar values are handled.

### Changed Files
- \src/System.Management.Automation/engine/LanguagePrimitives.cs\
- \	est/powershell/engine/Api/LanguagePrimitive.Tests.ps1\

## Testing

Added tests for:
- \[List[bool]]\$true\
- \[List[bool]]\$false\
- \[List[bool]]\$boolVar\
- \[List[psobject]]\$true\

Fixes #17731