### PR TITLE
[release/v7.6.1] Change the display name of PowerShell-LTS package to PowerShell LTS

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4285,7 +4285,7 @@ function New-MSIXPackage
         $displayName += ' Preview'
     } elseif ($LTS) {
         $ProductName += '-LTS'
-        $displayName += '-LTS'
+        $displayName += ' LTS'
     }
 
     Write-Verbose -Verbose "ProductName: $productName"


### PR DESCRIPTION
Backport of #27203 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27203$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports the MSIX package display-name adjustment for the PowerShell LTS package so the release/v7.6.1 packaging metadata matches the intended store presentation.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

This corrects the user-facing package display name shown for the PowerShell LTS package without changing the package family identity.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by cherry-picking the change onto release/v7.6.1 without conflicts. No local packaging run was performed; CI on the backport PR will validate the metadata change in the release branch context.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk because the change is narrowly scoped to package display-name metadata and does not alter package identity, runtime behavior, or core build logic.
