### PR TITLE
[release/v7.6.1] Delay update notification for one week to ensure all packages become available

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -28,6 +28,9 @@ namespace Microsoft.PowerShell
         private const string StableBuildInfoURL = "https://aka.ms/pwsh-buildinfo-stable";
         private const string PreviewBuildInfoURL = "https://aka.ms/pwsh-buildinfo-preview";
 
+        private const int NotificationDelayDays = 7;
+        private const int UpdateCheckBackoffDays = 7;
+
         /// <summary>
         /// The version of new update is persisted using a file, not as the file content, but instead baked in the file name in the following template:
         ///  `update{notification-type}_{version}_{publish-date}` -- held by 's_updateFileNameTemplate',
@@ -89,9 +92,18 @@ namespace Microsoft.PowerShell
             if (TryParseUpdateFile(
                     updateFilePath: out _,
                     out SemanticVersion lastUpdateVersion,
-                    lastUpdateDate: out _)
+                    out DateTime lastUpdateDate)
                && lastUpdateVersion != null)
             {
+                DateTime today = DateTime.UtcNow;
+                if ((today - lastUpdateDate).TotalDays < NotificationDelayDays)
+                {
+                    // The update was out less than 1 week ago and it's possible the packages are still rolling out.
+                    // We only show the notification when the update is at least 1 week old, to reduce the chance that
+                    // users see the notification but cannot get the new update when they try to install it.
+                    return;
+                }
+
                 string releaseTag = lastUpdateVersion.ToString();
                 string notificationMsgTemplate = s_notificationType == NotificationType.LTS
                     ? ManagedEntranceStrings.LTSUpdateNotificationMessage
@@ -169,7 +181,7 @@ namespace Microsoft.PowerShell
                 out DateTime lastUpdateDate);
 
             DateTime today = DateTime.UtcNow;
-            if (parseSuccess && updateFilePath != null && (today - lastUpdateDate).TotalDays < 7)
+            if (parseSuccess && updateFilePath != null && (today - lastUpdateDate).TotalDays < UpdateCheckBackoffDays)
             {
                 // There is an existing update file, and the last update was less than 1 week ago.
                 // It's unlikely a new version is released within 1 week, so we can skip this check.


### PR DESCRIPTION
Backport of #27095 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27095$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports the release timing adjustment that delays the update notification window so package availability can settle across release channels before users are prompted to update.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

This avoids users seeing update notifications before all packages for the release are broadly available, reducing confusion and failed update attempts during release rollout.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by cherry-picking the change onto release/v7.6.1 without conflicts. No local test run was performed; CI on the backport PR will validate the change in the release branch context.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk because the change is narrowly scoped to update notification timing and does not modify core engine or packaging logic. It adjusts a constant/value used for release behavior and cherry-picked cleanly.
