### PR TITLE
Add `deb-arm64` package type for Debian arm64

### DIFF
--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -132,6 +132,7 @@ jobs:
         'tar' { 'Signed-linux-x64', 'powershell*.tar.gz' }
         'tar-alpine-fxdependent' { 'Signed-fxdependent-noopt-linux-musl-x64', 'powershell*.tar.gz' }
         'deb' { 'Signed-linux-x64', 'powershell*.deb' }
+        'deb-arm64' { 'Signed-linux-arm64', 'powershell*.deb' }
         'rpm-fxdependent' { 'Signed-fxdependent-linux-x64', 'powershell*.rpm' }
         'rpm-fxdependent-arm64' { 'Signed-fxdependent-linux-arm64', 'powershell*.rpm' }
         'rpm' { 'Signed-linux-x64', 'powershell*.rpm' }

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -109,7 +109,7 @@ jobs:
   - pwsh: |
       $message = @()
       Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -filter *.deb | ForEach-Object {
-          if($_.Name -notmatch 'powershell(-preview|-lts)?_\d+\.\d+\.\d+([\-~][a-z]*.\d+)?-\d\.deb_amd64\.deb')
+          if($_.Name -notmatch 'powershell(-preview|-lts)?_\d+\.\d+\.\d+([\-~][a-z]*.\d+)?-\d\.deb_(amd64|arm64)\.deb')
           {
               $messageInstance = "$($_.Name) is not a valid package name"
               $message += $messageInstance

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -89,6 +89,13 @@ stages:
 
   - template: /.pipelines/templates/linux-package-build.yml@self
     parameters:
+      unsignedDrop: 'drop_linux_build_linux_arm64'
+      signedDrop: 'drop_linux_sign_linux_arm64'
+      packageType: deb-arm64
+      jobName: deb_arm64
+
+  - template: /.pipelines/templates/linux-package-build.yml@self
+    parameters:
       unsignedDrop: 'drop_linux_build_linux_fxd_x64_mariner'
       signedDrop: 'drop_linux_sign_linux_fxd_x64_mariner'
       packageType: rpm-fxdependent  #mariner-x64

--- a/test/packaging/linux/package-validation.tests.ps1
+++ b/test/packaging/linux/package-validation.tests.ps1
@@ -61,6 +61,7 @@ Describe "Linux Package Name Validation" {
             # - powershell-preview_7.6.0-preview.6-1.deb_amd64.deb
             # - powershell-lts_7.4.13-1.deb_amd64.deb
             # - powershell_7.4.13-1.deb_amd64.deb
+            # - powershell_7.6.0-1.deb_arm64.deb
             # Breakdown:
             # ^powershell            : Starts with 'powershell'
             # (-preview|-lts)?       : Optionally '-preview' or '-lts'

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -52,7 +52,7 @@ function Start-PSPackage {
         [string]$Name = "powershell",
 
         # Ubuntu, CentOS, Fedora, macOS, and Windows packages are supported
-        [ValidateSet("msix", "deb", "osxpkg", "rpm", "rpm-fxdependent", "rpm-fxdependent-arm64", "zip", "zip-pdb", "tar", "tar-arm", "tar-arm64", "tar-alpine", "fxdependent", "fxdependent-win-desktop", "min-size", "tar-alpine-fxdependent")]
+        [ValidateSet("msix", "deb", "deb-arm64", "osxpkg", "rpm", "rpm-fxdependent", "rpm-fxdependent-arm64", "zip", "zip-pdb", "tar", "tar-arm", "tar-arm64", "tar-alpine", "fxdependent", "fxdependent-win-desktop", "min-size", "tar-alpine-fxdependent")]
         [string[]]$Type,
 
         # Generate windows downlevel package
@@ -609,6 +609,24 @@ function Start-PSPackage {
                 foreach ($Distro in $Script:DebianDistributions) {
                     $Arguments["Distribution"] = $Distro
                     if ($PSCmdlet.ShouldProcess("Create DEB Package for $Distro")) {
+                        New-UnixPackage @Arguments
+                    }
+                }
+            }
+            'deb-arm64' {
+                $Arguments = @{
+                    Type = 'deb'
+                    PackageSourcePath = $Source
+                    Name = $Name
+                    Version = $Version
+                    Force = $Force
+                    NoSudo = $NoSudo
+                    LTS = $LTS
+                    HostArchitecture = "arm64"
+                }
+                foreach ($Distro in $Script:DebianDistributions) {
+                    $Arguments["Distribution"] = $Distro
+                    if ($PSCmdlet.ShouldProcess("Create DEB Package for $Distro (arm64)")) {
                         New-UnixPackage @Arguments
                     }
                 }


### PR DESCRIPTION
# PR Summary

Resolves the in-repo half of #24076 (DSR for Debian 12 arm64). We already build a `linux-arm64` self-contained binary and a `tar-arm64` tarball, but the only `.deb` we ship is `amd64`. This adds a `deb-arm64` packaging path that consumes the existing arm64 signed binary drop and emits a deb whose control field reports `Architecture: arm64` and whose filename ends in `_arm64.deb`.

## PR Context

The packaging logic itself was almost free — `New-DebPackage` already takes `HostArchitecture` and writes it verbatim into the deb control file and output filename, and Debian uses `arm64` natively (no `aarch64` translation like RPM needs). So the new switch arm in `Start-PSPackage` is a clone of `'deb'` with `HostArchitecture = "arm64"`.

Pipeline-side:

- `linux-package-build.yml` learns the `deb-arm64` packageType and maps it to the `Signed-linux-arm64` drop folder
- `PowerShell-Packages-Stages.yml` adds a `deb_arm64` job that consumes the existing `drop_linux_build_linux_arm64` / `drop_linux_sign_linux_arm64` artifacts (the same ones feeding `tar-arm64` today)
- `release-validate-packagenames.yml` widens the deb regex from `_amd64\.deb` to `_(amd64|arm64)\.deb`

I deliberately did not set `hostArchitecture: arm64` on the new job's pool. Per OneBranch's ARM64 Build Hosts guidance, that flag is for native compilation of arm64 code; we're just running `dpkg-deb` over already-built arm64 binaries, which is what `tar-arm64` does today on the default amd64 linux pool. The existing signing step's `files_to_sign: '**/*.rpm;**/*.deb'` glob already picks up the new artifact with no change.

The remaining DSR checklist items (Docker image in PowerShell/PowerShell-Docker, PMC publish, lifecycle and install-doc updates in MicrosoftDocs/PowerShell-Docs) live outside this repo and are tracked on #24076.

Drafted by Copilot (Claude Opus 4.7 (High reasoning)).

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
