### PR TITLE
[release/v7.6.2] Add `appLicensing` capability to Appx manifest

### DIFF
--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -43,6 +43,7 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <rescap:Capability Name="appLicensing" />
     <rescap:Capability Name="runFullTrust" />
     <rescap:Capability Name="unvirtualizedResources" />
     <rescap:Capability Name="packageManagement" />


### PR DESCRIPTION
Backport of #27412 to release/v7.6.2

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27412$$$
-->

Triggered by @daxian-dbw on behalf of @SteveL-MSFT

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes a potential "Error acquiring license from Store" error for users running PowerShell from the Windows Store. Also improves startup performance by avoiding an unnecessary Store license acquisition attempt.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified via the original PR. The change adds a restricted capability declaration to the Appx manifest. Only testable interactively through a Store-distributed build.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Single manifest declaration change. The `appLicensing` capability is a restricted capability that PowerShell 7 is authorized to use, and it only affects Store license behavior.
