### PR TITLE
[release/v7.5.6] Create Linux LTS deb/rpm packages for LTS releases

### DIFF
--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -155,10 +155,6 @@ jobs:
 
       Write-Verbose -Verbose "LTS: $LTS"
 
-      if ($LTS) {
-        Write-Verbose -Message "LTS Release: $LTS"
-      }
-
       if (-not (Test-Path $(ob_outputDirectory))) {
         New-Item -ItemType Directory -Path $(ob_outputDirectory) -Force
       }
@@ -167,6 +163,11 @@ jobs:
       Write-Verbose -Verbose "packageType = $packageType"
 
       Start-PSPackage -Type $packageType -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath
+
+      if ($LTS) {
+        Write-Verbose -Message "LTS Release: $LTS" -Verbose
+        Start-PSPackage -Type $packageType -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath -LTS
+      }
 
       $vstsCommandString = "vso[task.setvariable variable=PackageFilter]$pkgFilter"
       Write-Host ("sending " + $vstsCommandString)


### PR DESCRIPTION
Backport of #27049 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27049$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Required tooling change: Adds Linux LTS package (deb/rpm) support to the release branch's build infrastructure. This ensures v7.5.x LTS releases can be distributed as proper deb/rpm packages, which is critical for enterprise deployments on Linux systems.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Linux LTS releases require properly packaged deb/rpm distributions for user installation.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Backport verified by successful cherry-pick with no conflicts. Package generation for LTS releases was validated on v7.6 release branch. Verification includes: 1) CI pipeline confirmation on release branch, 2) Review of packaging configuration changes applied correctly, 3) Validation that LTS release tags trigger proper deb/rpm package builds.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk: This adds Linux LTS deb/rpm package support that was already validated in v7.6. The change is scoped to packaging configuration with minimal impact to core functionality. Verified by successful CI on v7.6 releases.
