### PR TITLE
[release/v7.6.2] Create PowerShell package for arm debian distribution

### DIFF
--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -124,6 +124,7 @@ jobs:
         'tar' { 'Signed-linux-x64', 'powershell*.tar.gz' }
         'tar-alpine-fxdependent' { 'Signed-fxdependent-noopt-linux-musl-x64', 'powershell*.tar.gz' }
         'deb' { 'Signed-linux-x64', 'powershell*.deb' }
+        'deb-arm64' { 'Signed-linux-arm64', 'powershell*.deb' }
         'rpm-fxdependent' { 'Signed-fxdependent-linux-x64', 'powershell*.rpm' }
         'rpm-fxdependent-arm64' { 'Signed-fxdependent-linux-arm64', 'powershell*.rpm' }
         'rpm' { 'Signed-linux-x64', 'powershell*.rpm' }

--- a/.pipelines/templates/release-validate-packagenames.yml
+++ b/.pipelines/templates/release-validate-packagenames.yml
@@ -109,7 +109,7 @@ jobs:
   - pwsh: |
       $message = @()
       Get-ChildItem $(System.ArtifactsDirectory)\* -recurse -filter *.deb | ForEach-Object {
-          if($_.Name -notmatch 'powershell(-preview|-lts)?_\d+\.\d+\.\d+([\-~][a-z]*.\d+)?-\d\.deb_amd64\.deb')
+          if($_.Name -notmatch 'powershell(-preview|-lts)?_\d+\.\d+\.\d+([\-~][a-z]*.\d+)?-\d\.deb_(amd64|arm64)\.deb')
           {
               $messageInstance = "$($_.Name) is not a valid package name"
               $message += $messageInstance

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -89,6 +89,13 @@ stages:
 
   - template: /.pipelines/templates/linux-package-build.yml@self
     parameters:
+      unsignedDrop: 'drop_linux_build_linux_arm64'
+      signedDrop: 'drop_linux_sign_linux_arm64'
+      packageType: deb-arm64
+      jobName: deb_arm64
+
+  - template: /.pipelines/templates/linux-package-build.yml@self
+    parameters:
       unsignedDrop: 'drop_linux_build_linux_fxd_x64_mariner'
       signedDrop: 'drop_linux_sign_linux_fxd_x64_mariner'
       packageType: rpm-fxdependent  #mariner-x64

--- a/test/packaging/linux/package-validation.tests.ps1
+++ b/test/packaging/linux/package-validation.tests.ps1
@@ -9,20 +9,20 @@ Describe "Linux Package Name Validation" {
         } else {
             $env:SYSTEM_ARTIFACTSDIRECTORY
         }
-        
+
         if (-not $artifactsDir) {
             throw "Artifacts directory not found. GITHUB_WORKSPACE or SYSTEM_ARTIFACTSDIRECTORY must be set."
         }
-        
+
         Write-Verbose "Artifacts directory: $artifactsDir" -Verbose
     }
-    
+
     Context "RPM Package Names" {
         It "Should have valid RPM package names" {
             $rpmPackages = Get-ChildItem -Path $artifactsDir -Recurse -Filter *.rpm -ErrorAction SilentlyContinue
-            
+
             $rpmPackages.Count | Should -BeGreaterThan 0 -Because "At least one RPM package should exist in the artifacts directory"
-            
+
             $invalidPackages = @()
             # Regex pattern for valid RPM package names.
             # Breakdown:
@@ -42,25 +42,26 @@ Describe "Linux Package Name Validation" {
                     Write-Warning "$($package.Name) is not a valid RPM package name"
                 }
             }
-            
+
             if ($invalidPackages.Count -gt 0) {
                 throw ($invalidPackages | Out-String)
             }
         }
     }
-    
+
     Context "DEB Package Names" {
         It "Should have valid DEB package names" {
             $debPackages = Get-ChildItem -Path $artifactsDir -Recurse -Filter *.deb -ErrorAction SilentlyContinue
-            
+
             $debPackages.Count | Should -BeGreaterThan 0 -Because "At least one DEB package should exist in the artifacts directory"
-            
+
             $invalidPackages = @()
             # Regex pattern for valid DEB package names.
             # Valid examples:
             # - powershell-preview_7.6.0-preview.6-1.deb_amd64.deb
             # - powershell-lts_7.4.13-1.deb_amd64.deb
             # - powershell_7.4.13-1.deb_amd64.deb
+            # - powershell_7.6.0-1.deb_arm64.deb
             # Breakdown:
             # ^powershell            : Starts with 'powershell'
             # (-preview|-lts)?       : Optionally '-preview' or '-lts'
@@ -78,19 +79,19 @@ Describe "Linux Package Name Validation" {
                     Write-Warning "$($package.Name) is not a valid DEB package name"
                 }
             }
-            
+
             if ($invalidPackages.Count -gt 0) {
                 throw ($invalidPackages | Out-String)
             }
         }
     }
