### PR TITLE
[release/v7.4.15] Bump actions/upload-artifact from 6 to 7

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -223,7 +223,7 @@ jobs:
         testResultsFolder: "${{ runner.workspace }}/testResults"
     - name: Upload package artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: macos-package
         path: "*.pkg"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/windows-packaging-reusable.yml
+++ b/.github/workflows/windows-packaging-reusable.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload Build Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-packaging-${{ matrix.architecture }}-${{ matrix.channel }}
           path: |

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -46,7 +46,7 @@ jobs:
           Write-Host "Completed xUnit test run."
 
       - name: Upload xUnit results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ inputs.test_results_artifact_name }}


### PR DESCRIPTION
Backport of #26914 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26914$$$
-->

Triggered by @adityapatwardhan on behalf of @app/dependabot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates GitHub Actions workflow artifact upload steps on the release/v7.4.15 branch to actions/upload-artifact v7 so release branch CI and packaging workflows stay aligned with supported action versions.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified the original PR diff applies to the four affected workflow files on release/v7.4.15, resolved branch-specific version conflicts by preserving the release branch workflow structure while updating only the upload-artifact action reference, and confirmed the cherry-pick completed successfully with a clean worktree. No product or Pester tests were applicable because this change only updates GitHub Actions workflow definitions.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

This changes CI/build infrastructure used by release workflows, so the blast radius is broader than a typical code fix. The change itself is narrowly scoped to artifact upload action references in four workflow files and mirrors the already-merged change from main, which reduces implementation risk.

## Merge Conflicts

Conflicts occurred in .github/workflows/macos-ci.yml, .github/workflows/scorecards.yml, .github/workflows/windows-packaging-reusable.yml, and .github/workflows/xunit-tests.yml because release/v7.4.15 still used older upload-artifact versions (v4 or an older pinned v3 digest) while the original PR updated from v6 to v7 on main. Resolved each conflict by keeping the release branch workflow layout intact and updating only the actions/upload-artifact reference to the v7 equivalent used by the original PR.
