### PR TITLE
[release/v7.4.16] Fix *nix permissions and use `certificate_logical_to_actual`

### DIFF
--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -3,7 +3,6 @@ parameters:
   signedeDrop: 'drop_linux_sign_linux_x64'
   packageType: deb
   jobName: 'deb'
-  signingProfile: 'CP-450779-pgpdetached'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -20,6 +19,7 @@ jobs:
     - name: skipNugetSecurityAnalysis
       value: true
     - group: DotNetPrivateBuildAccess
+    - group: certificate_logical_to_actual
     - name: ob_outputDirectory
       value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
     - name: ob_sdl_binskim_enabled
@@ -34,8 +34,16 @@ jobs:
       value: $(Build.SourcesDirectory)/PowerShell/.config/tsaoptions.json
     - name: ob_sdl_credscan_suppressionsFile
       value: $(Build.SourcesDirectory)/PowerShell/.config/suppress.json
-    - name: SigningProfile
-      value: ${{ parameters.signingProfile }}
+    # PGP signing profile selection: Mariner (Azure Linux) packages ship through
+    # a different distribution channel and must be signed with the Mariner release
+    # key; all other Linux packages use the standard PowerShell Linux key. Both
+    # key codes come from the `certificate_logical_to_actual` variable group.
+    - ${{ if startsWith(parameters.jobName, 'mariner') }}:
+      - name: SigningProfile
+        value: $(pgp_release_cert_id)
+    - ${{ else }}:
+      - name: SigningProfile
+        value: $(pgp_linux_cert_id)
 
   steps:
   - checkout: self

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -1,6 +1,6 @@
 parameters:
   unsignedDrop: 'drop_linux_build_linux_x64'
-  signedeDrop: 'drop_linux_sign_linux_x64'
+  signedDrop: 'drop_linux_sign_linux_x64'
   packageType: deb
   jobName: 'deb'
 

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -196,6 +196,13 @@ jobs:
       $pkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $pkgFilter -Recurse -File | Select-Object -ExpandProperty FullName
       Write-Verbose -Verbose "pkgPath: $pkgPath"
       Copy-Item -Path $pkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose
+
+      if ($pkgPath -like '*.tar.gz') {
+          $entry = & tar -tzvf $pkgPath | Where-Object { $_ -match '\spwsh$' } | Select-Object -First 1
+          if ($entry -notmatch '^-..x') {
+              throw "pwsh is not executable in $pkgPath : $entry"
+          }
+      }
     displayName: 'Copy artifacts to output directory'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -154,6 +154,10 @@ jobs:
 
       foreach($t in $tarPkgPath) {
         $file = $t.FullName
+        $entry = & tar -tzvf $file | Where-Object { $_ -match '\spwsh$' } | Select-Object -First 1
+        if ($entry -notmatch '^-..x') {
+            throw "pwsh is not executable in $file : $entry"
+        }
         Write-Verbose -verbose "Uploading $file to macos-pkgs"
         Write-Host "##vso[artifact.upload containerfolder=macos-pkgs;artifactname=macos-pkgs]$file"
       }

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -22,6 +22,7 @@ jobs:
     - name: skipNugetSecurityAnalysis
       value: true
     - group: DotNetPrivateBuildAccess
+    - group: certificate_logical_to_actual
     - name: ob_outputDirectory
       value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
     - name: ob_sdl_binskim_enabled
@@ -174,6 +175,7 @@ jobs:
     type: windows
 
   variables:
+  - group: certificate_logical_to_actual
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: ob_sdl_binskim_enabled
@@ -220,7 +222,7 @@ jobs:
       inline_operation: |
         [
           {
-            "KeyCode": "$(KeyCode)",
+            "KeyCode": "$(apple_cert_id)",
             "OperationCode": "MacAppDeveloperSign",
             "ToolName": "sign",
             "ToolVersion": "1.0",
@@ -230,6 +232,26 @@ jobs:
             }
           }
         ]
