### PR TITLE
[release/v7.6.1] Add in PDP-Media directory

### DIFF
--- a/.pipelines/templates/package-store-package.yml
+++ b/.pipelines/templates/package-store-package.yml
@@ -195,6 +195,7 @@ jobs:
         contents: '*.msixBundle'
         outSBName: 'PowerShellStorePackage'
         pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
+        pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
 
     - task: MS-RDX-MRO.windows-store-publish.package-task.store-package@3
       displayName: 'Create StoreBroker Package (Stable/LTS)'
@@ -206,6 +207,7 @@ jobs:
         contents: '*.msixBundle'
         outSBName: 'PowerShellStorePackage'
         pdpPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP'
+        pdpMediaPath: '$(System.DefaultWorkingDirectory)/PowerShell/.pipelines/store/PDP/PDP-Media'
 
     - pwsh: |
         $outputDirectory = "$(ob_outputDirectory)"


### PR DESCRIPTION
Backport of #27254 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27254$$$
-->

Triggered by @daxian-dbw on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Restores the `pdpMediaPath` parameter to the store package pipeline job. The Store broker task requires `PDPMediaPath` when `PDPPath` is specified; omitting it breaks the store packaging process.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

pdpMediaPath was removed in PR #27024 as part of a cleanup.

## Testing

This is a pipeline configuration change that can only be tested interactively/in CI. The change restores a parameter that was confirmed necessary by the Store broker task requirements.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Minimal risk — restores a previously working configuration parameter with no logic changes.
