### PR TITLE
[release/v7.6.1] Fix the `PSNativeCommandArgumentPassing` test

### DIFF
--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -5,12 +5,7 @@ param()
 
 Describe "Behavior is specific for each platform" -tags "CI" {
     It "PSNativeCommandArgumentPassing is set to 'Windows' on Windows systems" -skip:(-not $IsWindows) {
-        if ([Version]::TryParse($PSVersiontable.PSVersion.ToString(), [ref]$null)) {
-            $PSNativeCommandArgumentPassing | Should -BeExactly "Legacy"
-        }
-        else {
-            $PSNativeCommandArgumentPassing | Should -BeExactly "Windows"
-        }
+        $PSNativeCommandArgumentPassing | Should -BeExactly "Windows"
     }
     It "PSNativeCommandArgumentPassing is set to 'Standard' on non-Windows systems" -skip:($IsWindows) {
         $PSNativeCommandArgumentPassing | Should -Be "Standard"


### PR DESCRIPTION
Backport of #27057 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27057$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This backport fixes a failing test in release automation for stable/LTS servicing branches, which is required to keep validation pipelines healthy.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified that the original merged change was cherry-picked cleanly to release/v7.6.1 with no conflicts and reviewed the test update scope to ensure it remains limited to test behavior.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The change is test-only and scoped to the PSNativeCommandArgumentPassing test; no production runtime code paths are modified.
