### PR TITLE
Avoid decorating ErrorRecord during CliXml serialization

### DIFF
--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -1493,7 +1493,7 @@ namespace System.Management.Automation
             {
                 if (!member.IsHidden)
                 {
-                    target.Members.Add(member);
+                    target.InstanceMembers.Add(member.Copy());
                 }
             }
 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -1482,6 +1482,24 @@ namespace System.Management.Automation
             _writer.WriteEndElement();
         }
 
+        private static PSObject GetRemotingSerializationTarget(PSObject source)
+        {
+            PSObject target = source.Copy();
+
+            // Keep remoting-only notes local to the serialization wrapper, rather
+            // than writing them to the base object's resurrection table.
+            target.InstanceMembers = new PSMemberInfoInternalCollection<PSMemberInfo>();
+            foreach (PSMemberInfo member in source.InstanceMembers)
+            {
+                if (!member.IsHidden)
+                {
+                    target.Members.Add(member);
+                }
+            }
+
+            return target;
+        }
+
         private void HandleComplexTypePSObject
         (
             object source,
@@ -1514,6 +1532,7 @@ namespace System.Management.Automation
                     ErrorRecord errorRecord = mshSource.ImmediateBaseObject as ErrorRecord;
                     if (errorRecord != null)
                     {
+                        mshSource = GetRemotingSerializationTarget(mshSource);
                         errorRecord.ToPSObjectForRemoting(mshSource);
                         isErrorRecord = true;
                         break;
@@ -1522,6 +1541,7 @@ namespace System.Management.Automation
                     InformationalRecord informationalRecord = mshSource.ImmediateBaseObject as InformationalRecord;
                     if (informationalRecord != null)
                     {
+                        mshSource = GetRemotingSerializationTarget(mshSource);
                         informationalRecord.ToPSObjectForRemoting(mshSource);
                         isInformationalRecord = true;
                         break;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
@@ -36,10 +36,24 @@ Describe "CliXml test" -Tags "CI" {
             }
         }
 
-        function Get-ExtendedMemberName {
+        function Get-ExtendedMemberNames {
             param([object] $InputObject)
 
             @($InputObject | Get-Member -View Extended | Select-Object -ExpandProperty Name)
+        }
+
+        function New-TestErrorRecord {
+            try {
+                Write-Error foo -ErrorAction Stop
+            }
+            catch {
+                $_
+            }
+        }
+
+        function New-TestInformationRecord {
+            Write-Information foo -Tags test -InformationAction Continue -InformationVariable informationRecord 6>$null
+            $informationRecord[0]
         }
     }
 
@@ -193,13 +207,23 @@ Describe "CliXml test" -Tags "CI" {
 
         It "does not add remoting serialization members to ErrorRecord input" {
             $filePath = Join-Path $subFilePath 'error.xml'
-            Write-Error foo 2>$null
-            $errorRecord = $Error[0]
-            $before = Get-ExtendedMemberName $errorRecord
+            $errorRecord = New-TestErrorRecord
+            $before = Get-ExtendedMemberNames $errorRecord
 
             $errorRecord | Export-Clixml -Path $filePath
 
-            $after = Get-ExtendedMemberName $errorRecord
+            $after = Get-ExtendedMemberNames $errorRecord
+            @($after | Where-Object { $_ -notin $before }) | Should -BeNullOrEmpty
+        }
+
+        It "does not add remoting serialization members to InformationRecord input" {
+            $filePath = Join-Path $subFilePath 'information.xml'
+            $informationRecord = New-TestInformationRecord
+            $before = Get-ExtendedMemberNames $informationRecord
+
+            $informationRecord | Export-Clixml -Path $filePath
+
+            $after = Get-ExtendedMemberNames $informationRecord
             @($after | Where-Object { $_ -notin $before }) | Should -BeNullOrEmpty
         }
     }
@@ -252,13 +276,22 @@ Describe "CliXml test" -Tags "CI" {
         }
 
         It "does not add remoting serialization members to ErrorRecord input" {
-            Write-Error foo 2>$null
-            $errorRecord = $Error[0]
-            $before = Get-ExtendedMemberName $errorRecord
+            $errorRecord = New-TestErrorRecord
+            $before = Get-ExtendedMemberNames $errorRecord
 
             $null = $errorRecord | ConvertTo-CliXml
 
-            $after = Get-ExtendedMemberName $errorRecord
+            $after = Get-ExtendedMemberNames $errorRecord
+            @($after | Where-Object { $_ -notin $before }) | Should -BeNullOrEmpty
+        }
+
+        It "does not add remoting serialization members to InformationRecord input" {
+            $informationRecord = New-TestInformationRecord
+            $before = Get-ExtendedMemberNames $informationRecord
+
+            $null = $informationRecord | ConvertTo-CliXml
+
+            $after = Get-ExtendedMemberNames $informationRecord
             @($after | Where-Object { $_ -notin $before }) | Should -BeNullOrEmpty
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
@@ -35,6 +35,12 @@ Describe "CliXml test" -Tags "CI" {
                 $this.testFile = $file
             }
         }
+
+        function Get-ExtendedMemberName {
+            param([object] $InputObject)
+
+            @($InputObject | Get-Member -View Extended | Select-Object -ExpandProperty Name)
+        }
     }
 
     AfterAll {
@@ -184,6 +190,18 @@ Describe "CliXml test" -Tags "CI" {
             $cred.UserName | Should -BeExactly "Foo"
             $cred.Password | Should -BeOfType System.Security.SecureString
         }
+
+        It "does not add remoting serialization members to ErrorRecord input" {
+            $filePath = Join-Path $subFilePath 'error.xml'
+            Write-Error foo 2>$null
+            $errorRecord = $Error[0]
+            $before = Get-ExtendedMemberName $errorRecord
+
+            $errorRecord | Export-Clixml -Path $filePath
+
+            $after = Get-ExtendedMemberName $errorRecord
+            @($after | Where-Object { $_ -notin $before }) | Should -BeNullOrEmpty
+        }
     }
 
     Context "ConvertTo-CliXml"{
@@ -231,6 +249,17 @@ Describe "CliXml test" -Tags "CI" {
             }
 
             $isExisted | Should -BeTrue
+        }
+
+        It "does not add remoting serialization members to ErrorRecord input" {
+            Write-Error foo 2>$null
+            $errorRecord = $Error[0]
+            $before = Get-ExtendedMemberName $errorRecord
+
+            $null = $errorRecord | ConvertTo-CliXml
+
+            $after = Get-ExtendedMemberName $errorRecord
+            @($after | Where-Object { $_ -notin $before }) | Should -BeNullOrEmpty
         }
     }
 


