### PR TITLE
Avoid mutable ChildJobs enumeration in PSTaskJob

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -998,6 +998,7 @@ namespace System.Management.Automation.PSTasks
         #region Members
 
         private readonly PSTaskPool _taskPool;
+        private readonly List<PSTaskChildJob> _taskChildJobs;
         private bool _isOpen;
         private bool _stopSignaled;
 
@@ -1031,6 +1032,7 @@ namespace System.Management.Automation.PSTasks
             bool useNewRunspace) : base(command, string.Empty)
         {
             _taskPool = new PSTaskPool(throttleLimit, useNewRunspace);
+            _taskChildJobs = new List<PSTaskChildJob>();
             _isOpen = true;
             PSJobTypeName = nameof(PSTaskJob);
 
@@ -1056,7 +1058,7 @@ namespace System.Management.Automation.PSTasks
         {
             get
             {
-                foreach (var childJob in ChildJobs)
+                foreach (var childJob in _taskChildJobs)
                 {
                     if (childJob.HasMoreData)
                     {
@@ -1119,6 +1121,7 @@ namespace System.Management.Automation.PSTasks
             }
 
             ChildJobs.Add(childJob);
+            _taskChildJobs.Add(childJob);
             return true;
         }
 
@@ -1137,9 +1140,9 @@ namespace System.Management.Automation.PSTasks
             System.Threading.ThreadPool.QueueUserWorkItem(
                 (_) =>
                 {
-                    foreach (var childJob in ChildJobs)
+                    foreach (var childJob in _taskChildJobs)
                     {
-                        _taskPool.Add((PSTaskChildJob)childJob);
+                        _taskPool.Add(childJob);
                     }
 
                     _taskPool.Close();
@@ -1162,7 +1165,7 @@ namespace System.Management.Automation.PSTasks
 
                 // Final state will be 'Complete', only if all child jobs completed successfully.
                 JobState finalState = JobState.Completed;
-                foreach (var childJob in ChildJobs)
+                foreach (var childJob in _taskChildJobs)
                 {
                     if (childJob.JobStateInfo.State != JobState.Completed)
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -486,6 +486,35 @@ Describe 'ForEach-Object -Parallel -AsJob Basic Tests' -Tags 'CI' {
         $job | Wait-Job | Remove-Job
     }
 
+    It 'Does not crash when the ChildJobs collection is mutated while a parallel job starts' {
+        $testScript = Join-Path $TestDrive 'Mutate-ChildJobs.ps1'
+        $stdoutPath = Join-Path $TestDrive 'stdout.txt'
+        $stderrPath = Join-Path $TestDrive 'stderr.txt'
+        Set-Content -LiteralPath $testScript -Value @'
+$job = 0..20 | ForEach-Object -AsJob -Parallel {
+    Start-Sleep -Milliseconds 300
+    $_
+} -ThrottleLimit 2
+
+Start-Sleep -Milliseconds 100
+$job.ChildJobs.RemoveAt(15)
+
+$job | Wait-Job -Timeout 30 | Out-Null
+$job | Remove-Job -Force
+'@
+
+        $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
+        $process = Start-Process -FilePath $powershell -ArgumentList @(
+            '-NoLogo'
+            '-NoProfile'
+            '-NonInteractive'
+            '-File'
+            $testScript
+        ) -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -Wait -PassThru
+
+        $process.ExitCode | Should -Be 0
+    }
+
     It 'Verifies dollar underbar variable' {
 
         $expected = 1..10


### PR DESCRIPTION
# PR Summary

Avoids an unhandled process-terminating exception when `PSTaskJob.ChildJobs` is mutated while a `ForEach-Object -Parallel -AsJob` job is starting.

## PR Context

Fix #26160.

`PSTaskJob.Start()` currently enumerates the public `ChildJobs` list on a ThreadPool callback. That list is externally mutable, so removing an item can invalidate the enumerator and let the exception escape the ThreadPool callback. This change keeps an internal list of `PSTaskChildJob` objects for scheduler/state enumeration while preserving the existing public `ChildJobs` list for compatibility.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is focused on one issue
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [ ] This PR is ready to merge and is not work-in-progress
- [x] Breaking change: No
- [x] User-facing change: Not required
- [x] Tests added/updated

## Validation

- `Start-PSBuild -Clean -PSModuleRestore -UseNuGetOrg` built `pwsh.exe`. The Windows PowerShell 5.1 build wrapper emitted post-build `ConvertFrom-Json -Depth` compatibility warnings after build output was produced.
- `Start-PSPester -Path test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1 -UseNuGetOrg -ThrowOnFailure -Terse -SkipTestToolBuild` passed: 62 passed, 0 failed.