### PR TITLE
Fix `Start-Process -PassThru` when no handle is returned

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2649,10 +2649,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private Process StartWithShellExecute(ProcessStartInfo startInfo)
         {
-            Process result = null;
+            Process result = new() { StartInfo = startInfo };
             try
             {
-                result = Process.Start(startInfo);
+                if (!result.Start())
+                {
+                    string msg = StringUtil.Format(ProcessResources.FailedToCreateProcessObject, startInfo.FileName);
+                    WriteDebug(msg);
+                }
             }
             catch (Win32Exception ex)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -134,6 +134,10 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
         $process | Stop-Process
     }
 
+    It "Should start ms-settings URI with ShellExecute" -Skip:(!$isFullWin) {
+        Start-Process ms-settings: -PassThru
+    }
+
     It "Should be able to use the -WhatIf switch without performing the actual action" {
         $pingOutput = Join-Path $TestDrive "pingOutput.txt"
         { Start-Process -Wait $pingCommand -ArgumentList $pingParam -RedirectStandardOutput $pingOutput -WhatIf -ErrorAction Stop  @extraArgs} | Should -Not -Throw

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -135,7 +135,8 @@ Describe "Start-Process" -Tag "Feature","RequireAdminOnWindows" {
     }
 
     It "Should start ms-settings URI with ShellExecute" -Skip:(!$isFullWin) {
-        Start-Process ms-settings: -PassThru
+        { Start-Process ms-settings: -PassThru } | Should -Not -Throw
+        Get-Process "SystemSettings" | Stop-Process
     }
 
     It "Should be able to use the -WhatIf switch without performing the actual action" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
`Start-Process -PassThru` throw an exception when `Process.Start(info)` returns null, but [this is expected in some cases](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-shellexecuteinfoa#:~:text=be%20NULL.-,Note,-%3A%20ShellExecuteEx%20does). It confuses users when the process starts, but an exception is thrown (see #10996). The error message (`CannotStarttheProcess`) is also a bit ambiguous: `This command cannot be run completely because the system cannot find all the information required.`

I'm proposing a debug message instead of an exception, like the one used when a process is started as a different user and we can't retrieve the handle. Then returning a Process object with just `StartInfo`. If methods are called like `$process.Kill()`, a slightly more meaningful exception (`NoAssociatedProcess`) is thrown: `No process is associated with this object`. The null properties like `Name` might be confusing though.

These changes also impact `-Wait` - it would throw `NoAssociatedProcess` instead of `CannotStarttheProcess`.

I'm not sure if this is a breaking change, are exceptions considered an API contract? It would break code like this:

```pwsh
$target = "ms-settings:"
$name = "SystemSettings"
$process = $null
try {
  $process = Start-Process $target -PassThru
} catch {
  $process = Get-Process $name
}
$process.Kill()
```

Alternatively, we could use a more descriptive exception than `CannotStarttheProcess`? Perhaps a format string that mentions `-PassThru` or `-Wait`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
