### PR TITLE
[release/v7.4.15] Bump github/codeql-action from 4.32.4 to 4.32.6

### DIFF
--- a/.github/workflows/analyze-reusable.yml
+++ b/.github/workflows/analyze-reusable.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v3.29.5
+      uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.29.5
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -74,4 +74,4 @@ jobs:
       shell: pwsh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v3.29.5
+      uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.29.5

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@f72882a05ba58122a44b17f2fce8fb50e5c79a59 # v2.25.0
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.29.5
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Backport of #26942 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26942$$$
-->

Triggered by @adityapatwardhan on behalf of @app/dependabot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates the pinned github/codeql-action SHAs used by CodeQL and scorecard workflows on release/v7.4.15 so the release branch carries the same CodeQL action bump as main.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified the backport cherry-pick on release/v7.4.15 and resolved the two workflow conflicts by applying the newer github/codeql-action SHAs from the original PR. No Pester or product test suite was run because the change only updates pinned GitHub Actions workflow references.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

This changes security scanning workflow dependencies on a servicing branch. The scope is limited to pinned GitHub Actions SHAs in two workflow files, but workflow and build infrastructure changes can affect CI behavior broadly.

## Merge Conflicts

Cherry-pick conflicted in .github/workflows/analyze-reusable.yml and .github/workflows/scorecards.yml because release/v7.4.15 already pinned different github/codeql-action SHAs. Resolved by taking the newer 4.32.6-related SHA updates from the original PR for init, analyze, and upload-sarif.
