### PR TITLE
[release/v7.7.0-preview.1] PMC release: Use slash instead of back-slash for Linux container

### DIFF
--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -37,7 +37,7 @@ stages:
     - group: 'mscodehub-code-read-akv'
     - group: 'packages.microsoft.com'
     - name: ob_sdl_credscan_suppressionsFile
-      value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
+      value: $(Build.SourcesDirectory)/PowerShell/.config/suppress.json
     - name: ob_sdl_tsa_configFile
       value: $(Build.SourcesDirectory)/PowerShell/.config/tsaoptions.json
     steps:


### PR DESCRIPTION
Backport of #27315 to release/v7.7.0-preview.1

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27315$$$
-->

Triggered by @jshigetomi on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes CredScan failure in PMC release pipeline on Linux containers by using forward slashes instead of backslashes in the suppress.json path.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by original PR and successful merges to v7.4.15, v7.5.6, and v7.6.1 release branches. The fix corrects a path separator that caused CredScan to fail on Linux containers.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk — single character change (backslash to forward slash) in a pipeline YAML path variable; same fix already merged to v7.4, v7.5, and v7.6 release branches.

## Merge Conflicts

Conflict in .pipelines/templates/release-prep-for-ev2.yml: The release branch had an additional ob_sdl_tsa_configFile variable not present on master. Resolution: applied the backslash-to-forward-slash fix for ob_sdl_credscan_suppressionsFile and preserved the extra ob_sdl_tsa_configFile variable from the release branch.
