### PR TITLE
Fix ConvertTo-Json DateTime timezone test

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -134,10 +134,9 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
     It 'Should not serialize ETS properties added to DateTime' {
         $date = "2021-06-24T15:54:06.796999-07:00"
-        $d = [DateTime]::Parse($date)
+        $d = [DateTimeOffset]::Parse($date).UtcDateTime
 
-        # need to use wildcard here due to some systems may be configured with different culture setting showing time in different format
-        $d | ConvertTo-Json -Compress | Should -BeLike '"2021-06-24T*'
+        $d | ConvertTo-Json -Compress | Should -BeExactly '"2021-06-24T22:54:06.796999Z"'
         $d | ConvertTo-Json | ConvertFrom-Json | Should -Be $d
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -134,9 +134,11 @@ Describe 'ConvertTo-Json' -tags "CI" {
 
     It 'Should not serialize ETS properties added to DateTime' {
         $date = "2021-06-24T15:54:06.796999-07:00"
-        $d = [DateTimeOffset]::Parse($date).UtcDateTime
+        $d = [DateTimeOffset]::Parse($date, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind).UtcDateTime
 
-        $d | ConvertTo-Json -Compress | Should -BeExactly '"2021-06-24T22:54:06.796999Z"'
+        $json = $d | ConvertTo-Json -Compress
+        $json | Should -Match '^"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z"$'
+        [DateTime]::Parse($json.Trim('"'), [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind) | Should -Be $d
         $d | ConvertTo-Json | ConvertFrom-Json | Should -Be $d
     }
 


### PR DESCRIPTION
# PR Summary

Make the `ConvertTo-Json` DateTime ETS test independent of the machine's local timezone.

# PR Context

The test parsed `2021-06-24T15:54:06.796999-07:00` into a local `DateTime`, then expected the compressed JSON to start with `2021-06-24`. On machines at UTC+1 or later, that same instant serializes as the next local date, so the assertion fails even though `ConvertTo-Json` is behaving correctly.

This normalizes the fixture through `DateTimeOffset.Parse(...).UtcDateTime` and checks the exact UTC JSON string. The roundtrip assertion remains in place, so the test still verifies that DateTime is serialized as a scalar value rather than with ETS properties.

Fixes #27500

# PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
- **Testing - New and feature**
  - [x] N/A; fixes existing test coverage

## Tests

- Reproduced failure before the fix with `Start-PSPester -Path ./test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1 -UseNuGetOrg -SkipTestToolBuild -ThrowOnFailure`
- `Start-PSPester -Path ./test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1 -UseNuGetOrg -SkipTestToolBuild -ThrowOnFailure` (222 passed, 1 pending)
- `git diff --check`