### PR TITLE
[release/v7.5.7] Add `appLicensing` capability to Appx manifest

### DIFF
--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -43,6 +43,7 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <rescap:Capability Name="appLicensing" />
     <rescap:Capability Name="runFullTrust" />
     <rescap:Capability Name="unvirtualizedResources" />
     <rescap:Capability Name="packageManagement" />


### PR DESCRIPTION
Backport of #27412 to release/v7.5.7

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27412$$$
-->

Triggered by @adityapatwardhan on behalf of @SteveL-MSFT

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Adds appLicensing capability to Appx manifest for improved packaging.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

No new tests required; change validated by successful build and Appx manifest inspection.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This change only adds a capability to the Appx manifest and does not affect runtime behavior.
