### PR TITLE
[release/v7.4.15] [StepSecurity] ci: Harden GitHub Actions tags

### DIFF
--- a/.github/actions/build/ci/action.yml
+++ b/.github/actions/build/ci/action.yml
@@ -13,7 +13,7 @@ runs:
     if: github.event_name != 'PullRequest'
     run: Write-Host "##vso[build.updatebuildnumber]$env:BUILD_SOURCEBRANCHNAME-$env:BUILD_SOURCEVERSION-$((get-date).ToString("yyyyMMddhhmmss"))"
     shell: pwsh
-  - uses: actions/setup-dotnet@v4
+  - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
     with:
       global-json-file: ./global.json
   - name: Bootstrap
@@ -34,7 +34,7 @@ runs:
       Invoke-CIBuild
     shell: pwsh
   - name: Upload build artifact
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
     with:
       name: build
       path: ${{ runner.workspace }}/build

--- a/.github/actions/infrastructure/get-changed-files/action.yml
+++ b/.github/actions/infrastructure/get-changed-files/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Get changed files
       id: get-files
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const eventTypes = '${{ inputs.event-types }}'.split(',').map(t => t.trim());

--- a/.github/actions/infrastructure/path-filters/action.yml
+++ b/.github/actions/infrastructure/path-filters/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Check if GitHubWorkflowChanges is present
       id: filter
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
         FILES_JSON: ${{ steps.get-files.outputs.files }}
       with:

--- a/.github/actions/test/linux-packaging/action.yml
+++ b/.github/actions/test/linux-packaging/action.yml
@@ -11,7 +11,7 @@ runs:
       Show-Environment
     shell: pwsh
 
-  - uses: actions/setup-dotnet@v5
+  - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
     with:
       global-json-file: ./global.json
 
