### PR TITLE
[release/v7.6.2] Enable usage in AppContainers

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -967,7 +967,9 @@ namespace System.Management.Automation
 #if UNIX
             return Platform.SelectProductNameForDirectory(Platform.XDG_Type.USER_MODULES);
 #else
-            string myDocumentsPath = InternalTestHooks.SetMyDocumentsSpecialFolderToBlank ? string.Empty : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            string myDocumentsPath = InternalTestHooks.SetMyDocumentsSpecialFolderToBlank
+                ? string.Empty
+                : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.DoNotVerify);
             return string.IsNullOrEmpty(myDocumentsPath) ? null : Path.Combine(myDocumentsPath, Utils.ModuleDirectory);
 #endif
         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -569,7 +569,7 @@ namespace Microsoft.PowerShell.Commands
             if (driveIsFixed)
             {
                 // Since the drive is fixed, ensure the root is valid.
-                validDrive = Directory.Exists(drive.Root);
+                validDrive = SafeDoesPathExist(drive.Root);
             }
 
             if (validDrive)
@@ -908,7 +908,7 @@ namespace Microsoft.PowerShell.Commands
 
                         if (newDrive.DriveType == DriveType.Fixed)
                         {
-                            if (!newDrive.RootDirectory.Exists)
+                            if (!SafeDoesPathExist(newDrive.RootDirectory.FullName))
                             {
                                 continue;
                             }
@@ -1224,6 +1224,29 @@ namespace Microsoft.PowerShell.Commands
             catch (UnauthorizedAccessException accessException)
             {
                 WriteError(new ErrorRecord(accessException, "GetItemUnauthorizedAccessError", ErrorCategory.PermissionDenied, path));
+            }
+        }
+
+        private static bool SafeDoesPathExist(string rootDirectory)
+        {
+            if (Directory.Exists(rootDirectory))
+            {
+                return true;
+            }
+
+            try
+            {
+                return (File.GetAttributes(rootDirectory) & FileAttributes.Directory) is not 0;
+            }
+            // In some scenarios (like AppContainers) direct access to the root directory may
+            // be prevented, but more specific paths may be accessible.
+            catch (UnauthorizedAccessException)
+            {
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
Backport of #27266 to release/v7.6.2

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27266$$$
-->

Triggered by @daxian-dbw on behalf of @SeeminglyScience

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes issue #27253 where PowerShell fails to initialize in AppContainer environments. By default, AppContainers block access to the root of the system drive. PowerShell was incorrectly treating "access denied" as the drive not existing, causing initialization failures and preventing modules from loading.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated by the original PR. Testing can only be done interactively in an AppContainer environment. The fix treats "access denied" on the root of the system drive as evidence the drive exists, rather than treating it as absent.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Small targeted fix that changes how PowerShell treats "access denied" errors when checking drive accessibility in AppContainer environments. The change is additive — it only affects AppContainer scenarios where the root of the system drive is blocked.
