### PR TITLE
Respect explicit false for CSV UseCulture

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CsvCommands.cs
@@ -1787,12 +1787,9 @@ namespace Microsoft.PowerShell.Commands
                 case "UseCulture":
                 case "CulturePath":
                 case "CultureLiteralPath":
-                    if (useCulture)
-                    {
-                        // ListSeparator is apparently always a character even though the property returns a string, checked via:
-                        // [CultureInfo]::GetCultures("AllCultures") | % { ([CultureInfo]($_.Name)).TextInfo.ListSeparator } | ? Length -ne 1
-                        delimiter = CultureInfo.CurrentCulture.TextInfo.ListSeparator[0];
-                    }
+                    // ListSeparator is apparently always a character even though the property returns a string, checked via:
+                    // [CultureInfo]::GetCultures("AllCultures") | % { ([CultureInfo]($_.Name)).TextInfo.ListSeparator } | ? Length -ne 1
+                    delimiter = useCulture ? CultureInfo.CurrentCulture.TextInfo.ListSeparator[0] : ImportExportCSVHelper.CSVDelimiter;
 
                     break;
                 default:

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -60,6 +60,27 @@ a,b,c
         $actualLength | Should -Be 3
     }
 
+    It "Uses the default delimiter when -UseCulture is explicitly false" {
+        $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+        $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+
+        try {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [CultureInfo]'de-DE'
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = [CultureInfo]'de-DE'
+            [CultureInfo]::CurrentCulture.TextInfo.ListSeparator | Should -Not -BeExactly ','
+
+            $actualData = $testColumns | ConvertFrom-Csv -UseCulture:$false
+
+            $actualData.a | Should -Be 1
+            $actualData.b | Should -Be 2
+            $actualData.c | Should -Be 3
+        }
+        finally {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+        }
+    }
+
     It "Should Contain the Imported Type data" {
         $actualData = $testTypeData | ConvertFrom-Csv
         $actualData.PSObject.TypeNames.Count | Should -Be 2

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -27,6 +27,27 @@ Describe "ConvertTo-Csv DRT Unit Tests" -Tags "CI" {
         $returnObject[2] | Should -BeExactly "`"1`"$($delimiter)`"2`""
     }
 
+    It "Uses the default delimiter when -UseCulture is explicitly false" {
+        $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+        $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+
+        try {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [CultureInfo]'de-DE'
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = [CultureInfo]'de-DE'
+            [CultureInfo]::CurrentCulture.TextInfo.ListSeparator | Should -Not -BeExactly ','
+
+            $returnObject = $inputObject | ConvertTo-Csv -UseCulture:$false -IncludeTypeInformation
+            $returnObject.Count | Should -Be 3
+            $returnObject[0] | Should -BeExactly "#TYPE System.Management.Automation.PSCustomObject"
+            $returnObject[1] | Should -BeExactly "`"First`",`"Second`""
+            $returnObject[2] | Should -BeExactly "`"1`",`"2`""
+        }
+        finally {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+        }
+    }
+
     It "Test convertto-csv with Delimiter" {
         $returnObject = $inputObject | ConvertTo-Csv -Delimiter ";" -IncludeTypeInformation
         $returnObject.Count | Should -Be 3

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -91,6 +91,33 @@ Describe "Export-Csv" -Tags "CI" {
         $results[0] | Should -BeExactly "#TYPE System.String"
     }
 
+    It "Uses the default delimiter when -UseCulture is explicitly false" {
+        $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+        $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+
+        try {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [CultureInfo]'de-DE'
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = [CultureInfo]'de-DE'
+            [CultureInfo]::CurrentCulture.TextInfo.ListSeparator | Should -Not -BeExactly ','
+
+            $P1 | Export-Csv -Path $testCsv -UseCulture:$false
+            $results = Get-Content -Path $testCsv
+
+            $results[0] | Should -BeExactly '"P1"'
+            $results[1] | Should -BeExactly '"first"'
+
+            [pscustomobject]@{ H1 = 'V1'; H2 = 'V2' } | Export-Csv -Path $testCsv -UseCulture:$false
+            $results = Get-Content -Path $testCsv
+
+            $results[0] | Should -BeExactly '"H1","H2"'
+            $results[1] | Should -BeExactly '"V1","V2"'
+        }
+        finally {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+        }
+    }
+
     It "Should support -LiteralPath parameter" {
         $testObject | Export-Csv -LiteralPath $testCsv
         $results = Import-Csv -Path  $testCsv

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -20,6 +20,26 @@ Describe "Import-Csv DRT Unit Tests" -Tags "CI" {
         $returnObject.First | Should -Be 1
         $returnObject.Second | Should -Be 2
     }
+
+    It "Uses the default delimiter when -UseCulture is explicitly false" {
+        $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+        $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+
+        try {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [CultureInfo]'de-DE'
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = [CultureInfo]'de-DE'
+            [CultureInfo]::CurrentCulture.TextInfo.ListSeparator | Should -Not -BeExactly ','
+
+            $psObject | Export-Csv -Path $fileToGenerate
+            $returnObject = Import-Csv -Path $fileToGenerate -UseCulture:$false
+            $returnObject.First | Should -Be 1
+            $returnObject.Second | Should -Be 2
+        }
+        finally {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+        }
+    }
 }
 
 Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {


### PR DESCRIPTION
# PR Summary

Makes CSV commands treat `-UseCulture:$false` the same as omitting `-UseCulture`, so the default comma delimiter is used.

## PR Context

Fix #26513.

`ImportExportCSVHelper.SetDelimiter()` previously left the delimiter as the default `char` value when the active parameter set was a culture parameter set but the `UseCulture` switch value was explicitly false. This affected multiple CSV commands that share the helper. The helper now falls back to the default CSV delimiter when `UseCulture` is false, while preserving the culture-specific delimiter when it is true.

Regression tests cover:

- `ConvertTo-Csv -UseCulture:$false`
- `Export-Csv -UseCulture:$false`
- `Import-Csv -UseCulture:$false`
- `ConvertFrom-Csv -UseCulture:$false`

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is focused on one issue
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [x] This PR is ready to merge and is not work-in-progress
- [x] Breaking change: No
- [x] User-facing change: Not required
- [x] Tests added/updated

## Validation

- `Start-PSBuild -PSModuleRestore -UseNuGetOrg`
- `Start-PSPester -Path test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1,test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1,test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1,test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1 -UseNuGetOrg -ThrowOnFailure -Terse -SkipTestToolBuild`

Result: CSV command tests passed: 92 passed, 0 failed.