### PR TITLE
[release/v7.7.0-preview.1] Remove mariner2.0 from PMC mapping

### DIFF
--- a/tools/packages.microsoft.com/mapping.json
+++ b/tools/packages.microsoft.com/mapping.json
@@ -29,38 +29,6 @@
           "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.rh.x86_64.rpm"
       },
       {
-        "url": "cbl-mariner-2.0-prod-Microsoft-aarch64",
-        "distribution": [
-            "bionic"
-        ],
-        "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.aarch64.rpm",
-        "channel": "stable"
-      },
-      {
-          "url": "cbl-mariner-2.0-prod-Microsoft-x86_64",
-          "distribution": [
-              "bionic"
-          ],
-          "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.x86_64.rpm",
-          "channel": "stable"
-      },
-      {
-          "url": "cbl-mariner-2.0-preview-Microsoft-aarch64",
-          "distribution": [
-              "bionic"
-          ],
-          "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.aarch64.rpm",
-          "channel": "preview"
-      },
-      {
-          "url": "cbl-mariner-2.0-preview-Microsoft-x86_64",
-          "distribution": [
-              "bionic"
-          ],
-          "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.x86_64.rpm",
-          "channel": "preview"
-      },
-      {
         "url": "azurelinux-3.0-prod-ms-oss-aarch64",
         "distribution": [
             "bionic"


### PR DESCRIPTION
Backport of #27068 to release/v7.7.0-preview.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27068$$$
-->

Triggered by @jshigetomi on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Required tooling change. Updates the PMC (packages.microsoft.com) mapping configuration used by the release publish pipeline. PowerShell 7.6+ does not support Mariner 2.0; without this change, the v7.7.0-preview.1 release pipeline would attempt to publish packages to Mariner 2.0 repos that should no longer receive them. Users on Mariner-family distros should consume PowerShell from the AzureLinux 3 PMC feed instead.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by:
1. Cherry-picking the merge commit cleanly onto `release/v7.7.0-preview.1` with no conflicts.
2. Functional verification will occur during the actual v7.7.0-preview.1 PMC release — the publish pipeline will no longer attempt to push to Mariner 2.0 repositories.

No new tests required: change is config-only (PMC mapping table).

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk: change is isolated to the PMC `mapping.json` file (PowerShell package distribution config). It removes Mariner 2.0 entries because PowerShell 7.6+ is not supported on Mariner 2.0 — users on that distro should use AzureLinux 3 packages instead. No code changes, no runtime behavior change for end users; only affects which Mariner repository receives published packages during PMC publishing. Required for v7.7.0-preview.1 to keep its PMC mapping consistent with the supported-distro matrix. Note: original PR has only `Backport-7.6.x-Consider` (no 7.7.x label) — proceeding at user request.
