### PR TITLE
[release/v7.4.15] Publish `.msixbundle` package as a VPack

### DIFF
--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -1,0 +1,147 @@
+trigger: none
+
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'createVPack'
+  displayName: 'Create and Submit VPack'
+  type: boolean
+  default: true
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+- name: 'ReleaseTagVar'
+  type: string
+  displayName: 'Release Tag Var:'
+  default: 'fromBranch'
+
+name: msixbundle_vPack_$(date:yyMM).$(date:dd)$(rev:rrr)
+
+variables:
+  CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]
+  system.debug: ${{ parameters.debug }}
+  BuildSolution: $(Build.SourcesDirectory)\dirs.proj
+  ReleaseTagVar: ${{ parameters.ReleaseTagVar }}
+  BuildConfiguration: Release
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+  Codeql.Enabled: false  #  pipeline is not building artifacts; it repackages existing artifacts into a vpack
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+  pipelines:
+    - pipeline: PSPackagesOfficial
+      source: 'PowerShell-Packages-Official'
+      trigger:
+        branches:
+          include:
+            - master
+            - releases/*
+
+extends:
+  template: v2/Microsoft.Official.yml@templates
+  parameters:
+    platform:
+      name: 'windows_undocked' # windows undocked
+
+    cloudvault:
+      enabled: false
+
+    globalSdl:
+      useCustomPolicy: true # for signing code
+      disableLegacyManifest: true
+      # disabled Armory as we dont have any ARM templates to scan. It fails on some sample ARM templates.
+      armory:
+        enabled: false
+      sbom:
+        enabled: true
+      compiled:
+        enabled: false
+      credscan:
+        enabled: true
+        scanFolder:  $(Build.SourcesDirectory)
+        suppressionsFile: $(Build.SourcesDirectory)\.config\suppress.json
+      binskim:
+        enabled: false
+      # APIScan requires a non-Ready-To-Run build
+      apiscan:
+        enabled: false
+      asyncSDL:
+        enabled: false
+      tsaOptionsFile: .config/tsaoptions.json
+
+    stages:
+    - stage: build
+      jobs:
+      - job: main
+        pool:
+          type: windows
+
+        variables:
+          ob_outputDirectory: '$(BUILD.SOURCESDIRECTORY)\out'
+          ob_createvpack_enabled: ${{ parameters.createVPack }}
+          ob_createvpack_packagename: 'PowerShell.app'
+          ob_createvpack_owneralias: 'dongbow'
+          ob_createvpack_description: 'VPack for the PowerShell Application'
+          ob_createvpack_targetDestinationDirectory: '$(Destination)'
+          ob_createvpack_propsFile: false
+          ob_createvpack_provData: true
+          ob_createvpack_metadata: '$(Build.SourceVersion)'
+          ob_createvpack_versionAs: string
+          ob_createvpack_version: '$(version)'
+          ob_createvpack_verbose: true
+
+        steps:
+          - template: .pipelines/templates/SetVersionVariables.yml@self
+            parameters:
+              ReleaseTagVar: $(ReleaseTagVar)
+              UseJson: no
+
+          - pwsh: |
+              Write-Verbose -Verbose 'PowerShell Version: $(version)'
+              if('$(version)' -match '-') {
+                  throw "Don't release a preview build msixbundle package"
+              }
+            displayName: Stop any preview release
+
+          - download: PSPackagesOfficial
+            artifact: 'drop_msixbundle_CreateMSIXBundle'
+            displayName: Download package
+
+          - pwsh: |
+              $payloadDir = '$(Pipeline.Workspace)\PSPackagesOfficial\drop_msixbundle_CreateMSIXBundle'
+              Get-ChildItem $payloadDir -Recurse | Out-String -Width 150
+              $vstsCommandString = "vso[task.setvariable variable=PayloadDir]$payloadDir"
+              Write-Host "sending " + $vstsCommandString
+              Write-Host "##$vstsCommandString"
+            displayName: 'Capture Artifact Listing'
+
+          - pwsh: |
+              $bundlePackage = Get-ChildItem '$(PayloadDir)\*.msixbundle'
+              Write-Verbose -Verbose ("MSIX bundle package: " + $bundlePackage.FullName -join ', ')
+              if ($bundlePackage.Count -ne 1) {
+                  throw "Expected to find 1 MSIX bundle package, but found $($bundlePackage.Count)"
+              }
+
+              if (-not (Test-Path '$(ob_outputDirectory)' -PathType Container)) {
+                  $null = New-Item '$(ob_outputDirectory)' -ItemType Directory -ErrorAction Stop
+              }
+
+              $targetPath = Join-Path '$(ob_outputDirectory)' 'Microsoft.PowerShell_8wekyb3d8bbwe.msixbundle'
+              Copy-Item -Verbose -Path $bundlePackage.FullName -Destination $targetPath
+            displayName: 'Stage msixbundle for vpack'
+
+          - pwsh: |
+              Write-Verbose "VPack Version: $(ob_createvpack_version)" -Verbose
+              $vpackFiles = Get-ChildItem -Path $(ob_outputDirectory)\* -Recurse
+              if($vpackFiles.Count -eq 0) {
+                  throw "No files found in $(ob_outputDirectory)"
+              }
+              $vpackFiles | Out-String -Width 150
+            displayName: Debug Output Directory and Version
+            condition: succeededOrFailed()

--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -48,4 +48,5 @@
     <rescap:Capability Name="packageManagement" />
     <rescap:Capability Name="packageQuery" />
   </Capabilities>
+  <mp:PhoneIdentity PhoneProductId="$PHONEPRODUCTID$" PhonePublisherId="95d94207-0c7c-47ed-82db-d75c81153c35" />
 </Package>

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4286,8 +4286,17 @@ function New-MSIXPackage
 
     $ProductVersion = Get-WindowsVersion -PackageName $packageName
 
+    # Any app that is submitted to the Store must have a PhoneIdentity in its appxmanifest.
+    # If you submit a package without this information to the Store, the Store will silently modify your package to include it.
+    # To find the PhoneProductId value, you need to run a package through the Store certification process,
+    # and use the PhoneProductId value from the Store certified package to update the manifest in your source code.
+    # This is the PhoneProductId for the "Microsoft.PowerShell" package.
+    $PhoneProductId = "5b3ae196-2df7-446e-8060-94b4ad878387"
+
     $isPreview = Test-IsPreview -Version $ProductSemanticVersion
     if ($isPreview) {
+        # This is the PhoneProductId for the "Microsoft.PowerShellPreview" package.
+        $PhoneProductId = "67859fd2-b02a-45be-8fb5-62c569a3e8bf"
         Write-Verbose "Using Preview assets" -Verbose
     } elseif ($LTS) {
         # This is the PhoneProductId for the "Microsoft.PowerShell-LTS" package.
@@ -4301,7 +4310,14 @@ function New-MSIXPackage
     $releasePublisher = 'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'
 
     $appxManifest = Get-Content "$RepoRoot\assets\AppxManifest.xml" -Raw
-    $appxManifest = $appxManifest.Replace('$VERSION$', $ProductVersion).Replace('$ARCH$', $Architecture).Replace('$PRODUCTNAME$', $productName).Replace('$DISPLAYNAME$', $displayName).Replace('$PUBLISHER$', $releasePublisher)
+    $appxManifest = $appxManifest.
+        Replace('$VERSION$', $ProductVersion).
+        Replace('$ARCH$', $Architecture).
+        Replace('$PRODUCTNAME$', $productName).
+        Replace('$DISPLAYNAME$', $displayName).
+        Replace('$PUBLISHER$', $releasePublisher).
+        Replace('$PHONEPRODUCTID$', $PhoneProductId)
+
     $xml = [xml]$appxManifest
     if ($isPreview) {
         Write-Verbose -Verbose "Adding pwsh-preview.exe alias"


### PR DESCRIPTION
Backport of #25612 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:25612$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds the MSIX bundle vPack publishing pipeline and required packaging metadata updates needed for release tooling and store submission flow.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated through the original PR's Azure DevOps pipeline runs for msixbundle-vpack, build, and package pipelines. Cherry-pick completed cleanly on release/v7.4.15 after conflict resolution, and resulting branch has a clean working tree.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

This touches release pipeline and packaging artifacts, so release-process risk is high; scope is constrained to MSIX/vPack publishing and manifest/product-id handling already validated upstream.

## Merge Conflicts

Resolved conflicts in .pipelines/PowerShell-Release-Official.yml and .pipelines/templates/SetVersionVariables.yml by preserving release/v7.4.15 pipeline structure and keeping equivalent intended updates for readability/wording.
