### PR TITLE
Verify Apple codesign immediately after ESRP signing

### DIFF
--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -184,4 +184,23 @@ jobs:
       Expand-Archive -Path $zipFile -DestinationPath $signedDir -Force -Verbose
     displayName: Expand Apple-signed Mach-O binaries into signed output
 
+  - pwsh: |
+      $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
+      $expected = 'Developer ID Application: Microsoft Corporation'
+      $missing = @()
+      Get-ChildItem $signedDir -Recurse -Include 'pwsh', '*.dylib' | ForEach-Object {
+        $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+        $text = [System.Text.Encoding]::Latin1.GetString($bytes)
+        if (-not $text.Contains($expected)) {
+          $missing += $_.FullName
+          Write-Host "##[error]Missing '$expected' signature in $($_.FullName)"
+        } else {
+          Write-Host "OK: $($_.FullName)"
+        }
+      }
+      if ($missing.Count -gt 0) {
+        throw "ESRP did not apply a Developer ID signature to $($missing.Count) file(s): $($missing -join ', ')"
+      }
+    displayName: 'Verify Developer ID signature on Mach-O binaries'
+
   - template: /.pipelines/templates/step/finalize.yml@self


### PR DESCRIPTION
## PR Summary

Add an equivalent of `codesign --verify --deep --strict` step in the `Sign_macOS_*` jobs immediately after expanding the zip returned by ESRP. This is similar to the verification already run downstream in `mac-package-build.yml`, but running it inside the sign job means we fail fast in the producing pipeline instead of discovering the problem later in packaging. And it uses PowerShell to just look at the files so it can run on Windows.

## Motivation

In a release build, the `Sign_macOS_x64` job's ESRP submission returned `statusCode: pass` with `"1 files signed successfully!"`, but the returned zip contained byte-identical Mach-O entries with no Developer ID Application signature applied. ESRP silently no-op'd. The failure only surfaced in the downstream packaging pipeline's verify step (added in #27347), one stage later, after we had already published the bad `drop_macos_sign_x64` artifact.

Running the same verify here surfaces this class of silent ESRP no-op in the job that owns the signing, so:
- The signing job — not packaging — is what goes red, pointing the on-call directly at ESRP.
- The bad `drop_macos_sign_*` artifact is never published.
- Re-running just the failed sign job is sufficient to recover.

## PR Context

Defense-in-depth follow-up to #27347.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] **Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header** — N/A (pipeline YAML)
- [ ] This PR is ready to merge and is not work in progress
  - **Breaking changes**
    - [x] None
- [x] **User-facing changes** — None
- [ ] **Documentation needed** — N/A
- [ ] **Tests** — verified by next pipeline run

[Job-specific change to .pipelines/templates/mac.yml only]
