### PR TITLE
[release/v7.4.15] Download PMC Packages through `TemplateContext`

### DIFF
--- a/.pipelines/NonOfficial/PowerShell-Release-Azure-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Release-Azure-NonOfficial.yml
@@ -67,10 +67,16 @@ extends:
         exactToolVersion: 4.4.2
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
-      tsaOptionsFile: .config\tsaoptions.json
+      tsaOptionsFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
     stages:
       - template: /.pipelines/templates/release-prep-for-ev2.yml@self
         parameters:
           skipPublish: ${{ parameters.skipPublish }}
 
+      # NonOfficial: run the publish stage to verify templateContext artifact download,
+      # but skip the actual Ev2 push to PMC.
       - template: /.pipelines/templates/release-publish-pmc.yml@self
+        parameters:
+          releaseEnvironment: Test
+          stagePrefix: Test
+          skipEv2Push: true

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -67,7 +67,7 @@ extends:
         exactToolVersion: 4.4.2
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
-      tsaOptionsFile: .config\tsaoptions.json
+      tsaOptionsFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
     stages:
       - template: /.pipelines/templates/release-prep-for-ev2.yml@self
         parameters:

--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -11,6 +11,20 @@ stages:
     displayName: 'Copy EV2 Files to Artifact'
     pool:
       type: linux
+    templateContext:
+      inputs:
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_deb
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_rpm
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_mariner_x64
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_mariner_arm64
     variables:
     - name: ob_outputDirectory
       value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
@@ -24,6 +38,8 @@ stages:
     - group: 'packages.microsoft.com'
     - name: ob_sdl_credscan_suppressionsFile
       value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+    - name: ob_sdl_tsa_configFile
+      value: $(Build.SourcesDirectory)/PowerShell/.config/tsaoptions.json
     steps:
     - checkout: self ## the global setting on lfs didn't work
       lfs: false
@@ -99,39 +115,17 @@ stages:
       env:
         ob_restore_phase: true
 
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_deb'
-      displayName: 'Download artifact containing .deb_amd64.deb file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_rpm'
-      displayName: 'Download artifact containing .rh.x64_86.rpm file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_mariner_x64'
-      displayName: 'Download artifact containing .cm.x86_64.rpm file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_mariner_arm64'
-      displayName: 'Download artifact containing .cm.aarch64.rpm file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
     - pwsh: |
         Write-Verbose -Verbose "Copy ESRP signed .deb and .rpm packages"
-        $downloadedPipelineFolder = Join-Path '$(Pipeline.Workspace)' -ChildPath 'PSPackagesOfficial'
+        # templateContext.inputs places the PSPackagesOfficial pipelineArtifact files
+        # directly under $(Pipeline.Workspace), not in per-artifact subfolders.
+        $downloadedPipelineFolder = '$(Pipeline.Workspace)'
         $srcFilesFolder = Join-Path -Path '$(Pipeline.Workspace)' -ChildPath 'SourceFiles'
         New-Item -Path $srcFilesFolder -ItemType Directory
         $packagesFolder = Join-Path -Path $srcFilesFolder -ChildPath 'packages'
         New-Item -Path $packagesFolder -ItemType Directory
 
