### PR TITLE
Revert "Fetch latest ICU release version dynamically"

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2152,7 +2152,7 @@ function Get-PackageDependencies
         #   than the build version and we know that older versions just works.
         #
         $MinICUVersion = 60                    # runtime minimum supported
-        $BuildICUVersion = Get-IcuLatestRelease
+        $BuildICUVersion = 76                  # current build version
         $MaxICUVersion = $BuildICUVersion + 30 # headroom
 
         if ($Distribution -eq 'deb') {
@@ -5808,16 +5808,4 @@ function Test-IsProductFile {
     }
 
     return $false
-}
-
-# Get major version from latest ICU release (latest: stable version)
-function Get-IcuLatestRelease {
-    $response = Invoke-WebRequest -Uri "https://github.com/unicode-org/icu/releases/latest"
-    $tagUrl = ($response.Links | Where-Object href -like "*releases/tag/release-*")[0].href
-
-    if ($tagUrl -match 'release-(\d+)\.') {
-       return [int]$Matches[1]
-    }
-
-    throw "Unable to determine the latest ICU release version."
 }


### PR DESCRIPTION
Revert the PR #26827

During the 7.6.0 release, we found this change caused the packaging pipeline to break because it tried to access an external endpoint, which is forbidden in the Azure DevOps official build environment.

Given that, we cannot retrieve the latest ICU version dynamically in the packaging script. 