### PR TITLE
[release/v7.6.2] Remove unused step to clone Internal-PowerShellTeam-Tools repo in PMC publish pipeline

### DIFF
--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -60,20 +60,6 @@ stages:
         ob_restore_phase: true
 
     - pwsh: |
-        $branch = 'mirror-target'
-        $gitArgs = "clone",
-        "--verbose",
-        "--branch",
-        "$branch",
-        "https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools",
-        '$(Pipeline.Workspace)/tools'
-        $gitArgs | Write-Verbose -Verbose
-        git $gitArgs
-      displayName: Clone Internal-PowerShellTeam-Tools from MSCodeHub
-      env:
-        ob_restore_phase: true
-
-    - pwsh: |
         Get-ChildItem Env: | Out-String -Stream | write-Verbose -Verbose
       displayName: 'Capture Environment Variables'
       env:


### PR DESCRIPTION
Backport of #27495 to release/v7.6.2

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27495$$$
-->

Triggered by @SeeminglyScience on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Removes an unnecessary step in the PMC publish pipeline template that cloned the Internal-PowerShellTeam-Tools repository.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick completed cleanly with no conflicts; CI on the backport PR will validate the release pipeline template behavior.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

This changes release pipeline infrastructure behavior, which can have broad operational impact despite a narrowly scoped change.
