### PR TITLE
docs: fix inverted description of $ErrorActionPreference = Stop in FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,7 +33,7 @@ The [PoshCode][03] unofficial guide is our reference.
 
 Error handling in PowerShell is unique, as not all errors result in catchable exceptions by default.
 Setting `$ErrorActionPreference = 'Stop'` will likely do what you want; that is, cause
-non-terminating errors instead of terminating. Read the [GitHub issue][02] for more information.
+non-terminating errors to be treated as terminating (throwing catchable exceptions). Read the [GitHub issue][02] for more information.
 
 ## Where do I get the PowerShell Core SDK package?
 


### PR DESCRIPTION
## Summary

Fixes an incorrect description in `docs/FAQ.md` in the "Why did an error not throw an exception?" section.

### Problem

The current text reads:

> Setting `$ErrorActionPreference = 'Stop'` will likely do what you want; that is, cause **non-terminating errors instead of terminating**.

This is inverted and confusing. The preference causes non-terminating errors to be **treated as terminating** (i.e. they throw catchable exceptions), not the other way around.

### Fix

```diff
-Setting `$ErrorActionPreference = 'Stop'` will likely do what you want; that is, cause
-non-terminating errors instead of terminating.
+Setting `$ErrorActionPreference = 'Stop'` will likely do what you want; that is, cause
+non-terminating errors to be treated as terminating (throwing catchable exceptions).
```

Closes #27350

Signed-off-by: Cocoon-Break <86288566+lingxiu58@users.noreply.github.com>