### PR DESCRIPTION
## PR Summary

Fixes #25854.

`ConvertTo-CliXml` and `Export-CliXml` serialize `ErrorRecord` instances by adding remoting-specific note properties such as `ErrorCategory_Activity` and `InvocationInfo`. The serializer was adding those properties to the caller's `PSObject` wrapper, which caused the original `ErrorRecord` to gain serialization-only extended members after serialization completed.

This change serializes remoting records through a wrapper with local instance members, preserving the generated CliXml fields without decorating the caller's input object.

## PR Context

`PSObject.Copy()` alone still shares the base object's resurrection-table key, so note properties added to the copy are visible on wrappers around the same base object. The new helper resets the serialization wrapper's instance-member collection before adding remoting-only properties, while preserving existing visible instance members for serialization.

The same path is used for informational records, so the isolation is applied there too.

## PR Checklist

- [x] Tests pass

## Tests

- Reproduced before fix: serializing an `ErrorRecord` increased extended members from 1 to 13 and added `ErrorCategory_*`, `InvocationInfo`, `SerializeExtendedInfo`, and related serialization notes.
- Added regression coverage for both `Export-Clixml` and `ConvertTo-CliXml`.
- `Start-PSBuild -Configuration Debug -SMAOnly`
- Manual verification after fix: `ConvertTo-CliXml` and `Export-Clixml` added no extended members to the original `ErrorRecord`.
- Manual verification after fix: generated CliXml still contains `ErrorCategory_Category` and `ConvertFrom-CliXml` round-trips the error information.
- `Start-PSPester -Path .\test\powershell\Modules\Microsoft.PowerShell.Utility\clixml.tests.ps1 -Terse -ThrowOnFailure -SkipTestToolBuild -BinDir <publish>` (19 passed)
- `git diff --check` (line-ending warning only)