### PR TITLE
[release/v7.7.0-preview.1] Update `MaxVisitCount` and `MaxHashtableKeyCount` if `VisitorSafeValueContext` indicates `SkipLimitCheck` is true

### DIFF
--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -47,11 +47,15 @@ namespace System.Management.Automation.Language
         internal IsSafeValueVisitor(GetSafeValueVisitor.SafeValueContext safeValueContext)
         {
             _safeValueContext = safeValueContext;
+
+            bool skipSizeCheck = safeValueContext is GetSafeValueVisitor.SafeValueContext.SkipHashtableSizeCheck;
+            _maxVisitCount = skipSizeCheck ? uint.MaxValue : 5000;
+            _maxHashtableKeyCount = skipSizeCheck ? int.MaxValue : 500;
         }
 
         internal bool IsAstSafe(Ast ast)
         {
-            if ((bool)ast.Accept(this) && _visitCount < MaxVisitCount)
+            if ((bool)ast.Accept(this) && _visitCount < _maxVisitCount)
             {
                 return true;
             }
@@ -65,8 +69,8 @@ namespace System.Management.Automation.Language
         // This is a check of the number of visits
         private uint _visitCount = 0;
 
-        private const uint MaxVisitCount = 5000;
-        private const int MaxHashtableKeyCount = 500;
+        private readonly uint _maxVisitCount;
+        private readonly int _maxHashtableKeyCount;
 
         // Used to determine if we are being called within a GetPowerShell() context,
         // which does some additional security verification outside of the scope of
@@ -330,7 +334,7 @@ namespace System.Management.Automation.Language
 
         public object VisitHashtable(HashtableAst hashtableAst)
         {
-            if (hashtableAst.KeyValuePairs.Count > MaxHashtableKeyCount)
+            if (hashtableAst.KeyValuePairs.Count > _maxHashtableKeyCount)
             {
                 return false;
             }
@@ -373,7 +377,7 @@ namespace System.Management.Automation.Language
         {
             t_context = context;
 
-            if (safeValueContext == SafeValueContext.SkipHashtableSizeCheck || IsSafeValueVisitor.IsAstSafe(ast, safeValueContext))
+            if (IsSafeValueVisitor.IsAstSafe(ast, safeValueContext))
             {
                 return ast.Accept(new GetSafeValueVisitor());
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/PowerShellData.tests.ps1
@@ -49,4 +49,10 @@ Describe "Tests for the Import-PowerShellDataFile cmdlet" -Tags "CI" {
         $result = Import-PowerShellDataFile $largePsd1Path -SkipLimitCheck
         $result.Keys.Count | Should -Be 501
     }
+
+    It 'Fails if psd1 file is insecure while -SkipLimitCheck is used' {
+        $path = Setup -f insecure2.psd1 -Content '@{ Foo = [object] (calc.exe) }' -pass
+        { Import-PowerShellDataFile $path -SkipLimitCheck -ErrorAction Stop } |
+            Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.ImportPowerShellDataFileCommand"
+    }
 }


### PR DESCRIPTION
Backport of #27306 to release/v7.7.0-preview.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27306$$$
-->

Triggered by @jshigetomi on behalf of @SeeminglyScience

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Engine fix: ensures `MaxVisitCount` and `MaxHashtableKeyCount` are updated when `VisitorSafeValueContext` indicates `SkipLimitCheck` is true. Without this fix, expression evaluation can hit visit/key-count limits in safe-value contexts that should bypass them. Already merged to release/v7.4.x, v7.5.x, and v7.6.x.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original PR was verified by tests added with the change and has been successfully backported to release/v7.4.x, v7.5.x, and v7.6.x branches (all marked Backport-*-Done). Cherry-pick to release/v7.7.0-preview.1 applied cleanly with no conflicts. CI on the backport branch will validate the change in the preview branch context.</TestingDescription>
</invoke>

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk: small, well-scoped engine change to limit-check handling in `VisitorSafeValueContext`. The same change has already shipped successfully in v7.4, v7.5, and v7.6 release lines without issues. Cherry-pick was clean (no conflicts), so the code applied is identical to the already-validated versions.
