### PR TITLE
[release/v7.6.2] Specify linux-arm64 runtime if package type is deb-arm64 in packaging.psm1

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -121,6 +121,9 @@ function Start-PSPackage {
         elseif ($Type.Count -eq 1 -and $Type[0] -eq "tar-alpine-fxdependent") {
             New-PSOptions -Configuration "Release" -Runtime 'fxdependent-noopt-linux-musl-x64' -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
         }
+        elseif ($Type.Count -eq 1 -and $Type[0] -eq "deb-arm64") {
+            New-PSOptions -Configuration "Release" -Runtime 'linux-arm64' -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
+        }
         else {
             New-PSOptions -Configuration "Release" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
         }


### PR DESCRIPTION
Backport of #27401 to release/v7.6.2

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27401$$$
-->

Triggered by @daxian-dbw on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes arm64 Debian packaging by specifying the `linux-arm64` runtime in the `deb-arm64` branch of `Start-PSPackage`. This is a required follow-up fix to PR #26925 which introduced the `deb-arm64` package type.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified via the original PR. The fix adds a condition to set the `linux-arm64` runtime when `Start-PSPackage` is called with `deb-arm64` package type, preventing packaging failures for that architecture.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Targeted fix to the `deb-arm64` code path added by PR #26925. Without this, arm64 Debian packaging fails due to defaulting to `linux-x64` runtime. Only affects the new `deb-arm64` package type, no impact on existing types.
