### PR TITLE
[release/v7.5.6] Fix the APIScan pipeline

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -83,11 +83,11 @@ extends:
         break: true  # always break the build on binskim issues in addition to TSA upload
       policheck:
         break: true  # always break the build on policheck issues. You can disable it by setting to 'false'
-              # APIScan requires a non-Ready-To-Run build
+      # APIScan requires a non-Ready-To-Run build
       apiscan:
         enabled: true
         softwareName: "PowerShell" # Default is repo name
-        versionNumber: "7.5" # Default is build number
+        versionNumber: "7.6" # Default is build number
         isLargeApp: false # Default: false.
         symbolsFolder: $(SymbolsServerUrl);$(ob_outputDirectory)
 #softwareFolder - relative path to a folder to be scanned. Default value is root of artifacts folder.

--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -87,7 +87,7 @@ extends:
       apiscan:
         enabled: true
         softwareName: "PowerShell" # Default is repo name
-        versionNumber: "7.6" # Default is build number
+        versionNumber: "7.5" # Default is build number
         isLargeApp: false # Default: false.
         symbolsFolder: $(SymbolsServerUrl);$(ob_outputDirectory)
 #softwareFolder - relative path to a folder to be scanned. Default value is root of artifacts folder.

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -15,7 +15,6 @@ jobs:
       - name: branchCounter
         value: $[counter(variables['branchCounterKey'], 1)]
       - group: DotNetPrivateBuildAccess
-      - group: Azure Blob variable group
       - group: ReleasePipelineSecrets
       - group: mscodehub-feed-read-general
       - group: mscodehub-feed-read-akv
@@ -72,34 +71,6 @@ jobs:
       workingDirectory: '$(repoRoot)'
       retryCountOnTaskFailure: 2
 
-    - task: AzurePowerShell@5
-      displayName: Download winverify-private Artifacts
-      inputs:
-        azureSubscription: az-blob-cicd-infra
-        scriptType: inlineScript
-        azurePowerShellVersion: LatestVersion
-        workingDirectory: '$(repoRoot)'
-        pwsh: true
-        inline: |
-          # download smybols for getfilesiginforedist.dll
-          $downloadsDirectory = '$(Build.ArtifactStagingDirectory)/downloads'
-          $uploadedDirectory = '$(Build.ArtifactStagingDirectory)/uploaded'
-          $storageAccountName = "pscoretestdata"
-          $containerName = 'winverify-private'
-          $winverifySymbolsPath = New-Item -ItemType Directory -Path '$(System.ArtifactsDirectory)/winverify-symbols' -Force
-          $dllName = 'getfilesiginforedist.dll'
-          $winverifySymbolsDllPath = Join-Path $winverifySymbolsPath $dllName
-
-          $context = New-AzStorageContext -StorageAccountName $storageAccountName -UseConnectedAccount
-
-          Get-AzStorageBlobContent -Container $containerName -Blob $dllName -Destination $winverifySymbolsDllPath -Context $context
-
-    - pwsh: |
-        Get-ChildItem -Path '$(System.ArtifactsDirectory)/winverify-symbols'
-      displayName: Capture winverify-private Artifacts
-      workingDirectory: '$(repoRoot)'
-      condition: succeededOrFailed()
-
     - task: CodeQL3000Init@0 # Add CodeQL Init task right before your 'Build' step.
       displayName: 🔏 CodeQL 3000 Init
       condition: eq(variables['CODEQL_ENABLED'], 'true')
@@ -118,23 +89,35 @@ jobs:
           Remove-Item -Recurse -Force $OutputFolder/ref
         }
 
-        Copy-Item -Path "$OutputFolder\*" -Destination '$(ob_outputDirectory)' -Recurse -Verbose
+        $Destination = '$(ob_outputDirectory)'
+        if (-not (Test-Path $Destination)) {
+          Write-Verbose -Verbose -Message "Creating destination folder '$Destination'"
+          $null = mkdir $Destination
+        }
+
+        Copy-Item -Path "$OutputFolder\*" -Destination $Destination -Recurse -Verbose
       workingDirectory: '$(repoRoot)'
       displayName: 'Build PowerShell Source'
 
     - pwsh: |
-        # Only key windows runtimes
-        Get-ChildItem -Path '$(ob_outputDirectory)\runtimes\*' -File -Recurse | Where-Object {$_.FullName -notmatch '.*\/runtimes\/win'} | Foreach-Object {
+        # Only keep windows runtimes
+        Write-Verbose -Verbose -Message "Deleting non-win-x64 runtimes ..."
+        Get-ChildItem -Path '$(ob_outputDirectory)\runtimes\*' | Where-Object {$_.FullName -notmatch '.*\\runtimes\\win'} | Foreach-Object {
           Write-Verbose -Verbose -Message "Deleting $($_.FullName)"
-          Remove-Item -Force -Verbose -Path $_.FullName
+          Remove-Item -Path $_.FullName -Recurse -Force
         }
 
-        # Temporarily remove runtimes/win-x64  due to issues with that runtime
-        Get-ChildItem -Path '$(ob_outputDirectory)\runtimes\*' -File -Recurse | Where-Object {$_.FullName -match '.*\/runtimes\/win-x86\/'} | Foreach-Object {
+        # Remove win-x86/arm/arm64 runtimes due to issues with those runtimes
+        Write-Verbose -Verbose -Message "Temporarily deleting win-x86/arm/arm64 runtimes ..."
+        Get-ChildItem -Path '$(ob_outputDirectory)\runtimes\*' | Where-Object {$_.FullName -match '.*\\runtimes\\win-(x86|arm)'} | Foreach-Object {
           Write-Verbose -Verbose -Message "Deleting $($_.FullName)"
-          Remove-Item -Force -Verbose -Path $_.FullName
+          Remove-Item -Path $_.FullName -Recurse -Force
         }
 
+        Write-Host
+        Write-Verbose -Verbose -Message "Show content in 'runtimes' folder:"
+        Get-ChildItem -Path '$(ob_outputDirectory)\runtimes'
+        Write-Host
       workingDirectory: '$(repoRoot)'
       displayName: 'Remove unused runtimes'
 


### PR DESCRIPTION
Backport of #26016 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26016$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes the APIScan pipeline: keeps `win` and `win-x64` runtime folders when removing unused runtimes, and stops downloading `getfilesiginforedist.dll` from Azure blob (the build-produced version works correctly with `dotnet-symbols`).

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The APIScan validation pipeline was run and passed successfully. This change only affects CI/build tooling with no user-facing code changes, so no new automated tests are needed.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a CI/build pipeline-only fix with no changes to user-facing PowerShell code. The risk of regression is minimal.
