### PR TITLE
Fix WebResponseObject ToString encoding

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -128,13 +128,27 @@ namespace Microsoft.PowerShell.Commands
         {
             StringBuilder raw = ContentHelper.GetRawContentHeader(baseResponse);
 
-            // Use ASCII encoding for the RawContent visual view of the content.
+            // Keep the existing RawContent preview behavior.
             if (Content?.Length > 0)
             {
-                raw.Append(ToString());
+                raw.Append(GetRawContentPreview());
             }
 
             RawContent = raw.ToString();
+        }
+
+        private string GetRawContentPreview()
+        {
+            char[] stringContent = Encoding.ASCII.GetChars(Content!);
+            for (int counter = 0; counter < stringContent.Length; counter++)
+            {
+                if (!IsPrintable(stringContent[counter]))
+                {
+                    stringContent[counter] = '.';
+                }
+            }
+
+            return new string(stringContent);
         }
 
         private static bool IsPrintable(char c) => char.IsLetterOrDigit(c)
@@ -184,7 +198,10 @@ namespace Microsoft.PowerShell.Commands
                 return string.Empty;
             }
 
-            char[] stringContent = Encoding.ASCII.GetChars(Content);
+            string? characterSet = WebResponseHelper.GetCharacterSet(BaseResponse);
+            StreamHelper.TryGetEncoding(characterSet, out Encoding encoding);
+
+            char[] stringContent = encoding.GetChars(Content);
             for (int counter = 0; counter < stringContent.Length; counter++)
             {
                 if (!IsPrintable(stringContent[counter]))

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -574,6 +574,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
 
         $Result.Output.Encoding.BodyName | Should -Be 'utf-8'
         $Result.Output.Content | Should -Match '⡌⠁⠧⠑ ⠼⠁⠒  ⡍⠜⠇⠑⠹⠰⠎ ⡣⠕⠌'
+        $Result.Output.ToString() | Should -Match '⡌⠁⠧⠑ ⠼⠁⠒  ⡍⠜⠇⠑⠹⠰⠎ ⡣⠕⠌'
     }
 
     It "Invoke-WebRequest -ContentType overwrites Content-Type from -Headers." {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix `WebResponseObject.ToString()` so non-ASCII response content is preserved by decoding with the response charset instead of ASCII. Keep the legacy `RawContent` preview behavior unchanged and add a regression test for a UTF-8 response body, also this fixes issue #27154.

## PR Context

`Invoke-WebRequest` responses were losing non-ASCII characters when callers relied on `.ToString()`. This change keeps the fix narrow by updating the stringification path only, leaving the existing `RawContent` preview logic alone and covering the reported UTF-8 case with a regression test.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
