### PR TITLE
[release/v7.4.15] Select New MSIX Package Name

### DIFF
--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -216,7 +216,7 @@ jobs:
       }
 
       if ($packageTypes -contains 'msix') {
-        $msixPkgNameFilter = "powershell-*.msix"
+        $msixPkgNameFilter = "PowerShell*.msix"
         $msixPkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $msixPkgNameFilter -Recurse -File | Select-Object -ExpandProperty FullName
         Write-Verbose -Verbose "unsigned msixPkgPath: $msixPkgPath"
         Copy-Item -Path $msixPkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose

--- a/.pipelines/templates/packaging/windows/sign.yml
+++ b/.pipelines/templates/packaging/windows/sign.yml
@@ -202,7 +202,7 @@ jobs:
       }
 
       if ($packageTypes -contains 'msix') {
-        $msixPkgNameFilter = "powershell-*.msix"
+        $msixPkgNameFilter = "PowerShell*.msix"
         $msixPkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $msixPkgNameFilter -Recurse -File | Select-Object -ExpandProperty FullName
         Write-Verbose -Verbose "signed msixPkgPath: $msixPkgPath"
         Copy-Item -Path $msixPkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose


### PR DESCRIPTION
Backport of #27096 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27096$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

The MSIX package file filter was using a lowercase pattern `powershell-*.msix` which fails to match the actual capitalized file names (e.g., `PowerShellPreview-7.4.x-win-x64.msix`). This fix ensures the correct MSIX files are found and processed during signing and packaging on the release branch.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The change updates the `$msixPkgNameFilter` variable in the packaging and signing pipeline templates from `powershell-*.msix` to `PowerShell*.msix`. Verified by the original PR passing CI and confirmed the pattern matches release MSIX file naming conventions.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Simple string pattern fix in pipeline templates with no runtime logic changes. The original PR was verified and merged to master.
