### PR TITLE
Tolerate IO/JSON errors reading the per-user `powershell.config.json`

### DIFF
--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -411,6 +411,30 @@ namespace System.Management.Automation.Configuration
 
                         configData = serializer.Deserialize<JObject>(jsonReader) ?? emptyConfig;
                     }
+                    catch (Exception exc) when (
+                        scope == ConfigScope.CurrentUser &&
+                        (exc is IOException || exc is UnauthorizedAccessException || exc is JsonException))
+                    {
+                        // The per-user configuration file is unreadable (e.g. OneDrive cloud file provider
+                        // not running, permission denied, or corrupt/malformed JSON). Rather than failing
+                        // pwsh startup, fall back to defaults and emit a warning so the user knows the file
+                        // was skipped. See https://github.com/PowerShell/PowerShell/issues/27370.
+                        //
+                        // We intentionally do NOT apply this fallback to ConfigScope.AllUsers: that file is
+                        // admin-owned and on non-Windows platforms is the only source for security-relevant
+                        // policies (ScriptBlockLogging, Transcription, ConsoleSessionConfiguration, etc.).
+                        // If we cannot prove the admin's intent we must fail closed.
+                        try
+                        {
+                            Console.Error.WriteLine(StringUtil.Format(PSConfigurationStrings.CanNotReadConfigurationFile, fileName, exc.Message));
+                        }
+                        catch
+                        {
+                            // Best-effort warning; never let logging failures block startup.
+                        }
+
+                        configData = emptyConfig;
+                    }
                     catch (Exception exc)
                     {
                         throw PSTraceSource.NewInvalidOperationException(exc, PSConfigurationStrings.CanNotConfigurationFile, args: fileName);

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation.Internal;
+using System.Security;
 using System.Text;
 using System.Threading;
 
@@ -413,12 +414,12 @@ namespace System.Management.Automation.Configuration
                     }
                     catch (Exception exc) when (
                         scope == ConfigScope.CurrentUser &&
-                        (exc is IOException || exc is UnauthorizedAccessException || exc is JsonException))
+                        (exc is IOException || exc is UnauthorizedAccessException || exc is SecurityException || exc is JsonException))
                     {
                         // The per-user configuration file is unreadable (e.g. OneDrive cloud file provider
-                        // not running, permission denied, or corrupt/malformed JSON). Rather than failing
-                        // pwsh startup, fall back to defaults and emit a warning so the user knows the file
-                        // was skipped. See https://github.com/PowerShell/PowerShell/issues/27370.
+                        // not running, permission denied, ACL denied, or corrupt/malformed JSON). Rather
+                        // than failing pwsh startup, fall back to defaults and emit a warning so the user
+                        // knows the file was skipped. See https://github.com/PowerShell/PowerShell/issues/27370.
                         //
                         // We intentionally do NOT apply this fallback to ConfigScope.AllUsers: that file is
                         // admin-owned and on non-Windows platforms is the only source for security-relevant
@@ -459,7 +460,29 @@ namespace System.Management.Automation.Configuration
 
             if (configData != emptyConfig && configData.TryGetValue(key, StringComparison.OrdinalIgnoreCase, out JToken jToken))
             {
-                return jToken.ToObject<T>(serializer) ?? defaultValue;
+                try
+                {
+                    return jToken.ToObject<T>(serializer) ?? defaultValue;
+                }
+                catch (JsonException exc) when (scope == ConfigScope.CurrentUser)
+                {
+                    // The per-user JSON parsed successfully, but the value at <key> can't be
+                    // materialized as T (wrong type, malformed sub-document, etc.). Fall back
+                    // to the caller's default for this setting and emit a warning, mirroring
+                    // the file-level fallback above. AllUsers stays fail-closed for
+                    // security-relevant policies.
+                    // See https://github.com/PowerShell/PowerShell/issues/27370.
+                    try
+                    {
+                        Console.Error.WriteLine(StringUtil.Format(PSConfigurationStrings.CanNotReadConfigurationValue, key, fileName, exc.Message));
+                    }
+                    catch
+                    {
+                        // Best-effort warning; never let logging failures block startup.
+                    }
+
+                    return defaultValue;
+                }
             }
 
             return defaultValue;

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -425,14 +425,7 @@ namespace System.Management.Automation.Configuration
                         // admin-owned and on non-Windows platforms is the only source for security-relevant
                         // policies (ScriptBlockLogging, Transcription, ConsoleSessionConfiguration, etc.).
                         // If we cannot prove the admin's intent we must fail closed.
-                        try
-                        {
-                            Console.Error.WriteLine(StringUtil.Format(PSConfigurationStrings.CanNotReadConfigurationFile, fileName, exc.Message));
-                        }
-                        catch
-                        {
-                            // Best-effort warning; never let logging failures block startup.
-                        }
+                        TryWriteConfigWarning(StringUtil.Format(PSConfigurationStrings.CanNotReadConfigurationFile, fileName, exc.Message));
 
                         configData = emptyConfig;
                     }
