### PR TITLE
Treat Set-Location history paths as literal

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -244,6 +244,7 @@ namespace System.Management.Automation
             string driveName = null;
             ProviderInfo provider = null;
             string providerId = null;
+            bool suppressWildcardExpansion = literalPath;
 
             switch (originalPath)
             {
@@ -254,6 +255,7 @@ namespace System.Management.Automation
                     }
 
                     path = _setLocationHistory.Undo(this.CurrentLocation).Path;
+                    suppressWildcardExpansion = true;
                     break;
                 case string originalPathSwitch when !literalPath && originalPathSwitch.Equals("+", StringComparison.Ordinal):
                     if (_setLocationHistory.RedoCount <= 0)
@@ -262,6 +264,7 @@ namespace System.Management.Automation
                     }
 
                     path = _setLocationHistory.Redo(this.CurrentLocation).Path;
+                    suppressWildcardExpansion = true;
                     break;
                 default:
                     var pushPathInfo = GetNewPushPathInfo();
@@ -317,6 +320,8 @@ namespace System.Management.Automation
             }
 
             context ??= new CmdletProviderContext(this.ExecutionContext);
+
+            context.SuppressWildcardExpansion |= suppressWildcardExpansion;
 
             if (CurrentDrive != null)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -160,6 +160,21 @@ Describe "Set-Location" -Tags "CI" {
             (Get-Location).Path | Should -Be $initialLocation
         }
 
+        It 'Should navigate history paths with wildcard characters literally' {
+            $literalPath = Join-Path $TestDrive 'foo - bar(123-456)[foo]'
+            $null = [System.IO.Directory]::CreateDirectory($literalPath)
+
+            Set-Location $TestDrive
+            Set-Location -LiteralPath $literalPath
+            Set-Location $TestDrive
+
+            Set-Location -
+            (Get-Location).Path | Should -BeExactly $literalPath
+
+            Set-Location +
+            (Get-Location).Path | Should -BeExactly $TestDrive.ToString()
+        }
+
         It 'Location History is limited' {
             $initialLocation = (Get-Location).Path
             $maximumLocationHistory = 20


### PR DESCRIPTION
## Summary
- Treat `Set-Location -` / `Set-Location +` history entries as literal paths after they are read from location history
- Add regression coverage for history navigation to a directory whose name contains wildcard characters

## Details
`PathInfo.Path` values stored in the Set-Location history are already resolved paths. When `-` or `+` replaced the user input with a history path, the path was still globbed as a normal `-Path` value, so folder names containing characters like `[` and `]` failed to resolve.

Fixes #20701
Related #27507

## Validation
- `Start-PSBuild -NoPSModuleRestore -CI -SkipExperimentalFeatureGeneration -UseNuGetOrg`
- `Start-PSPester -Path ./test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1 -powershell ./src/powershell-win-core/bin/Debug/net11.0/win7-x64/publish/pwsh.exe -UseNuGetOrg -SkipTestToolBuild -ThrowOnFailure`

Result: Set-Location.Tests.ps1 passed: 22 passed, 0 failed, 2 skipped, 1 pending.