@@ -97,21 +97,21 @@ runs:
     shell: pwsh
 
   - name: Upload deb packages
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
     with:
       name: packages-deb
       path: ${{ runner.workspace }}/packages/*.deb
       if-no-files-found: ignore
 
   - name: Upload rpm packages
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
     with:
       name: packages-rpm
       path: ${{ runner.workspace }}/packages/*.rpm
       if-no-files-found: ignore
 
   - name: Upload tar.gz packages
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
     with:
       name: packages-tar
       path: ${{ runner.workspace }}/packages/*.tar.gz

--- a/.github/actions/test/nix/action.yml
+++ b/.github/actions/test/nix/action.yml
@@ -26,7 +26,7 @@ runs:
     shell: pwsh
 
   - name: Download Build Artifacts
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
     with:
       path: "${{ github.workspace }}"
 
@@ -39,7 +39,7 @@ runs:
       Write-LogGroupEnd -Title 'Artifacts Directory'
     shell: pwsh
 
-  - uses: actions/setup-dotnet@v4
+  - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
     with:
       global-json-file: ./global.json
 
@@ -53,7 +53,7 @@ runs:
       Write-LogGroupEnd -Title 'Bootstrap'
 
   - name: Extract Files
-    uses: actions/github-script@v7.0.0
+    uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
     env:
       DESTINATION_FOLDER: "${{ github.workspace }}/bins"
       ARCHIVE_FILE_PATTERNS: "${{ github.workspace }}/build/build.zip"

--- a/.github/actions/test/process-pester-results/action.yml
+++ b/.github/actions/test/process-pester-results/action.yml
@@ -21,7 +21,7 @@ runs:
 
   - name: Upload testResults artifact
     if: always()
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
     with:
       name: junit-pester-${{ inputs.name }}
       path: ${{ runner.workspace }}/testResults

--- a/.github/actions/test/windows/action.yml
+++ b/.github/actions/test/windows/action.yml
@@ -26,7 +26,7 @@ runs:
     shell: pwsh
 
   - name: Download Build Artifacts
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
     with:
       path: "${{ github.workspace }}"
 
@@ -39,7 +39,7 @@ runs:
       Write-LogGroupEnd -Title 'Artifacts Directory'
     shell: pwsh
 
-  - uses: actions/setup-dotnet@v4
+  - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
     with:
       global-json-file: .\global.json
 

--- a/.github/workflows/analyze-reusable.yml
+++ b/.github/workflows/analyze-reusable.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         fetch-depth: '0'
 
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         global-json-file: ./global.json
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -18,11 +18,11 @@ jobs:
 
     steps:
     - name: Check out the repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Verify PR has label starting with 'cl-'
       id: verify-labels
-      uses: actions/github-script@v6
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
           const labels = context.payload.pull_request.labels.map(label => label.name.toLowerCase());

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -55,7 +55,7 @@ jobs:
       packagingChanged: ${{ steps.filter.outputs.packagingChanged }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -74,7 +74,7 @@ jobs:
       contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check for merge conflict markers
         uses: "./.github/actions/infrastructure/merge-conflict-checker"
@@ -86,7 +86,7 @@ jobs:
     if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.buildModuleChanged == 'true' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
 
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Linux Unelevated CI
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Linux Elevated CI
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Linux Unelevated Others
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Linux Elevated Others
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Linux Packaging

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -55,7 +55,7 @@ jobs:
       packagingChanged: ${{ steps.filter.outputs.packagingChanged }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Change Detection
         id: filter
@@ -70,7 +70,7 @@ jobs:
     if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.buildModuleChanged == 'true' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Build
@@ -84,7 +84,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: macOS Unelevated CI
@@ -101,7 +101,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: macOS Elevated CI
@@ -118,7 +118,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: macOS Unelevated Others
@@ -135,7 +135,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: macOS Elevated Others
@@ -161,10 +161,10 @@ jobs:
       - macos-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 1000
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         global-json-file: ./global.json
     - name: Bootstrap packaging
@@ -223,7 +223,7 @@ jobs:
         testResultsFolder: "${{ runner.workspace }}/testResults"
     - name: Upload package artifact
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: macos-package
         path: "*.pkg"

--- a/.github/workflows/verify-markdown-links.yml
+++ b/.github/workflows/verify-markdown-links.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Verify markdown links
         id: verify

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -58,7 +58,7 @@ jobs:
       packagingChanged: ${{ steps.filter.outputs.packagingChanged }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Change Detection
         id: filter
@@ -73,7 +73,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Build
@@ -87,7 +87,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Windows Unelevated CI
@@ -104,7 +104,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Windows Elevated CI
@@ -121,7 +121,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Windows Unelevated Others
@@ -138,7 +138,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
       - name: Windows Elevated Others

--- a/.github/workflows/windows-packaging-reusable.yml
+++ b/.github/workflows/windows-packaging-reusable.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
 
@@ -64,7 +64,7 @@ jobs:
         shell: pwsh
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: ./global.json
 
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload Build Artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: windows-packaging-${{ matrix.architecture }}-${{ matrix.channel }}
           path: |

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ${{ inputs.runner_os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1000
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: ./global.json
 
@@ -49,7 +49,7 @@ jobs:
           Write-Host "Completed xUnit test run."
 
       - name: Upload xUnit results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: ${{ inputs.test_results_artifact_name }}


### PR DESCRIPTION
Backport of #27201 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27201$$$
-->

Triggered by @daxian-dbw on behalf of @step-security-bot

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Hardens GitHub Actions usage on release/v7.4.15 by replacing mutable action tag references with pinned commit SHAs. The backport preserves the release-branch workflow structure and carries over only the SHA pinning updates from the original PR.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by completing the cherry-pick on release/v7.4.15, reviewing the staged diff to confirm the backport only changes action references from version tags to pinned SHAs, and confirming the worktree is clean after cherry-pick completion. No local workflow execution was run; CI will validate behavior on the backport PR.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

This touches CI/build workflow infrastructure across multiple reusable workflows and action definitions. The risk is mitigated because the backport is narrowly scoped to immutable action pin updates only, with release-branch-specific runner and workflow structure intentionally preserved.

## Merge Conflicts

Conflicts occurred in .github/workflows/labels.yml, .github/workflows/linux-ci.yml, .github/workflows/macos-ci.yml, .github/workflows/verify-markdown-links.yml, .github/workflows/windows-ci.yml, .github/workflows/windows-packaging-reusable.yml, and .github/workflows/xunit-tests.yml. Resolution preserved the release/v7.4.15 workflow content and applied only the original PR's @v... to @<sha> action reference changes. Higher-version main-branch workflow differences such as runner upgrades were not brought into the backport.
