### PR TITLE
[release/v7.5.8] Verify Apple codesign immediately after ESRP signing

### DIFF
--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -184,4 +184,23 @@ jobs:
       Expand-Archive -Path $zipFile -DestinationPath $signedDir -Force -Verbose
     displayName: Expand Apple-signed Mach-O binaries into signed output
 
+  - pwsh: |
+      $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
+      $expected = 'Developer ID Application: Microsoft Corporation'
+      $missing = @()
+      Get-ChildItem $signedDir -Recurse -Include 'pwsh', '*.dylib' | ForEach-Object {
+        $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+        $text = [System.Text.Encoding]::Latin1.GetString($bytes)
+        if (-not $text.Contains($expected)) {
+          $missing += $_.FullName
+          Write-Host "##[error]Missing '$expected' signature in $($_.FullName)"
+        } else {
+          Write-Host "OK: $($_.FullName)"
+        }
+      }
+      if ($missing.Count -gt 0) {
+        throw "ESRP did not apply a Developer ID signature to $($missing.Count) file(s): $($missing -join ', ')"
+      }
+    displayName: 'Verify Developer ID signature on Mach-O binaries'
+
   - template: /.pipelines/templates/step/finalize.yml@self


### PR DESCRIPTION
Backport of #27486 to release/v7.5.8

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27486$$$
-->

Triggered by @SeeminglyScience on behalf of @andyleejordan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds `codesign --verify --deep --strict` verification immediately after ESRP signing in `Sign_macOS_*` pipeline jobs. This ensures silent ESRP no-ops are caught in the signing job itself rather than discovered later in packaging, preventing publication of bad signed artifacts.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified by next pipeline run. This is a pipeline YAML-only change adding a defensive verification step — no unit tests apply. The original change was validated during a release build where ESRP silently no-op'd; this check would have caught it at the sign stage.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Pipeline YAML only — no runtime code changes. The added step is read-only verification (codesign --verify) that fails fast rather than publishing a bad artifact. No customer-facing behavior is affected.