-        $packageFiles = Get-ChildItem -Path $downloadedPipelineFolder -Recurse -Directory -Filter "drop_*" | Get-ChildItem -File -Include *.deb, *.rpm
+        $packageFiles = Get-ChildItem -Path $downloadedPipelineFolder -File | Where-Object { $_.Extension -in '.deb', '.rpm' }
         foreach ($file in $packageFiles)
         {
           Write-Verbose -Verbose "copying file: $($file.FullName)"

--- a/.pipelines/templates/release-publish-pmc.yml
+++ b/.pipelines/templates/release-publish-pmc.yml
@@ -1,37 +1,56 @@
+parameters:
+- name: releaseEnvironment
+  type: string
+  default: Production
+  values:
+    - Production
+    - PPE
+    - Test
+- name: approvalServiceEnvironment
+  type: string
+  default: Production
+  values:
+    - Production
+    - PPE
+    - Test
+# OneBranch requires the stage name to be prefixed with the release environment.
+# Official uses 'Prod' for Production; NonProd validators require '<env>' (e.g. 'Test', 'PPE').
+- name: stagePrefix
+  type: string
+  default: Prod
+# When true, the Ev2 push step is skipped. Useful for NonOfficial dry-runs that
+# only want to validate artifact download via templateContext.inputs.
+- name: skipEv2Push
+  type: boolean
+  default: false
+
 stages:
-- stage: 'Prod_Release'
+- stage: ${{ parameters.stagePrefix }}_Release
   displayName: 'Deploy packages to PMC with EV2'
   dependsOn:
   - PrepForEV2
   variables:
     - name: ob_release_environment
-      value: "Production"
+      value: ${{ parameters.releaseEnvironment }}
     - name: repoRoot
       value: $(Build.SourcesDirectory)
   jobs:
-  - job: Prod_ReleaseJob
+  - job: ${{ parameters.stagePrefix }}_ReleaseJob
     displayName: Publish to PMC
     pool:
       type: release
+    templateContext:
+      inputs:
+        - input: pipelineArtifact
+          artifactName: drop_PrepForEV2_CopyEv2FilesToArtifact
 
     steps:
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        targetPath: '$(Pipeline.Workspace)'
-        artifact: drop_PrepForEV2_CopyEv2FilesToArtifact
-      displayName: 'Download drop_PrepForEV2_CopyEv2FilesToArtifact artifact that has all files needed'
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        buildType: 'current'
-        targetPath: '$(Pipeline.Workspace)'
-      displayName: 'Download to get EV2 Files'
-
-    - task: vsrm-ev2.vss-services-ev2.adm-release-task.ExpressV2Internal@1
-      displayName: 'Ev2: Push to PMC'
-      inputs:
-        UseServerMonitorTask: true
-        EndpointProviderType: ApprovalService
-        ApprovalServiceEnvironment: Production
-        ServiceRootPath: '$(Pipeline.Workspace)/drop_PrepForEV2_CopyEV2FilesToArtifact/EV2Specs/ServiceGroupRoot'
-        RolloutSpecPath: '$(Pipeline.Workspace)/drop_PrepForEV2_CopyEV2FilesToArtifact/EV2Specs/ServiceGroupRoot/RolloutSpec.json'
+    - ${{ if not(parameters.skipEv2Push) }}:
+      - task: vsrm-ev2.vss-services-ev2.adm-release-task.ExpressV2Internal@1
+        displayName: 'Ev2: Push to PMC'
+        inputs:
+          UseServerMonitorTask: true
+          EndpointProviderType: ApprovalService
+          ApprovalServiceEnvironment: ${{ parameters.approvalServiceEnvironment }}
+          ServiceRootPath: '$(Pipeline.Workspace)/EV2Specs/ServiceGroupRoot'
+          RolloutSpecPath: '$(Pipeline.Workspace)/EV2Specs/ServiceGroupRoot/RolloutSpec.json'


### PR DESCRIPTION
Backport of #27326 to release/v7.4.15

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27326$$$
-->

Triggered by @jshigetomi on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Required tooling change. Modifies the Azure DevOps release pipeline templates that publish PowerShell packages to PMC (packages.microsoft.com) via Ev2. Without this change, the v7.4.15 release pipeline cannot publish packages because the Ev2 environment has disallowed the previously-used DownloadPipelineArtifact task in the publish stage. The PR migrates artifact download to `templateContext.inputs`, parameterizes the publish stage (releaseEnvironment / approvalServiceEnvironment / stagePrefix / skipEv2Push), and adds a NonOfficial dry-run path that validates the new artifact download approach without performing the actual Ev2 push.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by:
1. Cherry-picking the merge commit cleanly onto `release/v7.4.15` (one trivial conflict resolved — see Merge Conflicts section).
2. Subagent-validated the resolved YAML for syntax correctness, presence of all 4 `templateContext.inputs` artifact entries, both SDL variables (`ob_sdl_credscan_suppressionsFile`, `ob_sdl_tsa_configFile`), removal of legacy `- download: PSPackagesOfficial` steps, and correct pwsh copy logic using `$(Pipeline.Workspace)` directly.
3. Pipeline-level validation will occur via the NonOfficial dry-run pipeline once this PR's CI runs (the original PR specifically added a NonOfficial path that exercises `templateContext.inputs` artifact download with `skipEv2Push: true`).

Functional verification of PMC publishing will happen during the actual v7.4.15 release using the publish stage with production parameters.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk because this modifies the release publishing pipeline (Ev2 push to PMC) on the live release branch. However, not taking this change blocks the v7.4.15 PMC release entirely — the Ev2 pipeline has disallowed the previous DownloadArtifacts task, so the existing pipeline cannot run. The change has been validated in master and is the explicit reason the original PR was authored ("PR was made to unblock 7.4.15 and 7.6.1 PMC releases"). Note: original PR currently has `Backport-7.4.x-Consider` (not Approved) — proceeding at user request given the unblock-release justification stated in the PR body.

## Merge Conflicts

Single conflict in `.pipelines/templates/release-prep-for-ev2.yml` at the `ob_sdl_credscan_suppressionsFile` variable. The PR changed this path from backslashes to forward slashes AND added a new `ob_sdl_tsa_configFile` variable. Resolution: kept the release branch's existing backslash path for `ob_sdl_credscan_suppressionsFile` (no functional change to that var on this branch) and added the new `ob_sdl_tsa_configFile` variable as introduced by the PR. All other hunks (templateContext.inputs block, removed `- download: PSPackagesOfficial` steps, updated pwsh copy logic) applied cleanly.
