### PR TITLE
[release/v7.5.6] Download PMC Packages through `TemplateContext`

### DIFF
--- a/.pipelines/NonOfficial/PowerShell-Release-Azure-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Release-Azure-NonOfficial.yml
@@ -67,10 +67,16 @@ extends:
         exactToolVersion: 4.4.2
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
-      tsaOptionsFile: .config\tsaoptions.json
+      tsaOptionsFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
     stages:
       - template: /.pipelines/templates/release-prep-for-ev2.yml@self
         parameters:
           skipPublish: ${{ parameters.skipPublish }}
 
+      # NonOfficial: run the publish stage to verify templateContext artifact download,
+      # but skip the actual Ev2 push to PMC.
       - template: /.pipelines/templates/release-publish-pmc.yml@self
+        parameters:
+          releaseEnvironment: Test
+          stagePrefix: Test
+          skipEv2Push: true

--- a/.pipelines/PowerShell-Release-Official-Azure.yml
+++ b/.pipelines/PowerShell-Release-Official-Azure.yml
@@ -67,7 +67,7 @@ extends:
         exactToolVersion: 4.4.2
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
-      tsaOptionsFile: .config\tsaoptions.json
+      tsaOptionsFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
     stages:
       - template: /.pipelines/templates/release-prep-for-ev2.yml@self
         parameters:

--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -11,6 +11,20 @@ stages:
     displayName: 'Copy EV2 Files to Artifact'
     pool:
       type: linux
+    templateContext:
+      inputs:
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_deb
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_rpm
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_mariner_x64
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_mariner_arm64
     variables:
     - name: ob_outputDirectory
       value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
@@ -24,6 +38,8 @@ stages:
     - group: 'packages.microsoft.com'
     - name: ob_sdl_credscan_suppressionsFile
       value: $(Build.SourcesDirectory)/PowerShell/.config/suppress.json
+    - name: ob_sdl_tsa_configFile
+      value: $(Build.SourcesDirectory)/PowerShell/.config/tsaoptions.json
     steps:
     - checkout: self ## the global setting on lfs didn't work
       lfs: false
@@ -99,39 +115,17 @@ stages:
       env:
         ob_restore_phase: true
 
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_deb'
-      displayName: 'Download artifact containing .deb_amd64.deb file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_rpm'
-      displayName: 'Download artifact containing .rh.x64_86.rpm file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_mariner_x64'
-      displayName: 'Download artifact containing .cm.x86_64.rpm file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
-    - download: PSPackagesOfficial
-      artifact: 'drop_linux_package_mariner_arm64'
-      displayName: 'Download artifact containing .cm.aarch64.rpm file from PSPackagesOfficial triggering pipeline'
-      env:
-        ob_restore_phase: true
-
     - pwsh: |
         Write-Verbose -Verbose "Copy ESRP signed .deb and .rpm packages"
-        $downloadedPipelineFolder = Join-Path '$(Pipeline.Workspace)' -ChildPath 'PSPackagesOfficial'
+        # templateContext.inputs places the PSPackagesOfficial pipelineArtifact files
+        # directly under $(Pipeline.Workspace), not in per-artifact subfolders.
+        $downloadedPipelineFolder = '$(Pipeline.Workspace)'
         $srcFilesFolder = Join-Path -Path '$(Pipeline.Workspace)' -ChildPath 'SourceFiles'
         New-Item -Path $srcFilesFolder -ItemType Directory
         $packagesFolder = Join-Path -Path $srcFilesFolder -ChildPath 'packages'
         New-Item -Path $packagesFolder -ItemType Directory
 
