### PR TITLE
Fix Set-Location history with wildcard paths

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -253,7 +253,7 @@ namespace System.Management.Automation
                         throw new InvalidOperationException(SessionStateStrings.LocationUndoStackIsEmpty);
                     }
 
-                    path = _setLocationHistory.Undo(this.CurrentLocation).Path;
+                    path = GetEscapedLocationHistoryPath(_setLocationHistory.Undo(this.CurrentLocation));
                     break;
                 case string originalPathSwitch when !literalPath && originalPathSwitch.Equals("+", StringComparison.Ordinal):
                     if (_setLocationHistory.RedoCount <= 0)
@@ -261,7 +261,7 @@ namespace System.Management.Automation
                         throw new InvalidOperationException(SessionStateStrings.LocationRedoStackIsEmpty);
                     }
 
-                    path = _setLocationHistory.Redo(this.CurrentLocation).Path;
+                    path = GetEscapedLocationHistoryPath(_setLocationHistory.Redo(this.CurrentLocation));
                     break;
                 default:
                     var pushPathInfo = GetNewPushPathInfo();
@@ -853,6 +853,13 @@ namespace System.Management.Automation
                 mshQualifiedPath);
 
             return newPushLocation;
+        }
+
+        private static string GetEscapedLocationHistoryPath(PathInfo location)
+        {
+            return LocationGlobber.GetMshQualifiedPath(
+                WildcardPattern.Escape(location.Path),
+                location.GetDrive());
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -253,7 +253,7 @@ namespace System.Management.Automation
                         throw new InvalidOperationException(SessionStateStrings.LocationUndoStackIsEmpty);
                     }
 
-                    path = GetEscapedLocationHistoryPath(_setLocationHistory.Undo(this.CurrentLocation));
+                    path = GetMshQualifiedEscapedLocationHistoryPath(_setLocationHistory.Undo(this.CurrentLocation));
                     break;
                 case string originalPathSwitch when !literalPath && originalPathSwitch.Equals("+", StringComparison.Ordinal):
                     if (_setLocationHistory.RedoCount <= 0)
@@ -261,7 +261,7 @@ namespace System.Management.Automation
                         throw new InvalidOperationException(SessionStateStrings.LocationRedoStackIsEmpty);
                     }
 
-                    path = GetEscapedLocationHistoryPath(_setLocationHistory.Redo(this.CurrentLocation));
+                    path = GetMshQualifiedEscapedLocationHistoryPath(_setLocationHistory.Redo(this.CurrentLocation));
                     break;
                 default:
                     var pushPathInfo = GetNewPushPathInfo();
@@ -855,7 +855,7 @@ namespace System.Management.Automation
             return newPushLocation;
         }
 
-        private static string GetEscapedLocationHistoryPath(PathInfo location)
+        private static string GetMshQualifiedEscapedLocationHistoryPath(PathInfo location)
         {
             return LocationGlobber.GetMshQualifiedPath(
                 WildcardPattern.Escape(location.Path),

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -154,17 +154,18 @@ Describe "Set-Location" -Tags "CI" {
             $otherPath = Join-Path $TestDrive 'other'
             $null = New-Item -ItemType Directory -Path $testPath
             $null = New-Item -ItemType Directory -Path $otherPath
+            $resolvedTestPath = (Resolve-Path -LiteralPath $testPath).Path
 
             Set-Location $TestDrive
-            $testDrivePath = (Get-Location).Path
+            $testDrivePath = (Resolve-Path -LiteralPath $TestDrive).Path
             Set-Location -LiteralPath $testPath
             Set-Location -LiteralPath $otherPath
             Set-Location -
-            (Get-Location).Path | Should -BeExactly $testPath
+            (Get-Location).Path | Should -Be $resolvedTestPath
             Set-Location -
-            (Get-Location).Path | Should -BeExactly $testDrivePath
+            (Get-Location).Path | Should -Be $testDrivePath
             Set-Location +
-            (Get-Location).Path | Should -BeExactly $testPath
+            (Get-Location).Path | Should -Be $resolvedTestPath
         }
 
         It 'Should go back to previous locations when specifying minus twice' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -149,6 +149,24 @@ Describe "Set-Location" -Tags "CI" {
             (Get-Location).Path | Should -Be $initialLocation
         }
 
+        It 'Should go through locations with wildcard characters when specifying minus and plus as paths' {
+            $testPath = Join-Path $TestDrive 'foo - bar(123-456)[foo]'
+            $otherPath = Join-Path $TestDrive 'other'
+            $null = New-Item -ItemType Directory -Path $testPath
+            $null = New-Item -ItemType Directory -Path $otherPath
+
+            Set-Location $TestDrive
+            $testDrivePath = (Get-Location).Path
+            Set-Location -LiteralPath $testPath
+            Set-Location -LiteralPath $otherPath
+            Set-Location -
+            (Get-Location).Path | Should -BeExactly $testPath
+            Set-Location -
+            (Get-Location).Path | Should -BeExactly $testDrivePath
+            Set-Location +
+            (Get-Location).Path | Should -BeExactly $testPath
+        }
+
         It 'Should go back to previous locations when specifying minus twice' {
             $initialLocation = (Get-Location).Path
             Set-Location ([System.IO.Path]::GetTempPath())


### PR DESCRIPTION
## PR Summary

Fixes #27507.

`Set-Location -` and `Set-Location +` replay paths saved in the location history. When the saved path contains wildcard characters such as `[foo]`, the replayed path was passed through normal wildcard expansion and failed to resolve the literal directory.

This change escapes the saved history path before resolving it, matching the existing `Pop-Location` behavior for stacked locations.

## PR Context

`Pop-Location` already escapes saved `PathInfo` entries before passing them back through `SetLocation`. The location-history undo/redo path used the raw saved path instead, so literal filesystem names containing wildcard characters were treated as patterns.

## PR Checklist

- [x] Tests pass

## Tests

- Manual repro before fix: old binary returned `PathNotFound` for `Set-Location -Path '-'` when the previous path contained `[abc]`.
- `Start-PSBuild -Configuration Debug -SMAOnly`
- Manual repro after fix: publish `pwsh.exe` returned the wildcard-containing path successfully.
- `Start-PSPester -Path .\test\powershell\Modules\Microsoft.PowerShell.Management\Set-Location.Tests.ps1 -Terse -ThrowOnFailure` (`22 passed, 0 failed, 2 skipped, 1 pending`; an existing non-fatal `New-Item` message was printed after the passing summary).