### PR TITLE
Fixes bug that UsingStatementAst.Copy always throws

### DIFF
--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -3037,8 +3037,8 @@ namespace System.Management.Automation.Language
         public override Ast Copy()
         {
             var copy = Alias != null
-                ? new UsingStatementAst(Extent, UsingStatementKind, Name, Alias)
-                : new UsingStatementAst(Extent, UsingStatementKind, Name);
+                ? new UsingStatementAst(Extent, UsingStatementKind, (StringConstantExpressionAst)Name.Copy(), (StringConstantExpressionAst)Alias.Copy())
+                : new UsingStatementAst(Extent, UsingStatementKind, (StringConstantExpressionAst)Name.Copy());
             copy.ModuleInfo = ModuleInfo;
 
             return copy;

--- a/test/powershell/Language/Parser/Ast.Tests.ps1
+++ b/test/powershell/Language/Parser/Ast.Tests.ps1
@@ -25,5 +25,12 @@ Describe "The SafeGetValue method on AST returns safe values" -Tags "CI" {
     It "A ScriptBlock AST fails with the proper error" {
         { { 1 }.Ast.SafeGetValue() } | Should -Throw -ErrorId "InvalidOperationException"
     }
+    It "UsingStatementAst.Copy() should not throw" {
+        {
+            [scriptblock]::Create(
+                'using namespace System;'
+            ).Ast.UsingStatements[0].Copy()
+        } | Should -Not -Throw
+    }
 
 }


### PR DESCRIPTION
 Fixes #8973

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Implements the change as suggested in the issue.

Fixes examples like

```
$ast = [System.Management.Automation.Language.Parser]::ParseInput('using namespace System', [ref] $null, [ref] $null)
$ast.UsingStatements[0].Copy()
```

or

```
[scriptblock]::Create(@'
using namespace System;
'@).Ast.UsingStatements[0].Copy()
```

which currently always throw.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

This should have been merged back when the issue was created. Really sad state that such issues with obvious solutions are closed by bots. Especially now in times of LLMs such issues could automatically be found and fixed...

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - N/A [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - N/A Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - N/A [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - N/A Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
