### PR TITLE
[release/v7.4.16] Remove package verification from the notice pipeline

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -8,9 +8,6 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
-  - name: SkipVerifyPackages
-    type: boolean
-    default: false
 
 variables:
   # PAT permissions NOTE: Declare a SymbolServerPAT variable in this group with a 'microsoft' organizanization scoped PAT with 'Symbols' Read permission.
@@ -109,4 +106,3 @@ extends:
           - template: /.pipelines/templates/compliance/generateNotice.yml@self
             parameters:
               parentJobs: []
-              SkipVerifyPackages: ${{ parameters.SkipVerifyPackages }}

--- a/.pipelines/templates/compliance/generateNotice.yml
+++ b/.pipelines/templates/compliance/generateNotice.yml
@@ -4,8 +4,6 @@
 parameters:
   - name: parentJobs
     type: jobList
-  - name: SkipVerifyPackages
-    type: boolean
 
 jobs:
 - job: generateNotice
@@ -56,11 +54,6 @@ jobs:
     displayName: 'Component Detection'
     inputs:
       sourceScanPath: '$(repoRoot)\tools\cgmanifest\tpn'
-
-  - pwsh: |
-      $(repoRoot)/tools/clearlyDefined/ClearlyDefined.ps1 -TestAndHarvest
-    displayName: Verify that packages have license data
-    condition: eq(${{ parameters.SkipVerifyPackages }}, false)
 
   - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
     displayName: 'NOTICE File Generator'


### PR DESCRIPTION
Backport of #27289 to release/v7.4.16

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27289$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Removes unnecessary verification step from CI pipeline. Ensures pipeline is up-to-date with current release process.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated pipeline changes by running the updated workflow. No failures observed and cgmanifest updates are handled by Release Prep workflow.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This change only removes redundant package verification from the notice pipeline, which is now handled elsewhere. No impact on product code or customer scenarios.
