### PR TITLE
Handle empty-string and null-value results returned from custom argument completer more properly

### DIFF
--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.PowerShell.Native" Version="700.0.0-rc.1" />
     <!-- Signing APIs -->
-  <PackageReference Include="Microsoft.Security.Extensions" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Security.Extensions" Version="1.4.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -601,7 +601,10 @@ namespace System.Management.Automation
                     completionContext.ExecutionContext.LanguageMode = PSLanguageMode.ConstrainedLanguage;
                 }
 
-                return GetResultHelper(completionContext, out replacementIndex, out replacementLength);
+                List<CompletionResult> results = GetResultHelper(completionContext, out replacementIndex, out replacementLength);
+                CompletionCompleters.RemoveLastNullCompletionResult(results);
+
+                return results;
             }
             finally
             {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2702,20 +2702,29 @@ namespace System.Management.Automation
                 return false;
             }
 
+            int initialCount = result.Count;
+
             foreach (var customResult in customResults)
             {
-                var resultAsCompletion = customResult.BaseObject as CompletionResult;
-                if (resultAsCompletion != null)
+                if (customResult is null)
+                {
+                    continue;
+                }
+
+                if (customResult.BaseObject is CompletionResult resultAsCompletion)
                 {
                     result.Add(resultAsCompletion);
                     continue;
                 }
 
                 var resultAsString = customResult.ToString();
-                result.Add(new CompletionResult(resultAsString));
+                if (!string.IsNullOrEmpty(resultAsString))
+                {
+                    result.Add(new CompletionResult(resultAsString));
+                }
             }
 
-            return true;
+            return result.Count > initialCount;
         }
 
         // All the methods for native command argument completion will add a null instance of the type CompletionResult to the end of the

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2702,10 +2702,10 @@ namespace System.Management.Automation
                 return false;
             }
 
-            if (customResults.Count is 1 && customResults[0] is { BaseObject: "" })
+            if (customResults.Count is 1 && customResults[0] is { BaseObject: "" or null })
             {
-                // If the script block returns a single empty string, we will treat it as if it has completed successfully
-                // but has no results to return.
+                // If the script block returns a single empty string or a null value, we will treat it as if it has
+                // completed successfully but has no results to return.
                 // This allows a custom completer to suppress the default completions that we may fall back otherwise.
                 return true;
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2702,7 +2702,7 @@ namespace System.Management.Automation
                 return false;
             }
 
-            if (customResults.Count is 1 && customResults[0] is { BaseObject: "" or null })
+            if (customResults.Count is 1 && customResults[0] is { BaseObject: "" } or null)
             {
                 // If the script block returns a single empty string or a null value, we will treat it as if it has
                 // completed successfully but has no results to return.

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2675,14 +2675,17 @@ namespace System.Management.Automation
                 scriptBlock,
                 new object[] { commandName, parameterName, wordToComplete, commandAst, GetBoundArgumentsAsHashtable(context) },
                 resultList);
-            if (result)
-            {
-                resultList.Add(CompletionResult.Null);
-            }
 
             return result;
         }
 
+        /// <summary>
+        /// Invoke the custom argument completer and process its return values.
+        /// If we consider the completion successful, we add a null instance of the type 'CompletionResult'
+        /// to the end of the 'result' list to indicate that the argument completion has been processed, so we
+        /// will not go through the default argument completion even if the 'result' list is still empty.
+        /// </summary>
+        /// <returns>'true' if the argument completion was successful. 'false' otherwise.</returns>
         private static bool InvokeScriptArgumentCompleter(
             ScriptBlock scriptBlock,
             object[] argumentsToCompleter,
@@ -2707,6 +2710,7 @@ namespace System.Management.Automation
                 // If the script block returns a single empty string or a null value, we will treat it as if it has
                 // completed successfully but has no results to return.
                 // This allows a custom completer to suppress the default completions that we may fall back otherwise.
+                result.Add(CompletionResult.Null);
                 return true;
             }
 
@@ -2732,7 +2736,13 @@ namespace System.Management.Automation
                 }
             }
 
-            return result.Count > initialCount;
+            bool success = result.Count > initialCount;
+            if (success)
+            {
+                result.Add(CompletionResult.Null);
+            }
+
+            return success;
         }
 
         // All the methods for native command argument completion will add a null instance of the type CompletionResult to the end of the
@@ -2740,9 +2750,9 @@ namespace System.Management.Automation
         // and has been processed already. So if the "result" list is still empty afterward, we will not go through the default argument completion anymore.
         #region Native Command Argument Completion
 
-        private static void RemoveLastNullCompletionResult(List<CompletionResult> result)
+        internal static void RemoveLastNullCompletionResult(List<CompletionResult> result)
         {
-            if (result.Count > 0 && result[result.Count - 1].Equals(CompletionResult.Null))
+            if (result?.Count > 0 && result[^1].Equals(CompletionResult.Null))
             {
                 result.RemoveAt(result.Count - 1);
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2702,6 +2702,14 @@ namespace System.Management.Automation
                 return false;
             }
 
+            if (customResults.Count is 1 && customResults[0] is { BaseObject: "" })
+            {
+                // If the script block returns a single empty string, we will treat it as if it has completed successfully
+                // but has no results to return.
+                // This allows a custom completer to suppress the default completions that we may fall back otherwise.
+                return true;
+            }
+
             int initialCount = result.Count;
 
             foreach (var customResult in customResults)

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -149,4 +149,150 @@ Describe "Tab completion bug fix" -Tags "CI" {
             Pop-Location
         }
     }
