### PR TITLE
[release/v7.5.6] Create LTS pkg and non-LTS pkg for macOS for LTS releases

### DIFF
--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -102,6 +102,10 @@ jobs:
       Restore-PSOptions -PSOptionsPath "$psoptionsPath"
       Get-PSOptions | Write-Verbose -Verbose
 
+      if (-not (Test-Path "$repoRoot/tools/metadata.json")) {
+        throw "metadata.json not found in $repoRoot/tools"
+      }
+
       $metadata = Get-Content "$repoRoot/tools/metadata.json" -Raw | ConvertFrom-Json
 
       Write-Verbose -Verbose "metadata:"
@@ -120,14 +124,19 @@ jobs:
       Write-Verbose -Verbose "LTS: $LTS"
 
       if ($LTS) {
-        Write-Verbose -Message "LTS Release: $LTS"
+        Write-Verbose -Message "LTS Release: $LTS" -Verbose
       }
 
       Start-PSBootstrap -Scenario Package
 
       $macosRuntime = "osx-$buildArch"
 
-      Start-PSPackage -Type osxpkg -SkipReleaseChecks -MacOSRuntime $macosRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath -LTS:$LTS
+      Start-PSPackage -Type osxpkg -SkipReleaseChecks -MacOSRuntime $macosRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath
+
+      if ($LTS) {
+        Start-PSPackage -Type osxpkg -SkipReleaseChecks -MacOSRuntime $macosRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath -LTS
+      }
+
       $pkgNameFilter = "powershell-*$macosRuntime.pkg"
       Write-Verbose -Verbose "Looking for pkg packages with filter: $pkgNameFilter in '$(Pipeline.Workspace)' to upload..."
       $pkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $pkgNameFilter -Recurse -File


### PR DESCRIPTION
Backport of #27039 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27039$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Required tooling change for release/v7.5.6. Enables both LTS and non-LTS packages to be created for macOS in LTS releases. Previously, the pipeline could only create one type. This change separates package creation logic, allowing both package types to be built from a single pipeline run.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR was verified by CI pipeline validation. Backport testing includes:
- Cherry-pick validation: No merge conflicts detected
- Template syntax validation: YAML structure preserved
- Logical flow verification: Changes properly separate LTS vs non-LTS package creation
- Metadata validation check ensures proper safeguards are in place

CI will validate the pipeline changes on the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk due to changes in macOS build pipeline. However, changes are well-scoped to the mac-package-build.yml template and primarily affect only macOS packaging for LTS releases. The added metadata.json validation improves robustness. No changes affect Windows, Linux, or other platforms. The separation of LTS and non-LTS package builds is a logical improvement that reduces complexity.