@@ -472,20 +465,33 @@ namespace System.Management.Automation.Configuration
                     // the file-level fallback above. AllUsers stays fail-closed for
                     // security-relevant policies.
                     // See https://github.com/PowerShell/PowerShell/issues/27370.
-                    try
-                    {
-                        Console.Error.WriteLine(StringUtil.Format(PSConfigurationStrings.CanNotReadConfigurationValue, key, fileName, exc.Message));
-                    }
-                    catch
-                    {
-                        // Best-effort warning; never let logging failures block startup.
-                    }
-
+                    TryWriteConfigWarning(StringUtil.Format(PSConfigurationStrings.CanNotReadConfigurationValue, key, fileName, exc.Message));
                     return defaultValue;
                 }
             }
 
             return defaultValue;
+        }
+
+        /// <summary>
+        /// Best-effort emission of a warning when the per-user configuration file (or one of its
+        /// values) can't be read. <see cref="ReadValueFromFile"/> is invoked very early in pwsh
+        /// startup -- before any host, runspace, or PowerShell warning stream exists -- so we
+        /// write directly to <see cref="Console.Error"/>. This matches existing startup-time
+        /// stderr writes in ConsoleHost (e.g. CannotLoadPSReadline). Centralizing this here
+        /// keeps formatting consistent and gives future hosts a single seam to swap the channel.
+        /// Failures inside the writer itself are swallowed so logging issues never block startup.
+        /// </summary>
+        private static void TryWriteConfigWarning(string message)
+        {
+            try
+            {
+                Console.Error.WriteLine("WARNING: " + message);
+            }
+            catch
+            {
+                // Best-effort warning; never let logging failures block startup.
+            }
         }
 
         private static FileStream OpenFileStreamWithRetry(string fullPath, FileMode mode, FileAccess access, FileShare share)

--- a/src/System.Management.Automation/resources/PSConfigurationStrings.resx
+++ b/src/System.Management.Automation/resources/PSConfigurationStrings.resx
@@ -123,4 +123,7 @@
   <data name="CanNotReadConfigurationFile" xml:space="preserve">
     <value>WARNING: Cannot read the PowerShell configuration file '{0}': {1}. Falling back to default settings.</value>
   </data>
+  <data name="CanNotReadConfigurationValue" xml:space="preserve">
+    <value>WARNING: Cannot read setting '{0}' from PowerShell configuration file '{1}': {2}. Falling back to default for this setting.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/PSConfigurationStrings.resx
+++ b/src/System.Management.Automation/resources/PSConfigurationStrings.resx
@@ -120,4 +120,7 @@
   <data name="CanNotConfigurationFile" xml:space="preserve">
     <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
   </data>
+  <data name="CanNotReadConfigurationFile" xml:space="preserve">
+    <value>WARNING: Cannot read the PowerShell configuration file '{0}': {1}. Falling back to default settings.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/PSConfigurationStrings.resx
+++ b/src/System.Management.Automation/resources/PSConfigurationStrings.resx
@@ -121,9 +121,9 @@
     <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
   </data>
   <data name="CanNotReadConfigurationFile" xml:space="preserve">
-    <value>WARNING: Cannot read the PowerShell configuration file '{0}': {1}. Falling back to default settings.</value>
+    <value>Cannot read the PowerShell configuration file '{0}': {1}. Falling back to default settings.</value>
   </data>
   <data name="CanNotReadConfigurationValue" xml:space="preserve">
