### PR TITLE
[release/v7.6.2] Add macOS binary code signing and package notarization

### DIFF
--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -69,6 +69,14 @@ jobs:
       $psOptPath = "$(OB_OUTPUTDIRECTORY)/psoptions.json"
       Save-PSOptions -PSOptionsPath $psOptPath
 
+      $entitlements = "$(PowerShellRoot)/assets/macos-entitlements.plist"
+      $pwshBin = "$(OB_OUTPUTDIRECTORY)/pwsh"
+      Write-Verbose -Verbose "Applying entitlements to $pwshBin"
+      codesign --sign - --force --options runtime --entitlements $entitlements $pwshBin
+      if ($LASTEXITCODE -ne 0) {
+        throw "codesign failed with exit code $LASTEXITCODE"
+      }
+
       # Since we are using custom pool for macOS, we need to use artifact.upload to publish the artifacts
       Write-Host "##vso[artifact.upload containerfolder=$artifactName;artifactname=$artifactName]$(OB_OUTPUTDIRECTORY)"
 

--- a/assets/macos-entitlements.plist
+++ b/assets/macos-entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Backport of #27347 to release/v7.6.2

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27347$$$
-->

Triggered by @daxian-dbw on behalf of @andyleejordan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds Apple notarization for macOS packages: signs and hardens binaries using ESRP/OneBranch signing tasks, notarizes the PKG installer, and applies entitlements required for the hardened runtime.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified via the original PR. The signing and notarization flow was validated interactively. No automated tests added as this can only be tested through the full pipeline run.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Significant pipeline changes to add Apple notarization support, but all changes are confined to build/signing pipeline templates and tooling. No runtime code changes.
