### PR TITLE
[release/v7.6.2] Remove mariner2.0 from PMC mapping

### DIFF
--- a/tools/packages.microsoft.com/mapping.json
+++ b/tools/packages.microsoft.com/mapping.json
@@ -29,38 +29,6 @@
           "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.rh.x86_64.rpm"
       },
       {
-        "url": "cbl-mariner-2.0-prod-Microsoft-aarch64",
-        "distribution": [
-            "bionic"
-        ],
-        "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.aarch64.rpm",
-        "channel": "stable"
-      },
-      {
-          "url": "cbl-mariner-2.0-prod-Microsoft-x86_64",
-          "distribution": [
-              "bionic"
-          ],
-          "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.x86_64.rpm",
-          "channel": "stable"
-      },
-      {
-          "url": "cbl-mariner-2.0-preview-Microsoft-aarch64",
-          "distribution": [
-              "bionic"
-          ],
-          "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.aarch64.rpm",
-          "channel": "preview"
-      },
-      {
-          "url": "cbl-mariner-2.0-preview-Microsoft-x86_64",
-          "distribution": [
-              "bionic"
-          ],
-          "PackageFormat": "PACKAGE_NAME-POWERSHELL_RELEASE-1.cm.x86_64.rpm",
-          "channel": "preview"
-      },
-      {
         "url": "azurelinux-3.0-prod-ms-oss-aarch64",
         "distribution": [
             "bionic"


### PR DESCRIPTION
Backport of #27068 to release/v7.6.2

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27068$$$
-->

Triggered by @daxian-dbw on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Removes mariner2.0 from the PMC package mapping since PowerShell 7.6 is not supported on mariner 2.0. Users should use the AzureLinux3 PMC feed instead.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated by the original PR. The change removes mariner2.0 from the PMC mapping as PowerShell 7.6 is not supported on mariner 2.0. Users should obtain packages from the AzureLinux3 PMC feed instead.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Removes an unsupported platform (mariner 2.0) from packaging configuration. No code logic changes, only a configuration/mapping update.
