### PR TITLE
[release/v7.6.1] PSStyle: validate background index against BackgroundColorMap

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
@@ -892,7 +892,7 @@ namespace System.Management.Automation
                 throw new ArgumentOutOfRangeException(paramName: nameof(foregroundColor));
             }
 
-            if (backIndex < 0 || backIndex >= ForegroundColorMap.Length)
+            if (backIndex < 0 || backIndex >= BackgroundColorMap.Length)
             {
                 throw new ArgumentOutOfRangeException(paramName: nameof(backgroundColor));
             }


### PR DESCRIPTION
Backport of #27106 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27106$$$
-->

Triggered by @daxian-dbw on behalf of @cuiweixie

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes `FromAnsiColor` incorrectly raising `ArgumentOutOfRangeException` when validating background color index against `ForegroundColorMap.Length` instead of `BackgroundColorMap.Length`. Customers using PSStyle background colors with maps that differ in size would encounter unexpected exceptions.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Manual code review verified the fix uses the correct map (`BackgroundColorMap`) for bounds validation in the background color branch. CI will validate the change.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Single-line bounds check fix — corrects which map length is used for validation. No behavioral change for valid inputs, and the fix only affects the error path when maps differ in size.
