### PR TITLE
Fix using expression for invalid property

### DIFF
--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -347,23 +347,28 @@ namespace System.Management.Automation
                     usingAst = (UsingExpressionAst)usingAsts[i];
                     if (IsInForeachParallelCallingScope(scriptBlock.Ast, usingAst))
                     {
-                        var value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);
+                        object value = null;
+                        try
+                        {
+                            value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);
+                        }
+                        catch (RuntimeException rte)
+                        {
+                            if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("VariableIsUndefined", StringComparison.Ordinal))
+                            {
+                                throw InterpreterError.NewInterpreterException(
+                                    targetObject: null,
+                                    exceptionType: typeof(RuntimeException),
+                                    errorPosition: usingAst.Extent,
+                                    resourceIdAndErrorId: "UsingVariableIsUndefined",
+                                    resourceString: AutomationExceptions.UsingVariableIsUndefined,
+                                    args: rte.ErrorRecord.TargetObject);
+                            }
+                        }
+
                         string usingAstKey = PsUtils.GetUsingExpressionKey(usingAst);
                         usingValueMap.TryAdd(usingAstKey, value);
                     }
-                }
-            }
-            catch (RuntimeException rte)
-            {
-                if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("VariableIsUndefined", StringComparison.Ordinal))
-                {
-                    throw InterpreterError.NewInterpreterException(
-                        targetObject: null,
-                        exceptionType: typeof(RuntimeException),
-                        errorPosition: usingAst.Extent,
-                        resourceIdAndErrorId: "UsingVariableIsUndefined",
-                        resourceString: AutomationExceptions.UsingVariableIsUndefined,
-                        args: rte.ErrorRecord.TargetObject);
                 }
             }
             finally
@@ -556,7 +561,18 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);
+                        try
+                        {
+                            value = Compiler.GetExpressionValue(usingAst.SubExpression, isTrustedInput, context);
+                        }
+                        catch (RuntimeException rte)
+                        {
+                            if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("VariableIsUndefined", StringComparison.Ordinal))
+                            {
+                                throw InterpreterError.NewInterpreterException(null, typeof(RuntimeException),
+                                    usingAst.Extent, "UsingVariableIsUndefined", AutomationExceptions.UsingVariableIsUndefined, rte.ErrorRecord.TargetObject);
+                            }
+                        }
                     }
 
                     // Collect UsingExpression value as an array
@@ -565,18 +581,6 @@ namespace System.Management.Automation
                     // Collect UsingExpression value as a dictionary
                     string usingAstKey = PsUtils.GetUsingExpressionKey(usingAst);
                     usingValueMap.TryAdd(usingAstKey, value);
-                }
-            }
-            catch (RuntimeException rte)
-            {
-                if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("VariableIsUndefined", StringComparison.Ordinal))
-                {
-                    throw InterpreterError.NewInterpreterException(null, typeof(RuntimeException),
-                        usingAst.Extent, "UsingVariableIsUndefined", AutomationExceptions.UsingVariableIsUndefined, rte.ErrorRecord.TargetObject);
-                }
-                else if (rte.ErrorRecord.FullyQualifiedErrorId.Equals("CantGetUsingExpressionValueWithSpecifiedVariableDictionary", StringComparison.Ordinal))
-                {
-                    throw;
                 }
             }
             finally

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -267,6 +267,33 @@ Describe 'ForEach-Object -Parallel Basic Tests' -Tags 'CI' {
         $usingErrors[0].FullyQualifiedErrorId | Should -BeExactly 'UsingVariableIsUndefined,Microsoft.PowerShell.Commands.ForEachObjectCommand'
     }
 
