### PR TITLE
PSStyle: validate background index against BackgroundColorMap

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -892,7 +892,7 @@ namespace System.Management.Automation
                 throw new ArgumentOutOfRangeException(paramName: nameof(foregroundColor));
             }
 
-            if (backIndex < 0 || backIndex >= ForegroundColorMap.Length)
+            if (backIndex < 0 || backIndex >= BackgroundColorMap.Length)
             {
                 throw new ArgumentOutOfRangeException(paramName: nameof(backgroundColor));
             }


### PR DESCRIPTION
## Summary

Fixes `FromAnsiColor` so the background color index is validated against `BackgroundColorMap.Length` instead of `ForegroundColorMap.Length`, matching the map used for conversion and avoiding incorrect `ArgumentOutOfRangeException` behavior when the two maps differ in size.

## Changes

- In `PSStyle.cs`, compare `backIndex` to `BackgroundColorMap.Length` in the background branch.

## Testing

- Manual review; consider adding a unit test if `ForegroundColorMap` and `BackgroundColorMap` lengths can diverge in this codebase.