### PR TITLE
[release/v7.5.6] PMC release: Use slash instead of back-slash for Linux container

### DIFF
--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -23,7 +23,7 @@ stages:
     - group: 'mscodehub-code-read-akv'
     - group: 'packages.microsoft.com'
     - name: ob_sdl_credscan_suppressionsFile
-      value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      value: $(Build.SourcesDirectory)/PowerShell/.config/suppress.json
     steps:
     - checkout: self ## the global setting on lfs didn't work
       lfs: false


### PR DESCRIPTION
Backport of #27315 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27315$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes the CreadScan step failure in the PMC release pipeline when running in Linux containers — the back-slash path separator is invalid on Linux, causing the step to fail to locate files.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Fix verified by the original PR #27315. Backport cherry-picked cleanly without conflicts. CI checks will validate the fix on the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Single path separator character change (backslash to forward slash) in a packaging pipeline script. No runtime code changes, no API or behavior changes for end users.
