### PR TITLE
Assign HtmlEncode result back to -Title in ConvertTo-Html

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertTo-Html.cs
@@ -451,7 +451,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (!string.IsNullOrEmpty(_title))
             {
-                WebUtility.HtmlEncode(_title);
+                _title = WebUtility.HtmlEncode(_title);
             }
 
             // This first line ensures w3c validation will succeed. However we are not specifying

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
@@ -99,6 +99,15 @@ Body Text
         $returnString | Should -Be $expectedValue
     }
 
+    It "ConvertTo-Html -Title HTML-encodes special characters in the document title" {
+        # Regression: BeginProcessing must assign WebUtility.HtmlEncode(_title) back to _title;
+        # otherwise the encode result is discarded and raw <, >, &, " appear in <title>.
+        $title = 'A <B> & C "D"'
+        $expectedInner = [System.Net.WebUtility]::HtmlEncode($title)
+        $returnString = ($customObject | ConvertTo-Html -Title $title) -join $newLine
+        $returnString | Should -Match "<title>$([regex]::Escape($expectedInner))</title>"
+    }
+
     It "Test ConvertTo-Html pre and post" {
         $returnString = ($customObject | ConvertTo-Html -PreContent "Before the object" -PostContent "After the object") -join $newLine
         $expectedValue = normalizeLineEnds @"


### PR DESCRIPTION
## Summary

Ensures `-Title` text is HTML-encoded in the generated document so characters such as `<`, `>`, `&`, and quotes do not break the `<title>` element or inject unintended markup.

## Changes

- Assign `WebUtility.HtmlEncode(_title)` back to `_title` in `BeginProcessing`.
- Add a Pester regression test that compares the emitted `<title>` content to `[System.Net.WebUtility]::HtmlEncode` for the same input.

## Testing

- `Invoke-Pester` on `test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1` (new `It` block).