### PR TITLE
ThrottleManager: fix IgnoreStop setter to honor assigned value

### DIFF
--- a/src/System.Management.Automation/engine/remoting/common/throttlemanager.cs
+++ b/src/System.Management.Automation/engine/remoting/common/throttlemanager.cs
@@ -127,7 +127,7 @@ namespace System.Management.Automation.Remoting
 
             set
             {
-                _ignoreStop = true;
+                _ignoreStop = value;
             }
         }
 


### PR DESCRIPTION
## Summary

Ensures `IgnoreStop` can be set to `false` as intended. The setter previously ignored the assigned value and always set the backing field to `true`.

## Changes

- In `throttlemanager.cs`, set `_ignoreStop` from the property `value` instead of a constant `true`.