### PR TITLE
[release/v7.5.6] Create infrastructure to create two msixs and msixbundles for LTS and Stable

### DIFF
--- a/.pipelines/templates/package-create-msix.yml
+++ b/.pipelines/templates/package-create-msix.yml
@@ -85,17 +85,44 @@ jobs:
             $null = Copy-Item -Path $msixFile.FullName -Destination $sourceDir -Force -Verbose
         }
 
-        $file = Get-ChildItem $sourceDir | Select-Object -First 1
-        $prefix = ($file.BaseName -split "-win")[0]
-        $pkgName = "$prefix.msixbundle"
-        Write-Verbose -Verbose "Creating $pkgName"
-
         $makeappx = '$(MakeAppxPath)'
         $outputDir = "$sourceDir\output"
         New-Item $outputDir -Type Directory -Force > $null
-        & $makeappx bundle /d $sourceDir /p "$outputDir\$pkgName"
 
-        Get-ChildItem -Path $sourceDir -Recurse
+        # Separate LTS and Stable/Preview MSIX files by filename convention
+        $ltsMsix = @(Get-ChildItem $sourceDir -Filter '*.msix' | Where-Object { $_.BaseName -match '-LTS-' })
+        $stableMsix = @(Get-ChildItem $sourceDir -Filter '*.msix' | Where-Object { $_.BaseName -notmatch '-LTS-' })
+
+        Write-Verbose -Verbose "Stable/Preview MSIX files: $($stableMsix.Name -join ', ')"
+        Write-Verbose -Verbose "LTS MSIX files: $($ltsMsix.Name -join ', ')"
+
+        # Create Stable/Preview bundle
+        if ($stableMsix.Count -gt 0) {
+            $stableDir = "$sourceDir\stable"
+            New-Item $stableDir -Type Directory -Force > $null
+            $stableMsix | Copy-Item -Destination $stableDir -Force
+            $file = $stableMsix | Select-Object -First 1
+            $prefix = ($file.BaseName -split "-win")[0]
+            $stableBundleName = "$prefix.msixbundle"
+            Write-Verbose -Verbose "Creating Stable/Preview bundle: $stableBundleName"
+            & $makeappx bundle /d $stableDir /p "$outputDir\$stableBundleName"
+        }
+
+        # Create LTS bundle
+        if ($ltsMsix.Count -gt 0) {
+            $ltsDir = "$sourceDir\lts"
+            New-Item $ltsDir -Type Directory -Force > $null
+            $ltsMsix | Copy-Item -Destination $ltsDir -Force
+            $file = $ltsMsix | Select-Object -First 1
+            $prefix = ($file.BaseName -split "-win")[0]
+            $ltsBundleName = "$prefix.msixbundle"
+            Write-Verbose -Verbose "Creating LTS bundle: $ltsBundleName"
+            & $makeappx bundle /d $ltsDir /p "$outputDir\$ltsBundleName"
+        }
+
+        Write-Verbose -Verbose "Created bundles:"
+        Get-ChildItem -Path $outputDir -Recurse
+
         $vstsCommandString = "vso[task.setvariable variable=BundleDir]$outputDir"
         Write-Host "sending " + $vstsCommandString
         Write-Host "##$vstsCommandString"
@@ -112,16 +139,18 @@ jobs:
         search_root: '$(BundleDir)'
 
     - pwsh: |
-        $signedBundle = Get-ChildItem -Path $(BundleDir) -Filter "*.msixbundle" -File
-        Write-Verbose -Verbose "Signed bundle: $signedBundle"
+        $signedBundles = @(Get-ChildItem -Path $(BundleDir) -Filter "*.msixbundle" -File)
+        Write-Verbose -Verbose "Signed bundles: $($signedBundles.Name -join ', ')"
 
         if (-not (Test-Path $(ob_outputDirectory))) {
           New-Item -ItemType Directory -Path $(ob_outputDirectory) -Force
         }
 
-        Copy-Item -Path $signedBundle.FullName -Destination "$(ob_outputDirectory)" -Verbose
+        foreach ($bundle in $signedBundles) {
+          Copy-Item -Path $bundle.FullName -Destination "$(ob_outputDirectory)" -Verbose
+        }
 
-        Write-Verbose -Verbose "Uploaded Bundle:"
+        Write-Verbose -Verbose "Uploaded Bundles:"
         Get-ChildItem -Path $(ob_outputDirectory) | Write-Verbose -Verbose
       displayName: Upload msixbundle to Artifacts
 
@@ -225,6 +254,29 @@ jobs:
         Write-Host "##vso[task.setvariable variable=ServiceConnection]$($config.ServiceEndpoint)"
         Write-Host "##vso[task.setvariable variable=SBConfigPath]$($sbConfigPath)"
 
