### PR TITLE
[release/v7.5.6] Bump actions/upload-artifact from 6 to 7

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -226,7 +226,7 @@ jobs:
         testResultsFolder: "${{ runner.workspace }}/testResults"
     - name: Upload package artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: macos-package
         path: "*.pkg"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/windows-packaging-reusable.yml
+++ b/.github/workflows/windows-packaging-reusable.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload Build Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-packaging-${{ matrix.architecture }}-${{ matrix.channel }}
           path: |

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -46,7 +46,7 @@ jobs:
           Write-Host "Completed xUnit test run."
 
       - name: Upload xUnit results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ inputs.test_results_artifact_name }}


### PR DESCRIPTION
Backport of #26914 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26914$$$
-->

Triggered by @adityapatwardhan on behalf of @app/dependabot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates GitHub Actions workflows on release/v7.5.6 to use actions/upload-artifact v7 so artifact upload steps remain on supported action versions.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated the backport by successfully cherry-picking the original merge commit onto release/v7.5.6 and resolving workflow-version conflicts in the four affected workflow files; changes are limited to upload-artifact action version updates.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

This touches CI workflow definitions only (no runtime product code). Risk is moderate because pipeline behavior can change with action-version upgrades, but scope is narrow and aligns with upstream merged change.

## Merge Conflicts

Cherry-pick conflicts occurred because release/v7.5.6 had actions/upload-artifact v4 references while the original PR moved v6 to v7 on master. Resolved by applying the intended end state (v7 reference/hash) in .github/workflows/macos-ci.yml, .github/workflows/scorecards.yml, .github/workflows/windows-packaging-reusable.yml, and .github/workflows/xunit-tests.yml.
