### PR TITLE
Bound member invocation logging argument strings

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3657,6 +3657,23 @@ namespace System.Management.Automation
         );
 #endif
 
+        private const int MaxLoggedArgumentStringLength = 4096;
+
+        private static string LimitLoggedArgumentString(string value)
+        {
+            if (value is null || value.Length <= MaxLoggedArgumentStringLength)
+            {
+                return value;
+            }
+
+            string originalLength = value.Length.ToString(CultureInfo.InvariantCulture);
+            return string.Concat(
+                value.AsSpan(0, MaxLoggedArgumentStringLength),
+                "...<truncated; original length: ".AsSpan(),
+                originalLength.AsSpan(),
+                ">".AsSpan());
+        }
+
         private static string ArgumentToString(object arg)
         {
             object baseObj = PSObject.Base(arg);
@@ -3669,7 +3686,7 @@ namespace System.Management.Automation
             // The comparisons below are ordered by the likelihood of arguments being of those types.
             if (baseObj is string str)
             {
-                return str;
+                return LimitLoggedArgumentString(str);
             }
 
             // Special case some types to call 'ToString' on the object. For the rest, we return its
@@ -3683,7 +3700,7 @@ namespace System.Management.Automation
                 || baseType == typeof(BigInteger)
                 || baseType == typeof(decimal))
             {
-                return baseObj.ToString();
+                return LimitLoggedArgumentString(baseObj.ToString());
             }
 
             return baseType.FullName;

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -3667,11 +3667,14 @@ namespace System.Management.Automation
             }
 
             string originalLength = value.Length.ToString(CultureInfo.InvariantCulture);
-            return string.Concat(
-                value.AsSpan(0, MaxLoggedArgumentStringLength),
+            string truncationMarker = string.Concat(
                 "...<truncated; original length: ".AsSpan(),
                 originalLength.AsSpan(),
                 ">".AsSpan());
+            int prefixLength = MaxLoggedArgumentStringLength - truncationMarker.Length;
+            return string.Concat(
+                value.AsSpan(0, prefixLength),
+                truncationMarker.AsSpan());
         }
 
         private static string ArgumentToString(object arg)

--- a/test/powershell/engine/Logging/MemberInvocationLogging.Tests.ps1
+++ b/test/powershell/engine/Logging/MemberInvocationLogging.Tests.ps1
@@ -7,6 +7,9 @@ Describe 'Member invocation logging' -Tags 'CI' {
         $argumentToString = $type.GetMethod(
             'ArgumentToString',
             [System.Reflection.BindingFlags]'NonPublic, Static')
+        $maxLoggedArgumentStringLength = [int]$type.GetField(
+            'MaxLoggedArgumentStringLength',
+            [System.Reflection.BindingFlags]'NonPublic, Static').GetRawConstantValue()
     }
 
     It 'Keeps short string arguments unchanged' {
@@ -15,13 +18,33 @@ Describe 'Member invocation logging' -Tags 'CI' {
         $argumentToString.Invoke($null, [object[]]@($value)) | Should -BeExactly $value
     }
 
+    It 'Keeps string arguments at the maximum length unchanged' {
+        $value = 'a' * $maxLoggedArgumentStringLength
+
+        $argumentToString.Invoke($null, [object[]]@($value)) | Should -BeExactly $value
+    }
+
     It 'Limits long string arguments' {
-        $value = 'a' * 5000
+        $originalLength = $maxLoggedArgumentStringLength + 904
+        $value = 'a' * $originalLength
+
+        $result = $argumentToString.Invoke($null, [object[]]@($value))
+        $truncationMarker = "...<truncated; original length: $originalLength>"
+        $expectedPrefixLength = $maxLoggedArgumentStringLength - $truncationMarker.Length
+
+        $result.Length | Should -Be $maxLoggedArgumentStringLength
+        $result.StartsWith(('a' * $expectedPrefixLength), [System.StringComparison]::Ordinal) | Should -BeTrue
+        $result | Should -Match $truncationMarker
+    }
+
+    It 'Limits string arguments just over the maximum length' {
+        $originalLength = $maxLoggedArgumentStringLength + 1
+        $value = 'a' * $originalLength
 
         $result = $argumentToString.Invoke($null, [object[]]@($value))
 
+        $result.Length | Should -Be $maxLoggedArgumentStringLength
         $result.Length | Should -BeLessThan $value.Length
-        $result.StartsWith(('a' * 4096), [System.StringComparison]::Ordinal) | Should -BeTrue
-        $result | Should -Match '<truncated; original length: 5000>'
+        $result | Should -Match "<truncated; original length: $originalLength>"
     }
 }