+
+    Context 'Native CLI argument completion' {
+        BeforeAll {
+            $testDir = Join-Path $TestDrive "TempTestDir"
+            $file1 = Join-Path $testDir "abc.ps1"
+            $file2 = Join-Path $testDir "def.py"
+
+            New-Item -ItemType Directory -Path $testDir > $null
+            New-Item -ItemType File -Path $file1 > $null
+            New-Item -ItemType File -Path $file2 > $null
+
+            $dirSep = [System.IO.Path]::DirectorySeparatorChar
+            $relative_name_abc = ".${dirSep}abc.ps1"
+            $relative_name_def = ".${dirSep}def.py"
+        }
+
+        AfterAll {
+            ## Unregister the completer for 'ping' to avoid affecting other tests.
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock $null
+        }
+
+        It 'Completer script block returning nothing should fall back to file name completion' {
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
+                param($WordToComplete, $CommandAst, $CursorPosition)
+            }
+
+            try {
+                Push-Location -Path $testDir
+                $cmd = "ping "
+                $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+                $result.CompletionMatches | Should -Not -BeNullOrEmpty
+                $result.CompletionMatches.Count | Should -Be 2
+                $result.CompletionMatches[0].CompletionText | Should -BeExactly $relative_name_abc
+                $result.CompletionMatches[1].CompletionText | Should -BeExactly $relative_name_def
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'Completer script block returning $null should suppress default completion fallback' {
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
+                param($WordToComplete, $CommandAst, $CursorPosition)
+                return $null
+            }
+
+            try {
+                Push-Location -Path $testDir
+                $cmd = "ping "
+                ## This call should not throw, and should suppress the default file name completion fallback, returning no results.
+                $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+                $result.CompletionMatches.Count | Should -Be 0
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'Completer script block returning empty string should suppress default completion fallback' {
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
+                param($WordToComplete, $CommandAst, $CursorPosition)
+                return ''
+            }
+
+            try {
+                Push-Location -Path $testDir
+                $cmd = "ping "
+                ## This call should not throw, and should suppress the default file name completion fallback, returning no results.
+                $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+                $result.CompletionMatches.Count | Should -Be 0
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'Completer script block returning empty-string-only array should fall back to default completion' {
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
+                param($WordToComplete, $CommandAst, $CursorPosition)
+                return '', ''
+            }
+
+            try {
+                Push-Location -Path $testDir
+                $cmd = "ping "
+                ## This call should not throw, and should fall back to the default completion.
+                $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+                $result.CompletionMatches.Count | Should -Be 2
+                $result.CompletionMatches[0].CompletionText | Should -BeExactly $relative_name_abc
+                $result.CompletionMatches[1].CompletionText | Should -BeExactly $relative_name_def
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'Completer script block returning null-value-only array should fall back to default completion' {
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
+                param($WordToComplete, $CommandAst, $CursorPosition)
+                return $null, $null
+            }
+
+            try {
+                Push-Location -Path $testDir
+                $cmd = "ping "
+                ## This call should not throw, and should fall back to the default completion.
+                $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+                $result.CompletionMatches.Count | Should -Be 2
+                $result.CompletionMatches[0].CompletionText | Should -BeExactly $relative_name_abc
+                $result.CompletionMatches[1].CompletionText | Should -BeExactly $relative_name_def
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'Completer script block returning a single string works as expected' {
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
+                param($WordToComplete, $CommandAst, $CursorPosition)
+                return 'hello'
+            }
+
+            try {
+                Push-Location -Path $testDir
+                $cmd = "ping "
+                $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+                $result.CompletionMatches.Count | Should -Be 1
+                $result.CompletionMatches[0].CompletionText | Should -BeExactly "hello"
+            } finally {
+                Pop-Location
+            }
+        }
+
+        It 'Completer script block returning an array that contains non-empty-or-null strings works as expected' {
+            register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
+                param($WordToComplete, $CommandAst, $CursorPosition)
+                return '', 'hello', $null, 'world'
+            }
+
+            try {
+                Push-Location -Path $testDir
+                $cmd = "ping "
+                $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+                $result.CompletionMatches.Count | Should -Be 2
+                $result.CompletionMatches[0].CompletionText | Should -BeExactly "hello"
+                $result.CompletionMatches[1].CompletionText | Should -BeExactly "world"
+            } finally {
+                Pop-Location
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The constructor of `CompletionResult` doesn't allow an empty string argument. Exception will be thrown if an empty string is passed in.

For example, with an argument completer defined like this (or, use `return $null`):
```
register-ArgumentCompleter -Native -CommandName ping -ScriptBlock {
    param($WordToComplete, $CommandAst, $CursorPosition)
    return ''
}
```
You will get an exception when calling `TabExpansion2` for `ping`:
```
PS:49> $result = TabExpansion2 -inputScript 'ping ' -cursorColumn 5
MethodInvocationException:
Line |
  40 |  …      return [System.Management.Automation.CommandCompletion]::Complet …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "CompleteInput" with "3" argument(s): "Cannot process argument because the value of argument "completionText" is null. Change the value of argument "completionText" to a non-null value."
```

This PR improves how `InvokeScriptArgumentCompleter` handles the return values from a custom argument completer script block:
1. Avoid `ArgumentException` or `NullReferenceException` when the return values include `null` or empty string.
2. Today, when a custom completer returns `$null` or an empty string, due to the exception (which gets swallowed by `PSReadLine`), the user-perceived behavior is -- no result, and default completion (e.g. file names) is suppressed. So, it's not uncommon for developers to intentionally depend on this behavior suppress file name completion.
   - **This behavior is explicitly preserved** -- when a custom completer script block returns `$null` or empty string, the completion is considered successfully, and we will not fall back to default completions.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
