### PR TITLE
[release/v7.6.1] Select New MSIX Package Name

### DIFF
--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -220,7 +220,7 @@ jobs:
       }
 
       if ($packageTypes -contains 'msix') {
-        $msixPkgNameFilter = "powershell-*.msix"
+        $msixPkgNameFilter = "PowerShell*.msix"
         $msixPkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $msixPkgNameFilter -Recurse -File | Select-Object -ExpandProperty FullName
         Write-Verbose -Verbose "unsigned msixPkgPath: $msixPkgPath"
         Copy-Item -Path $msixPkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose

--- a/.pipelines/templates/packaging/windows/sign.yml
+++ b/.pipelines/templates/packaging/windows/sign.yml
@@ -202,7 +202,7 @@ jobs:
       }
 
       if ($packageTypes -contains 'msix') {
-        $msixPkgNameFilter = "powershell-*.msix"
+        $msixPkgNameFilter = "PowerShell*.msix"
         $msixPkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $msixPkgNameFilter -Recurse -File | Select-Object -ExpandProperty FullName
         Write-Verbose -Verbose "signed msixPkgPath: $msixPkgPath"
         Copy-Item -Path $msixPkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose


### PR DESCRIPTION
Backport of #27096 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27096$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Ensures the Windows packaging/sign pipeline selects MSIX artifacts that use the actual PowerShell* naming convention, including preview package names.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated by cherry-picking cleanly to release/v7.6.1 and confirming the change is limited to the packaging/sign templates that define the MSIX filename filter used by the pipeline.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The change is a narrow string filter update in packaging pipeline templates and does not affect product runtime behavior.
