### PR TITLE
Support Split-Path switches with LiteralPath

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.Commands
         private const string LiteralPathQualifierSet = "LiteralPathQualifierSet";
 
         /// <summary>
-        /// The parameter set name to get the noqualifier set for LiteralPath.
+        /// The parameter set name to return the path without the qualifier for LiteralPath.
         /// </summary>
         private const string LiteralPathNoQualifierSet = "LiteralPathNoQualifierSet";
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -22,8 +22,14 @@ namespace Microsoft.PowerShell.Commands
                                                            noQualifierSet,
                                                            parentSet,
                                                            qualifierSet,
-                                                           literalPathSet})]
-    [OutputType(typeof(bool), ParameterSetName = new[] { isAbsoluteSet })]
+                                                           literalPathSet,
+                                                           literalPathLeafSet,
+                                                           literalPathLeafBaseSet,
+                                                           literalPathExtensionSet,
+                                                           literalPathNoQualifierSet,
+                                                           literalPathQualifierSet})]
+    [OutputType(typeof(bool), ParameterSetName = new[] { isAbsoluteSet,
+                                                         literalPathIsAbsoluteSet })]
     public class SplitPathCommand : CoreCommandWithCredentialsBase
     {
         #region Parameters
@@ -69,6 +75,36 @@ namespace Microsoft.PowerShell.Commands
         private const string literalPathSet = "LiteralPathSet";
 
         /// <summary>
+        /// The parameter set name to get the leaf name for LiteralPath.
+        /// </summary>
+        private const string literalPathLeafSet = "LiteralPathLeafSet";
+
+        /// <summary>
+        /// The parameter set name to get the leaf base name for LiteralPath.
+        /// </summary>
+        private const string literalPathLeafBaseSet = "LiteralPathLeafBaseSet";
+
+        /// <summary>
+        /// The parameter set name to get the extension for LiteralPath.
+        /// </summary>
+        private const string literalPathExtensionSet = "LiteralPathExtensionSet";
+
+        /// <summary>
+        /// The parameter set name to get the qualifier for LiteralPath.
+        /// </summary>
+        private const string literalPathQualifierSet = "LiteralPathQualifierSet";
+
+        /// <summary>
+        /// The parameter set name to get the noqualifier set for LiteralPath.
+        /// </summary>
+        private const string literalPathNoQualifierSet = "LiteralPathNoQualifierSet";
+
+        /// <summary>
+        /// The parameter set name to get the IsAbsolute set for LiteralPath.
+        /// </summary>
+        private const string literalPathIsAbsoluteSet = "LiteralPathIsAbsoluteSet";
+
+        /// <summary>
         /// Gets or sets the path parameter to the command.
         /// </summary>
         [Parameter(Position = 0, ParameterSetName = parentSet, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
@@ -83,7 +119,13 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the literal path parameter to the command.
         /// </summary>
-        [Parameter(ParameterSetName = "LiteralPathSet", Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathLeafSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathLeafBaseSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathExtensionSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathQualifierSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathNoQualifierSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathIsAbsoluteSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
         [Alias("PSPath", "LP")]
         public string[] LiteralPath
         {
@@ -108,6 +150,7 @@ namespace Microsoft.PowerShell.Commands
         /// the PowerShell path.
         /// </value>
         [Parameter(ParameterSetName = qualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Qualifier { get; set; }
 
         /// <summary>
@@ -119,6 +162,7 @@ namespace Microsoft.PowerShell.Commands
         /// the PowerShell path.
         /// </value>
         [Parameter(ParameterSetName = noQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathNoQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter NoQualifier { get; set; }
 
         /// <summary>
@@ -128,6 +172,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true the parent of the path will be returned.
         /// </value>
         [Parameter(ParameterSetName = parentSet, Mandatory = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathSet, Mandatory = false, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Parent { get; set; } = true;
 
         /// <summary>
@@ -137,6 +182,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true the leaf name of the path will be returned.
         /// </value>
         [Parameter(ParameterSetName = leafSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathLeafSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Leaf { get; set; }
 
         /// <summary>
@@ -146,6 +192,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true the leaf base name of the path will be returned.
         /// </value>
         [Parameter(ParameterSetName = leafBaseSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathLeafBaseSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter LeafBase { get; set; }
 
         /// <summary>
@@ -155,6 +202,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true the extension of the path will be returned.
         /// </value>
         [Parameter(ParameterSetName = extensionSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = literalPathExtensionSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Extension { get; set; }
 
         /// <summary>
@@ -168,6 +216,7 @@ namespace Microsoft.PowerShell.Commands
         /// Determines if the path is an absolute path.
         /// </summary>
         [Parameter(ParameterSetName = isAbsoluteSet, Mandatory = true)]
+        [Parameter(ParameterSetName = literalPathIsAbsoluteSet, Mandatory = true)]
         public SwitchParameter IsAbsolute { get; set; }
 
         #endregion Parameters

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -22,14 +22,14 @@ namespace Microsoft.PowerShell.Commands
                                                            noQualifierSet,
                                                            parentSet,
                                                            qualifierSet,
-                                                           literalPathSet,
-                                                           literalPathLeafSet,
-                                                           literalPathLeafBaseSet,
-                                                           literalPathExtensionSet,
-                                                           literalPathNoQualifierSet,
-                                                           literalPathQualifierSet})]
-    [OutputType(typeof(bool), ParameterSetName = new[] { isAbsoluteSet,
-                                                         literalPathIsAbsoluteSet })]
+                                                           literalPathSet})]
+    [OutputType(typeof(string), ParameterSetName = new[] { LiteralPathLeafSet })]
+    [OutputType(typeof(string), ParameterSetName = new[] { LiteralPathLeafBaseSet })]
+    [OutputType(typeof(string), ParameterSetName = new[] { LiteralPathExtensionSet })]
+    [OutputType(typeof(string), ParameterSetName = new[] { LiteralPathNoQualifierSet })]
+    [OutputType(typeof(string), ParameterSetName = new[] { LiteralPathQualifierSet })]
+    [OutputType(typeof(bool), ParameterSetName = new[] { isAbsoluteSet })]
+    [OutputType(typeof(bool), ParameterSetName = new[] { LiteralPathIsAbsoluteSet })]
     public class SplitPathCommand : CoreCommandWithCredentialsBase
     {
         #region Parameters
@@ -77,32 +77,32 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// The parameter set name to get the leaf name for LiteralPath.
         /// </summary>
-        private const string literalPathLeafSet = "LiteralPathLeafSet";
+        private const string LiteralPathLeafSet = "LiteralPathLeafSet";
 
         /// <summary>
         /// The parameter set name to get the leaf base name for LiteralPath.
         /// </summary>
-        private const string literalPathLeafBaseSet = "LiteralPathLeafBaseSet";
+        private const string LiteralPathLeafBaseSet = "LiteralPathLeafBaseSet";
 
         /// <summary>
         /// The parameter set name to get the extension for LiteralPath.
         /// </summary>
-        private const string literalPathExtensionSet = "LiteralPathExtensionSet";
+        private const string LiteralPathExtensionSet = "LiteralPathExtensionSet";
 
         /// <summary>
         /// The parameter set name to get the qualifier for LiteralPath.
         /// </summary>
-        private const string literalPathQualifierSet = "LiteralPathQualifierSet";
+        private const string LiteralPathQualifierSet = "LiteralPathQualifierSet";
 
         /// <summary>
         /// The parameter set name to get the noqualifier set for LiteralPath.
         /// </summary>
-        private const string literalPathNoQualifierSet = "LiteralPathNoQualifierSet";
+        private const string LiteralPathNoQualifierSet = "LiteralPathNoQualifierSet";
 
         /// <summary>
         /// The parameter set name to get the IsAbsolute set for LiteralPath.
         /// </summary>
-        private const string literalPathIsAbsoluteSet = "LiteralPathIsAbsoluteSet";
+        private const string LiteralPathIsAbsoluteSet = "LiteralPathIsAbsoluteSet";
 
         /// <summary>
         /// Gets or sets the path parameter to the command.
@@ -120,12 +120,12 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the literal path parameter to the command.
         /// </summary>
         [Parameter(ParameterSetName = literalPathSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathLeafSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathLeafBaseSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathExtensionSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathQualifierSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathNoQualifierSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathIsAbsoluteSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathLeafSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathLeafBaseSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathExtensionSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathQualifierSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathNoQualifierSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathIsAbsoluteSet, Mandatory = true, ValueFromPipeline = false, ValueFromPipelineByPropertyName = true)]
         [Alias("PSPath", "LP")]
         public string[] LiteralPath
         {
@@ -150,7 +150,7 @@ namespace Microsoft.PowerShell.Commands
         /// the PowerShell path.
         /// </value>
         [Parameter(ParameterSetName = qualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Qualifier { get; set; }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.Commands
         /// the PowerShell path.
         /// </value>
         [Parameter(ParameterSetName = noQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathNoQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathNoQualifierSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter NoQualifier { get; set; }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true the leaf name of the path will be returned.
         /// </value>
         [Parameter(ParameterSetName = leafSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathLeafSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathLeafSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Leaf { get; set; }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true the leaf base name of the path will be returned.
         /// </value>
         [Parameter(ParameterSetName = leafBaseSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathLeafBaseSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathLeafBaseSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter LeafBase { get; set; }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Microsoft.PowerShell.Commands
         /// If true the extension of the path will be returned.
         /// </value>
         [Parameter(ParameterSetName = extensionSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
-        [Parameter(ParameterSetName = literalPathExtensionSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = LiteralPathExtensionSet, Mandatory = true, ValueFromPipelineByPropertyName = true)]
         public SwitchParameter Extension { get; set; }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace Microsoft.PowerShell.Commands
         /// Determines if the path is an absolute path.
         /// </summary>
         [Parameter(ParameterSetName = isAbsoluteSet, Mandatory = true)]
-        [Parameter(ParameterSetName = literalPathIsAbsoluteSet, Mandatory = true)]
+        [Parameter(ParameterSetName = LiteralPathIsAbsoluteSet, Mandatory = true)]
         public SwitchParameter IsAbsolute { get; set; }
 
         #endregion Parameters

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -96,6 +96,26 @@ Describe "Split-Path" -Tags "CI" {
 	Split-Path -Parent "\\server1\share1"        | Should -BeExactly "${dirSep}${dirSep}server1"
     }
 
+    It "Should support parsing switches with LiteralPath" {
+        $literalDir = Join-Path -Path $TestDrive -ChildPath 'parent[dir]'
+        $literalPath = Join-Path -Path $literalDir -ChildPath 'child[file].txt'
+        $null = New-Item -ItemType Directory -Path $literalDir
+        $null = New-Item -ItemType File -Path $literalPath
+
+        Split-Path -LiteralPath $literalPath -Parent | Should -BeExactly $literalDir
+        Split-Path -LiteralPath $literalPath -Leaf | Should -BeExactly 'child[file].txt'
+        Split-Path -LiteralPath $literalPath -LeafBase | Should -BeExactly 'child[file]'
+        Split-Path -LiteralPath $literalPath -Extension | Should -BeExactly '.txt'
+        Split-Path -LiteralPath $literalPath -Qualifier | Should -BeExactly (Split-Path -Path $literalPath -Qualifier)
+        Split-Path -LiteralPath $literalPath -NoQualifier | Should -BeExactly (Split-Path -Path $literalPath -NoQualifier)
+        Split-Path -LiteralPath $literalPath -IsAbsolute | Should -BeTrue
+    }
+
+    It "Should reject conflicting parsing switches with LiteralPath" {
+        { Split-Path -LiteralPath TestDrive:\file.txt -Parent -Leaf -ErrorAction Stop } |
+            Should -Throw -ErrorId 'AmbiguousParameterSet,Microsoft.PowerShell.Commands.SplitPathCommand'
+    }
+
     It 'Does not split a drive letter' {
         Split-Path -Path 'C:\' | Should -BeNullOrEmpty
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -99,16 +99,16 @@ Describe "Split-Path" -Tags "CI" {
     It "Should support parsing switches with LiteralPath" {
         $literalDir = Join-Path -Path $TestDrive -ChildPath 'parent[dir]'
         $literalPath = Join-Path -Path $literalDir -ChildPath 'child[file].txt'
-        $null = New-Item -ItemType Directory -Path $literalDir
-        $null = New-Item -ItemType File -Path $literalPath
+        [void][System.IO.Directory]::CreateDirectory($literalDir)
+        [System.IO.File]::WriteAllText($literalPath, '')
 
         Split-Path -LiteralPath $literalPath -Parent | Should -BeExactly $literalDir
         Split-Path -LiteralPath $literalPath -Leaf | Should -BeExactly 'child[file].txt'
         Split-Path -LiteralPath $literalPath -LeafBase | Should -BeExactly 'child[file]'
         Split-Path -LiteralPath $literalPath -Extension | Should -BeExactly '.txt'
-        Split-Path -LiteralPath $literalPath -Qualifier | Should -BeExactly (Split-Path -Path $literalPath -Qualifier)
-        Split-Path -LiteralPath $literalPath -NoQualifier | Should -BeExactly (Split-Path -Path $literalPath -NoQualifier)
         Split-Path -LiteralPath $literalPath -IsAbsolute | Should -BeTrue
+        Split-Path -LiteralPath env:PATH -Qualifier | Should -BeExactly 'env:'
+        Split-Path -LiteralPath env:PATH -NoQualifier | Should -BeExactly 'PATH'
     }
 
     It "Should reject conflicting parsing switches with LiteralPath" {


### PR DESCRIPTION
## PR Summary
Fixes #20705.

Split-Path -LiteralPath only had a single parameter set, so switches such as -Parent, -Leaf, -LeafBase, -Extension, -Qualifier, -NoQualifier, and -IsAbsolute could not be combined with it even though -LiteralPath should generally mirror -Path while suppressing wildcard expansion.

This adds separate literal-path parameter sets for the parsing switches so the valid combinations work, while conflicting switches remain rejected by parameter binding.

## PR Context
The PowerShell cmdlets working group reviewed the issue and agreed that -LiteralPath should work with the same switches as -Path, excluding edge cases.

## PR Checklist
- [x] Make sure all .cs, .ps1 and .psm1 files have the correct copyright header
- [x] Make sure you are merging your commits to the correct branch
- [x] Make sure you added tests for your changes
- [x] Make sure you run the relevant tests successfully

## Validation
- Start-PSBuild -NoPSModuleRestore -CI -SkipExperimentalFeatureGeneration -UseNuGetOrg
- Start-PSPester -Path test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1 -UseNuGetOrg -ThrowOnFailure -Terse -SkipTestToolBuild -BinDir <publish>

Result: Split-Path.Tests.ps1 passed: 17 passed, 0 failed.