### PR TITLE
Fix transcript logging for exit flow control

### DIFF
--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -162,6 +162,9 @@ namespace System.Management.Automation.Internal
 
         internal void LogExecutionException(Exception exception)
         {
+            if (exception is FlowControlException)
+                return;
+
             _executionFailed = true;
 
             // Only log one terminating error for pipeline execution.

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -152,7 +152,9 @@ namespace System.Management.Automation.Internal
         internal void LogExecutionError(InvocationInfo invocationInfo, ErrorRecord errorRecord)
         {
             if (errorRecord == null)
+            {
                 return;
+            }
 
             string message = StringUtil.Format(PipelineStrings.PipelineExecutionNonTerminatingError, GetCommand(invocationInfo), errorRecord.ToString());
             Log(message, invocationInfo, PipelineExecutionStatus.Error);
@@ -163,13 +165,17 @@ namespace System.Management.Automation.Internal
         internal void LogExecutionException(Exception exception)
         {
             if (exception is FlowControlException)
+            {
                 return;
+            }
 
             _executionFailed = true;
 
             // Only log one terminating error for pipeline execution.
             if (_terminatingErrorLogged)
+            {
                 return;
+            }
 
             _terminatingErrorLogged = true;
 

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -161,6 +161,28 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $transcriptFilePath | Should -FileContentMatch "PowerShell transcript end"
     }
 
+    It "Transcription should not record a terminating error when an advanced function exits" {
+        $scriptFilePath = Join-Path $TestDrive "exit-script.ps1"
+        $exitTranscriptFilePath = Join-Path $TestDrive "exit-transcript.txt"
+
+        @"
+Start-Transcript -Path '$exitTranscriptFilePath'
+function Exit-Script {
+    [CmdletBinding()]
+    param()
+    exit 255
+}
+
+Exit-Script
+"@ | Set-Content -Path $scriptFilePath
+
+        & "$PSHOME/pwsh" -NoProfile -File $scriptFilePath *> $null
+
+        $LASTEXITCODE | Should -Be 255
+        $exitTranscriptFilePath | Should -Exist
+        Get-Content -Path $exitTranscriptFilePath -Raw | Should -Not -Match 'TerminatingError\(\): "System error\."'
+    }
+
     It "Transcription should record native command output" {
         $script = {
             Start-Transcript -Path $transcriptFilePath

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -176,11 +176,13 @@ function Exit-Script {
 Exit-Script
 "@ | Set-Content -Path $scriptFilePath
 
-        & "$PSHOME/pwsh" -NoProfile -File $scriptFilePath *> $null
+        $pwshName = if ($IsWindows) { "pwsh.exe" } else { "pwsh" }
+        $pwsh = Join-Path $PSHOME $pwshName
+        & $pwsh -NoProfile -File $scriptFilePath *> $null
 
         $LASTEXITCODE | Should -Be 255
         $exitTranscriptFilePath | Should -Exist
-        Get-Content -Path $exitTranscriptFilePath -Raw | Should -Not -Match 'TerminatingError\(\): "System error\."'
+        Get-Content -Path $exitTranscriptFilePath -Raw | Should -Not -Match 'TerminatingError\(\)'
     }
 
     It "Transcription should record native command output" {


### PR DESCRIPTION
﻿## Problem
Using `exit` inside an advanced function can cause transcript logging to record `TerminatingError(): "System error."`, even though `exit` is a flow-control operation rather than an error that should be written to the transcript.

## Root cause
`PipelineProcessor.LogExecutionException` logs every exception it receives as a terminating pipeline error. `ExitException` derives from `FlowControlException`, so the transcript path treats the internal control-flow exception as a user-visible terminating error.

## Solution
Skip transcript terminating-error logging for `FlowControlException` instances, and add a regression test that launches a child PowerShell process where an advanced function exits with code 255 while transcription is active.

## Tests run
- Reproduced before the fix with local `pwsh`: transcript contained `PS>TerminatingError(): "System error."`
- `Start-PSBuild -UseNuGetOrg -SkipExperimentalFeatureGeneration`
- `Start-PSPester -Path ./test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1 -UseNuGetOrg -SkipTestToolBuild -ThrowOnFailure` (23 passed)
- `git diff --check` (only existing Windows line-ending warnings)

Fixes #26625
