### PR TITLE
Handle resume responses without Content-Range

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -579,14 +579,16 @@ namespace Microsoft.PowerShell.Commands
                             bool _isSuccess = response.IsSuccessStatusCode;
 
                             // Check if the Resume range was not satisfiable because the file already completed downloading.
-                            // This happens when the local file is the same size as the remote file.
-                            if (IsResumeRangeAlreadyComplete(response))
+                            if (IsResumeRangeAlreadyComplete(response, out bool isMissingContentRange))
                             {
                                 _isSuccess = true;
-                                WriteVerbose(string.Format(
+                                string skippedMessage = string.Format(
                                     CultureInfo.CurrentCulture,
-                                    WebCmdletStrings.OutFileWritingSkipped,
-                                    OutFile));
+                                    isMissingContentRange
+                                        ? WebCmdletStrings.OutFileWritingSkippedWithoutContentRange
+                                        : WebCmdletStrings.OutFileWritingSkipped,
+                                    OutFile);
+                                WriteVerbose(skippedMessage);
 
                                 // Disable writing to the OutFile.
                                 OutFile = null;
@@ -1730,18 +1732,24 @@ namespace Microsoft.PowerShell.Commands
 
         private bool IsPersistentSession() => MyInvocation.BoundParameters.ContainsKey(nameof(WebSession)) || MyInvocation.BoundParameters.ContainsKey(nameof(SessionVariable));
 
-        private bool IsResumeRangeAlreadyComplete(HttpResponseMessage response)
+        private bool IsResumeRangeAlreadyComplete(HttpResponseMessage response, out bool isMissingContentRange)
         {
+            isMissingContentRange = false;
             if (!Resume.IsPresent || response.StatusCode != HttpStatusCode.RequestedRangeNotSatisfiable)
             {
                 return false;
             }
 
             ContentRangeHeaderValue contentRange = response.Content.Headers.ContentRange;
-
             // RFC 9110 only says 416 responses SHOULD include Content-Range. Treat a missing
             // header as an already-complete resume instead of failing with a null reference.
-            return contentRange is null || (contentRange.HasLength && contentRange.Length == _resumeFileSize);
+            if (contentRange is null)
+            {
+                isMissingContentRange = true;
+                return true;
+            }
+
+            return contentRange.HasLength && contentRange.Length == _resumeFileSize;
         }
 
         private bool ShouldRetryWithoutResumeRange(HttpResponseMessage response)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -582,11 +582,12 @@ namespace Microsoft.PowerShell.Commands
                             if (IsResumeRangeAlreadyComplete(response, out bool isMissingContentRange))
                             {
                                 _isSuccess = true;
+                                string skippedMessageFormat = isMissingContentRange
+                                    ? WebCmdletStrings.OutFileWritingSkippedWithoutContentRange
+                                    : WebCmdletStrings.OutFileWritingSkipped;
                                 string skippedMessage = string.Format(
                                     CultureInfo.CurrentCulture,
-                                    isMissingContentRange
-                                        ? WebCmdletStrings.OutFileWritingSkippedWithoutContentRange
-                                        : WebCmdletStrings.OutFileWritingSkipped,
+                                    skippedMessageFormat,
                                     OutFile);
                                 WriteVerbose(skippedMessage);
 
@@ -1741,6 +1742,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             ContentRangeHeaderValue contentRange = response.Content.Headers.ContentRange;
+
             // RFC 9110 only says 416 responses SHOULD include Content-Range. Treat a missing
             // header as an already-complete resume instead of failing with a null reference.
             if (contentRange is null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -580,10 +580,7 @@ namespace Microsoft.PowerShell.Commands
 
                             // Check if the Resume range was not satisfiable because the file already completed downloading.
                             // This happens when the local file is the same size as the remote file.
-                            if (Resume.IsPresent
-                                && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable
-                                && response.Content.Headers.ContentRange.HasLength
-                                && response.Content.Headers.ContentRange.Length == _resumeFileSize)
+                            if (IsResumeRangeAlreadyComplete(response))
                             {
                                 _isSuccess = true;
                                 WriteVerbose(string.Format(
@@ -1354,10 +1351,7 @@ namespace Microsoft.PowerShell.Commands
                 // Request again without the Range header because the server indicated the range was not satisfiable.
                 // This happens when the local file is larger than the remote file.
                 // If the size of the remote file is the same as the local file, there is nothing to resume.
-                if (Resume.IsPresent
-                    && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable
-                    && (response.Content.Headers.ContentRange.HasLength
-                    && response.Content.Headers.ContentRange.Length != _resumeFileSize))
+                if (ShouldRetryWithoutResumeRange(response))
                 {
                     _cancelToken.Cancel();
 
@@ -1735,6 +1729,31 @@ namespace Microsoft.PowerShell.Commands
         }
 
         private bool IsPersistentSession() => MyInvocation.BoundParameters.ContainsKey(nameof(WebSession)) || MyInvocation.BoundParameters.ContainsKey(nameof(SessionVariable));
+
+        private bool IsResumeRangeAlreadyComplete(HttpResponseMessage response)
+        {
+            if (!Resume.IsPresent || response.StatusCode != HttpStatusCode.RequestedRangeNotSatisfiable)
+            {
+                return false;
+            }
+
+            ContentRangeHeaderValue contentRange = response.Content.Headers.ContentRange;
+
+            // RFC 9110 only says 416 responses SHOULD include Content-Range. Treat a missing
+            // header as an already-complete resume instead of failing with a null reference.
+            return contentRange is null || (contentRange.HasLength && contentRange.Length == _resumeFileSize);
+        }
+
+        private bool ShouldRetryWithoutResumeRange(HttpResponseMessage response)
+        {
+            if (!Resume.IsPresent || response.StatusCode != HttpStatusCode.RequestedRangeNotSatisfiable)
+            {
+                return false;
+            }
+
+            ContentRangeHeaderValue contentRange = response.Content.Headers.ContentRange;
+            return contentRange is not null && contentRange.HasLength && contentRange.Length != _resumeFileSize;
+        }
 
         /// <summary>
         /// Sets the ContentLength property of the request and writes the specified content to the request's RequestStream.

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -189,6 +189,9 @@
   <data name="OutFileWritingSkipped" xml:space="preserve">
     <value>The file will not be re-downloaded because the remote file is the same size as the OutFile: {0}</value>
   </data>
+  <data name="OutFileWritingSkippedWithoutContentRange" xml:space="preserve">
+    <value>The file will not be re-downloaded because the server returned HTTP 416 without a Content-Range header. Assuming the OutFile is already complete: {0}</value>
+  </data>
   <data name="ProxyCredentialConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: ProxyCredential and ProxyUseDefaultCredentials. Specify either ProxyCredential or ProxyUseDefaultCredentials, then retry.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2213,6 +2213,23 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             $response.StatusCode | Should -Be 416
             $response.Headers.'Content-Range'[0] | Should -BeExactly "bytes */$referenceFileSize"
         }
+
+        It "Invoke-WebRequest -Resume treats 416 without Content-Range as a completed download" {
+            # Download the entire file
+            $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'MissingContentRange'
+            $null = Invoke-WebRequest -Uri $uri -OutFile $outFile
+            $fileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
+
+            $response = Invoke-WebRequest -Uri $uri -OutFile $outFile -Resume -PassThru
+
+            $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
+            $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
+            Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $referenceFileSize
+            $response.Headers.'X-WebListener-Has-Range'[0] | Should -BeExactly 'true'
+            $response.Headers.'X-WebListener-Request-Range'[0] | Should -BeExactly "bytes=$fileSize-"
+            $response.StatusCode | Should -Be 416
+            $response.Headers.ContainsKey('Content-Range') | Should -BeFalse
+        }
     }
 
     Context "Invoke-WebRequest retry tests" {
@@ -4243,6 +4260,22 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             $Headers.'X-WebListener-Has-Range'[0] | Should -BeExactly 'true'
             $Headers.'X-WebListener-Request-Range'[0] | Should -BeExactly "bytes=$fileSize-"
             $Headers.'Content-Range'[0] | Should -BeExactly "bytes */$referenceFileSize"
+        }
+
+        It "Invoke-RestMethod -Resume treats 416 without Content-Range as a completed download" {
+            # Download the entire file
+            $uri = Get-WebListenerUrl -Test 'Resume' -TestValue 'MissingContentRange'
+            $null = Invoke-RestMethod -Uri $uri -OutFile $outFile
+            $fileSize = Get-Item $outFile | Select-Object -ExpandProperty Length
+
+            Invoke-RestMethod -Uri $uri -OutFile $outFile -ResponseHeadersVariable 'Headers' -Resume
+
+            $outFileHash = Get-FileHash -Algorithm SHA256 -Path $outFile
+            $outFileHash.Hash | Should -BeExactly $referenceFileHash.Hash
+            Get-Item $outFile | Select-Object -ExpandProperty Length | Should -Be $referenceFileSize
+            $Headers.'X-WebListener-Has-Range'[0] | Should -BeExactly 'true'
+            $Headers.'X-WebListener-Request-Range'[0] | Should -BeExactly "bytes=$fileSize-"
+            $Headers.ContainsKey('Content-Range') | Should -BeFalse
         }
     }
 

--- a/test/tools/WebListener/Controllers/ResumeController.cs
+++ b/test/tools/WebListener/Controllers/ResumeController.cs
@@ -74,6 +74,22 @@ namespace mvc.Controllers
             await Response.Body.WriteAsync(FileBytes, 0, FileBytes.Length);
         }
 
+        public async void MissingContentRange()
+        {
+            SetResumeResponseHeaders();
+            string rangeHeader;
+            if (TryGetRangeHeader(out rangeHeader))
+            {
+                Response.StatusCode = StatusCodes.Status416RequestedRangeNotSatisfiable;
+                return;
+            }
+
+            Response.ContentType = MediaTypeNames.Application.Octet;
+            Response.ContentLength = FileBytes.Length;
+            Response.StatusCode = StatusCodes.Status200OK;
+            await Response.Body.WriteAsync(FileBytes, 0, FileBytes.Length);
+        }
+
         public async void Bytes(int NumberBytes)
         {
             if (NumberBytes > FileBytes.Length || NumberBytes < 0)

--- a/test/tools/WebListener/Controllers/ResumeController.cs
+++ b/test/tools/WebListener/Controllers/ResumeController.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Net.Mime;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
@@ -74,11 +75,10 @@ namespace mvc.Controllers
             await Response.Body.WriteAsync(FileBytes, 0, FileBytes.Length);
         }
 
-        public async void MissingContentRange()
+        public async Task MissingContentRange()
         {
             SetResumeResponseHeaders();
-            string rangeHeader;
-            if (TryGetRangeHeader(out rangeHeader))
+            if (TryGetRangeHeader(out _))
             {
                 Response.StatusCode = StatusCodes.Status416RequestedRangeNotSatisfiable;
                 return;


### PR DESCRIPTION
## Problem

`Invoke-WebRequest -Resume` and `Invoke-RestMethod -Resume` can throw a `NullReferenceException` when a server responds to an already-complete range request with `416 Requested Range Not Satisfiable` but omits the optional `Content-Range` header.

Fixes #23948.

## Root Cause

The resume code dereferenced `response.Content.Headers.ContentRange` for every `416` response. RFC 9110 says a `416` response should include `Content-Range`, but it is not mandatory, and some servers omit it when the requested range starts at EOF.

## Solution

- Treat `416` responses without `Content-Range` as an already-complete resumed download.
- Keep the existing retry-without-range behavior when `Content-Range` is present and shows the remote size differs from the local file size.
- Add a WebListener endpoint that simulates `416` without `Content-Range`.
- Add regression coverage for both `Invoke-WebRequest` and `Invoke-RestMethod`.

## Tests

- Reproduced the original `NullReferenceException` locally with a tiny HTTP server returning `416` without `Content-Range`.
- `Start-PSBuild -Configuration Debug -NoPSModuleRestore`
- `Publish-PSTestTools`
- Manual WebListener verification for `Invoke-WebRequest -Resume` and `Invoke-RestMethod -Resume` against the new `MissingContentRange` endpoint.
- `git diff --check` (only existing Windows line-ending notices)