### PR TITLE
[release/v7.5.6] Pin ready-to-merge.yml reusable workflow to commit SHA

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -238,7 +238,7 @@ jobs:
       - infrastructure_tests
       # - analyze
     if: always()
-    uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@v1.0.0
+    uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@c8b3ad5819ad7078f3e375519b4f8c6232d1cbdf # v1.0.0
     with:
       needs_context: ${{ toJson(needs) }}
   linux_packaging:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -240,6 +240,6 @@ jobs:
       - macos_test_unelevated_ci
       - macos_test_unelevated_others
     if: always()
-    uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@v1.0.0
+    uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@c8b3ad5819ad7078f3e375519b4f8c6232d1cbdf # v1.0.0
     with:
       needs_context: ${{ toJson(needs) }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -183,6 +183,6 @@ jobs:
       - analyze
       - windows_packaging
     if: always()
-    uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@v1.0.0
+    uses: PowerShell/compliance/.github/workflows/ready-to-merge.yml@c8b3ad5819ad7078f3e375519b4f8c6232d1cbdf # v1.0.0
     with:
       needs_context: ${{ toJson(needs) }}


### PR DESCRIPTION
Backport of #27204 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27204$$$
-->

Triggered by @daxian-dbw on behalf of @copilot-swe-agent

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports the security hardening change that pins the ready-to-merge.yml reusable workflow reference from the v1.0.0 tag to a specific commit SHA. Pinning CI workflow references to commit SHAs is a security best practice that prevents tag mutation attacks.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

No functional code changes — only CI YAML workflow file updates. Backport cherry-picked cleanly without conflicts.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Change is limited to three .github/workflows/ files. The only modification is pinning a uses: reference from a tag to a commit SHA. No code changes, no dependency changes, no breaking changes possible.
