### PR TITLE
[release/v7.4.16] Add macOS binary code signing and package notarization

### DIFF
--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -77,6 +77,14 @@ jobs:
     continueOnError: true
 
   - pwsh: |
+      $signedDir = "$(Pipeline.Workspace)/CoOrdinatedBuildPipeline/drop_macos_sign_${{ parameters.buildArchitecture }}/Signed-${{ parameters.buildArchitecture }}"
+      Get-ChildItem $signedDir -Recurse -Include 'pwsh', '*.dylib' | ForEach-Object {
+        codesign --verify --deep --strict --verbose=4 $_.FullName
+        if ($LASTEXITCODE -ne 0) { throw "codesign verification failed for $($_.FullName)" }
+      }
+    displayName: 'Verify Apple codesign on signed binaries'
+
+  - pwsh: |
       # Add -SkipReleaseChecks as a mitigation to unblock release.
       # macos-10.15 does not allow creating a folder under root. Hence, moving the folder.
 
@@ -158,7 +166,12 @@ jobs:
         Write-Host "##vso[artifact.upload containerfolder=macos-pkgs;artifactname=macos-pkgs]$file"
       }
 
+      $packageInfo = Get-MacOSPackageIdentifierInfo -Version '$(Version)' -LTS:$LTS
+      Write-Verbose -Verbose "BundleId: $($packageInfo.PackageIdentifier)"
+      Write-Host "##vso[task.setvariable variable=BundleId;isOutput=true]$($packageInfo.PackageIdentifier)"
+
     displayName: 'Package ${{ parameters.buildArchitecture}}'
+    name: packageStep
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
 
@@ -178,7 +191,8 @@ jobs:
     value: $(Build.SourcesDirectory)/PowerShell/.config/suppress.json
   - name: BuildArch
     value: ${{ parameters.buildArchitecture }}
-  - group: mscodehub-macos-package-signing
+  - name: BundleId
+    value: $[ dependencies.package_macOS_${{ parameters.buildArchitecture }}.outputs['packageStep.BundleId'] ]
 
   steps:
   - download: current
@@ -216,32 +230,59 @@ jobs:
       inline_operation: |
         [
           {
-            "KeyCode": "$(KeyCode)",
+            "KeyCode": "CP-401337-Apple",
             "OperationCode": "MacAppDeveloperSign",
             "ToolName": "sign",
             "ToolVersion": "1.0",
             "Parameters": {
-              "Hardening": "Enable",
-              "OpusInfo": "http://microsoft.com"
+              "Hardening": "--options=runtime"
             }
           }
         ]
 
+  - task: onebranch.pipeline.signing@1
+    displayName: 'OneBranch Notarize Package'
+    inputs:
+      command: 'sign'
+      files_to_sign: '**/*-osx-*.zip'
+      search_root: '$(Pipeline.Workspace)'
+      inline_operation: |
+        [
+          {
+            "KeyCode": "CP-401337-Apple",
+            "OperationCode": "MacAppNotarize",
+            "ToolName": "sign",
+            "ToolVersion": "1.0",
+            "Parameters": {
+              "BundleId": "$(BundleId)"
+            }
+          }
+        ]
+    timeoutInMinutes: 120
+
   - pwsh: |
       $signedPkg = Get-ChildItem -Path $(Pipeline.Workspace) -Filter "*osx*.zip" -File
 
+      if (-not (Test-Path $(ob_outputDirectory))) {
+        $null = New-Item -Path $(ob_outputDirectory) -ItemType Directory
+      }
+
+      $expandDir = "$(Pipeline.Workspace)/pkgExpand"
+      $null = New-Item -Path $expandDir -ItemType Directory -Force
+
       $signedPkg | ForEach-Object {
         Write-Verbose -Verbose "Signed package zip: $_"
+        Expand-Archive -Path $_ -DestinationPath $expandDir -Verbose
+      }
 
-        if (-not (Test-Path $_)) {
-          throw "Package not found: $_"
-        }
+      # ESRP's signing pipeline nests the PKG inside a '<hash>.zip.unzipped' subfolder
+      $pkgFile = Get-ChildItem -Path $expandDir -Filter '*.pkg' -Recurse -File
+      if (-not $pkgFile) {
+        throw "Package not found in: $signedPkg"
+      }
 
