### PR TITLE
Avoid mutable ChildJobs enumeration in PSTaskJob

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -999,7 +999,6 @@ namespace System.Management.Automation.PSTasks
 
         private readonly PSTaskPool _taskPool;
         private readonly object _syncObject = new();
-        private readonly List<PSTaskChildJob> _taskChildJobs = new();
         private bool _isOpen;
         private bool _stopSignaled;
 
@@ -1060,7 +1059,7 @@ namespace System.Management.Automation.PSTasks
             {
                 lock (_syncObject)
                 {
-                    foreach (PSTaskChildJob childJob in _taskChildJobs)
+                    foreach (Job childJob in ChildJobs)
                     {
                         if (childJob.HasMoreData)
                         {
@@ -1126,7 +1125,6 @@ namespace System.Management.Automation.PSTasks
                 }
 
                 ChildJobs.Add(childJob);
-                _taskChildJobs.Add(childJob);
                 return true;
             }
         }
@@ -1141,7 +1139,11 @@ namespace System.Management.Automation.PSTasks
             lock (_syncObject)
             {
                 _isOpen = false;
-                childJobs = _taskChildJobs.ToArray();
+                childJobs = new PSTaskChildJob[ChildJobs.Count];
+                for (int i = 0; i < ChildJobs.Count; i++)
+                {
+                    childJobs[i] = (PSTaskChildJob)ChildJobs[i];
+                }
             }
 
             SetJobState(JobState.Running);
@@ -1179,7 +1181,7 @@ namespace System.Management.Automation.PSTasks
                 JobState finalState = JobState.Completed;
                 lock (_syncObject)
                 {
-                    foreach (PSTaskChildJob childJob in _taskChildJobs)
+                    foreach (Job childJob in ChildJobs)
                     {
                         if (childJob.JobStateInfo.State != JobState.Completed)
                         {

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Management.Automation.Host;
 using System.Management.Automation.Language;
 using System.Management.Automation.Remoting.Internal;
@@ -999,6 +998,8 @@ namespace System.Management.Automation.PSTasks
         #region Members
 
         private readonly PSTaskPool _taskPool;
+        private readonly object _syncObject = new();
+        private readonly List<PSTaskChildJob> _taskChildJobs = new();
         private bool _isOpen;
         private bool _stopSignaled;
 
@@ -1057,11 +1058,14 @@ namespace System.Management.Automation.PSTasks
         {
             get
             {
-                foreach (var childJob in ChildJobs.ToArray())
+                lock (_syncObject)
                 {
-                    if (childJob.HasMoreData)
+                    foreach (PSTaskChildJob childJob in _taskChildJobs)
                     {
-                        return true;
+                        if (childJob.HasMoreData)
+                        {
+                            return true;
+                        }
                     }
                 }
 
@@ -1114,13 +1118,17 @@ namespace System.Management.Automation.PSTasks
         /// <returns>True when child job is successfully added.</returns>
         internal bool AddJob(PSTaskChildJob childJob)
         {
-            if (!_isOpen)
+            lock (_syncObject)
             {
-                return false;
-            }
+                if (!_isOpen)
+                {
+                    return false;
+                }
 
-            ChildJobs.Add(childJob);
-            return true;
+                ChildJobs.Add(childJob);
+                _taskChildJobs.Add(childJob);
+                return true;
+            }
         }
 
         /// <summary>
@@ -1129,7 +1137,13 @@ namespace System.Management.Automation.PSTasks
         /// </summary>
         internal void Start()
         {
-            _isOpen = false;
+            PSTaskChildJob[] childJobs;
+            lock (_syncObject)
+            {
+                _isOpen = false;
+                childJobs = _taskChildJobs.ToArray();
+            }
+
             SetJobState(JobState.Running);
 
             // Submit jobs to the task pool, blocking when throttle limit is reached.
@@ -1138,7 +1152,7 @@ namespace System.Management.Automation.PSTasks
             System.Threading.ThreadPool.QueueUserWorkItem(
                 (_) =>
                 {
-                    foreach (PSTaskChildJob childJob in ChildJobs.ToArray())
+                    foreach (PSTaskChildJob childJob in childJobs)
                     {
                         _taskPool.Add(childJob);
                     }
@@ -1163,12 +1177,15 @@ namespace System.Management.Automation.PSTasks
 
                 // Final state will be 'Complete', only if all child jobs completed successfully.
                 JobState finalState = JobState.Completed;
-                foreach (var childJob in ChildJobs.ToArray())
+                lock (_syncObject)
                 {
-                    if (childJob.JobStateInfo.State != JobState.Completed)
+                    foreach (PSTaskChildJob childJob in _taskChildJobs)
                     {
-                        finalState = JobState.Failed;
-                        break;
+                        if (childJob.JobStateInfo.State != JobState.Completed)
+                        {
+                            finalState = JobState.Failed;
+                            break;
+                        }
                     }
                 }
 

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Management.Automation.Host;
 using System.Management.Automation.Language;
 using System.Management.Automation.Remoting.Internal;
@@ -998,7 +999,6 @@ namespace System.Management.Automation.PSTasks
         #region Members
 
         private readonly PSTaskPool _taskPool;
-        private readonly List<PSTaskChildJob> _taskChildJobs;
         private bool _isOpen;
         private bool _stopSignaled;
 
@@ -1032,7 +1032,6 @@ namespace System.Management.Automation.PSTasks
             bool useNewRunspace) : base(command, string.Empty)
         {
             _taskPool = new PSTaskPool(throttleLimit, useNewRunspace);
-            _taskChildJobs = new List<PSTaskChildJob>();
             _isOpen = true;
             PSJobTypeName = nameof(PSTaskJob);
 
@@ -1058,7 +1057,7 @@ namespace System.Management.Automation.PSTasks
         {
             get
             {
-                foreach (var childJob in _taskChildJobs)
+                foreach (var childJob in ChildJobs.ToArray())
                 {
                     if (childJob.HasMoreData)
                     {
@@ -1121,7 +1120,6 @@ namespace System.Management.Automation.PSTasks
             }
 
             ChildJobs.Add(childJob);
-            _taskChildJobs.Add(childJob);
             return true;
         }
 
@@ -1140,7 +1138,7 @@ namespace System.Management.Automation.PSTasks
             System.Threading.ThreadPool.QueueUserWorkItem(
                 (_) =>
                 {
-                    foreach (var childJob in _taskChildJobs)
+                    foreach (PSTaskChildJob childJob in ChildJobs.ToArray())
                     {
                         _taskPool.Add(childJob);
                     }
@@ -1165,7 +1163,7 @@ namespace System.Management.Automation.PSTasks
 
                 // Final state will be 'Complete', only if all child jobs completed successfully.
                 JobState finalState = JobState.Completed;
-                foreach (var childJob in _taskChildJobs)
+                foreach (var childJob in ChildJobs.ToArray())
                 {
                     if (childJob.JobStateInfo.State != JobState.Completed)
                     {

--- a/src/System.Management.Automation/engine/hostifaces/PSTask.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSTask.cs
@@ -998,6 +998,7 @@ namespace System.Management.Automation.PSTasks
         #region Members
 
         private readonly PSTaskPool _taskPool;
+        private readonly List<PSTaskChildJob> _taskChildJobs;
         private bool _isOpen;
         private bool _stopSignaled;
 
@@ -1031,6 +1032,7 @@ namespace System.Management.Automation.PSTasks
             bool useNewRunspace) : base(command, string.Empty)
         {
             _taskPool = new PSTaskPool(throttleLimit, useNewRunspace);
+            _taskChildJobs = new List<PSTaskChildJob>();
             _isOpen = true;
             PSJobTypeName = nameof(PSTaskJob);
 
@@ -1056,7 +1058,7 @@ namespace System.Management.Automation.PSTasks
         {
             get
             {
-                foreach (var childJob in ChildJobs)
+                foreach (var childJob in _taskChildJobs)
                 {
                     if (childJob.HasMoreData)
                     {
@@ -1119,6 +1121,7 @@ namespace System.Management.Automation.PSTasks
             }
 
             ChildJobs.Add(childJob);
+            _taskChildJobs.Add(childJob);
             return true;
         }
 
@@ -1137,9 +1140,9 @@ namespace System.Management.Automation.PSTasks
             System.Threading.ThreadPool.QueueUserWorkItem(
                 (_) =>
                 {
-                    foreach (var childJob in ChildJobs)
+                    foreach (var childJob in _taskChildJobs)
                     {
-                        _taskPool.Add((PSTaskChildJob)childJob);
+                        _taskPool.Add(childJob);
                     }
 
                     _taskPool.Close();
@@ -1162,7 +1165,7 @@ namespace System.Management.Automation.PSTasks
 
                 // Final state will be 'Complete', only if all child jobs completed successfully.
                 JobState finalState = JobState.Completed;
-                foreach (var childJob in ChildJobs)
+                foreach (var childJob in _taskChildJobs)
                 {
                     if (childJob.JobStateInfo.State != JobState.Completed)
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -496,7 +496,6 @@ $job = 0..20 | ForEach-Object -AsJob -Parallel {
     $_
 } -ThrottleLimit 2
 
-Start-Sleep -Milliseconds 100
 $deadline = [DateTime]::UtcNow.AddSeconds(30)
 while ($job.ChildJobs.Count -le 15 -and [DateTime]::UtcNow -lt $deadline) {
     Start-Sleep -Milliseconds 100
@@ -513,14 +512,30 @@ $job | Remove-Job -Force
 '@
 
         $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
+        if ($IsWindows) {
+            $powershell += ".exe"
+        }
+
         $process = Start-Process -FilePath $powershell -ArgumentList @(
             '-NoLogo'
             '-NoProfile'
             '-NonInteractive'
             '-File'
             $testScript
-        ) -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -Wait -PassThru
+        ) -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
 
+        try {
+            $process | Wait-Process -Timeout 60 -ErrorAction Stop
+        }
+        catch {
+            if (-not $process.HasExited) {
+                $process | Stop-Process -Force
+            }
+
+            throw
+        }
+
+        $process.Refresh()
         $process.ExitCode | Should -Be 0
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -486,6 +486,35 @@ Describe 'ForEach-Object -Parallel -AsJob Basic Tests' -Tags 'CI' {
         $job | Wait-Job | Remove-Job
     }
 
+    It 'Does not crash when the ChildJobs collection is mutated while a parallel job starts' {
+        $testScript = Join-Path $TestDrive 'Mutate-ChildJobs.ps1'
+        $stdoutPath = Join-Path $TestDrive 'stdout.txt'
+        $stderrPath = Join-Path $TestDrive 'stderr.txt'
+        Set-Content -LiteralPath $testScript -Value @'
+$job = 0..20 | ForEach-Object -AsJob -Parallel {
+    Start-Sleep -Milliseconds 300
+    $_
+} -ThrottleLimit 2
+
+Start-Sleep -Milliseconds 100
+$job.ChildJobs.RemoveAt(15)
+
+$job | Wait-Job -Timeout 30 | Out-Null
+$job | Remove-Job -Force
+'@
+
+        $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
+        $process = Start-Process -FilePath $powershell -ArgumentList @(
+            '-NoLogo'
+            '-NoProfile'
+            '-NonInteractive'
+            '-File'
+            $testScript
+        ) -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -Wait -PassThru
+
+        $process.ExitCode | Should -Be 0
+    }
+
     It 'Verifies dollar underbar variable' {
 
         $expected = 1..10

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -497,6 +497,15 @@ $job = 0..20 | ForEach-Object -AsJob -Parallel {
 } -ThrottleLimit 2
 
 Start-Sleep -Milliseconds 100
+$deadline = [DateTime]::UtcNow.AddSeconds(30)
+while ($job.ChildJobs.Count -le 15 -and [DateTime]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 100
+}
+
+if ($job.ChildJobs.Count -le 15) {
+    throw "Timed out waiting for child jobs to be created."
+}
+
 $job.ChildJobs.RemoveAt(15)
 
 $job | Wait-Job -Timeout 30 | Out-Null

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1
@@ -511,11 +511,8 @@ $job | Wait-Job -Timeout 30 | Out-Null
 $job | Remove-Job -Force
 '@
 
-        $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
-        if ($IsWindows) {
-            $powershell += ".exe"
-        }
-
+        $powershellName = if ($IsWindows) { "pwsh.exe" } else { "pwsh" }
+        $powershell = Join-Path -Path $PSHOME -ChildPath $powershellName
         $process = Start-Process -FilePath $powershell -ArgumentList @(
             '-NoLogo'
             '-NoProfile'


### PR DESCRIPTION
# PR Summary

Avoids an unhandled process-terminating exception when `PSTaskJob.ChildJobs` is mutated while a `ForEach-Object -Parallel -AsJob` job is starting.

## PR Context

Fix #26160.

`PSTaskJob.Start()` currently enumerates the public `ChildJobs` list on a ThreadPool callback. That list is externally mutable, so removing an item can invalidate the enumerator and let the exception escape the ThreadPool callback. This change snapshots the authoritative `ChildJobs` list at the internal enumeration points, so external mutations do not invalidate active enumerators and the public collection remains the source of truth.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is focused on one issue
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [x] This PR is ready to merge and is not work-in-progress
- [x] Breaking change: No
- [x] User-facing change: Not required
- [x] Tests added/updated

## Validation

- `Start-PSBuild -PSModuleRestore -UseNuGetOrg`
- `Start-PSPester -Path test/powershell/Modules/Microsoft.PowerShell.Utility/Foreach-Object-Parallel.Tests.ps1 -UseNuGetOrg -ThrowOnFailure -Terse -SkipTestToolBuild`

Result: Foreach-Object-Parallel.Tests.ps1 passed: 62 passed, 0 failed.