+
+  - task: onebranch.pipeline.signing@1
+    displayName: 'OneBranch Notarize Package'
+    inputs:
+      command: 'sign'
+      files_to_sign: '**/*-osx-*.zip'
+      search_root: '$(Pipeline.Workspace)'
+      inline_operation: |
+        [
+          {
+            "KeyCode": "$(apple_cert_id)",
+            "OperationCode": "MacAppNotarize",
+            "ToolName": "sign",
+            "ToolVersion": "1.0",
+            "Parameters": {
+              "BundleId": "$(BundleId)"
+            }
+          }
+        ]
+    timeoutInMinutes: 120
 
   - pwsh: |
       $signedPkg = Get-ChildItem -Path $(Pipeline.Workspace) -Filter "*osx*.zip" -File

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -144,4 +144,36 @@ jobs:
       binPath: $(DropRootPath)
       OfficialBuild: $(ps_official_build)
 
+  # Apple-sign the Mach-O binaries inside the signed output.
+  - pwsh: |
+      $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
+      $zipFile = "$(Pipeline.Workspace)/macho-$(BuildArchitecture).zip"
+      Compress-Archive -Path "$signedDir/*" -DestinationPath $zipFile -Force
+    displayName: Compress signed folder for Apple signing
+
+  - task: onebranch.pipeline.signing@1
+    displayName: Apple CodeSign Mach-O binaries
+    inputs:
+      command: 'sign'
+      files_to_sign: 'macho-$(BuildArchitecture).zip'
+      search_root: '$(Pipeline.Workspace)'
+      inline_operation: |
+        [
+          {
+            "KeyCode": "$(apple_cert_id)",
+            "OperationCode": "MacAppDeveloperSign",
+            "ToolName": "sign",
+            "ToolVersion": "1.0",
+            "Parameters": {
+              "Hardening": "--options=runtime"
+            }
+          }
+        ]
+
+  - pwsh: |
+      $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
+      $zipFile = "$(Pipeline.Workspace)/macho-$(BuildArchitecture).zip"
+      Expand-Archive -Path $zipFile -DestinationPath $signedDir -Force -Verbose
+    displayName: Expand Apple-signed Mach-O binaries into signed output
+
   - template: /.pipelines/templates/step/finalize.yml@self

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -23,6 +23,7 @@ jobs:
     - group: mscodehub-feed-read-general
     - group: mscodehub-feed-read-akv
     - group: DotNetPrivateBuildAccess
+    - group: certificate_logical_to_actual
 
   steps:
   - checkout: self
@@ -208,7 +209,7 @@ jobs:
     displayName: Sign nupkg files
     inputs:
       command: 'sign'
-      cp_code: 'CP-401405'
+      cp_code: '$(nuget_cert_id)'
       files_to_sign: '**\*.nupkg'
       search_root: '$(Pipeline.Workspace)\nupkg'
 
@@ -268,7 +269,7 @@ jobs:
     displayName: Sign nupkg files
     inputs:
       command: 'sign'
-      cp_code: 'CP-401405'
+      cp_code: '$(nuget_cert_id)'
       files_to_sign: '**\*.nupkg'
       search_root: '$(Pipeline.Workspace)\globaltools'
 

--- a/.pipelines/templates/shouldSign.yml
+++ b/.pipelines/templates/shouldSign.yml
@@ -6,11 +6,11 @@ parameters:
 steps:
 - powershell: |
     $shouldSign = $true
