### PR TITLE
Respect CommandType during fuzzy Get-Command lookup

### DIFF
--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -886,10 +886,9 @@ namespace Microsoft.PowerShell.Commands
                         {
                             if (TotalCount < 0 || count < TotalCount)
                             {
-                                IEnumerable<CommandInfo> commands;
                                 if (UseFuzzyMatching)
                                 {
-                                    foreach (var commandScore in ModuleUtils.GetFuzzyMatchingCommands(
+                                    foreach (CommandScore commandScore in ModuleUtils.GetFuzzyMatchingCommands(
                                         plainCommandName,
                                         Context,
                                         MyInvocation.CommandOrigin,
@@ -897,37 +896,49 @@ namespace Microsoft.PowerShell.Commands
                                         rediscoverImportedModules: true,
                                         moduleVersionRequired: _isFullyQualifiedModuleSpecified))
                                     {
-                                        _commandScores.Add(commandScore);
-                                    }
+                                        CommandInfo current = commandScore.Command;
 
-                                    commands = _commandScores.Select(static x => x.Command);
+                                        if (IsCommandMatch(ref current, out isDuplicate) && (!IsCommandInResult(current)) && IsParameterMatch(current))
+                                        {
+                                            _accumulatedResults.Add(current);
+                                            _commandScores.Add(new CommandScore(current, commandScore.Score));
+
+                                            // Make sure we don't exceed the TotalCount parameter
+                                            ++count;
+
+                                            if (TotalCount >= 0 && count >= TotalCount)
+                                            {
+                                                break;
+                                            }
+                                        }
+                                    }
                                 }
                                 else
                                 {
-                                    commands = ModuleUtils.GetMatchingCommands(
+                                    IEnumerable<CommandInfo> commands = ModuleUtils.GetMatchingCommands(
                                         plainCommandName,
                                         Context,
                                         MyInvocation.CommandOrigin,
                                         rediscoverImportedModules: true,
                                         moduleVersionRequired: _isFullyQualifiedModuleSpecified,
                                         useAbbreviationExpansion: UseAbbreviationExpansion);
-                                }
 
-                                foreach (CommandInfo command in commands)
-                                {
-                                    // Cannot pass in "command" by ref (foreach iteration variable)
-                                    CommandInfo current = command;
-
-                                    if (IsCommandMatch(ref current, out isDuplicate) && (!IsCommandInResult(current)) && IsParameterMatch(current))
+                                    foreach (CommandInfo command in commands)
                                     {
-                                        _accumulatedResults.Add(current);
+                                        // Cannot pass in "command" by ref (foreach iteration variable)
+                                        CommandInfo current = command;
 
-                                        // Make sure we don't exceed the TotalCount parameter
-                                        ++count;
-
-                                        if (TotalCount >= 0 && count >= TotalCount)
+                                        if (IsCommandMatch(ref current, out isDuplicate) && (!IsCommandInResult(current)) && IsParameterMatch(current))
                                         {
-                                            break;
+                                            _accumulatedResults.Add(current);
+
+                                            // Make sure we don't exceed the TotalCount parameter
+                                            ++count;
+
+                                            if (TotalCount >= 0 && count >= TotalCount)
+                                            {
+                                                break;
+                                            }
                                         }
                                     }
                                 }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -898,18 +898,9 @@ namespace Microsoft.PowerShell.Commands
                                     {
                                         CommandInfo current = commandScore.Command;
 
-                                        if (IsCommandMatch(ref current, out isDuplicate) && (!IsCommandInResult(current)) && IsParameterMatch(current))
+                                        if (TryAddCommandToResults(ref current, commandScore.Score, ref count, out isDuplicate))
                                         {
-                                            _accumulatedResults.Add(current);
-                                            _commandScores.Add(new CommandScore(current, commandScore.Score));
-
-                                            // Make sure we don't exceed the TotalCount parameter
-                                            ++count;
-
-                                            if (TotalCount >= 0 && count >= TotalCount)
-                                            {
-                                                break;
-                                            }
+                                            break;
                                         }
                                     }
                                 }
@@ -928,17 +919,9 @@ namespace Microsoft.PowerShell.Commands
                                         // Cannot pass in "command" by ref (foreach iteration variable)
                                         CommandInfo current = command;
 
-                                        if (IsCommandMatch(ref current, out isDuplicate) && (!IsCommandInResult(current)) && IsParameterMatch(current))
+                                        if (TryAddCommandToResults(ref current, null, ref count, out isDuplicate))
                                         {
-                                            _accumulatedResults.Add(current);
-
-                                            // Make sure we don't exceed the TotalCount parameter
-                                            ++count;
-
-                                            if (TotalCount >= 0 && count >= TotalCount)
-                                            {
-                                                break;
-                                            }
+                                            break;
                                         }
                                     }
                                 }
@@ -975,6 +958,28 @@ namespace Microsoft.PowerShell.Commands
                             exception));
                 }
             }
