### PR TITLE
[release/v7.6.1] [StepSecurity] ci: Harden GitHub Actions tokens

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,64 @@
+name: "Copilot Setup Steps"
+
+# Allow testing of the setup steps from your repository's "Actions" tab.
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/copilot-setup-steps.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  # See https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1000
+
+      - name: Bootstrap
+        if: success()
+        run: |-
+          $title = 'Import Build.psm1'
+          Write-Host "::group::$title"
+          Import-Module ./build.psm1 -Verbose -ErrorAction Stop
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Switch to public feed'
+          Write-LogGroupStart -Title $title
+          Switch-PSNugetConfig -Source Public
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Bootstrap'
+          Write-LogGroupStart -Title $title
+          Start-PSBootstrap -Scenario DotNet
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Install .NET Tools'
+          Write-LogGroupStart -Title $title
+          Start-PSBootstrap -Scenario Tools
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Sync Tags'
+          Write-LogGroupStart -Title $title
+          Sync-PSTags -AddRemoteIfMissing
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Setup .NET environment variables'
+          Write-LogGroupStart -Title $title
+          Find-DotNet -SetDotnetRoot
+          Write-LogGroupEnd -Title $title
+        shell: pwsh

--- a/.github/workflows/windows-packaging-reusable.yml
+++ b/.github/workflows/windows-packaging-reusable.yml
@@ -13,6 +13,9 @@ env:
   SYSTEM_ARTIFACTSDIRECTORY: ${{ github.workspace }}/artifacts
   BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ github.workspace }}/artifacts
 
+permissions:
+  contents: read
+
 jobs:
   package:
     name: ${{ matrix.architecture }} - ${{ matrix.channel }}

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: testResults-xunit
 
+permissions:
+  contents: read
+
 jobs:
   xunit:
     name: Run xUnit Tests


### PR DESCRIPTION
Backport of #27202 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27202$$$
-->

Triggered by @daxian-dbw on behalf of @step-security-bot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports the GitHub Actions token permission hardening needed to apply least-privilege defaults to release workflow definitions.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by cherry-picking onto release/v7.6.1 and resolving a single delete-vs-add conflict in .github/workflows/copilot-setup-steps.yml by keeping the incoming workflow file from the PR. No local workflow run was performed; CI on the backport PR will validate the updated workflow permissions.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk because the change affects CI workflow permissions, which can break automation if permissions are too restrictive. The scope is limited to workflow metadata and the conflict resolution preserved the incoming security hardening change.

## Merge Conflicts

Conflict in .github/workflows/copilot-setup-steps.yml. On release/v7.6.1 the file was absent, while the incoming PR modified it to add workflow-level permissions. Resolved as a delete-vs-add conflict by keeping the incoming workflow file so the token hardening change is preserved.