-    $authenticodeCert = 'CP-230012'
-    $msixCert = 'CP-230012'
+    $authenticodeCert = '$(authenticode_cert_id)'
+    $msixCert = '$(authenticode_cert_id)'
     if($env:IS_DAILY -eq 'true')
     {
-      $authenticodeCert = 'CP-460906'
+      $authenticodeCert = '$(authenticode_test_cert_id)'
     }
     if($env:SKIP_SIGNING -eq 'Yes')
     {

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -93,7 +93,6 @@ stages:
       signedDrop: 'drop_linux_sign_linux_fxd_x64_mariner'
       packageType: rpm-fxdependent  #mariner-x64
       jobName: mariner_x64
-      signingProfile: 'CP-459159-pgpdetached'
 
   - template: /.pipelines/templates/linux-package-build.yml@self
     parameters:
@@ -101,7 +100,6 @@ stages:
       signedDrop: 'drop_linux_sign_linux_fxd_arm64_mariner'
       packageType: rpm-fxdependent-arm64 #mariner-arm64
       jobName: mariner_arm64
-      signingProfile: 'CP-459159-pgpdetached'
 
   - template: /.pipelines/templates/linux-package-build.yml@self
     parameters:

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -313,7 +313,7 @@ jobs:
     displayName: Sign nupkg files
     inputs:
       command: 'sign'
-      cp_code: 'CP-401405'
+      cp_code: '$(nuget_cert_id)'
       files_to_sign: '**\*.nupkg'
       search_root: '$(ob_outputDirectory)\globaltool'
     condition: and(succeeded(), eq(variables['Architecture'], 'fxdependent'))

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -792,6 +792,18 @@ function New-TarballPackage {
     $Staging = "$PSScriptRoot/staging"
     New-StagingFolder -StagingPath $Staging -PackageSourcePath $PackageSourcePath -R2RVerification $R2RVerification
 
+    # Ensure PowerShell executable has correct permissions in tarball
+    $pwshInStaging = Join-Path $Staging 'pwsh'
+    if (Test-Path -LiteralPath $pwshInStaging) {
+        Start-NativeExecution { chmod 755 $pwshInStaging }
+    }
+
+    # Included .NET executable for producing crash dumps
+    $createdumpInStaging = Join-Path $Staging 'createdump'
+    if (Test-Path -LiteralPath $createdumpInStaging) {
+        Start-NativeExecution { chmod 755 $createdumpInStaging }
+    }
+
     if (Get-Command -Name tar -CommandType Application -ErrorAction Ignore) {
         if ($Force -or $PSCmdlet.ShouldProcess("Create tarball package")) {
             $options = "-czf"
@@ -1208,7 +1220,11 @@ function New-UnixPackage {
                 find $Staging -type f | xargs chmod 644
                 chmod 644 $ManGzipInfo.GzipFile
                 # refers to executable, does not vary by channel
-                chmod 755 "$Staging/pwsh" #only the executable file should be granted the execution permission
+                chmod 755 "$Staging/pwsh" # only the executable file should be granted the execution permission
+                # Included .NET executable for producing crash dumps
+                if (Test-Path "$Staging/createdump") {
+                    chmod 755 "$Staging/createdump"
+                }
             }
         }
 
@@ -1886,6 +1902,12 @@ $(if ($extendedDescription) { $extendedDescription + "`n" })
         $pwshPath = "$targetPath/pwsh"
         if (Test-Path $pwshPath) {
             Start-NativeExecution { chmod 755 $pwshPath }
+        }
+
+        # Included .NET executable for producing crash dumps
+        $createdumpPath = "$targetPath/createdump"
+        if (Test-Path $createdumpPath) {
+            Start-NativeExecution { chmod 755 $createdumpPath }
         }
 
         # Calculate md5sums for all files in data directory (excluding symlinks)


### PR DESCRIPTION
Backport of #27385 to release/v7.4.16

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27385$$$
-->

Triggered by @adityapatwardhan on behalf of @andyleejordan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates build and packaging scripts to use new ESRP key variables and correct file permissions for release artifacts.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Restores executable permissions for pwsh in tarballs, adds regression tests, and finalizes ESRP key abstraction. Addresses #23968 and internal build issues.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated by running full build and packaging pipelines for Linux and macOS. Regression tests added for tarball permissions. All artifacts verified for correct signing and permissions.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Changes are limited to packaging scripts and build pipelines. Extensively tested with new regression tests and verified in internal builds.
