### PR TITLE
Remove package verification from the notice pipeline

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -8,9 +8,6 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
-  - name: SkipVerifyPackages
-    type: boolean
-    default: false
 
 variables:
   # PAT permissions NOTE: Declare a SymbolServerPAT variable in this group with a 'microsoft' organizanization scoped PAT with 'Symbols' Read permission.
@@ -112,4 +109,3 @@ extends:
           - template: /.pipelines/templates/compliance/generateNotice.yml@self
             parameters:
               parentJobs: []
-              SkipVerifyPackages: ${{ parameters.SkipVerifyPackages }}

--- a/.pipelines/templates/compliance/generateNotice.yml
+++ b/.pipelines/templates/compliance/generateNotice.yml
@@ -4,8 +4,6 @@
 parameters:
   - name: parentJobs
     type: jobList
-  - name: SkipVerifyPackages
-    type: boolean
 
 jobs:
 - job: generateNotice
@@ -56,11 +54,6 @@ jobs:
     displayName: 'Component Detection'
     inputs:
       sourceScanPath: '$(repoRoot)\tools\cgmanifest\tpn'
-
-  - pwsh: |
-      $(repoRoot)/tools/clearlyDefined/ClearlyDefined.ps1 -TestAndHarvest
-    displayName: Verify that packages have license data
-    condition: eq(${{ parameters.SkipVerifyPackages }}, false)
 
   - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
     displayName: 'NOTICE File Generator'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Now that the "Release Prep" workflow does the work to update `cgmanifest.json`, we should remove package verification from the notice pipeline.