+        # Select the correct bundle based on channel
+        $bundleFiles = @(Get-ChildItem -Path '$(BundleDir)' -Filter '*.msixbundle')
+        Write-Verbose -Verbose "Available bundles: $($bundleFiles.Name -join ', ')"
+
+        if ($IsLTS) {
+          $bundleFile = $bundleFiles | Where-Object { $_.Name -match '-LTS-' }
+        } else {
+          # Catches Stable or Preview
+          $bundleFile = $bundleFiles | Where-Object { $_.Name -notmatch '-LTS-' }
+        }
+
+        if (-not $bundleFile) {
+          Write-Error "No matching bundle found for channel '$currentChannel'. Available bundles: $($bundleFiles.Name -join ', ')"
+          exit 1
+        }
+
+        # Copy the selected bundle to a dedicated directory for store packaging
+        $storeBundleDir = '$(Pipeline.Workspace)\releasePipeline\msix\store-bundle'
+        New-Item $storeBundleDir -Type Directory -Force > $null
+        Copy-Item -Path $bundleFile.FullName -Destination $storeBundleDir -Force -Verbose
+        Write-Host "##vso[task.setvariable variable=StoreBundleDir]$storeBundleDir"
+        Write-Verbose -Verbose "Selected bundle for store packaging: $($bundleFile.Name)"
+
         # These variables are used in the next tasks to determine which ServiceEndpoint to use
         $ltsValue = $IsLTS.ToString().ToLower()
         $stableValue = $IsStable.ToString().ToLower()
@@ -256,7 +308,7 @@ jobs:
       inputs:
         serviceEndpoint: 'StoreAppPublish-Preview'
         sbConfigPath: '$(SBConfigPath)'
-        sourceFolder: '$(BundleDir)'
+        sourceFolder: '$(StoreBundleDir)'
         contents: '*.msixBundle'
         outSBName: 'PowerShellStorePackage'
         pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
@@ -268,7 +320,7 @@ jobs:
       inputs:
         serviceEndpoint: 'StoreAppPublish-Private'
         sbConfigPath: '$(SBConfigPath)'
-        sourceFolder: '$(BundleDir)'
+        sourceFolder: '$(StoreBundleDir)'
         contents: '*.msixBundle'
         outSBName: 'PowerShellStorePackage'
         pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'

--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -136,12 +136,14 @@ jobs:
 
       # Don't build LTS packages for rebuild branches
       $LTS = $metadata.LTSRelease.Package -and -not $isRebuildBranch
+      $Stable = [bool]$metadata.StableRelease.Package
 
       if ($isRebuildBranch) {
         Write-Verbose -Message "Rebuild branch detected, skipping LTS package build" -Verbose
       }
 
       Write-Verbose -Verbose "LTS: $LTS"
+      Write-Verbose -Verbose "Stable: $Stable"
 
       if ($LTS) {
         Write-Verbose -Message "LTS Release: $LTS"
@@ -174,6 +176,12 @@ jobs:
       Set-Location $repoRoot
 
       Start-PSPackage -Type $packageTypes -SkipReleaseChecks -WindowsRuntime $WindowsRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath -LTS:$LTS
+
+      # When both LTS and Stable are requested, also build the Stable MSIX
+      if ($packageTypes -contains 'msix' -and $LTS -and $Stable) {
+        Write-Verbose -Verbose "Both LTS and Stable packages requested. Building additional Stable MSIX."
+        Start-PSPackage -Type msix -SkipReleaseChecks -WindowsRuntime $WindowsRuntime -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath
+      }
 
     displayName: 'Build Packages (Unsigned)'
     env:

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4257,18 +4257,8 @@ function New-MSIXPackage
 
     $makepri = Get-Item (Join-Path $makeappx.Directory "makepri.exe") -ErrorAction Stop
 
+    $displayName = $ProductName
     $ProductSemanticVersion = Get-PackageSemanticVersion -Version $ProductVersion
-    $productSemanticVersionWithName = $ProductName + '-' + $ProductSemanticVersion
-    $packageName = $productSemanticVersionWithName
-    if ($Private) {
-        $ProductNameSuffix = 'Private'
-    }
-
-    if ($ProductNameSuffix) {
-        $packageName += "-$ProductNameSuffix"
-    }
-
-    $displayName = $productName
 
     if ($Private) {
         $ProductName = 'PowerShell-Private'
@@ -4283,6 +4273,13 @@ function New-MSIXPackage
 
     Write-Verbose -Verbose "ProductName: $productName"
     Write-Verbose -Verbose "DisplayName: $displayName"
+
+    $packageName = $ProductName + '-' + $ProductSemanticVersion
+
+    # Appends Architecture to the package name
+    if ($ProductNameSuffix) {
+        $packageName += "-$ProductNameSuffix"
+    }
 
     $ProductVersion = Get-WindowsVersion -PackageName $packageName
 


### PR DESCRIPTION
Backport of #27056 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27056$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports Windows packaging and pipeline updates so release/v7.5.6 can build and handle LTS and Stable/Preview MSIX bundles correctly in parallel.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick applied cleanly with no merge conflicts on release/v7.5.6. Backport PR CI will validate packaging and pipeline behavior on the target release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

This changes packaging and CI pipeline behavior for Windows MSIX artifacts; impact scope is broad, but change parity with merged mainline fix reduces implementation risk.
