### PR TITLE
Fix positional parameter re-binding when parameter appears in multiple sets

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1823,6 +1823,14 @@ namespace System.Management.Automation.Language
             uint localParameterSetFlag = 0;
             foreach (PositionalCommandParameter parameter in nextPositionalParameters.Values)
             {
+                // Skip parameters that were already bound at a previous position.
+                // Mirrors the same guard in BindPositionalParametersInSet().
+                // See https://github.com/PowerShell/PowerShell/issues/2212
+                if (_boundParameters.ContainsKey(parameter.Parameter.Parameter.Name))
+                {
+                    continue;
+                }
+
                 foreach (ParameterSetSpecificMetadata parameterSetData in parameter.ParameterSetData)
                 {
                     // Skip it if it's not in the specified parameter set

--- a/src/System.Management.Automation/engine/ParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderController.cs
@@ -929,6 +929,16 @@ namespace System.Management.Automation
 
             foreach (PositionalCommandParameter parameter in nextPositionalParameters.Values)
             {
+                // Skip parameters that were already bound at a previous position.
+                // A parameter can appear at multiple positions across different parameter sets
+                // (e.g., Position=0 in set 'Two' and Position=1 in set 'One'). Once bound,
+                // it must not be re-bound (and overwritten) when the loop reaches the other position.
+                // See https://github.com/PowerShell/PowerShell/issues/2212
+                if (BoundParameters.ContainsKey(parameter.Parameter.Parameter.Name))
+                {
+                    continue;
+                }
+
                 foreach (ParameterSetSpecificMetadata parameterSetData in parameter.ParameterSetData)
                 {
                     // if the parameter is not in the specified parameter set, don't consider it

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -51,7 +51,7 @@ Describe "TabCompletion" -Tags CI {
                 New-ModuleManifest -Path "$($NewDir.FullName)\$ModuleName.psd1" -RootModule "$ModuleName.psm1" -FunctionsToExport "MyTestFunction" -ModuleVersion $NewDir.Name
             }
 
-            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir            
+            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir
             $Res = TabExpansion2 -inputScript MyTestFunction
             $Res.CompletionMatches.Count | Should -Be 2
             $SortedMatches = $Res.CompletionMatches.CompletionText | Sort-Object
@@ -82,7 +82,7 @@ Describe "TabCompletion" -Tags CI {
                 New-ModuleManifest -Path "$($NewDir.FullName)\$ModuleName.psd1" -RootModule "$ModuleName.psm1" -FunctionsToExport "MyTestFunction" -ModuleVersion $NewDir.Name
             }
 
-            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir            
+            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir
             $Res = TabExpansion2 -inputScript 'Import-Module -Name TestModule'
             $Res.CompletionMatches.Count | Should -Be 1
             $Res.CompletionMatches[0].CompletionText | Should -Be TestModule1
@@ -165,21 +165,21 @@ Describe "TabCompletion" -Tags CI {
         $res = TabExpansion2 -inputScript 'param($PS = $P'
         $res.CompletionMatches.Count | Should -BeGreaterThan 0
     }
-    
+
     It 'Should complete variable with description and value <Value>' -TestCases @(
         @{ Value = 1; Expected = '[int]$VariableWithDescription - Variable description' }
         @{ Value = 'string'; Expected = '[string]$VariableWithDescription - Variable description' }
         @{ Value = $null; Expected = 'VariableWithDescription - Variable description' }
     ) {
         param ($Value, $Expected)
-        
+
         New-Variable -Name VariableWithDescription -Value $Value -Description 'Variable description' -Force
         $res = TabExpansion2 -inputScript '$VariableWithDescription'
         $res.CompletionMatches.Count | Should -Be 1
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '$VariableWithDescription'
         $res.CompletionMatches[0].ToolTip | Should -BeExactly $Expected
     }
-    
+
     It 'Should complete environment variable' {
         try {
             $env:PWSH_TEST_1 = 'value 1'
@@ -226,7 +226,7 @@ Describe "TabCompletion" -Tags CI {
         @{ Value = $null; Expected = 'VariableWithDescription - Variable description' }
     ) {
         param ($Value, $Expected)
-        
+
         New-Variable -Name VariableWithDescription -Value $Value -Description 'Variable description' -Force
         $res = TabExpansion2 -inputScript '$local:VariableWithDescription'
         $res.CompletionMatches.Count | Should -Be 1
@@ -1191,7 +1191,7 @@ param([ValidatePattern(
                 [Parameter(ParameterSetName = 'SetWithoutHelp')]
                 [string]
                 $ParamWithHelp,
-                
+
                 [Parameter(ParameterSetName = 'SetWithHelp')]
                 [switch]
                 $ParamWithoutHelp
@@ -1733,7 +1733,7 @@ param([ValidatePattern(
 
             $commaSeparators = "',' ', '"
             $semiColonSeparators = "';' '; '"
-            
+
             $squareBracketFormatString = "'[{0}]'"
             $curlyBraceFormatString = "'{0:N2}'"
         }
@@ -2097,6 +2097,159 @@ Verb-Noun -Param1 Hello ^
         $res.CompletionMatches[0].CompletionText | Should -Be "Attributes"
     }
 
+    Context 'Positional parameter completion with multi-set parameters (issue #2212)' {
+        BeforeAll {
+            function Test-Func2212 {
+                [CmdletBinding(DefaultParameterSetName = 'Two')]
+                param(
+                    [Parameter(ParameterSetName = 'One', Position = 1)]
+                    [Parameter(ParameterSetName = 'Two', Position = 0)]
+                    [string]$First,
+
+                    [Parameter(ParameterSetName = 'Two', Position = 1)]
+                    [string]$Second,
+
+                    [Parameter(ParameterSetName = 'One', Position = 0)]
+                    [string]$OnlyOne
+                )
+            }
+
+            function Test-FuncSamePos {
+                [CmdletBinding(DefaultParameterSetName = 'Alpha')]
+                param(
+                    [Parameter(ParameterSetName = 'Alpha', Position = 0)]
+                    [string]$AlphaValue,
+
+                    [Parameter(ParameterSetName = 'Beta', Position = 0)]
+                    [string]$BetaValue
+                )
+            }
+
+            function Test-FuncMultiSetNamed {
+                [CmdletBinding(DefaultParameterSetName = 'A')]
+                param(
+                    [Parameter(ParameterSetName = 'A', Position = 0)]
+                    [Parameter(ParameterSetName = 'B', Position = 1)]
+                    [string]$Alpha,
+
+                    [Parameter(ParameterSetName = 'A')]
+                    [string]$OnlyA,
+
+                    [Parameter(ParameterSetName = 'B', Position = 0)]
+                    [string]$OnlyB
+                )
+            }
+
+            function Test-Func2212Arg {
+                [CmdletBinding()]
+                param(
+                    [Parameter(Position = 0)]
+                    [string]$Param1,
+
+                    [Parameter(Position = 1)]
+                    [System.Management.Automation.ActionPreference]$Param2
+                )
+            }
+
+            function Test-Func2212FakeBound {
+                [CmdletBinding(DefaultParameterSetName = 'Two')]
+                param(
+                    [Parameter(ParameterSetName = 'One', Position = 1)]
+                    [Parameter(ParameterSetName = 'Two', Position = 0)]
+                    [string]$First,
+
+                    [Parameter(ParameterSetName = 'Two', Position = 1)]
+                    [string]$Second,
+
+                    [Parameter(ParameterSetName = 'One', Position = 0)]
+                    [string]$OnlyOne,
+
+                    [ArgumentCompleter({
+                        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+                        $hasFirst = [string]$fakeBoundParameters.Contains('First')
+                        $hasSecond = [string]$fakeBoundParameters.Contains('Second')
+                        $hasOnlyOne = [string]$fakeBoundParameters.Contains('OnlyOne')
+
+                        $firstValue = if ($fakeBoundParameters.Contains('First')) { [string]$fakeBoundParameters['First'] } else { '<none>' }
+                        $secondValue = if ($fakeBoundParameters.Contains('Second')) { [string]$fakeBoundParameters['Second'] } else { '<none>' }
+                        $onlyOneValue = if ($fakeBoundParameters.Contains('OnlyOne')) { [string]$fakeBoundParameters['OnlyOne'] } else { '<none>' }
+
+                        $results = @(
+                            "HasFirst:$hasFirst",
+                            "HasSecond:$hasSecond",
+                            "HasOnlyOne:$hasOnlyOne",
+                            "FirstValue:$firstValue",
+                            "SecondValue:$secondValue",
+                            "OnlyOneValue:$onlyOneValue"
+                        )
+
+                        foreach ($item in $results)
+                        {
+                            [System.Management.Automation.CompletionResult]::new($item, $item, 'ParameterValue', $item)
+                        }
+                    })]
+                    [string]$Probe
+                )
+            }
+        }
+
+        it 'Should not offer already-bound positional parameter for completion (issue #2212)' {
+            $ScriptInput = 'Test-Func2212 Hello -'
+            $res = TabExpansion2 -inputScript $ScriptInput -cursorColumn $ScriptInput.Length
+            $completionTexts = $res.CompletionMatches.CompletionText
+            $completionTexts | Should -Contain '-Second'
+            $completionTexts | Should -Not -Contain '-First'
+        }
+
+        it 'Should not offer re-bound parameter after two positional args (issue #2212)' {
+            $ScriptInput = 'Test-Func2212 Hello World -'
+            $res = TabExpansion2 -inputScript $ScriptInput -cursorColumn $ScriptInput.Length
+            $completionTexts = $res.CompletionMatches.CompletionText
+            $completionTexts | Should -Not -Contain '-First'
+            $completionTexts | Should -Not -Contain '-Second'
+            $completionTexts | Should -Contain '-Verbose'
+        }
+
+        it 'Should offer correct parameters when named param narrows set with multi-position parameter' {
+            $ScriptInput = 'Test-FuncMultiSetNamed -OnlyA val -'
+            $res = TabExpansion2 -inputScript $ScriptInput -cursorColumn $ScriptInput.Length
+            $completionTexts = $res.CompletionMatches.CompletionText
+            $completionTexts | Should -Contain '-Alpha'
+            $completionTexts | Should -Not -Contain '-OnlyB'
+        }
+
+        it 'Should complete argument for correct positional parameter with multi-set positions' {
+            $ScriptInput = 'Test-Func2212Arg Hello '
+            $res = TabExpansion2 -inputScript $ScriptInput -cursorColumn $ScriptInput.Length
+            $completionTexts = $res.CompletionMatches.CompletionText
+            $completionTexts | Should -Contain 'Break'
+            $completionTexts | Should -Contain 'Continue'
+        }
+
+        it 'Should handle same numeric position in different sets during completion' {
+            $ScriptInput = 'Test-FuncSamePos val1 -'
+            $res = TabExpansion2 -inputScript $ScriptInput -cursorColumn $ScriptInput.Length
+            $completionTexts = $res.CompletionMatches.CompletionText
+            $completionTexts | Should -Not -Contain '-AlphaValue'
+            $completionTexts | Should -Not -Contain '-BetaValue'
+            $completionTexts | Should -Contain '-Verbose'
+        }
+
+        it 'Should pass correct fakeBoundParameters for multi-set positional binding (issue #2212)' {
+            $ScriptInput = 'Test-Func2212FakeBound Hello World -Probe '
+            $res = TabExpansion2 -inputScript $ScriptInput -cursorColumn $ScriptInput.Length
+            $completionTexts = $res.CompletionMatches.CompletionText
+
+            $completionTexts | Should -Contain 'HasFirst:True'
+            $completionTexts | Should -Contain 'HasSecond:True'
+            $completionTexts | Should -Contain 'HasOnlyOne:False'
+            $completionTexts | Should -Contain 'FirstValue:Hello'
+            $completionTexts | Should -Contain 'SecondValue:World'
+            $completionTexts | Should -Contain 'OnlyOneValue:<none>'
+        }
+    }
+
     it 'Should complete base class members of types without type definition AST' {
         $res = TabExpansion2 -inputScript @'
 class InheritedClassTest : System.Attribute
@@ -2408,7 +2561,7 @@ param ($Param1)
             $null = New-Item -Path $TestFile
             $res = TabExpansion2 -ast $scriptAst -tokens $tokens -positionOfCursor $cursorPosition
             Pop-Location
-                        
+
             $ExpectedPath = Join-Path -Path '.\' -ChildPath $ExpectedFileName
             $res.CompletionMatches.CompletionText | Where-Object {$_ -Like "*$ExpectedFileName"} | Should -Be $ExpectedPath
         }

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -515,4 +515,135 @@ Describe "Tests for parameter binding" -Tags "CI" {
         #The position of the enumerator shouldn't be modified
         $b.current | Should -Be 1
     }
+
+    Context 'Positional parameter binding across multiple parameter sets (issue #2212)' {
+        It 'Parameter with different positions across parameter sets binds correctly' {
+            function Test-PositionalBinding2212 {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ParameterSetName = 'Two', Position = 0)]
+                    [Parameter(ParameterSetName = 'One', Position = 1)]
+                    [string] $First,
+
+                    [Parameter(ParameterSetName = 'Two', Position = 1)]
+                    [string] $Second
+                )
+
+                @{
+                    ParameterSet = $PSCmdlet.ParameterSetName
+                    First = $First
+                    Second = $Second
+                }
+            }
+
+            $result = Test-PositionalBinding2212 Hello World
+            $result.ParameterSet | Should -BeExactly 'Two'
+            $result.First | Should -BeExactly 'Hello'
+            $result.Second | Should -BeExactly 'World'
+        }
+
+        It 'PSBoundParameters correctly reflects positional binding across parameter sets' {
+            function Test-BoundParams2212 {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ParameterSetName = 'Two', Position = 0)]
+                    [Parameter(ParameterSetName = 'One', Position = 1)]
+                    [string] $First,
+
+                    [Parameter(ParameterSetName = 'Two', Position = 1)]
+                    [string] $Second
+                )
+
+                $PSBoundParameters
+            }
+
+            $bound = Test-BoundParams2212 Hello World
+            $bound['First'] | Should -BeExactly 'Hello'
+            $bound['Second'] | Should -BeExactly 'World'
+            $bound.Count | Should -Be 2
+        }
+
+        It 'Named parameter binding still works when parameter has different positions across sets' {
+            function Test-NamedBinding2212 {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ParameterSetName = 'Two', Position = 0)]
+                    [Parameter(ParameterSetName = 'One', Position = 1)]
+                    [string] $First,
+
+                    [Parameter(ParameterSetName = 'Two', Position = 1)]
+                    [string] $Second
+                )
+
+                @{
+                    ParameterSet = $PSCmdlet.ParameterSetName
+                    First = $First
+                    Second = $Second
+                }
+            }
+
+            $result = Test-NamedBinding2212 -First Hello -Second World
+            $result.ParameterSet | Should -BeExactly 'Two'
+            $result.First | Should -BeExactly 'Hello'
+            $result.Second | Should -BeExactly 'World'
+        }
+
+        It 'Parameter at same numeric position across sets does not double-bind' {
+            # Regression: Position=5 in SetA and Position=5 in SetB caused the same
+            # double-binding symptom as the primary issue.
+            function Test-PositionalSamePosition {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ParameterSetName = 'SetA', Position = 0)]
+                    [Parameter(ParameterSetName = 'SetB', Position = 5)]
+                    [string] $Alpha,
+
+                    [Parameter(ParameterSetName = 'SetA', Position = 5)]
+                    [string] $Beta
+                )
+
+                @{
+                    ParameterSet = $PSCmdlet.ParameterSetName
+                    Alpha = $Alpha
+                    Beta = $Beta
+                }
+            }
+
+            $result = Test-PositionalSamePosition Foo Bar
+            $result.ParameterSet | Should -BeExactly 'SetA'
+            $result.Alpha | Should -BeExactly 'Foo'
+            $result.Beta | Should -BeExactly 'Bar'
+        }
+
+        It 'Parameter at different positions across three parameter sets binds correctly' {
+            function Test-ThreeSetPositional {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ParameterSetName = 'A', Position = 0)]
+                    [Parameter(ParameterSetName = 'B', Position = 1)]
+                    [Parameter(ParameterSetName = 'C', Position = 2)]
+                    [string] $Param1,
+
+                    [Parameter(ParameterSetName = 'A', Position = 1)]
+                    [string] $Param2,
+
+                    [Parameter(ParameterSetName = 'A', Position = 2)]
+                    [string] $Param3
+                )
+
+                @{
+                    ParameterSet = $PSCmdlet.ParameterSetName
+                    Param1 = $Param1
+                    Param2 = $Param2
+                    Param3 = $Param3
+                }
+            }
+
+            $result = Test-ThreeSetPositional X Y Z
+            $result.ParameterSet | Should -BeExactly 'A'
+            $result.Param1 | Should -BeExactly 'X'
+            $result.Param2 | Should -BeExactly 'Y'
+            $result.Param3 | Should -BeExactly 'Z'
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