-    <value>WARNING: Cannot read setting '{0}' from PowerShell configuration file '{1}': {2}. Falling back to default for this setting.</value>
+    <value>Cannot read setting '{0}' from PowerShell configuration file '{1}': {2}. Falling back to default for this setting.</value>
   </data>
 </root>

--- a/test/xUnit/csharp/test_PSConfiguration.cs
+++ b/test/xUnit/csharp/test_PSConfiguration.cs
@@ -987,7 +987,8 @@ namespace PSTests.Sequential
             fixture.CompareConsoleSessionConfiguration(consoleSessionConfiguration, null);
         }
 
-        [Fact, Priority(11)]
+        [Fact]
+        [Priority(11)]
         public void PowerShellConfig_GetPowerShellPolicies_BrokenSystemConfig()
         {
             fixture.SetupConfigFile5();
@@ -1000,7 +1001,8 @@ namespace PSTests.Sequential
             Assert.Null(currentUserPolicies);
         }
 
-        [Fact, Priority(12)]
+        [Fact]
+        [Priority(12)]
         public void PowerShellConfig_BrokenCurrentUserConfig_FallsBackToDefaults()
         {
             fixture.SetupBrokenCurrentUserConfigOnly();

--- a/test/xUnit/csharp/test_PSConfiguration.cs
+++ b/test/xUnit/csharp/test_PSConfiguration.cs
@@ -1002,14 +1002,15 @@ namespace PSTests.Sequential
 
         [Fact]
         [Priority(11)]
-        public void PowerShellConfig_GetPowerShellPolicies_BrokenSystemConfig()
+        public void PowerShellConfig_BrokenSystemConfig_Throws_BrokenCurrentUserConfig_FallsBack()
         {
             fixture.SetupConfigFile5();
             fixture.ForceReadingFromFile();
 
+            // Broken system-wide config still hard-fails (admin-owned, security-relevant).
             Assert.Throws<System.Management.Automation.PSInvalidOperationException>(() => PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.AllUsers));
 
-            // Malformed per-user file should fall back to defaults
+            // Broken per-user config falls back to defaults (#27370).
             PowerShellPolicies currentUserPolicies = PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.CurrentUser);
             Assert.Null(currentUserPolicies);
         }
@@ -1047,6 +1048,57 @@ namespace PSTests.Sequential
 
             PowerShellPolicies policies = PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.CurrentUser);
             Assert.Null(policies);
+        }
+
+        [Fact]
+        [Priority(14)]
+        public void PowerShellConfig_BrokenCurrentUserConfig_EmitsWarningToStderr()
+        {
+            // A regression in the warning path would still let startup succeed (this is the
+            // whole point of the fail-open) -- but the user would silently lose their config
+            // with no indication. This test pins the user-visible warning so that doesn't
+            // happen quietly.
+            fixture.SetupBrokenCurrentUserConfigOnly();
+            fixture.ForceReadingFromFile();
+
+            string stderr = CaptureStderr(() =>
+                PowerShellConfig.Instance.GetExecutionPolicy(ConfigScope.CurrentUser, "Microsoft.PowerShell"));
+
+            Assert.Contains("WARNING:", stderr);
+            Assert.Contains("Falling back to default settings", stderr);
+        }
+
+        [Fact]
+        [Priority(15)]
+        public void PowerShellConfig_TypeMismatchInCurrentUserConfig_EmitsWarningToStderr()
+        {
+            // Pin the user-visible warning for the per-key fail-open path as well.
+            fixture.SetupTypeMismatchedCurrentUserConfig();
+            fixture.ForceReadingFromFile();
+
+            string stderr = CaptureStderr(() =>
+                PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.CurrentUser));
+
+            Assert.Contains("WARNING:", stderr);
+            Assert.Contains("PowerShellPolicies", stderr);
+            Assert.Contains("Falling back to default for this setting", stderr);
+        }
+
+        private static string CaptureStderr(Action action)
+        {
+            var captured = new StringWriter();
+            TextWriter originalError = Console.Error;
+            try
+            {
+                Console.SetError(captured);
+                action();
+            }
+            finally
+            {
+                Console.SetError(originalError);
+            }
+
+            return captured.ToString();
         }
     }
 }

