### PR TITLE
Fix Remove-Item confirmation message

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2718,7 +2718,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         // Get the localized prompt string
 
-                        string prompt = StringUtil.Format(NavigationResources.RemoveItemWithChildren, resolvedPath.Path);
+                        string prompt = StringUtil.Format(NavigationResources.RemoveItemWithChildren, providerPath);
 
                         // Confirm the user wants to remove all children and the item even if
                         // they did not specify -recurse


### PR DESCRIPTION
Use earlier obtained `providerPath` to format the prompt string.

before:
<img width="855" height="137" alt="图片" src="https://github.com/user-attachments/assets/b297063c-ec6a-48f1-a5d7-adc258dfd927" />
after:
<img width="1059" height="118" alt="图片" src="https://github.com/user-attachments/assets/05e2f8f3-7d65-4aba-be86-846f390936f5" />
