### PR TITLE
Replace ConvertTo-SecureString -AsPlainText in GetCredential.Tests.ps1

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -97,7 +97,7 @@ Describe "Get-Credential Test" -Tag "CI" {
     }
     It "Get-Credential `$credential" {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
-        $password = ConvertTo-SecureString -String "CredTest" -AsPlainText -Force
+        $password = [System.Net.NetworkCredential]::new('', 'CredTest').SecurePassword
         $credential = [pscredential]::new("John", $password)
 
         $cred = Get-Credential $credential


### PR DESCRIPTION
This pull request updates the way a secure password is created in the `Get-Credential` test to use a more standard .NET approach. Instead of using `ConvertTo-SecureString`, it now uses the `SecurePassword` property from a `System.Net.NetworkCredential` object.

- Test improvement:
  * In `GetCredential.Tests.ps1`, replaced `ConvertTo-SecureString -AsPlainText -Force` with `[System.Net.NetworkCredential]::new('', 'CredTest').SecurePassword` to generate a secure string for test credentials.