### PR TITLE
[release/v7.4.16] Remove unused step to clone Internal-PowerShellTeam-Tools repo in PMC publish pipeline

### DIFF
--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -60,20 +60,6 @@ stages:
         ob_restore_phase: true
 
     - pwsh: |
-        $branch = 'mirror-target'
-        $gitArgs = "clone",
-        "--verbose",
-        "--branch",
-        "$branch",
-        "https://$(mscodehubCodeReadPat)@mscodehub.visualstudio.com/PowerShellCore/_git/Internal-PowerShellTeam-Tools",
-        '$(Pipeline.Workspace)/tools'
-        $gitArgs | Write-Verbose -Verbose
-        git $gitArgs
-      displayName: Clone Internal-PowerShellTeam-Tools from MSCodeHub
-      env:
-        ob_restore_phase: true
-
-    - pwsh: |
         Get-ChildItem Env: | Out-String -Stream | write-Verbose -Verbose
       displayName: 'Capture Environment Variables'
       env:


### PR DESCRIPTION
Backport of #27495 to release/v7.4.16

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27495$$$
-->

Triggered by @SeeminglyScience on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Simplifies PMC publish pipeline by removing unnecessary repository clone step that was no longer being used.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Pipeline change was tested and merged on main without issues. This backport applies the same cleanup to the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Low risk: This PR removes unused code, not modifying or adding functionality. The step was already abandoned on main. Change scope is limited to PMC pipeline configuration.
