### PR TITLE
Prefer literal Select-Object property matches

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -303,6 +303,45 @@ namespace Microsoft.PowerShell.Commands
 
         private List<UniquePSObjectHelper> _uniques = null;
 
+        private static List<PSPropertyExpression> ResolvePropertyNames(PSPropertyExpression expression, PSObject inputObject)
+        {
+            PSPropertyExpression literalExpression = ResolveEscapedLiteralPropertyName(expression, inputObject);
+            return literalExpression is null
+                ? expression.ResolveNames(inputObject)
+                : new List<PSPropertyExpression> { literalExpression };
+        }
+
+        private static List<PSPropertyExpressionResult> GetPropertyValues(PSPropertyExpression expression, PSObject inputObject)
+        {
+            List<PSPropertyExpressionResult> expressionResults = new();
+            foreach (PSPropertyExpression resolvedName in ResolvePropertyNames(expression, inputObject))
+            {
+                expressionResults.AddRange(resolvedName.GetValues(inputObject));
+            }
+
+            return expressionResults;
+        }
+
+        private static PSPropertyExpression ResolveEscapedLiteralPropertyName(PSPropertyExpression expression, PSObject inputObject)
+        {
+            if (expression.Script is not null || expression.HasWildCardCharacters)
+            {
+                return null;
+            }
+
+            string expressionText = expression.ToString();
+            string propertyName = WildcardPattern.Unescape(expressionText);
+            if (string.Equals(propertyName, expressionText, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            PSPropertyInfo member = inputObject.Properties[propertyName];
+            return member is null
+                ? null
+                : new PSPropertyExpression(member.Name, isResolved: true);
+        }
+
         private void ProcessExpressionParameter()
         {
             TerminatingErrorContext invocationContext = new(this);
@@ -544,35 +583,6 @@ namespace Microsoft.PowerShell.Commands
                     inputObject);
                 throw new SelectObjectException(errorRecord);
             }
-        }
-
-        private static List<PSPropertyExpression> ResolvePropertyNames(PSPropertyExpression expression, PSObject inputObject)
-        {
-            PSPropertyExpression literalExpression = GetLiteralPropertyExpression(expression, inputObject);
-            return literalExpression is null
-                ? expression.ResolveNames(inputObject)
-                : new List<PSPropertyExpression> { literalExpression };
-        }
-
-        private static List<PSPropertyExpressionResult> GetPropertyValues(PSPropertyExpression expression, PSObject inputObject)
-        {
-            PSPropertyExpression literalExpression = GetLiteralPropertyExpression(expression, inputObject);
-            return literalExpression is null
-                ? expression.GetValues(inputObject)
-                : literalExpression.GetValues(inputObject);
-        }
-
-        private static PSPropertyExpression GetLiteralPropertyExpression(PSPropertyExpression expression, PSObject inputObject)
-        {
-            if (expression.Script is not null)
-            {
-                return null;
-            }
-
-            string propertyName = WildcardPattern.Unescape(expression.ToString());
-            return inputObject.Properties[propertyName] is null
-                ? null
-                : new PSPropertyExpression(propertyName, isResolved: true);
         }
 
         private void AddNoteProperties(PSObject expandedObject, PSObject inputObject, IEnumerable<PSNoteProperty> matchedProperties)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -396,7 +396,7 @@ namespace Microsoft.PowerShell.Commands
 
             PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
             List<PSPropertyExpressionResult> expressionResults = new();
-            foreach (PSPropertyExpression resolvedName in ex.ResolveNames(inputObject))
+            foreach (PSPropertyExpression resolvedName in ResolvePropertyNames(ex, inputObject))
             {
                 if (_exclusionFilter == null || !_exclusionFilter.IsMatch(resolvedName))
                 {
@@ -470,7 +470,7 @@ namespace Microsoft.PowerShell.Commands
             List<PSNoteProperty> matchedProperties)
         {
             PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
-            List<PSPropertyExpressionResult> expressionResults = ex.GetValues(inputObject);
+            List<PSPropertyExpressionResult> expressionResults = GetPropertyValues(ex, inputObject);
 
             if (expressionResults.Count == 0)
             {
@@ -544,6 +544,35 @@ namespace Microsoft.PowerShell.Commands
                     inputObject);
                 throw new SelectObjectException(errorRecord);
             }
+        }
+
+        private static List<PSPropertyExpression> ResolvePropertyNames(PSPropertyExpression expression, PSObject inputObject)
+        {
+            PSPropertyExpression literalExpression = GetLiteralPropertyExpression(expression, inputObject);
+            return literalExpression is null
+                ? expression.ResolveNames(inputObject)
+                : new List<PSPropertyExpression> { literalExpression };
+        }
+
+        private static List<PSPropertyExpressionResult> GetPropertyValues(PSPropertyExpression expression, PSObject inputObject)
+        {
+            PSPropertyExpression literalExpression = GetLiteralPropertyExpression(expression, inputObject);
+            return literalExpression is null
+                ? expression.GetValues(inputObject)
+                : literalExpression.GetValues(inputObject);
+        }
+
+        private static PSPropertyExpression GetLiteralPropertyExpression(PSPropertyExpression expression, PSObject inputObject)
+        {
+            if (expression.Script is not null)
+            {
+                return null;
+            }
+
+            string propertyName = WildcardPattern.Unescape(expression.ToString());
+            return inputObject.Properties[propertyName] is null
+                ? null
+                : new PSPropertyExpression(propertyName, isResolved: true);
         }
 
         private void AddNoteProperties(PSObject expandedObject, PSObject inputObject, IEnumerable<PSNoteProperty> matchedProperties)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -96,7 +96,18 @@ Describe "Select-Object" -Tags "CI" {
         $result.'Foo[]' | Should -BeExactly 'brackets'
     }
 