+        }
+
+        private bool TryAddCommandToResults(ref CommandInfo current, int? fuzzyScore, ref int currentCount, out bool isDuplicate)
+        {
+            if (IsCommandMatch(ref current, out isDuplicate) && (!IsCommandInResult(current)) && IsParameterMatch(current))
+            {
+                _accumulatedResults.Add(current);
+                if (fuzzyScore is int score)
+                {
+                    _commandScores.Add(new CommandScore(current, score));
+                }
+
+                // Make sure we don't exceed the TotalCount parameter
+                ++currentCount;
+
+                if (TotalCount >= 0 && currentCount >= TotalCount)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool FindCommandForName(SearchResolutionOptions options, string commandName, bool isPattern, bool emitErrors, ref int currentCount, out bool isDuplicate)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -29,6 +29,23 @@ Describe "Get-Command Feature tests" -Tag Feature {
                 $cmd.Score | Should -BeLessOrEqual 3
             }
         }
+
+        It "Should respect CommandType when fuzzy matching" {
+            function Invoke-ZzqFuzzyCommandTypeThing { }
+            Set-Alias -Name Invoke-ZzqFuzzyCommandTypeThang -Value Invoke-ZzqFuzzyCommandTypeThing
+
+            try {
+                $cmds = Get-Command Invoke-ZzqFuzzyCommandTypeThng -UseFuzzyMatching -CommandType Function
+
+                $cmds.Name | Should -Contain 'Invoke-ZzqFuzzyCommandTypeThing'
+                $cmds.Name | Should -Not -Contain 'Invoke-ZzqFuzzyCommandTypeThang'
+                $cmds.CommandType | Should -Not -Contain ([System.Management.Automation.CommandTypes]::Alias)
+            }
+            finally {
+                Remove-Item -Path Function:\Invoke-ZzqFuzzyCommandTypeThing -ErrorAction SilentlyContinue
+                Remove-Item -Path Alias:\Invoke-ZzqFuzzyCommandTypeThang -ErrorAction SilentlyContinue
+            }
+        }
     }
 
     Context "-UseAbbreviationExpansion tests" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -31,10 +31,10 @@ Describe "Get-Command Feature tests" -Tag Feature {
         }
 
         It "Should respect CommandType when fuzzy matching" {
-            function Invoke-ZzqFuzzyCommandTypeThing { }
-            Set-Alias -Name Invoke-ZzqFuzzyCommandTypeThang -Value Invoke-ZzqFuzzyCommandTypeThing
-
             try {
+                function Invoke-ZzqFuzzyCommandTypeThing { }
+                Set-Alias -Name Invoke-ZzqFuzzyCommandTypeThang -Value Invoke-ZzqFuzzyCommandTypeThing -Force
+
                 $cmds = Get-Command Invoke-ZzqFuzzyCommandTypeThng -UseFuzzyMatching -CommandType Function
 
                 $cmds.Name | Should -Contain 'Invoke-ZzqFuzzyCommandTypeThing'


### PR DESCRIPTION
## PR Summary
Fixes #26592.

When Get-Command discovers fuzzy matches from available modules, it currently records fuzzy scores before applying the normal CommandType and parameter filters. OutputResultsHelper later emits from the score list, so commands filtered out of the accumulated result set can still appear in output.

This change keeps fuzzy scores only for commands that pass the same matching path used for accumulated results. The non-fuzzy module lookup path is unchanged.

## PR Context
Get-Command -UseFuzzyMatching -CommandType <type> should return only commands of the requested type.

## PR Checklist
- [x] Make sure all .cs, .ps1 and .psm1 files have the correct copyright header
- [x] Make sure you are merging your commits to the correct branch
- [x] Make sure you added tests for your changes
- [x] Make sure you run the relevant tests successfully

## Validation
- Start-PSBuild -NoPSModuleRestore -CI -SkipExperimentalFeatureGeneration -UseNuGetOrg
- Start-PSPester -Path test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1 -UseNuGetOrg -ThrowOnFailure -Terse -SkipTestToolBuild -BinDir <publish>

Result: Get-Command.Tests.ps1 passed: 23 passed, 0 failed.