### PR TITLE
Update New-Item unknown item type message

### DIFF
--- a/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
+++ b/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
@@ -205,7 +205,7 @@
     <value>Directory {0} cannot be removed because it is not empty.</value>
   </data>
   <data name="UnknownType" xml:space="preserve">
-    <value>The type is not a known type for the file system. Only "file","directory" or "symboliclink" can be specified.</value>
+    <value>The type is not a known type for the file system. Only "file", "directory", "symboliclink", "junction", or "hardlink" can be specified.</value>
   </data>
   <data name="PathOutSideBasePath" xml:space="preserve">
     <value>Cannot process the path because the specified path refers to an item that is outside the basePath.</value>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -79,6 +79,17 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $newFile.Name | Should -BeExactly $newTestFile
         }
 
+        It "New-Item reports all supported file system item types for an unknown item type" {
+            $errorRecord = {
+                New-Item -Path (Join-Path $TestDrive "unknown-type") -ItemType UnknownType -ErrorAction Stop
+            } | Should -Throw -PassThru
+
+            $errorRecord.FullyQualifiedErrorId | Should -BeExactly "Argument,Microsoft.PowerShell.Commands.NewItemCommand"
+            foreach ($itemType in '"file"', '"directory"', '"symboliclink"', '"junction"', '"hardlink"') {
+                $errorRecord.Exception.Message | Should -Match ([regex]::Escape($itemType))
+            }
+        }
+
         It "Verify Remove-Item for directory" {
             $existsBefore = Test-Path $testDir
             Remove-Item -Path $testDir -Recurse -Force


### PR DESCRIPTION
## Summary
- Include `junction` and `hardlink` in the file-system provider's unknown `New-Item -ItemType` error message
- Add a regression assertion for the supported item-type list

## Details
The filesystem provider already recognizes `file`, `directory`, `symboliclink`, `junction`, and `hardlink`, but the unknown-type error message still listed only the older three values.

Fixes #27248

## Validation
- `Start-PSBuild -NoPSModuleRestore -CI -SkipExperimentalFeatureGeneration -UseNuGetOrg`
- Direct validation with the built `pwsh.exe`: `New-Item -ItemType UnknownType` rejects the type and the message includes both `junction` and `hardlink`.
- Added regression coverage for the supported item-type list.