-    It "Should prefer an exact property name before wildcard expansion" {
+    It "Should preserve matched member casing for escaped wildcard property names" {
+        $inputObject = [pscustomobject]@{
+            'Foo[]' = 'brackets'
+        }
+
+        $result = $inputObject | Select-Object -Property ([WildcardPattern]::Escape('foo[]'))
+
+        $result.PSObject.Properties.Name | Should -BeExactly 'Foo[]'
+        $result.'Foo[]' | Should -BeExactly 'brackets'
+    }
+
+    It "Should preserve wildcard expansion when an exact wildcard-pattern property exists" {
         $inputObject = [pscustomobject]@{
             'Foo*' = 'literal'
             'Foo1' = 'wildcard'
@@ -104,8 +115,10 @@ Describe "Select-Object" -Tags "CI" {
 
         $result = $inputObject | Select-Object -Property 'Foo*'
 
-        $result.PSObject.Properties.Name | Should -BeExactly 'Foo*'
+        $result.PSObject.Properties.Name | Should -Contain 'Foo*'
+        $result.PSObject.Properties.Name | Should -Contain 'Foo1'
         $result.'Foo*' | Should -BeExactly 'literal'
+        $result.Foo1 | Should -BeExactly 'wildcard'
     }
 
     It "Should expand literal property names that contain wildcard characters" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -84,6 +84,41 @@ Describe "Select-Object" -Tags "CI" {
         $result[0].Mode | Should -BeNullOrEmpty
     }
 
+    It "Should select literal property names that contain wildcard characters" {
+        $inputObject = [pscustomobject]@{
+            'Foo[]' = 'brackets'
+            'Foo1' = 'wildcard'
+        }
+
+        $result = $inputObject | Select-Object -Property ([WildcardPattern]::Escape('Foo[]'))
+
+        $result.PSObject.Properties.Name | Should -BeExactly 'Foo[]'
+        $result.'Foo[]' | Should -BeExactly 'brackets'
+    }
+
+    It "Should prefer an exact property name before wildcard expansion" {
+        $inputObject = [pscustomobject]@{
+            'Foo*' = 'literal'
+            'Foo1' = 'wildcard'
+        }
+
+        $result = $inputObject | Select-Object -Property 'Foo*'
+
+        $result.PSObject.Properties.Name | Should -BeExactly 'Foo*'
+        $result.'Foo*' | Should -BeExactly 'literal'
+    }
+
+    It "Should expand literal property names that contain wildcard characters" {
+        $inputObject = [pscustomobject]@{
+            'Foo[]' = 'brackets'
+            'Foo1' = 'wildcard'
+        }
+
+        $result = $inputObject | Select-Object -ExpandProperty ([WildcardPattern]::Escape('Foo[]'))
+
+        $result | Should -BeExactly 'brackets'
+    }
+
     It "Should send output to pipe properly" {
         { $dirObject | Select-Object -Unique | pipelineConsume } | Should -Not -Throw
     }


### PR DESCRIPTION
# PR Summary

Makes `Select-Object` prefer an exact property-name match before treating wildcard-looking property arguments as wildcard patterns.

## PR Context

Fix #25982.

The cmdlet currently treats property names containing wildcard characters only as wildcard patterns, even when the input object has a property whose literal name matches the requested value. This means a generated object with a property such as `Foo[]` cannot reliably select or expand that property even when the caller uses `[WildcardPattern]::Escape()`.

This change checks for a literal property match first, using the wildcard-unescaped property expression where applicable. If no exact property exists, existing wildcard expansion behavior is preserved.

Regression tests cover:

- escaped literal property names such as `Foo[]`
- exact property names such as `Foo*` taking precedence over wildcard expansion
- `-ExpandProperty` with escaped literal property names

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is focused on one issue
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [x] This PR is ready to merge and is not work-in-progress
- [x] Breaking change: No
- [x] User-facing change: Not required
- [x] Tests added/updated

## Validation

- `Start-PSBuild -NoPSModuleRestore -CI -SkipExperimentalFeatureGeneration -UseNuGetOrg`
- Direct repro with `[WildcardPattern]::Escape('Foo[]')` succeeds for both `-Property` and `-ExpandProperty`.
- `Start-PSPester -Path test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1 -UseNuGetOrg -ThrowOnFailure -Terse -SkipTestToolBuild`

Result: Select-Object.Tests.ps1 passed: 54 passed, 0 failed.