### PR TITLE
[release/v7.4.15] Fix a preview detection test for the packaging script

### DIFF
--- a/test/packaging/packaging.tests.ps1
+++ b/test/packaging/packaging.tests.ps1
@@ -46,18 +46,15 @@ Describe "Packaging Module Functions" {
             $result.PackageIdentifier | Should -Be "com.microsoft.powershell"
         }
 
-        It "Should NOT use package name for preview detection (bug fix verification)" {
+        It "Should NOT use package name for preview detection (bug fix verification) - <Name>" -TestCases @(
+            @{ Version = "7.6.0-preview.6"; Name = "Preview" }
+            @{ Version = "7.6.0-rc.1"; Name = "RC" }
+        ) {
             # This test verifies the fix for issue #26673
             # The bug was using ($Name -like '*-preview') which always returned false
             # because preview builds use Name="powershell" not "powershell-preview"
-            
-            $Version = "7.6.0-preview.6"
-            $Name = "powershell"  # Preview builds use "powershell" not "powershell-preview"
-            
-            # The INCORRECT logic (the bug): $Name -like '*-preview'
-            $incorrectCheck = $Name -like '*-preview'
-            $incorrectCheck | Should -Be $false -Because "Package name is 'powershell' not 'powershell-preview'"
-            
+            param($Version)
+
             # The CORRECT logic (the fix): uses version string
             $result = Get-MacOSPackageIdentifierInfo -Version $Version -LTS:$false
             $result.IsPreview | Should -Be $true -Because "Version string correctly identifies preview"


### PR DESCRIPTION
Backport of #26882 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26882$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Adjusts the packaging test for preview detection so the release/v7.4.15 branch validates the intended packaging behavior without changing shipped product code.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

This backport is test-only. The original change updated packaging test expectations for preview detection, the cherry-pick applied cleanly to release/v7.4.15, and CI on the backport PR will validate the packaging test suite on the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk because the change only updates a packaging test and does not affect runtime or shipped binaries.
