### PR TITLE
[release/v7.5.7] Exclude .exe packages from publishing to GitHub

### DIFF
--- a/.pipelines/templates/release-githubNuget.yml
+++ b/.pipelines/templates/release-githubNuget.yml
@@ -35,6 +35,14 @@ jobs:
       targetType: inline
       script: |
         $Path = "$(Pipeline.Workspace)/GitHubPackages"
+
+        # The .exe packages are for Windows Update only and should not be uploaded to GitHub release.
+        $exefiles = Get-ChildItem -Path $Path -Filter *.exe
+        if ($exefiles) {
+            Write-Verbose -Verbose "Remove .exe packages:"
+            $exefiles | Remove-Item -Force -Verbose
+        }
+
         $OutputPath = Join-Path $Path 'hashes.sha256'
         $packages  = Get-ChildItem -Path $Path -Include * -Recurse -File
         $checksums = $packages |


### PR DESCRIPTION
Backport of #26859 to release/v7.5.7

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26859$$$
-->

Triggered by @adityapatwardhan on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This change ensures release packaging behavior is correct for GitHub releases by excluding .exe packages intended only for Windows Update from published GitHub artifacts.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick applied cleanly onto release/v7.5.7 with no conflicts. Verified branch commit and push succeeded. The change scope is limited to release packaging artifact selection logic from the original PR.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Build/release pipeline change is small and targeted: it removes a known-unwanted artifact type (.exe) from GitHub publishing. It aligns with existing release intent and has minimal runtime/customer behavior risk.