--- a/test/xUnit/csharp/test_PSConfiguration.cs
+++ b/test/xUnit/csharp/test_PSConfiguration.cs
@@ -382,6 +382,15 @@ namespace PSTests.Sequential
             CreateBrokenConfigFile(currentUserConfigFile);
         }
 
+        public void SetupBrokenCurrentUserConfigOnly()
+        {
+            CleanupConfigFiles();
+
+            // Only the per-user config file is broken; the system-wide file is absent.
+            // Used to verify the #27370 fail-open path for ConfigScope.CurrentUser.
+            CreateBrokenConfigFile(currentUserConfigFile);
+        }
+
         private static void CreateBrokenConfigFile(string fileName)
         {
             File.WriteAllText(fileName, "[abbra");
@@ -985,7 +994,29 @@ namespace PSTests.Sequential
             fixture.ForceReadingFromFile();
 
             Assert.Throws<System.Management.Automation.PSInvalidOperationException>(() => PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.AllUsers));
-            Assert.Throws<System.Management.Automation.PSInvalidOperationException>(() => PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.CurrentUser));
+
+            // Malformed per-user file should fall back to defaults
+            PowerShellPolicies currentUserPolicies = PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.CurrentUser);
+            Assert.Null(currentUserPolicies);
+        }
+
+        [Fact, Priority(12)]
+        public void PowerShellConfig_BrokenCurrentUserConfig_FallsBackToDefaults()
+        {
+            fixture.SetupBrokenCurrentUserConfigOnly();
+            fixture.ForceReadingFromFile();
+
+            // ExecutionPolicy returns null (caller falls back to GP / registry / Restricted).
+            string execPolicy = PowerShellConfig.Instance.GetExecutionPolicy(ConfigScope.CurrentUser, "Microsoft.PowerShell");
+            Assert.Null(execPolicy);
+
+            // Module path returns null (caller uses built-in defaults).
+            string modulePath = PowerShellConfig.Instance.GetModulePath(ConfigScope.CurrentUser);
+            Assert.Null(modulePath);
+
+            // Experimental features list is empty.
+            string[] features = PowerShellConfig.Instance.GetExperimentalFeatures();
+            Assert.Empty(features);
         }
     }
 }

--- a/test/xUnit/csharp/test_PSConfiguration.cs
+++ b/test/xUnit/csharp/test_PSConfiguration.cs
@@ -391,6 +391,19 @@ namespace PSTests.Sequential
             CreateBrokenConfigFile(currentUserConfigFile);
         }
 