+    It 'Invalid property does not break subsequent using references' {
+        $Var1 = "Hello"
+        $Var2 = $null
+        $Var3 = "World"
+        $result = 1 | ForEach-Object -Parallel {
+            $Var1 = $using:Var1
+
+            # Even if this won't run, the client validates the property in
+            # strict mode and throws PropertyNotFoundException. This should
+            # not affect the other $using variables.
+            $Var2 = if ($false) { $using:Var2.InvalidProperty }
+            $Var3 = $using:Var3
+
+            [PSCustomObject]@{
+                Item = $_
+                Var1 = $Var1
+                Var2 = $Var2
+                Var3 = $Var3
+            }
+        }
+
+        $result.Item | Should -BeExactly 1
+        $result.Var1 | Should -Be Hello
+        $result.Var2 | Should -BeNullOrEmpty
+        $result.Var3 | Should -Be World
+    }
+
     It 'Verifies terminating error streaming' {
 
         $result = 1..1 | ForEach-Object -Parallel { throw 'Terminating Error!'; "Hello" } 2>&1

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -382,6 +382,31 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
         $result | Should -Be 100
     }
 
+    It 'Ignores invalid $using variables' {
+        $Var1 = "Hello"
+        $Var2 = $null
+        $Var3 = "World"
+        $result = Invoke-Command -Session $openSession -ScriptBlock {
+            $Var1 = $using:Var1
+
+            # Even if this won't run, the client validates the property in
+            # strict mode and throws PropertyNotFoundException. This should
+            # not affect the other $using variables.
+            $Var2 = if ($false) { $using:Var2.InvalidProperty }
+            $Var3 = $using:Var3
+
+            [PSCustomObject]@{
+                Var1 = $Var1
+                Var2 = $Var2
+                Var3 = $Var3
+            }
+        }
+
+        $result.Var1 | Should -Be Hello
+        $result.Var2 | Should -BeNullOrEmpty
+        $result.Var3 | Should -Be World
+    }
+
     It '$Host.Version should be PSVersion' {
         $session = New-RemoteSession -ConfigurationName $endPoint
         try {

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -382,7 +382,7 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
         $result | Should -Be 100
     }
 
-    It 'Ignores invalid $using variables' {
+    It 'Invalid property on $using does not affect other $using variables' {
         $Var1 = "Hello"
         $Var2 = $null
         $Var3 = "World"


### PR DESCRIPTION
# PR Summary
Fixes the using expression builder when encountering a using expression with invalid property. Previously such a property would stop the using builder from working on the remaining using statements while ignoring the error. From this change it will still ignore the error but continue working on the remaining expressions.

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/issues/27340

Currently if a using expression throws an error, like an invalid property, when building the using expression it would stop the using value builder from processing the remaining expressions. With this change it instead still continues to process the remaining expressions while still keeping the invalid one as `$null` like before.

This fixes this statement:

```powershell
$var1 = 1
$var2 = 2
$var3 = 3
1 | ForEach-Object -Parallel {
    Write-Host "var1 $using:var1"
    Write-Host "var2 $($using:var2.InvalidProp)"
    Write-Host "var3 $using:var3"
}
```

```
var1 1
InvalidOperation: 
Line |
   3 |      Write-Host "var2 $($using:var2.InvalidProp)"
     |                         ~~~~~~~~~~~~~~~~~~~~~~~
     | A Using variable cannot be retrieved. A Using variable can be used only with Invoke-Command, Start-Job, or InlineScript in the script workflow. When it is used with Invoke-Command, the Using variable is valid only if the script block is invoked on a remote computer.
var2 
InvalidOperation: 
Line |
   4 |      Write-Host "var3 $using:var3"
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | A Using variable cannot be retrieved. A Using variable can be used only with Invoke-Command, Start-Job, or InlineScript in the script workflow. When it is used with Invoke-Command, the Using variable is valid only if the script block is invoked on a remote computer.
```

With the changes here it now becomes

```
var1 1
var2 
var3 3
```

This better reflects how the same statement would work in a normal invocation with the same vars outside of `$using:`.

```powershell
$var1 = 1
$var2 = 2
$var3 = 3
& {
    Write-Host "var1 $var1"
    Write-Host "var2 $($var2.InvalidProp)"
    Write-Host "var3 $var3"
}

# var1 1
# var2 
# var3 3
```

The only exception to this was if the inner scriptblock had enabled strict mode but the existing logic isn't equipped to deal with this as it already ignores errors on the client side. All this PR does is to continue resolving the remaining expressions rather than leaving it as unset.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
