### PR TITLE
[release/v7.7.0-preview.1] Fix changelog grab failure when only one header exists.

### DIFF
--- a/.pipelines/templates/release-githubNuget.yml
+++ b/.pipelines/templates/release-githubNuget.yml
@@ -89,11 +89,21 @@ jobs:
         $changelog = Get-Content -Path $filePath
   
         $headingPattern = "^## \[\d+\.\d+\.\d+"
-        $headingStartLines = $changelog | Select-String -Pattern $headingPattern | Select-Object -ExpandProperty LineNumber
+        $headingStartLines = @($changelog | Select-String -Pattern $headingPattern | Select-Object -ExpandProperty LineNumber)
+
+        if ($headingStartLines.Count -eq 0) {
+            throw "No release heading matching '$headingPattern' found in $filePath"
+        }
+
         $startLine = $headingStartLines[0]
-        $endLine = $headingStartLines[1] - 1
-  
-        $clContent = $changelog | Select-Object -Skip ($startLine-1) -First ($endLine - $startLine) | Out-String
+        if ($headingStartLines.Count -ge 2) {
+            $endLine = $headingStartLines[1] - 1
+        } else {
+            # Only one release heading present; take through end of file.
+            $endLine = $changelog.Count
+        }
+
+        $clContent = $changelog | Select-Object -Skip ($startLine-1) -First ($endLine - $startLine + 1) | Out-String
 
         $StringBuilder = [System.Text.StringBuilder]::new($clContent, $clContent.Length + 2kb)
         $StringBuilder.AppendLine().AppendLine() > $null


### PR DESCRIPTION
Backport of #27371 to release/v7.7.0-preview.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27371$$$
-->

Triggered by @jshigetomi on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes changelog extraction in release pipeline to handle cases with only one release heading, unblocking the 7.7.0-preview.1 GitHub release.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by original PR — logic correctly handles changelogs with only one release heading. N/A for automated tests (pipeline script change).

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk — only modifies changelog extraction logic in release pipeline YAML; no runtime or customer-facing impact.
