### PR TITLE
[release/v7.6.1] PMC release: Use slash instead of back-slash for Linux container

### DIFF
--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -23,7 +23,7 @@ stages:
     - group: 'mscodehub-code-read-akv'
     - group: 'packages.microsoft.com'
     - name: ob_sdl_credscan_suppressionsFile
-      value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      value: $(Build.SourcesDirectory)/PowerShell/.config/suppress.json
     steps:
     - checkout: self ## the global setting on lfs didn't work
       lfs: false


### PR DESCRIPTION
Backport of #27315 to release/v7.6.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27315$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This is a required tooling change that fixes the PMC release build pipeline for Linux containers. Without this fix, the CredScan step fails because the path with backslashes is not properly resolved in Linux environments.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

This backport applies the same fix already successfully tested and merged to v7.5.6 (PR #27318). The change fixes Linux container builds by using forward slashes instead of backslashes in file paths within the release-prep-for-ev2.yml pipeline template.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Medium risk as this modifies the build pipeline, but the change is minimal (single line), well-tested through the v7.5.6 backport, and directly addresses a specific build failure in Linux containers without affecting other functionality.
