### PR TITLE
Preserve Get-TypeData hidden members

### DIFF
--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -3264,11 +3264,17 @@ namespace System.Management.Automation
                 }
 
                 CloneBaseProperties(memberSet);
+                memberSet.inheritMembers = this.inheritMembers;
                 return memberSet;
             }
             else
             {
-                return new PSMemberSet(name, _constructorPSObject);
+                PSMemberSet memberSet = new PSMemberSet(name, _constructorPSObject)
+                {
+                    inheritMembers = this.inheritMembers
+                };
+
+                return memberSet;
             }
         }
 

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -4151,10 +4151,18 @@ namespace System.Management.Automation.Runspaces
                 var membersData = new Collection<TypeMemberData>();
                 foreach (var m in memberSet.Members)
                 {
-                    membersData.Add(GetTypeMemberDataFromPSMemberInfo(m));
+                    TypeMemberData memberData = GetTypeMemberDataFromPSMemberInfo(m);
+                    if (memberData != null)
+                    {
+                        membersData.Add(memberData);
+                    }
                 }
 
-                return new MemberSetData(memberSet.Name, membersData) { IsHidden = memberSet.IsHidden };
+                return new MemberSetData(memberSet.Name, membersData)
+                {
+                    IsHidden = memberSet.IsHidden,
+                    InheritMembers = memberSet.InheritMembers
+                };
             }
 
             return null;

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -4103,13 +4103,13 @@ namespace System.Management.Automation.Runspaces
             var note = member as PSNoteProperty;
             if (note != null)
             {
-                return new NotePropertyData(note.Name, note.Value);
+                return new NotePropertyData(note.Name, note.Value) { IsHidden = note.IsHidden };
             }
 
             var alias = member as PSAliasProperty;
             if (alias != null)
             {
-                return new AliasPropertyData(alias.Name, alias.ReferencedMemberName);
+                return new AliasPropertyData(alias.Name, alias.ReferencedMemberName) { IsHidden = alias.IsHidden };
             }
 
             var scriptProperty = member as PSScriptProperty;
@@ -4117,7 +4117,7 @@ namespace System.Management.Automation.Runspaces
             {
                 ScriptBlock getter = scriptProperty.IsGettable ? scriptProperty.GetterScript : null;
                 ScriptBlock setter = scriptProperty.IsSettable ? scriptProperty.SetterScript : null;
-                return new ScriptPropertyData(scriptProperty.Name, getter, setter);
+                return new ScriptPropertyData(scriptProperty.Name, getter, setter) { IsHidden = scriptProperty.IsHidden };
             }
 
             var codeProperty = member as PSCodeProperty;
@@ -4125,7 +4125,7 @@ namespace System.Management.Automation.Runspaces
             {
                 MethodInfo getter = codeProperty.IsGettable ? codeProperty.GetterCodeReference : null;
                 MethodInfo setter = codeProperty.IsSettable ? codeProperty.SetterCodeReference : null;
-                return new CodePropertyData(codeProperty.Name, getter, setter);
+                return new CodePropertyData(codeProperty.Name, getter, setter) { IsHidden = codeProperty.IsHidden };
             }
 
             var scriptMethod = member as PSScriptMethod;
@@ -4154,7 +4154,7 @@ namespace System.Management.Automation.Runspaces
                     membersData.Add(GetTypeMemberDataFromPSMemberInfo(m));
                 }
 
-                return new MemberSetData(memberSet.Name, membersData);
+                return new MemberSetData(memberSet.Name, membersData) { IsHidden = memberSet.IsHidden };
             }
 
             return null;

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -4125,7 +4125,7 @@ namespace System.Management.Automation.Runspaces
             {
                 MethodInfo getter = codeProperty.IsGettable ? codeProperty.GetterCodeReference : null;
                 MethodInfo setter = codeProperty.IsSettable ? codeProperty.SetterCodeReference : null;
-                return new CodePropertyData(codeProperty.Name, getter, setter) { IsHidden = codeProperty.IsHidden };
+                return new CodePropertyData(codeProperty.Name, getter, setter);
             }
 
             var scriptMethod = member as PSScriptMethod;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/typedata.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/typedata.tests.ps1
@@ -51,6 +51,27 @@ Get-TypeData System.Void
             $type[0].TypeName | Should -Be System.Void
             $type[0].TypeAdapter.FullName | Should -Be Microsoft.PowerShell.Cim.CimInstanceAdapter
         }
+
+        It "Preserves IsHidden when round-tripping TypeData" {
+            $typeName = "HiddenTypeData$(Get-Random)"
+            $result = $ps.AddScript(@"
+`$typeData = [System.Management.Automation.Runspaces.TypeData]::new('$typeName')
+`$visibleMember = [System.Management.Automation.Runspaces.NotePropertyData]::new('VisibleMember', 'Visible')
+`$hiddenMember = [System.Management.Automation.Runspaces.NotePropertyData]::new('HiddenMember', 'Hidden')
+`$hiddenMember.IsHidden = `$true
+`$typeData.Members.Add(`$visibleMember.Name, `$visibleMember)
+`$typeData.Members.Add(`$hiddenMember.Name, `$hiddenMember)
+try {
+    Update-TypeData -TypeData `$typeData -Force
+    (Get-TypeData -TypeName '$typeName').Members['HiddenMember'].IsHidden
+}
+finally {
+    Remove-TypeData -TypeName '$typeName' -ErrorAction SilentlyContinue
+}
+"@).Invoke()
+
+            $result | Should -BeTrue
+        }
     }
 
     Context "Remove-TypeData" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/typedata.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/typedata.tests.ps1
@@ -72,6 +72,27 @@ finally {
 
             $result | Should -BeTrue
         }
+
+        It "Preserves InheritMembers when round-tripping MemberSetData" {
+            $typeName = "MemberSetTypeData$(Get-Random)"
+            $result = $ps.AddScript(@"
+`$typeData = [System.Management.Automation.Runspaces.TypeData]::new('$typeName')
+`$members = [System.Collections.ObjectModel.Collection[System.Management.Automation.Runspaces.TypeMemberData]]::new()
+`$members.Add([System.Management.Automation.Runspaces.NotePropertyData]::new('VisibleMember', 'Visible'))
+`$memberSet = [System.Management.Automation.Runspaces.MemberSetData]::new('VisibleSet', `$members)
+`$memberSet.InheritMembers = `$false
+`$typeData.Members.Add(`$memberSet.Name, `$memberSet)
+try {
+    Update-TypeData -TypeData `$typeData -Force
+    (Get-TypeData -TypeName '$typeName').Members['VisibleSet'].InheritMembers
+}
+finally {
+    Remove-TypeData -TypeName '$typeName' -ErrorAction SilentlyContinue
+}
+"@).Invoke()
+
+            $result | Should -BeFalse
+        }
     }
 
     Context "Remove-TypeData" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Preserve hidden type data members when `Get-TypeData` reconstructs `TypeData` from the live type table. This fixes issue #27131 and adds a regression test to verify that hidden note properties stay hidden after an `Update-TypeData` and `Get-TypeData` round-trip.

## PR Context

`Get-TypeData` was dropping the `IsHidden` flag when it converted live `PSMemberInfo` instances back into `TypeMemberData`. The underlying type table already preserved the hidden state, so this change corrects the reconstruction path rather than changing the storage model or the way hidden members behave at runtime.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
