### PR TITLE
[release/v7.4.15] release-upload-buildinfo: replace version-comparison channel gating with metadata flags

### DIFF
--- a/.pipelines/templates/release-upload-buildinfo.yml
+++ b/.pipelines/templates/release-upload-buildinfo.yml
@@ -51,12 +51,17 @@ jobs:
       Import-Module "$toolsDirectory/ci.psm1"
       $jsonFile = Get-Item "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/BuildInfoJson/*.json"
       $fileName = Split-Path $jsonFile -Leaf
+      # The build itself has already determined if it is preview or stable/LTS,
+      # we just need to check via the file name
+      $isPreview = $fileName -eq "preview.json"
+      $isStable = $fileName -eq "stable.json"
 
       $dateTime = [datetime]::UtcNow
       $dateTime = [datetime]::new($dateTime.Ticks - ($dateTime.Ticks % [timespan]::TicksPerSecond), $dateTime.Kind)
 
       $metadata = Get-Content -LiteralPath "$toolsDirectory/metadata.json" -ErrorAction Stop | ConvertFrom-Json
-      $stableReleaseTag = $metadata.StableReleaseTag -Replace 'v',''
+      # Note: version tags in metadata.json (e.g. StableReleaseTag) may not reflect the current release being
+      # published, so they must not be used to gate channel decisions. Use the explicit publish flags instead.
       $stableRelease = $metadata.StableRelease.PublishToChannels
       $ltsRelease = $metadata.LTSRelease.PublishToChannels
 
@@ -71,7 +76,7 @@ jobs:
       $targetFile = "$ENV:PIPELINE_WORKSPACE/$fileName"
       ConvertTo-Json -InputObject $buildInfo | Out-File $targetFile -Encoding ascii
 
-      if ($fileName -eq "preview.json") {
+      if ($isPreview) {
         Set-BuildVariable -Name UploadPreview -Value YES
       } else {
         Set-BuildVariable -Name UploadPreview -Value NO
@@ -80,9 +85,7 @@ jobs:
       Set-BuildVariable -Name PreviewBuildInfoFile -Value $targetFile
 
       ## Create 'lts.json' if marked as a LTS release.
-      if ($fileName -eq "stable.json") {
-        [System.Management.Automation.SemanticVersion] $stableVersion = $stableReleaseTag
-        [System.Management.Automation.SemanticVersion] $currentVersion = $currentReleaseTag
+      if ($isStable) {
         if ($ltsRelease) {
           $ltsFile = "$ENV:PIPELINE_WORKSPACE/lts.json"
           Copy-Item -Path $targetFile -Destination $ltsFile -Force
@@ -92,18 +95,24 @@ jobs:
           Set-BuildVariable -Name UploadLTS -Value NO
         }
 
-        ## Only update the stable.json if the current version is greater than the stable version.
-        if ($currentVersion -gt $stableVersion) {
-          $versionFile = "$ENV:PIPELINE_WORKSPACE/$($currentVersion.Major)-$($currentVersion.Minor).json"
-          Copy-Item -Path $targetFile -Destination $versionFile -Force
-          Set-BuildVariable -Name StableBuildInfoFile -Value $versionFile
+        ## Gate stable.json upload on the metadata publish flag.
+        if ($stableRelease) {
+          Set-BuildVariable -Name StableBuildInfoFile -Value $targetFile
           Set-BuildVariable -Name UploadStable -Value YES
         } else {
           Set-BuildVariable -Name UploadStable -Value NO
         }
 
+        ## Always publish the version-specific {Major}-{Minor}.json for non-preview builds.
+        [System.Management.Automation.SemanticVersion] $currentVersion = $currentReleaseTag
+        $versionFile = "$ENV:PIPELINE_WORKSPACE/$($currentVersion.Major)-$($currentVersion.Minor).json"
+        Copy-Item -Path $targetFile -Destination $versionFile -Force
+        Set-BuildVariable -Name VersionSpecificBuildInfoFile -Value $versionFile
+        Set-BuildVariable -Name UploadVersionSpecific -Value YES
+
       } else {
         Set-BuildVariable -Name UploadStable -Value NO
+        Set-BuildVariable -Name UploadVersionSpecific -Value NO
       }
     displayName: Create json files
 
@@ -144,4 +153,12 @@ jobs:
           Write-Verbose -Verbose "Uploading $jsonFile to $containerName/$prefix/$blobName"
           Set-AzStorageBlobContent -File $jsonFile -Container $containerName -Blob "$prefix/$blobName" -Context $storageContext -Force
         }
-    condition: and(succeeded(), or(eq(variables['UploadPreview'], 'YES'), eq(variables['UploadLTS'], 'YES'), eq(variables['UploadStable'], 'YES')))
+
+        #version-specific
+        if ($env:UploadVersionSpecific -eq 'YES') {
+          $jsonFile = "$env:VersionSpecificBuildInfoFile"
+          $blobName = Get-Item $jsonFile | Split-Path -Leaf
+          Write-Verbose -Verbose "Uploading $jsonFile to $containerName/$prefix/$blobName"
+          Set-AzStorageBlobContent -File $jsonFile -Container $containerName -Blob "$prefix/$blobName" -Context $storageContext -Force
+        }
+    condition: and(succeeded(), or(eq(variables['UploadPreview'], 'YES'), eq(variables['UploadLTS'], 'YES'), eq(variables['UploadStable'], 'YES'), eq(variables['UploadVersionSpecific'], 'YES')))


### PR DESCRIPTION
Backport of #27074 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27074$$$
-->

Triggered by @adityapatwardhan on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports release buildinfo publishing logic to gate stable uploads via metadata flags and always publish version-specific non-preview buildinfo files.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick applied to release/v7.4.15 with one conflict in .pipelines/templates/release-upload-buildinfo.yml, resolved by preserving metadata-flag channel-gating behavior from the original PR. Verified resulting script includes UploadVersionSpecific variable wiring, stable gating by StableRelease.PublishToChannels, and upload task condition updates.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Scoped pipeline-template changes in a single file with behavior already validated in main; moderate risk due to release publishing path impact but no broad runtime code changes.

## Merge Conflicts

Resolved one conflict in .pipelines/templates/release-upload-buildinfo.yml around obsolete StableReleaseTag comparison by keeping the metadata-flag guidance and logic from PR #27074.