Fixes a bug where a parameter declared with **different `Position` values across multiple parameter sets** would be bound twice during positional argument processing, overwriting the correct value.

#2212 

### Root Cause

`EvaluateUnboundPositionalParameters()` correctly inserts a parameter into the sorted positional dictionary once per parameter set it belongs to — meaning a parameter that is `Position=0` in set `Two` and `Position=1` in set `One` appears at **both** dictionary keys. When `BindPositionalParametersInSet()` iterates these keys in sorted order, it would bind the parameter at position 0 (correctly), then encounter the same parameter again at position 1 and re-bind it — overwriting `$First` with the argument intended for `$Second`, and then also binding `$Second` to that same argument.

### Fix

Added a `BoundParameters.ContainsKey` guard at the top of the outer `foreach` loop in `BindPositionalParametersInSet()` (`ParameterBinderController.cs`) so that a parameter already bound at an earlier position is skipped. The equivalent guard was added to `BindPseudoPositionalParameterInSet()` in `PseudoParameterBinder.cs` so that tab-completion behavior stays consistent with runtime binding.

### Files Changed

| File | Change |
|------|--------|
| `engine/ParameterBinderController.cs` | Skip already-bound parameters in `BindPositionalParametersInSet()` |
| `engine/CommandCompletion/PseudoParameterBinder.cs` | Same guard in `BindPseudoPositionalParameterInSet()` for consistency |
| `ParameterBinding.Tests.ps1` | 5 new Pester tests covering the exact repro and edge cases |

### Testing

All 5 new `CI`-tagged tests pass (`Tests Passed: 44, Failed: 0`) when run against the fixed build on Windows x64.

Reproduction from the original issue:

```powershell
function Test-It {
    [CmdletBinding()]
    param(
        [Parameter(ParameterSetName = 'Two', Position = 0)]
        [Parameter(ParameterSetName = 'One', Position = 1)]
        [string] $First,

        [Parameter(ParameterSetName = 'Two', Position = 1)]
        [string] $Second
    )
    "$First / $Second"
}

Test-It Hello World   # Before fix: "World / World"  After fix: "Hello / World"
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)