-        if (-not (Test-Path $(ob_outputDirectory))) {
-          $null = New-Item -Path $(ob_outputDirectory) -ItemType Directory
-        }
-
-        Expand-Archive -Path $_ -DestinationPath $(ob_outputDirectory) -Verbose
+      $pkgFile | ForEach-Object {
+        Move-Item -Path $_ -Destination $(ob_outputDirectory) -Verbose
       }
 
       Write-Verbose -Verbose "Expanded pkg file:"

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -144,4 +144,36 @@ jobs:
       binPath: $(DropRootPath)
       OfficialBuild: $(ps_official_build)
 
+  # Apple-sign the Mach-O binaries inside the signed output.
+  - pwsh: |
+      $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
+      $zipFile = "$(Pipeline.Workspace)/macho-$(BuildArchitecture).zip"
+      Compress-Archive -Path "$signedDir/*" -DestinationPath $zipFile -Force
+    displayName: Compress signed folder for Apple signing
+
+  - task: onebranch.pipeline.signing@1
+    displayName: Apple CodeSign Mach-O binaries
+    inputs:
+      command: 'sign'
+      files_to_sign: 'macho-$(BuildArchitecture).zip'
+      search_root: '$(Pipeline.Workspace)'
+      inline_operation: |
+        [
+          {
+            "KeyCode": "CP-401337-Apple",
+            "OperationCode": "MacAppDeveloperSign",
+            "ToolName": "sign",
+            "ToolVersion": "1.0",
+            "Parameters": {
+              "Hardening": "--options=runtime"
+            }
+          }
+        ]
+
+  - pwsh: |
+      $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
+      $zipFile = "$(Pipeline.Workspace)/macho-$(BuildArchitecture).zip"
+      Expand-Archive -Path $zipFile -DestinationPath $signedDir -Force -Verbose
+    displayName: Expand Apple-signed Mach-O binaries into signed output
+
   - template: /.pipelines/templates/step/finalize.yml@self

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -69,6 +69,14 @@ jobs:
       $psOptPath = "$(OB_OUTPUTDIRECTORY)/psoptions.json"
       Save-PSOptions -PSOptionsPath $psOptPath
 
+      $entitlements = "$(PowerShellRoot)/assets/macos-entitlements.plist"
+      $pwshBin = "$(OB_OUTPUTDIRECTORY)/pwsh"
+      Write-Verbose -Verbose "Applying entitlements to $pwshBin"
+      codesign --sign - --force --options runtime --entitlements $entitlements $pwshBin
+      if ($LASTEXITCODE -ne 0) {
+        throw "codesign failed with exit code $LASTEXITCODE"
+      }
+
       # Since we are using custom pool for macOS, we need to use artifact.upload to publish the artifacts
       Write-Host "##vso[artifact.upload containerfolder=$artifactName;artifactname=$artifactName]$(OB_OUTPUTDIRECTORY)"
 

--- a/assets/macos-entitlements.plist
+++ b/assets/macos-entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -26,6 +26,7 @@
         'Test-PackageManifest'
         'Update-PSSignedBuildFolder'
         'Test-Bom'
+        'Get-MacOSPackageIdentifierInfo'
     )
     RootModule        = "packaging.psm1"
     RequiredModules   = @("build")


### PR DESCRIPTION
Backport of #27347 to release/v7.4.16

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27347$$$
-->

Triggered by @adityapatwardhan on behalf of @andyleejordan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Backports build and packaging pipeline updates required to support macOS binary signing and notarization in the release branch pipeline.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Ensures release packaging/signing workflow works correctly for macOS artifacts and avoids pipeline regressions during release engineering.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick applied cleanly in D:\PSGit\PowerShell-backport with no conflicts. Validation will run via CI on the backport PR for release/v7.4.16 pipeline paths.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Changes are in build/pipeline packaging and signing flow; they are scoped to release engineering but can affect release pipeline behavior if incorrect.
