### PR TITLE
[release/v7.6.1] Add verbose message to Get-Service when properties cannot be returned

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -674,13 +674,30 @@ namespace Microsoft.PowerShell.Commands
         #endregion Overrides
 
 #nullable enable
+
+        /// <summary>
+        /// Writes a verbose message when a service property query fails.
+        /// </summary>
+        /// <param name="serviceName">Name of the service.</param>
+        /// <param name="propertyName">Name of the property that failed to be queried.</param>
+        private void WriteServicePropertyError(string serviceName, string propertyName)
+        {
+            Win32Exception e = new(Marshal.GetLastWin32Error());
+            WriteVerbose(
+                StringUtil.Format(
+                    ServiceResources.CouldNotGetServiceProperty,
+                    serviceName,
+                    propertyName,
+                    e.Message));
+        }
+
         /// <summary>
         /// Adds UserName, Description, BinaryPathName, DelayedAutoStart and StartupType to a ServiceController object.
         /// </summary>
         /// <param name="scManagerHandle">Handle to the local SCManager instance.</param>
         /// <param name="service"></param>
         /// <returns>ServiceController as PSObject with UserName, Description and StartupType added.</returns>
-        private static PSObject AddProperties(nint scManagerHandle, ServiceController service)
+        private PSObject AddProperties(nint scManagerHandle, ServiceController service)
         {
             NakedWin32Handle hService = nint.Zero;
 
@@ -709,6 +726,10 @@ namespace Microsoft.PowerShell.Commands
                     {
                         description = descriptionInfo.lpDescription;
                     }
+                    else
+                    {
+                        WriteServicePropertyError(service.ServiceName, nameof(NativeMethods.SERVICE_DESCRIPTIONW));
+                    }
 
                     if (NativeMethods.QueryServiceConfig2(
                         hService,
@@ -716,6 +737,10 @@ namespace Microsoft.PowerShell.Commands
                         out NativeMethods.SERVICE_DELAYED_AUTO_START_INFO autostartInfo))
                     {
                         isDelayedAutoStart = autostartInfo.fDelayedAutostart;
+                    }
+                    else
+                    {
+                        WriteServicePropertyError(service.ServiceName, nameof(NativeMethods.SERVICE_DELAYED_AUTO_START_INFO));
                     }
 
                     if (NativeMethods.QueryServiceConfig(
@@ -731,6 +756,15 @@ namespace Microsoft.PowerShell.Commands
                                 isDelayedAutoStart.Value);
                         }
                     }
+                    else
+                    {
+                        WriteServicePropertyError(service.ServiceName, nameof(NativeMethods.QUERY_SERVICE_CONFIG));
+                    }
+                }
+                else
+                {
+                    // handle when OpenServiceW itself fails:
+                    WriteServicePropertyError(service.ServiceName, nameof(NativeMethods.SERVICE_QUERY_CONFIG));
                 }
             }
             finally

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -212,5 +212,8 @@
   </data>
   <data name="UnsupportedStartupType" xml:space="preserve">
     <value>The startup type '{0}' is not supported by {1}.</value>
+  </data>
+  <data name="CouldNotGetServiceProperty" xml:space="preserve">
+    <value>Could not retrieve property '{1}' for service '{0}': {2}</value>
   </data>
 </root>


### PR DESCRIPTION
Backport of #27109 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27109$$$
-->

Triggered by @daxian-dbw on behalf of @reabr

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [x] Customer reported
- [ ] Found internally

Fixes #24272 – adds verbose messages to `Get-Service` when service properties (Description, DelayedAutoStart, BinaryPathName, StartupType, UserName) cannot be retrieved due to permissions or other issues. Only visible when using `-Verbose`, so it is non-intrusive by default.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified locally that verbose messages appear for services with missing MUI resources (e.g. NPSMSvc, WaaSMedicSvc) when running `Get-Service -Verbose`. Backport applies cleanly with no conflicts.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Only adds verbose output when `-Verbose` is explicitly used; standard `Get-Service` behavior is completely unchanged.
