### PR TITLE
[release/v7.4.16] Add `appLicensing` capability to Appx manifest

### DIFF
--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -43,6 +43,7 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <rescap:Capability Name="appLicensing" />
     <rescap:Capability Name="runFullTrust" />
     <rescap:Capability Name="unvirtualizedResources" />
     <rescap:Capability Name="packageManagement" />


### PR DESCRIPTION
Backport of #27412 to release/v7.4.16

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27412$$$
-->

Triggered by @adityapatwardhan on behalf of @SteveL-MSFT

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates Appx manifest for Store compatibility.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

No product code changes. CI workflows validate manifest updates.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Appx manifest update only; no product code changes.
