### PR TITLE
[release/v7.6.1] Update Changelog for release v7.6.1

### DIFF
--- a/CHANGELOG/7.6.md
+++ b/CHANGELOG/7.6.md
@@ -46,7 +46,6 @@
 [7.6.1]: https://github.com/PowerShell/PowerShell/compare/v7.6.0...v7.6.1
 
 ## [7.6.0] - 2026-03-12
->>>>>>> 5093967db (Update Changelog for release v7.6.1 (#27304))
 
 ### General Cmdlet Updates and Fixes
 

--- a/CHANGELOG/7.6.md
+++ b/CHANGELOG/7.6.md
@@ -1,6 +1,52 @@
 # 7.6 Changelog
 
+## [7.6.1]
+
+### General Cmdlet Updates and Fixes
+
+- Delay update notification for one week to ensure all packages become available (#27215)
+
+### Tests
+
+- Fix the `PSNativeCommandArgumentPassing` test (#27179)
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 10.0.202</p>
+
+</summary>
+
+<ul>
+<li>Fix PMC Repo URL for RHEL10 (#27061) (#27062)</li>
+<li>Update branch for release (#27287)</li>
+<li>Fix package pipeline by adding in PDP-Media directory (#27257)</li>
+<li>Pin ready-to-merge.yml reusable workflow to commit SHA (#27245)</li>
+<li>[StepSecurity] ci: Harden GitHub Actions tags (#27236)</li>
+<li>Build, package, and create VPack for the PowerShell-LTS store package within the same <code>msixbundle-vpack</code> pipeline (#27237)</li>
+<li>Change the display name of PowerShell-LTS package to PowerShell LTS (#27219)</li>
+<li>[StepSecurity] ci: Harden GitHub Actions tokens (#27218)</li>
+<li>Redo windows image fix to use latest image (#27217)</li>
+<li>Add comment-based help documentation to build.psm1 functions (#27216)</li>
+<li>Separate Store Package Creation, Skip Polling for Store Publish, Clean up PDP-Media (#27214)</li>
+<li>Bump github/codeql-action from 4.34.1 to 4.35.1 (#27184)</li>
+<li>Bump github/codeql-action from 4.32.6 to 4.34.1 (#27182)</li>
+<li>Select New MSIX Package Name (#27183)</li>
+<li>Update the PhoneProductId to be the official LTS id used by Store (#27181)</li>
+<li>release-upload-buildinfo: replace version-comparison channel gating with metadata flags (#27180)</li>
+<li>Move <code>_GetDependencies</code> MSBuild target from dynamic generation in <code>build.psm1</code> into <code>Microsoft.PowerShell.SDK.csproj</code> (#27177)</li>
+<li>Separate Official and NonOfficial templates for ADO pipelines (#27176)</li>
+</ul>
+
+</details>
+
+[7.6.1]: https://github.com/PowerShell/PowerShell/compare/v7.6.0...v7.6.1
+
 ## [7.6.0] - 2026-03-12
+>>>>>>> 5093967db (Update Changelog for release v7.6.1 (#27304))
 
 ### General Cmdlet Updates and Fixes
 


### PR DESCRIPTION
Backport of #27304 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27304$$$
-->

Triggered by @adityapatwardhan on behalf of @adityapatwardhan

Original CL Label: CL-Docs

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Ensures release/v7.6.1 changelog accurately reflects the shipped fixes and build changes so users can reference correct release notes.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified cherry-pick completion and reviewed CHANGELOG/7.6.md to confirm the full 7.6.1 section and compare link were present without conflict markers. Confirmed clean git status after resolution.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Single-file changelog-only backport with no product/runtime code changes. Manual conflict resolution was limited to preserving the existing 7.6.0 heading style while keeping the 7.6.1 content intact.

## Merge Conflicts

Conflict in CHANGELOG/7.6.md at the top heading block. Resolved by keeping the full 7.6.1 section from the original PR and preserving release-branch formatting for the existing 7.6.0 heading (`## [7.6.0] - 2026-03-12`).
