### PR TITLE
[release/v7.4.15] Move `_GetDependencies` MSBuild target from dynamic generation in `build.psm1` into `Microsoft.PowerShell.SDK.csproj`

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -2663,38 +2663,17 @@ function Start-TypeGen
     # Add .NET CLI tools to PATH
     Find-Dotnet
 
-    # This custom target depends on 'ResolveAssemblyReferencesDesignTime', whose definition can be found in the sdk folder.
-    # To find the available properties of '_ReferencesFromRAR' when switching to a new dotnet sdk, follow the steps below:
-    #   1. create a dummy project using the new dotnet sdk.
-    #   2. build the dummy project with this command:
-    #      dotnet msbuild .\dummy.csproj /t:ResolveAssemblyReferencesDesignTime /fileLogger /noconsolelogger /v:diag
-    #   3. search '_ReferencesFromRAR' in the produced 'msbuild.log' file. You will find the properties there.
-    $GetDependenciesTargetPath = "$PSScriptRoot/src/Microsoft.PowerShell.SDK/obj/Microsoft.PowerShell.SDK.csproj.TypeCatalog.targets"
-    $GetDependenciesTargetValue = @'
-<Project>
-    <Target Name="_GetDependencies"
-            DependsOnTargets="ResolveAssemblyReferencesDesignTime">
-        <ItemGroup>
-            <_RefAssemblyPath Include="%(_ReferencesFromRAR.OriginalItemSpec)%3B" Condition=" '%(_ReferencesFromRAR.NuGetPackageId)' != 'Microsoft.Management.Infrastructure' "/>
-        </ItemGroup>
-        <WriteLinesToFile File="$(_DependencyFile)" Lines="@(_RefAssemblyPath)" Overwrite="true" />
-    </Target>
-</Project>
-'@
-    New-Item -ItemType Directory -Path (Split-Path -Path $GetDependenciesTargetPath -Parent) -Force > $null
-    Set-Content -Path $GetDependenciesTargetPath -Value $GetDependenciesTargetValue -Force -Encoding Ascii
-
     Push-Location "$PSScriptRoot/src/Microsoft.PowerShell.SDK"
     try {
         $ps_inc_file = "$PSScriptRoot/src/TypeCatalogGen/$IncFileName"
-        dotnet msbuild .\Microsoft.PowerShell.SDK.csproj /t:_GetDependencies "/property:DesignTimeBuild=true;_DependencyFile=$ps_inc_file" /nologo
+        Start-NativeExecution { dotnet msbuild .\Microsoft.PowerShell.SDK.csproj /t:_GetDependencies "/property:DesignTimeBuild=true;_DependencyFile=$ps_inc_file" /nologo }
     } finally {
         Pop-Location
     }
 
     Push-Location "$PSScriptRoot/src/TypeCatalogGen"
     try {
-        dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $IncFileName
+        Start-NativeExecution { dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $IncFileName }
     } finally {
         Pop-Location
     }

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -44,4 +44,26 @@
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.25" />
   </ItemGroup>
 
+  <!--
+    This target is invoked explicitly by Start-TypeGen in build.psm1 to collect the list of
+    reference assembly paths needed by TypeCatalogGen. It is not run during a normal build.
+
+    To find the available properties of '_ReferencesFromRAR' when switching to a new dotnet sdk:
+      1. Create a dummy project using the new dotnet sdk.
+      2. Build the dummy project with:
+         dotnet msbuild ./dummy.csproj /t:ResolveAssemblyReferencesDesignTime /fileLogger /noconsolelogger /v:diag
+      3. Search '_ReferencesFromRAR' in the produced 'msbuild.log' file.
+  -->
+  <Target Name="_GetDependencies"
+          DependsOnTargets="ResolveAssemblyReferencesDesignTime">
+    <ItemGroup>
+      <!--
+        Excludes 'Microsoft.Management.Infrastructure' from the type catalog reference list,
+        as it is provided separately at runtime and must not be included in the generated catalog.
+      -->
+      <_RefAssemblyPath Include="%(_ReferencesFromRAR.OriginalItemSpec)%3B" Condition=" '%(_ReferencesFromRAR.NuGetPackageId)' != 'Microsoft.Management.Infrastructure' "/>
+    </ItemGroup>
+    <WriteLinesToFile File="$(_DependencyFile)" Lines="@(_RefAssemblyPath)" Overwrite="true" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Backport of #27052 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27052$$$
-->

Triggered by @adityapatwardhan on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Moves _GetDependencies target into Microsoft.PowerShell.SDK.csproj and removes dynamic generation in build.psm1 so the release/v7.4.15 build path stays deterministic and aligned with main.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick applied cleanly on release/v7.4.15 with no merge conflicts. Backport PR CI will validate build and packaging flows for this branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Touches build generation logic and project file wiring, but the exact merged change from main was cherry-picked without manual edits, reducing divergence risk.
