### PR TITLE
Change the display name of PowerShell-LTS package to 'PowerShell LTS'

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4285,7 +4285,7 @@ function New-MSIXPackage
         $displayName += ' Preview'
     } elseif ($LTS) {
         $ProductName += '-LTS'
-        $displayName += '-LTS'
+        $displayName += ' LTS'
     }
 
     Write-Verbose -Verbose "ProductName: $productName"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Change the display name of PowerShell-LTS MSIX package to from 'PowerShell-LTS' to 'PowerShell LTS'.
The package's family identity name is unchanged.