### PR TITLE
LanguagePrimitives: fix second enum value in wildcard duplicate-match error

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -2214,7 +2214,7 @@ namespace System.Management.Automation
                         if (!multipleValues && foundOne)
                         {
                             object firstValue = Enum.ToObject(destinationType, returnUInt64);
-                            object secondValue = Enum.ToObject(destinationType, Convert.ToUInt64(values.GetValue(i), CultureInfo.CurrentCulture));
+                            object secondValue = Enum.ToObject(destinationType, Convert.ToUInt64(values.GetValue(j), CultureInfo.CurrentCulture));
                             throw new PSInvalidCastException("InvalidCastEnumTwoStringsFoundAndNoFlags", null,
                                 ExtendedTypeSystem.InvalidCastExceptionEnumerationMoreThanOneValue,
                                 sourceValue, destinationType, firstValue, secondValue);

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -223,4 +223,37 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $convertedValue = [System.Management.Automation.LanguagePrimitives]::ConvertTo($formattedNumber, [bigint])
         $convertedValue | Should -Be 1
     }
+
+    It 'Wildcard enum string matching two members lists both distinct values in the cast error' {
+        # Regression: the second conflicting match used values.GetValue(i) (outer source index) instead of
+        # values.GetValue(j) (enum member index), so the message repeated the first member as the second.
+        # LanguagePrimitives.ConvertTo(string, enum) often resolves via Enum.Parse / EnumMinimumDisambiguation
+        # first; EnumSingleTypeConverter.ConvertFrom hits the wildcard branch that contains the fix.
+        $enumTypeName = 'TestLanguagePrimitivesEnumDup.TwoMemberNoFlags'
+        if (-not ($enumTypeName -as [type])) {
+            Add-Type -TypeDefinition @'
+namespace TestLanguagePrimitivesEnumDup {
+    public enum TwoMemberNoFlags {
+        Alpha = 0,
+        Beta = 1
+    }
+}
+'@
+        }
+
+        $enumType = [TestLanguagePrimitivesEnumDup.TwoMemberNoFlags]
+        $asm = [System.Management.Automation.LanguagePrimitives].Assembly
+        $converterType = $asm.GetType('System.Management.Automation.LanguagePrimitives+EnumSingleTypeConverter')
+        $inst = [Activator]::CreateInstance($converterType, $true)
+        $ex = $null
+        try {
+            $null = $inst.ConvertFrom('*', $enumType, [cultureinfo]::InvariantCulture, $true)
+        } catch {
+            $ex = $_.Exception.GetBaseException()
+        }
+
+        $ex | Should -BeOfType [System.Management.Automation.PSInvalidCastException]
+        $ex.Message | Should -Match '\(Alpha, Beta\)'
+        $ex.Message | Should -Not -Match '\(Alpha, Alpha\)'
+    }
 }


### PR DESCRIPTION
## Summary

Ensures the `InvalidCastEnumTwoStringsFoundAndNoFlags` error lists the correct second enumerator when a wildcard string matches two names on a non-flags enumeration (the message previously repeated the first match).

## Changes

- In `EnumSingleTypeConverter.BaseConvertFrom`, use `values.GetValue(j)` for the second conflicting match instead of `values.GetValue(i)`.
- Add a Pester regression test that calls `EnumSingleTypeConverter.ConvertFrom` (via reflection) so the wildcard branch is exercised.

## Testing

- Local: `Invoke-Pester` on `test/powershell/engine/Api/LanguagePrimitive.Tests.ps1` (new `It` block).