### PR TITLE
[release/v7.6.1] Redo windows image fix to use latest image

### DIFF
--- a/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
@@ -39,7 +39,7 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/azurelinux/build:3.0
   - name: WindowsContainerImage
-    value: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
+    value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)]
   - name: ReleaseTagVar

--- a/.pipelines/templates/variables/PowerShell-vPack-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-vPack-Variables.yml
@@ -19,7 +19,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: WindowsContainerImage
-    value: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+    value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
   - name: Codeql.Enabled
     value: false  #  pipeline is not building artifacts; it repackages existing artifacts into a vpack
   - name: DOTNET_CLI_TELEMETRY_OPTOUT


### PR DESCRIPTION
Backport of #27198 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27198$$$
-->

Triggered by @daxian-dbw on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports the Windows container image update in release pipeline variable templates so release/v7.6.1 uses the latest supported LTSC 2022 build environment.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by cherry-picking onto release/v7.6.1 without conflicts. No local pipeline run was performed; CI on the backport PR will validate the updated build environment references in the release branch context.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk because the change affects the Windows build environment used by release pipelines. The scope is limited to two variable template updates and the change cherry-picked cleanly, but infrastructure image changes can have broad CI impact.
