### PR TITLE
[release/v7.4.15] Mirror .NET/runtime ICU version range in PowerShell

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2125,6 +2125,22 @@ function Get-PackageDependencies
 
         # These should match those in the Dockerfiles, but exclude tools like Git, which, and curl
         $Dependencies = @()
+
+        # ICU version range follows .NET runtime policy.
+        # See: https://github.com/dotnet/runtime/blob/3fe8518d51bbcaa179bbe275b2597fbe1b88bc5a/src/native/libs/System.Globalization.Native/pal_icushim.c#L235-L243
+        #
+        # Version range rationale:
+        # - The runtime supports ICU versions >= the version it was built against
+        #   and <= that version + 30, to allow sufficient headroom for future releases.
+        # - ICU typically releases about twice per year, so +30 provides roughly
+        #   15 years of forward compatibility.
+        # - On some platforms, the minimum supported version may be lower
+        #   than the build version and we know that older versions just works.
+        #
+        $MinICUVersion = 60                    # runtime minimum supported
+        $BuildICUVersion = 74                  # current build version for v7.4.15
+        $MaxICUVersion = $BuildICUVersion + 30 # headroom
+
         if ($Distribution -eq 'deb') {
             $Dependencies = @(
                 "libc6",
@@ -2132,10 +2148,14 @@ function Get-PackageDependencies
                 "libgssapi-krb5-2",
                 "libstdc++6",
                 "zlib1g",
-                "libicu74|libicu72|libicu71|libicu70|libicu69|libicu68|libicu67|libicu66|libicu65|libicu63|libicu60|libicu57|libicu55|libicu52",
+                (($MaxICUVersion..$MinICUVersion).ForEach{ "libicu$_" } -join '|'),
                 "libssl3|libssl1.1|libssl1.0.2|libssl1.0.0"
             )
-
+        } elseif ($Distribution -eq 'rh') {
+            $Dependencies = @(
+                "openssl-libs",
+                "libicu"
+            )
         } elseif ($Distribution -eq 'rh') {
             $Dependencies = @(
                 "openssl-libs",


### PR DESCRIPTION
Backport of #26304 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26304$$$
-->

Triggered by @adityapatwardhan on behalf of @kasperk81

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates the Get-PackageDependencies function to use a dynamic ICU version range instead of a hardcoded list. This change applies to deb package dependencies and provides forward compatibility for future ICU releases while maintaining compatibility down to ICU 60.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified that the dynamic ICU version range calculation works correctly with $BuildICUVersion=74 for v7.4.15, generating the expected version range from 60 to 104 for deb packages. This mirrors the .NET runtime approach for broader compatibility with different ICU versions.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The change expands the acceptable ICU versions for deb packages from a fixed list to a dynamic range (60-104 for v7.4.15), which increases compatibility without breaking existing functionality. The .NET runtime uses the same approach, providing validation for this pattern.
