### PR TITLE
[release/v7.4.15] Change the display name of PowerShell-LTS package to PowerShell LTS

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -4271,7 +4271,7 @@ function New-MSIXPackage
         $displayName += ' Preview'
     } elseif ($LTS) {
         $ProductName += '-LTS'
-        $displayName += '-LTS'
+        $displayName += ' LTS'
     }
 
     Write-Verbose -Verbose "ProductName: $productName"


### PR DESCRIPTION
Backport of #27203 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27203$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Updates the displayed Microsoft Store package name from 'PowerShell-LTS' to 'PowerShell LTS' while keeping the package family identity unchanged, improving presentation for users without changing install identity.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The cherry-pick applied cleanly to release/v7.4.15 and changes only the packaging metadata used for the PowerShell-LTS MSIX package display name. CI on the backport PR will validate the packaging pipeline with the updated metadata.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk because the change only updates displayed package metadata and does not alter package identity, upgrade behavior, or runtime code.
