### PR TITLE
[release/v7.4.15] Bump actions/dependency-review-action from 4.8.3 to 4.9.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,4 +19,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@0efb1d1d84fc9633afcdaad14c485cbbc90ef46c # v2.5.1
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0


### PR DESCRIPTION
Backport of #26938 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26938$$$
-->

Triggered by @adityapatwardhan on behalf of @app/dependabot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates the dependency review GitHub Action pin on the release branch so security/dependency review checks use the intended version.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified the backport cherry-pick applies cleanly to release/v7.4.15 after conflict resolution, and confirmed the workflow file contains the expected dependency-review-action v4.9.0 pin.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Single-line workflow action pin update with no runtime product code changes; impact is limited to CI dependency review behavior.

## Merge Conflicts

Resolved one conflict in .github/workflows/dependency-review.yml by preserving the release branch checkout action pin and applying only the dependency-review-action bump to v4.9.0.
