### PR TITLE
[release/v7.6.1] release-upload-buildinfo: replace version-comparison channel gating with metadata flags

### DIFF
--- a/.pipelines/templates/release-upload-buildinfo.yml
+++ b/.pipelines/templates/release-upload-buildinfo.yml
@@ -51,14 +51,17 @@ jobs:
       Import-Module "$toolsDirectory/ci.psm1"
       $jsonFile = Get-Item "$ENV:PIPELINE_WORKSPACE/PSPackagesOfficial/BuildInfoJson/*.json"
       $fileName = Split-Path $jsonFile -Leaf
+      # The build itself has already determined if it is preview or stable/LTS,
+      # we just need to check via the file name
+      $isPreview = $fileName -eq "preview.json"
+      $isStable = $fileName -eq "stable.json"
 
       $dateTime = [datetime]::UtcNow
       $dateTime = [datetime]::new($dateTime.Ticks - ($dateTime.Ticks % [timespan]::TicksPerSecond), $dateTime.Kind)
 
       $metadata = Get-Content -LiteralPath "$toolsDirectory/metadata.json" -ErrorAction Stop | ConvertFrom-Json
-      $stableReleaseTag = $metadata.StableReleaseTag -Replace 'v',''
-
-      $currentReleaseTag = $buildInfo.ReleaseTag -Replace 'v',''
+      # Note: version tags in metadata.json (e.g. StableReleaseTag) may not reflect the current release being
+      # published, so they must not be used to gate channel decisions. Use the explicit publish flags instead.
       $stableRelease = $metadata.StableRelease.PublishToChannels
       $ltsRelease = $metadata.LTSRelease.PublishToChannels
 
@@ -73,7 +76,7 @@ jobs:
       $targetFile = "$ENV:PIPELINE_WORKSPACE/$fileName"
       ConvertTo-Json -InputObject $buildInfo | Out-File $targetFile -Encoding ascii
 
-      if ($fileName -eq "preview.json") {
+      if ($isPreview) {
         Set-BuildVariable -Name UploadPreview -Value YES
       } else {
         Set-BuildVariable -Name UploadPreview -Value NO
@@ -82,9 +85,7 @@ jobs:
       Set-BuildVariable -Name PreviewBuildInfoFile -Value $targetFile
 
       ## Create 'lts.json' if marked as a LTS release.
-      if ($fileName -eq "stable.json") {
-        [System.Management.Automation.SemanticVersion] $stableVersion = $stableReleaseTag
-        [System.Management.Automation.SemanticVersion] $currentVersion = $currentReleaseTag
+      if ($isStable) {
         if ($ltsRelease) {
           $ltsFile = "$ENV:PIPELINE_WORKSPACE/lts.json"
           Copy-Item -Path $targetFile -Destination $ltsFile -Force
@@ -94,18 +95,24 @@ jobs:
           Set-BuildVariable -Name UploadLTS -Value NO
         }
 
-        ## Only update the stable.json if the current version is greater than the stable version.
-        if ($currentVersion -gt $stableVersion) {
-          $versionFile = "$ENV:PIPELINE_WORKSPACE/$($currentVersion.Major)-$($currentVersion.Minor).json"
-          Copy-Item -Path $targetFile -Destination $versionFile -Force
-          Set-BuildVariable -Name StableBuildInfoFile -Value $versionFile
+        ## Gate stable.json upload on the metadata publish flag.
+        if ($stableRelease) {
+          Set-BuildVariable -Name StableBuildInfoFile -Value $targetFile
           Set-BuildVariable -Name UploadStable -Value YES
         } else {
           Set-BuildVariable -Name UploadStable -Value NO
         }
 
+        ## Always publish the version-specific {Major}-{Minor}.json for non-preview builds.
+        [System.Management.Automation.SemanticVersion] $currentVersion = $currentReleaseTag
+        $versionFile = "$ENV:PIPELINE_WORKSPACE/$($currentVersion.Major)-$($currentVersion.Minor).json"
+        Copy-Item -Path $targetFile -Destination $versionFile -Force
+        Set-BuildVariable -Name VersionSpecificBuildInfoFile -Value $versionFile
+        Set-BuildVariable -Name UploadVersionSpecific -Value YES
+
       } else {
         Set-BuildVariable -Name UploadStable -Value NO
+        Set-BuildVariable -Name UploadVersionSpecific -Value NO
       }
     displayName: Create json files
 
@@ -146,4 +153,12 @@ jobs:
           Write-Verbose -Verbose "Uploading $jsonFile to $containerName/$prefix/$blobName"
           Set-AzStorageBlobContent -File $jsonFile -Container $containerName -Blob "$prefix/$blobName" -Context $storageContext -Force
         }
-    condition: and(succeeded(), or(eq(variables['UploadPreview'], 'YES'), eq(variables['UploadLTS'], 'YES'), eq(variables['UploadStable'], 'YES')))
+
+        #version-specific
+        if ($env:UploadVersionSpecific -eq 'YES') {
+          $jsonFile = "$env:VersionSpecificBuildInfoFile"
+          $blobName = Get-Item $jsonFile | Split-Path -Leaf
+          Write-Verbose -Verbose "Uploading $jsonFile to $containerName/$prefix/$blobName"
+          Set-AzStorageBlobContent -File $jsonFile -Container $containerName -Blob "$prefix/$blobName" -Context $storageContext -Force
+        }
+    condition: and(succeeded(), or(eq(variables['UploadPreview'], 'YES'), eq(variables['UploadLTS'], 'YES'), eq(variables['UploadStable'], 'YES'), eq(variables['UploadVersionSpecific'], 'YES')))


### PR DESCRIPTION
Backport of #27074 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27074$$$
-->

Triggered by @adityapatwardhan on behalf of @app/copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports release-upload-buildinfo channel gating metadata fixes used by release build and packaging upload automation.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified cherry-pick applied cleanly with no conflicts in the backport branch and validated branch creation against release/v7.6.1 target.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

The change is scoped to release build-info upload automation and channel gating logic, with moderate risk limited to release metadata publication behavior.