-    
+
     Context "Tar.Gz Package Names" {
         It "Should have valid tar.gz package names" {
             $tarPackages = Get-ChildItem -Path $artifactsDir -Recurse -Filter *.tar.gz -ErrorAction SilentlyContinue
-            
+
             $tarPackages.Count | Should -BeGreaterThan 0 -Because "At least one tar.gz package should exist in the artifacts directory"
-            
+
             $invalidPackages = @()
             foreach ($package in $tarPackages) {
                 # Pattern matches: powershell-7.6.0-preview.6-linux-x64.tar.gz or powershell-7.6.0-linux-x64.tar.gz
@@ -100,17 +101,17 @@ Describe "Linux Package Name Validation" {
                     Write-Warning "$($package.Name) is not a valid tar.gz package name"
                 }
             }
-            
+
             if ($invalidPackages.Count -gt 0) {
                 throw ($invalidPackages | Out-String)
             }
         }
     }
-    
+
     Context "Package Existence" {
         It "Should find at least one package in artifacts directory" {
             $allPackages = Get-ChildItem -Path $artifactsDir -Recurse -Include *.rpm, *.tar.gz, *.deb -ErrorAction SilentlyContinue
-            
+
             $allPackages.Count | Should -BeGreaterThan 0 -Because "At least one package should exist in the artifacts directory"
         }
     }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -52,7 +52,7 @@ function Start-PSPackage {
         [string]$Name = "powershell",
 
         # Ubuntu, CentOS, Fedora, macOS, and Windows packages are supported
-        [ValidateSet("msix", "deb", "osxpkg", "rpm", "rpm-fxdependent", "rpm-fxdependent-arm64", "msi", "zip", "zip-pdb", "tar", "tar-arm", "tar-arm64", "tar-alpine", "fxdependent", "fxdependent-win-desktop", "min-size", "tar-alpine-fxdependent")]
+        [ValidateSet("msix", "deb", "deb-arm64", "osxpkg", "rpm", "rpm-fxdependent", "rpm-fxdependent-arm64", "msi", "zip", "zip-pdb", "tar", "tar-arm", "tar-arm64", "tar-alpine", "fxdependent", "fxdependent-win-desktop", "min-size", "tar-alpine-fxdependent")]
         [string[]]$Type,
 
         # Generate windows downlevel package
@@ -641,6 +641,24 @@ function Start-PSPackage {
                     }
                 }
             }
+            'deb-arm64' {
+                $Arguments = @{
+                    Type = 'deb'
+                    PackageSourcePath = $Source
+                    Name = $Name
+                    Version = $Version
+                    Force = $Force
+                    NoSudo = $NoSudo
+                    LTS = $LTS
+                    HostArchitecture = "arm64"
+                }
+                foreach ($Distro in $Script:DebianDistributions) {
+                    $Arguments["Distribution"] = $Distro
+                    if ($PSCmdlet.ShouldProcess("Create DEB Package for $Distro")) {
+                        New-UnixPackage @Arguments
+                    }
+                }
+            }
             'rpm' {
                 $Arguments = @{
                     Type = 'rpm'
@@ -1060,7 +1078,7 @@ function New-UnixPackage {
         # This is a string because strings are appended to it
         [string]$Iteration = "1",
 
-        # Host architecture values allowed for deb type packages: amd64
+        # Host architecture values allowed for deb type packages: amd64, arm64
         # Host architecture values allowed for rpm type packages include: x86_64, aarch64, native, all, noarch, any
         # Host architecture values allowed for osxpkg type packages include: x86_64, arm64
         [string]


### PR DESCRIPTION
Backport of #26925 to release/v7.6.2

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26925$$$
-->

Triggered by @daxian-dbw on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds arm64 Debian package build support to the packaging pipeline, including a new `deb-arm64` package type, updated pipeline stages, and package name validation regex updates.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified via the original PR. Regression test validates that the `pwsh` binary inside arm64 Debian packages has executable permissions. Package name validation regex updated to accept `arm64` suffix.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Adds a new `deb-arm64` package type to the build pipeline. Existing package types are untouched, but the change touches core packaging logic and pipeline templates.

## Merge Conflicts

Conflict in tools/packaging/packaging.psm1 ValidateSet — release branch additionally contains `msi` type not present in master. Resolved by keeping both `deb-arm64` (from the PR) and `msi` (from the release branch).