-        $packageFiles = Get-ChildItem -Path $downloadedPipelineFolder -Recurse -Directory -Filter "drop_*" | Get-ChildItem -File -Include *.deb, *.rpm
+        $packageFiles = Get-ChildItem -Path $downloadedPipelineFolder -File | Where-Object { $_.Extension -in '.deb', '.rpm' }
         foreach ($file in $packageFiles)
         {
           Write-Verbose -Verbose "copying file: $($file.FullName)"

--- a/.pipelines/templates/release-publish-pmc.yml
+++ b/.pipelines/templates/release-publish-pmc.yml
@@ -1,37 +1,56 @@
+parameters:
+- name: releaseEnvironment
+  type: string
+  default: Production
+  values:
+    - Production
+    - PPE
+    - Test
+- name: approvalServiceEnvironment
+  type: string
+  default: Production
+  values:
+    - Production
+    - PPE
+    - Test
+# OneBranch requires the stage name to be prefixed with the release environment.
+# Official uses 'Prod' for Production; NonProd validators require '<env>' (e.g. 'Test', 'PPE').
+- name: stagePrefix
+  type: string
+  default: Prod
+# When true, the Ev2 push step is skipped. Useful for NonOfficial dry-runs that
+# only want to validate artifact download via templateContext.inputs.
+- name: skipEv2Push
+  type: boolean
+  default: false
+
 stages:
-- stage: 'Prod_Release'
+- stage: ${{ parameters.stagePrefix }}_Release
   displayName: 'Deploy packages to PMC with EV2'
   dependsOn:
   - PrepForEV2
   variables:
     - name: ob_release_environment
-      value: "Production"
+      value: ${{ parameters.releaseEnvironment }}
     - name: repoRoot
       value: $(Build.SourcesDirectory)
   jobs:
-  - job: Prod_ReleaseJob
+  - job: ${{ parameters.stagePrefix }}_ReleaseJob
     displayName: Publish to PMC
     pool:
       type: release
+    templateContext:
+      inputs:
+        - input: pipelineArtifact
+          artifactName: drop_PrepForEV2_CopyEv2FilesToArtifact
 
     steps:
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        targetPath: '$(Pipeline.Workspace)'
-        artifact: drop_PrepForEV2_CopyEv2FilesToArtifact
-      displayName: 'Download drop_PrepForEV2_CopyEv2FilesToArtifact artifact that has all files needed'
-
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        buildType: 'current'
-        targetPath: '$(Pipeline.Workspace)'
-      displayName: 'Download to get EV2 Files'
-
-    - task: vsrm-ev2.vss-services-ev2.adm-release-task.ExpressV2Internal@1
-      displayName: 'Ev2: Push to PMC'
-      inputs:
-        UseServerMonitorTask: true
-        EndpointProviderType: ApprovalService
-        ApprovalServiceEnvironment: Production
-        ServiceRootPath: '$(Pipeline.Workspace)/drop_PrepForEV2_CopyEV2FilesToArtifact/EV2Specs/ServiceGroupRoot'
-        RolloutSpecPath: '$(Pipeline.Workspace)/drop_PrepForEV2_CopyEV2FilesToArtifact/EV2Specs/ServiceGroupRoot/RolloutSpec.json'
+    - ${{ if not(parameters.skipEv2Push) }}:
+      - task: vsrm-ev2.vss-services-ev2.adm-release-task.ExpressV2Internal@1
+        displayName: 'Ev2: Push to PMC'
+        inputs:
+          UseServerMonitorTask: true
+          EndpointProviderType: ApprovalService
+          ApprovalServiceEnvironment: ${{ parameters.approvalServiceEnvironment }}
+          ServiceRootPath: '$(Pipeline.Workspace)/EV2Specs/ServiceGroupRoot'
+          RolloutSpecPath: '$(Pipeline.Workspace)/EV2Specs/ServiceGroupRoot/RolloutSpec.json'


### PR DESCRIPTION
Backport of #27326 to release/v7.5.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27326$$$
-->

Triggered by @daxian-dbw on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This backports the Azure pipeline fix that refactors artifact download steps to use `templateContext.inputs` in the PMC release pipeline. This is required to unblock PMC releases on the v7.5.6 release branch, as the EV2 pipeline no longer allows the DownloadArtifacts task.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The original PR was validated as part of fixing the 7.4.15 and 7.6.1 PMC releases (PRs #27330 and #27331 which have been merged). This cherry-pick applied cleanly with no conflicts. Pipeline changes are validated when the release pipeline runs against the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a build/release pipeline YAML change only — no product code or runtime behavior is modified. The same fix has already been successfully applied and merged to the v7.4.15 and v7.6.1 release branches (PRs #27330 and #27331).
