### PR TITLE
[release/v7.5.6] Redo windows image fix to use latest image

### DIFF
--- a/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
@@ -39,7 +39,7 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/azurelinux/build:3.0
   - name: WindowsContainerImage
-    value: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
+    value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)]
   - name: ReleaseTagVar

--- a/.pipelines/templates/variables/PowerShell-vPack-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-vPack-Variables.yml
@@ -19,7 +19,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: WindowsContainerImage
-    value: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+    value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
   - name: Codeql.Enabled
     value: false  #  pipeline is not building artifacts; it repackages existing artifacts into a vpack
   - name: DOTNET_CLI_TELEMETRY_OPTOUT


### PR DESCRIPTION
Backport of #27198 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27198$$$
-->

Triggered by @daxian-dbw on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates pipeline variable templates to use the current supported Windows LTSC 2022 container image for release packaging. This is required to keep release branch packaging infrastructure aligned with the supported build environment.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick applied cleanly to release/v7.5.6. The backport changes only two pipeline variable templates and relies on release branch CI to validate the packaging environment after PR creation.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk because the change affects release packaging infrastructure and the Windows build environment, but the scope is limited to two variable values and matches the validated change on main.
