### PR TITLE
PMC release: Use slash instead of back-slash for Linux container

### DIFF
--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -23,7 +23,7 @@ stages:
     - group: 'mscodehub-code-read-akv'
     - group: 'packages.microsoft.com'
     - name: ob_sdl_credscan_suppressionsFile
-      value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      value: $(Build.SourcesDirectory)/PowerShell/.config/suppress.json
     steps:
     - checkout: self ## the global setting on lfs didn't work
       lfs: false


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Use slash instead of back-slash for Linux container. Otherwise, the `CreadScan` step fails because it cannot find the file.