+        public void SetupTypeMismatchedCurrentUserConfig()
+        {
+            CleanupConfigFiles();
+
+            // Per-user config is syntactically valid JSON, but PowerShellPolicies has the
+            // wrong nested shape: ScriptExecution should be an object but is a string.
+            // This triggers JsonSerializationException inside jToken.ToObject<T>() and
+            // exercises the per-key fail-open path for #27370.
+            File.WriteAllText(
+                currentUserConfigFile,
+                "{ \"PowerShellPolicies\": { \"ScriptExecution\": \"not-an-object\" } }");
+        }
+
         private static void CreateBrokenConfigFile(string fileName)
         {
             File.WriteAllText(fileName, "[abbra");
@@ -1019,6 +1032,21 @@ namespace PSTests.Sequential
             // Experimental features list is empty.
             string[] features = PowerShellConfig.Instance.GetExperimentalFeatures();
             Assert.Empty(features);
+        }
+
+        [Fact]
+        [Priority(13)]
+        public void PowerShellConfig_TypeMismatchInCurrentUserConfig_FallsBackToDefaults()
+        {
+            // Verifies the per-key fail-open path: the file parses as JSON, but a value
+            // can't be materialized as its target type. Without this fallback the
+            // JsonSerializationException would propagate out of GetPolicySetting and
+            // crash startup just like #27370.
+            fixture.SetupTypeMismatchedCurrentUserConfig();
+            fixture.ForceReadingFromFile();
+
+            PowerShellPolicies policies = PowerShellConfig.Instance.GetPowerShellPolicies(ConfigScope.CurrentUser);
+            Assert.Null(policies);
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request improves how PowerShell handles unreadable or malformed per-user configuration files. Instead of failing to start, PowerShell now falls back to default settings and emits a warning when the per-user config is unreadable, while maintaining strict failure for system-wide config issues. This addresses a startup-time crash caused by transient cloud file provider failures (e.g., OneDrive not yet running on a fresh login). The PR also adds new tests to verify this behavior.

**Configuration file handling improvements:**

* Updated `PSConfiguration.cs` so the per-user (`ConfigScope.CurrentUser`) config read fails open in two places:
  * **File-level fallback:** opening or root-parsing the file. Catches `IOException`, `UnauthorizedAccessException`, `SecurityException`, and `JsonException` (including the OneDrive-cloud-file-provider IOException that motivated #27370).
  * **Per-key fallback:** when a syntactically valid file contains a value that can't be materialized as the target type (e.g., `PowerShellPolicies.ScriptExecution` is a string instead of an object). Catches `JsonException` / `JsonSerializationException` from `jToken.ToObject<T>(serializer)` so a single malformed setting doesn't crash startup.
* Both fallback paths route through a single `TryWriteConfigWarning` helper that writes a best-effort warning to `Console.Error`. `Console.Error` is intentional at this layer: `ReadValueFromFile` runs very early in startup, before any host, runspace, or PowerShell warning stream exists. This matches existing startup-time stderr writes in `ConsoleHost.cs` (e.g., `CannotLoadPSReadline`, `SlowProfileLoadingMessage`). Centralizing the call gives future hosts a single seam to swap the channel.
* Neither fallback applies to the system-wide (`ConfigScope.AllUsers`) config file, which remains a hard failure for security reasons (admin-owned, sole source of security-relevant policies on non-Windows).
* Added two new localized resource strings to `PSConfigurationStrings.resx`:
  * `CanNotReadConfigurationFile` — for the file-level fallback.
  * `CanNotReadConfigurationValue` — for the per-key fallback.
  * Strings are prefix-free; the helper applies the `WARNING:` label so the resource content stays usable if a future host routes these through the warning stream.

**Testing enhancements:**

* Added two fixture helpers in `test_PSConfiguration.cs`:
  * `SetupBrokenCurrentUserConfigOnly` — broken per-user config, no system config (file-level path).
  * `SetupTypeMismatchedCurrentUserConfig` — valid JSON with a wrong nested shape (per-key path).
* Added a `CaptureStderr(Action)` helper that redirects `Console.Error` so tests can assert the warning was actually emitted.
* New / updated xUnit tests:
  * `PowerShellConfig_BrokenSystemConfig_Throws_BrokenCurrentUserConfig_FallsBack` *(renamed from `PowerShellConfig_GetPowerShellPolicies_BrokenSystemConfig`)* — asserts both fail-closed for `AllUsers` and fail-open for `CurrentUser`.
  * `PowerShellConfig_BrokenCurrentUserConfig_FallsBackToDefaults` — broken per-user file returns defaults via `GetExecutionPolicy`, `GetModulePath`, `GetExperimentalFeatures`.
  * `PowerShellConfig_TypeMismatchInCurrentUserConfig_FallsBackToDefaults` — valid JSON with a type-mismatched value returns null instead of throwing.
  * `PowerShellConfig_BrokenCurrentUserConfig_EmitsWarningToStderr` — pins that the file-level warning is actually written.
  * `PowerShellConfig_TypeMismatchInCurrentUserConfig_EmitsWarningToStderr` — pins that the per-key warning is actually written.

## PR Context

Fixes #27370

The original report showed pwsh hard-failing at startup with `IOException: The cloud file provider is not running` when the user's `powershell.config.json` lives in a OneDrive-synced `Documents\PowerShell` folder and OneDrive hasn't started yet. The same code path also blew up on permission-denied and corrupt-JSON cases. After this PR, all of those scenarios warn to stderr and fall back to default settings (so `$profile`, execution policy, module path, etc. work as if the file were absent), while the admin-owned `AllUsers` config still fails closed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
