### PR TITLE
[release/v7.4.15] [StepSecurity] ci: Harden GitHub Actions tokens

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,64 @@
+name: "Copilot Setup Steps"
+
+# Allow testing of the setup steps from your repository's "Actions" tab.
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/copilot-setup-steps.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  # See https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1000
+
+      - name: Bootstrap
+        if: success()
+        run: |-
+          $title = 'Import Build.psm1'
+          Write-Host "::group::$title"
+          Import-Module ./build.psm1 -Verbose -ErrorAction Stop
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Switch to public feed'
+          Write-LogGroupStart -Title $title
+          Switch-PSNugetConfig -Source Public
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Bootstrap'
+          Write-LogGroupStart -Title $title
+          Start-PSBootstrap -Scenario DotNet
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Install .NET Tools'
+          Write-LogGroupStart -Title $title
+          Start-PSBootstrap -Scenario Tools
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Sync Tags'
+          Write-LogGroupStart -Title $title
+          Sync-PSTags -AddRemoteIfMissing
+          Write-LogGroupEnd -Title $title
+
+          $title = 'Setup .NET environment variables'
+          Write-LogGroupStart -Title $title
+          Find-DotNet -SetDotnetRoot
+          Write-LogGroupEnd -Title $title
+        shell: pwsh

--- a/.github/workflows/windows-packaging-reusable.yml
+++ b/.github/workflows/windows-packaging-reusable.yml
@@ -13,6 +13,9 @@ env:
   SYSTEM_ARTIFACTSDIRECTORY: ${{ github.workspace }}/artifacts
   BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ github.workspace }}/artifacts
 
+permissions:
+  contents: read
+
 jobs:
   package:
     name: ${{ matrix.architecture }} - ${{ matrix.channel }}

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: testResults-xunit
 
+permissions:
+  contents: read
+
 jobs:
   xunit:
     name: Run xUnit Tests


### PR DESCRIPTION
Backport of #27202 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27202$$$
-->

Triggered by @daxian-dbw on behalf of @step-security-bot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds least-privilege GitHub Actions token permissions to release/v7.4.15 workflows used for Copilot setup, Windows packaging, and xUnit test execution.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The cherry-pick completed on release/v7.4.15 after resolving one workflow file state conflict. The resulting workflows all include the intended top-level read-only contents permission, and CI on the backport PR will validate that the affected reusable workflows still execute successfully.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk because the change affects workflow permissions across build and test automation, but it narrows privileges rather than expanding behavior and is limited to three workflow files.

## Merge Conflicts

Resolved one delete/update conflict in .github/workflows/copilot-setup-steps.yml by keeping the valid workflow file content and preserving the intended top-level 'permissions: contents: read' hardening from the original PR.
