### PR TITLE
Host: fix Rectangle.GetHashCode when Left XOR Right is negative

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
@@ -875,7 +875,7 @@ namespace System.Management.Automation.Host
                 }
                 else
                 {
-                    i64 += (UInt64)(-upper);
+                    i64 += (UInt64)(-lower);
                 }
             }
             else

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -96,3 +96,13 @@ Describe 'PushRunspaceLocalFailure' -Tags 'CI' {
         }
     }
 }
+
+Describe 'Host.Rectangle.GetHashCode' -Tags 'CI' {
+    It 'Folds negative (Left XOR Right) using lower, not upper, bits' {
+        # Regression: the branch for lower < 0 (and not Int32.MinValue) incorrectly did
+        # i64 += (UInt64)(-upper) instead of (UInt64)(-lower).
+        # left=-1, right=0 -> lower = -1; top=bottom=0 -> upper = 0. Correct i64 low part is 1; buggy was 0.
+        $rect = [System.Management.Automation.Host.Rectangle]::new(-1, 0, 0, 0)
+        $rect.GetHashCode() | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Summary

Corrects `Rectangle.GetHashCode()` when `(Left ^ Right)` is negative (and not `Int32.MinValue`): the lower 32-bit contribution must use `-lower`, not `-upper`, so the hash matches the intended mix of vertical and horizontal XOR halves.

## Changes

- In `MshHostRawUserInterface.cs`, use `(UInt64)(-lower)` in the non-`MinValue` negative branch of the lower-half fold.
- Add a `Host.Rectangle.GetHashCode` Pester test (`Tags: CI`) for `Rectangle(-1, 0, 0, 0)` (expected `GetHashCode() == 1` with the fix).

## Testing

- `Invoke-Pester` on `test/powershell/Host/HostUtilities.Tests.ps1` (new `Describe` block).