### PR TITLE
[release/v7.5.6] Bump actions/dependency-review-action from 4.8.3 to 4.9.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,4 +19,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0


### PR DESCRIPTION
Backport of #26938 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26938$$$
-->

Triggered by @adityapatwardhan on behalf of @app/dependabot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates the pinned GitHub Actions dependency review action on the release branch to keep CI security tooling current.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified the cherry-picked workflow change only updates actions/dependency-review-action pin in .github/workflows/dependency-review.yml and preserves release/v7.5.6-specific checkout pin. Cherry-pick completed cleanly after resolving one workflow-line conflict.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Single-line workflow action version bump in CI/security tooling; scoped change with no product runtime impact.

## Merge Conflicts

Conflict in .github/workflows/dependency-review.yml on the dependency-review-action pin due branch drift. Resolved by keeping release/v7.5.6 checkout pin and applying the intended dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 update.
