### PR TITLE
[release/v7.7.0-preview.1] Enable usage in AppContainers

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -967,7 +967,9 @@ namespace System.Management.Automation
 #if UNIX
             return Platform.SelectProductNameForDirectory(Platform.XDG_Type.USER_MODULES);
 #else
-            string myDocumentsPath = InternalTestHooks.SetMyDocumentsSpecialFolderToBlank ? string.Empty : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            string myDocumentsPath = InternalTestHooks.SetMyDocumentsSpecialFolderToBlank
+                ? string.Empty
+                : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.DoNotVerify);
             return string.IsNullOrEmpty(myDocumentsPath) ? null : Path.Combine(myDocumentsPath, Utils.ModuleDirectory);
 #endif
         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -569,7 +569,7 @@ namespace Microsoft.PowerShell.Commands
             if (driveIsFixed)
             {
                 // Since the drive is fixed, ensure the root is valid.
-                validDrive = Directory.Exists(drive.Root);
+                validDrive = SafeDoesPathExist(drive.Root);
             }
 
             if (validDrive)
@@ -908,7 +908,7 @@ namespace Microsoft.PowerShell.Commands
 
                         if (newDrive.DriveType == DriveType.Fixed)
                         {
-                            if (!newDrive.RootDirectory.Exists)
+                            if (!SafeDoesPathExist(newDrive.RootDirectory.FullName))
                             {
                                 continue;
                             }
@@ -1224,6 +1224,29 @@ namespace Microsoft.PowerShell.Commands
             catch (UnauthorizedAccessException accessException)
             {
                 WriteError(new ErrorRecord(accessException, "GetItemUnauthorizedAccessError", ErrorCategory.PermissionDenied, path));
+            }
+        }
+
+        private static bool SafeDoesPathExist(string rootDirectory)
+        {
+            if (Directory.Exists(rootDirectory))
+            {
+                return true;
+            }
+
+            try
+            {
+                return (File.GetAttributes(rootDirectory) & FileAttributes.Directory) is not 0;
+            }
+            // In some scenarios (like AppContainers) direct access to the root directory may
+            // be prevented, but more specific paths may be accessible.
+            catch (UnauthorizedAccessException)
+            {
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
Backport of #27266 to release/v7.7.0-preview.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27266$$$
-->

Triggered by @jshigetomi on behalf of @SeeminglyScience

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [x] Customer reported
- [ ] Found internally

Fixes #27253. When PowerShell runs inside a Windows AppContainer, the root of the system drive (e.g. C:\) is not directly accessible. The previous fixed-drive validation treated Directory.Exists returning false (due to access-denied) as evidence the drive was missing, which caused PowerShell to skip mounting all FileSystem PSDrives and effectively broke module loading and most cmdlets. This change treats UnauthorizedAccessException on the drive root as evidence the drive does exist, allowing PowerShell to operate normally in sandboxed AppContainer environments.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

No new automated tests - AppContainer behavior cannot be exercised by the existing CI matrix without process-isolation infrastructure (the original PR was marked "N/A or can only be tested interactively"). The original fix was verified manually by the author by running PowerShell inside an AppContainer and confirming PSDrives mount and the personal module path resolves. Backport verification: cherry-pick applied cleanly with no conflicts against release/v7.7.0-preview.1; CI on the backport branch will exercise all existing FileSystemProvider and module-path tests to confirm no regression in the non-AppContainer fast path (where Directory.Exists still short-circuits).

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk. The change is narrowly scoped (28 additions / 3 deletions across 2 files) and behavior is strictly more permissive only on the previously-failing access-denied path: (1) SafeDoesPathExist is a new private static helper used solely for fixed-drive root validation in NewDrive and InitializeDefaultDrives - it preserves the existing Directory.Exists fast path and only widens behavior when that returns false; (2) Environment.SpecialFolderOption.DoNotVerify for MyDocuments is the documented .NET pattern for sandboxed/redirected profile scenarios and only changes behavior when the shell's verification step would have failed. Non-AppContainer behavior is unchanged. Two PowerShell maintainers (TravisEz13, asklar) approved the original PR.
