### PR TITLE
Fix changelog grab failure when only one header exists.

### DIFF
--- a/.pipelines/templates/release-githubNuget.yml
+++ b/.pipelines/templates/release-githubNuget.yml
@@ -89,11 +89,21 @@ jobs:
         $changelog = Get-Content -Path $filePath
   
         $headingPattern = "^## \[\d+\.\d+\.\d+"
-        $headingStartLines = $changelog | Select-String -Pattern $headingPattern | Select-Object -ExpandProperty LineNumber
+        $headingStartLines = @($changelog | Select-String -Pattern $headingPattern | Select-Object -ExpandProperty LineNumber)
+
+        if ($headingStartLines.Count -eq 0) {
+            throw "No release heading matching '$headingPattern' found in $filePath"
+        }
+
         $startLine = $headingStartLines[0]
-        $endLine = $headingStartLines[1] - 1
-  
-        $clContent = $changelog | Select-Object -Skip ($startLine-1) -First ($endLine - $startLine) | Out-String
+        if ($headingStartLines.Count -ge 2) {
+            $endLine = $headingStartLines[1] - 1
+        } else {
+            # Only one release heading present; take through end of file.
+            $endLine = $changelog.Count
+        }
+
+        $clContent = $changelog | Select-Object -Skip ($startLine-1) -First ($endLine - $startLine + 1) | Out-String
 
         $StringBuilder = [System.Text.StringBuilder]::new($clContent, $clContent.Length + 2kb)
         $StringBuilder.AppendLine().AppendLine() > $null


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request improves the robustness of the changelog extraction logic in the `.pipelines/templates/release-githubNuget.yml` pipeline script. The script now handles cases where there may be only one release heading in the changelog and provides a clear error if no headings are found.

Changelog extraction improvements:

* Ensured that `$headingStartLines` is always an array and added a check to throw an error if no release heading matching the expected pattern is found in the changelog file.
* Updated the logic to correctly handle changelogs with only one release heading by extracting content through the end of the file, and fixed the calculation of the number of lines to extract.

## PR Context

This unblocks 7.7.0-preview.1 github release

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
