### PR TITLE
[release/v7.5.7] Fix checks for local user config file paths

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -153,13 +153,16 @@ namespace Microsoft.PowerShell
             try
             {
                 string profileDir = Platform.CacheDirectory;
-#if !UNIX
-                if (!Directory.Exists(profileDir))
+                if (!string.IsNullOrEmpty(profileDir))
                 {
-                    Directory.CreateDirectory(profileDir);
-                }
+#if !UNIX
+                    if (!Directory.Exists(profileDir))
+                    {
+                        Directory.CreateDirectory(profileDir);
+                    }
 #endif
-                ProfileOptimization.SetProfileRoot(profileDir);
+                    ProfileOptimization.SetProfileRoot(profileDir);
+                }
             }
             catch
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/UpdatesNotification.cs
@@ -60,12 +60,12 @@ namespace Microsoft.PowerShell
         static UpdatesNotification()
         {
             s_notificationType = GetNotificationType();
-            CanNotifyUpdates = s_notificationType != NotificationType.Off;
+            CanNotifyUpdates = s_notificationType != NotificationType.Off
+                && Platform.TryDeriveFromCache(PSVersionInfo.GitCommitId, out s_cacheDirectory);
 
             if (CanNotifyUpdates)
             {
                 s_enumOptions = new EnumerationOptions();
-                s_cacheDirectory = Path.Combine(Platform.CacheDirectory, PSVersionInfo.GitCommitId);
 
                 // Build the template/pattern strings for the configured notification type.
                 string typeNum = ((int)s_notificationType).ToString();

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1218,11 +1218,17 @@ namespace System.Management.Automation
                         string tempDir = directory.TrimStart();
                         if (tempDir.EqualsOrdinalIgnoreCase("~"))
                         {
-                            tempDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                            tempDir = Environment.GetFolderPath(
+                                Environment.SpecialFolder.UserProfile,
+                                Environment.SpecialFolderOption.DoNotVerify);
                         }
                         else if (tempDir.StartsWith("~" + Path.DirectorySeparatorChar))
                         {
-                            tempDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + Path.DirectorySeparatorChar + tempDir.Substring(2);
+                            tempDir = Environment.GetFolderPath(
+                                Environment.SpecialFolder.UserProfile,
+                                Environment.SpecialFolderOption.DoNotVerify)
+                                + Path.DirectorySeparatorChar
+                                + tempDir.Substring(2);
                         }
 
                         _cachedPath.Add(tempDir);

--- a/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
+++ b/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
@@ -664,6 +664,11 @@ namespace System.Management.Automation
 
         public void QueueSerialization()
         {
+            if (string.IsNullOrEmpty(s_cacheStoreLocation))
+            {
+                return;
+            }
+
             // We expect many modules to rapidly call for serialization.
             // Instead of doing it right away, we'll queue a task that starts writing
             // after it seems like we've stopped adding stuff to write out.  This is
@@ -1121,7 +1126,7 @@ namespace System.Management.Automation
                 cacheFileName = string.Create(CultureInfo.InvariantCulture, $"{cacheFileName}-{hashString}");
             }
 
-            s_cacheStoreLocation = Path.Combine(Platform.CacheDirectory, cacheFileName);
+            Platform.TryDeriveFromCache(cacheFileName, out s_cacheStoreLocation);
         }
     }
 

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -89,7 +89,10 @@ namespace System.Management.Automation.Configuration
             // Note: This directory may or may not exist depending upon the execution scenario.
             // Writes will attempt to create the directory if it does not already exist.
             perUserConfigDirectory = Platform.ConfigDirectory;
-            perUserConfigFile = Path.Combine(perUserConfigDirectory, ConfigFileName);
+            if (!string.IsNullOrEmpty(perUserConfigDirectory))
+            {
+                perUserConfigFile = Path.Combine(perUserConfigDirectory, ConfigFileName);
+            }
 
             emptyConfig = new JObject();
             configRoots = new JObject[2];
@@ -387,6 +390,11 @@ namespace System.Management.Automation.Configuration
         private T ReadValueFromFile<T>(ConfigScope scope, string key, T defaultValue = default)
         {
             string fileName = GetConfigFilePath(scope);
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return defaultValue;
+            }
+
             JObject configData = configRoots[(int)scope];
 
             if (configData == null)

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -208,10 +208,11 @@ namespace System.Management.Automation
             else
             {
                 basePath = GetAllUsersFolderPath(shellId);
-                if (string.IsNullOrEmpty(basePath))
-                {
-                    return string.Empty;
-                }
+            }
+
+            if (string.IsNullOrEmpty(basePath))
+            {
+                return string.Empty;
             }
 
             string profileName = useTestProfile ? "profile_test.ps1" : "profile.ps1";

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -1156,6 +1156,11 @@ namespace System.Management.Automation.Host
                 }
             }
 
+            if (string.IsNullOrEmpty(baseDirectory))
+            {
+                return string.Empty;
+            }
+
             if (includeDate)
             {
                 baseDirectory = Path.Combine(baseDirectory, DateTime.Now.ToString("yyyyMMdd", CultureInfo.InvariantCulture));

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -164,6 +164,8 @@ namespace Microsoft.PowerShell.Telemetry
 
         private static readonly HashSet<string> s_knownSubsystemNames;
 
+        private static readonly string s_uuidPath;
+
         /// <summary>Gets a value indicating whether telemetry can be sent.</summary>
         public static bool CanSendTelemetry { get; private set; }
 

--- a/src/System.Management.Automation/utils/Telemetry.cs
+++ b/src/System.Management.Automation/utils/Telemetry.cs
@@ -177,7 +177,8 @@ namespace Microsoft.PowerShell.Telemetry
         static ApplicationInsightsTelemetry()
         {
             // If we can't send telemetry, there's no reason to do any of this
-            CanSendTelemetry = !GetEnvironmentVariableAsBool(name: _telemetryOptoutEnvVar, defaultValue: false);
+            CanSendTelemetry = !GetEnvironmentVariableAsBool(name: _telemetryOptoutEnvVar, defaultValue: false)
+                && Platform.TryDeriveFromCache("telemetry.uuid", out s_uuidPath);
             if (CanSendTelemetry)
             {
                 s_sessionId = Guid.NewGuid().ToString();


### PR DESCRIPTION
Backport of #26269 to release/v7.5.7

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26269$$$
-->

Triggered by @adityapatwardhan on behalf of @SeeminglyScience

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes user configuration path handling so SYSTEM uses the expected default config location and skips user config loading when the configured Documents folder resolves to an empty/whitespace path.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick completed onto release/v7.5.7 and conflict resolution preserved release-specific telemetry module lists while applying the config-path fix logic. The changed files match the original PR scope and the backport commit applied cleanly after resolving one conflict in Telemetry.cs.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Change is scoped to path derivation and guard logic for user config locations. The backport keeps existing release branch behavior outside this targeted fix, minimizing regression surface.

## Merge Conflicts

Resolved one conflict in src/System.Management.Automation/utils/Telemetry.cs by preserving release/v7.5.7 content and applying the intended CanSendTelemetry/telemetry.uuid path derivation update from PR #26269.
