### PR TITLE
Fix repeat builds with persisted source-generated files

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -109,9 +109,6 @@
 
     </PropertyGroup>
 
-    <!-- Remove existing generated files by source generators because new source code will soon be generated when the build starts -->
-    <RemoveDir Directories="gen\SourceGenerated" Condition="Exists('gen\SourceGenerated')" />
-
     <!-- Output For Debugging
       <WriteLinesToFile File="targetfile1.txt"
         Lines="ReleaseTag=$(ReleaseTag);

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -51,8 +51,6 @@
 
   <ItemGroup>
     <!-- exclude code of source generators from compilation and IDEs (e.g. vscode and visual studio) -->
-    <Compile Remove="SourceGenerators\**\*.cs" />
-    <!-- keep persisted generator output visible on disk without compiling it as project source -->
     <Compile Remove="gen\SourceGenerated\**\*.cs" />
 
     <Compile Remove="cimSupport\cmdletization\xml\cmdlets-over-objects.objectModel.autogen.cs" />

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -52,6 +52,8 @@
   <ItemGroup>
     <!-- exclude code of source generators from compilation and IDEs (e.g. vscode and visual studio) -->
     <Compile Remove="SourceGenerators\**\*.cs" />
+    <!-- keep persisted generator output visible on disk without compiling it as project source -->
+    <Compile Remove="gen\SourceGenerated\**\*.cs" />
 
     <Compile Remove="cimSupport\cmdletization\xml\cmdlets-over-objects.objectModel.autogen.cs" />
     <Compile Remove="cimSupport\cmdletization\xml\cmdlets-over-objects.xmlSerializer.autogen.cs" />


### PR DESCRIPTION
# PR Summary

Remove the removal of existing generated files by source generators to allow persisted generator output to remain visible on disk without compiling it as project source.

## PR Context

This change addresses issues with repeat builds by ensuring that source-generated files are not deleted at the start of the build process, thus maintaining their availability for subsequent builds.
  
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