--- a/test/powershell/engine/Logging/MemberInvocationLogging.Tests.ps1
+++ b/test/powershell/engine/Logging/MemberInvocationLogging.Tests.ps1
@@ -6,7 +6,10 @@ Describe 'Member invocation logging' -Tags 'CI' {
         $type = [psobject].Assembly.GetType('System.Management.Automation.MemberInvocationLoggingOps')
         $argumentToString = $type.GetMethod(
             'ArgumentToString',
-            [System.Reflection.BindingFlags]'NonPublic, Static')
+            [System.Reflection.BindingFlags]'NonPublic, Static',
+            $null,
+            [type[]]@([object]),
+            $null)
         $maxLoggedArgumentStringLength = [int]$type.GetField(
             'MaxLoggedArgumentStringLength',
             [System.Reflection.BindingFlags]'NonPublic, Static').GetRawConstantValue()
@@ -34,7 +37,7 @@ Describe 'Member invocation logging' -Tags 'CI' {
 
         $result.Length | Should -Be $maxLoggedArgumentStringLength
         $result.StartsWith(('a' * $expectedPrefixLength), [System.StringComparison]::Ordinal) | Should -BeTrue
-        $result | Should -Match $truncationMarker
+        $result.EndsWith($truncationMarker, [System.StringComparison]::Ordinal) | Should -BeTrue
     }
 
     It 'Limits string arguments just over the maximum length' {
@@ -45,6 +48,16 @@ Describe 'Member invocation logging' -Tags 'CI' {
 
         $result.Length | Should -Be $maxLoggedArgumentStringLength
         $result.Length | Should -BeLessThan $value.Length
-        $result | Should -Match "<truncated; original length: $originalLength>"
+        $result.EndsWith("...<truncated; original length: $originalLength>", [System.StringComparison]::Ordinal) | Should -BeTrue
+    }
+
+    It 'Limits long non-string special-cased arguments' {
+        $originalLength = $maxLoggedArgumentStringLength + 101
+        $value = [System.Numerics.BigInteger]::Pow([System.Numerics.BigInteger]10, $originalLength - 1)
+
+        $result = $argumentToString.Invoke($null, [object[]]@($value))
+
+        $result.Length | Should -Be $maxLoggedArgumentStringLength
+        $result.EndsWith("...<truncated; original length: $originalLength>", [System.StringComparison]::Ordinal) | Should -BeTrue
     }
 }

--- a/test/powershell/engine/Logging/MemberInvocationLogging.Tests.ps1
+++ b/test/powershell/engine/Logging/MemberInvocationLogging.Tests.ps1
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Member invocation logging' -Tags 'CI' {
+    BeforeAll {
+        $type = [psobject].Assembly.GetType('System.Management.Automation.MemberInvocationLoggingOps')
+        $argumentToString = $type.GetMethod(
+            'ArgumentToString',
+            [System.Reflection.BindingFlags]'NonPublic, Static')
+    }
+
+    It 'Keeps short string arguments unchanged' {
+        $value = 'short argument'
+
+        $argumentToString.Invoke($null, [object[]]@($value)) | Should -BeExactly $value
+    }
+
+    It 'Limits long string arguments' {
+        $value = 'a' * 5000
+
+        $result = $argumentToString.Invoke($null, [object[]]@($value))
+
+        $result.Length | Should -BeLessThan $value.Length
+        $result.StartsWith(('a' * 4096), [System.StringComparison]::Ordinal) | Should -BeTrue
+        $result | Should -Match '<truncated; original length: 5000>'
+    }
+}


### PR DESCRIPTION
# PR Summary

Bounds long string values included in member invocation logging while preserving the method invocation and recording the original string length.

## PR Context

Addresses #21473.

`MemberInvocationLoggingOps.ArgumentToString()` currently returns full string arguments, so `LogMemberInvocation()` can build very large AMSI report content for calls such as `FromBase64String` with large strings. This change keeps strings at or below the limit unchanged, caps longer logged string values to 4096 characters total, and appends a marker with the original length. It also applies the same bound to special primitive-like `ToString()` results, such as very large `BigInteger` values.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is focused on one issue
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [x] This PR is ready to merge and is not work-in-progress
- [x] Breaking change: No
- [x] User-facing change: Not required
- [x] Tests added/updated

## Validation

- `Start-PSBuild -PSModuleRestore -UseNuGetOrg` built `pwsh.exe`. The Windows PowerShell 5.1 build wrapper emitted post-build `ConvertFrom-Json -Depth` compatibility warnings after build output was produced.
- `Start-PSPester -Path test/powershell/engine/Logging/MemberInvocationLogging.Tests.ps1 -UseNuGetOrg -ThrowOnFailure -Terse -SkipTestToolBuild` passed: 4 passed, 0 failed.