### PR TITLE
Fix HelpSystem tests for invariant culture

### DIFF
--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -417,29 +417,45 @@ Describe "Get-Help should find pattern alias" -Tags "CI" {
 
 Describe "help function uses full view by default" -Tags "CI" {
     BeforeAll {
+        $script:helpFullViewInvariantCultureLCID = [System.Globalization.CultureInfo]::InvariantCulture.LCID
+        $script:helpFullViewEnUSCulture = [System.Globalization.CultureInfo]::GetCultureInfo('en-US')
+    }
+
+    BeforeEach {
         $script:helpFullViewCultureState = @{
             CurrentCulture = [System.Globalization.CultureInfo]::CurrentCulture
             CurrentUICulture = [System.Globalization.CultureInfo]::CurrentUICulture
-            Changed = $false
+            CurrentCultureChanged = $false
+            CurrentUICultureChanged = $false
         }
 
-        if ($script:helpFullViewCultureState.CurrentCulture.LCID -eq 127 -or
-            $script:helpFullViewCultureState.CurrentUICulture.LCID -eq 127) {
-            # The full help content used by these assertions is localized for en-US.
-            $enUSCulture = [System.Globalization.CultureInfo]::GetCultureInfo('en-US')
-            [System.Globalization.CultureInfo]::CurrentCulture = $enUSCulture
-            [System.Globalization.CultureInfo]::CurrentUICulture = $enUSCulture
-            $script:helpFullViewCultureState.Changed = $true
+        # The full help content used by these assertions is localized for en-US.
+        if ($script:helpFullViewCultureState.CurrentCulture.LCID -eq $script:helpFullViewInvariantCultureLCID) {
+            [System.Globalization.CultureInfo]::CurrentCulture = $script:helpFullViewEnUSCulture
+            $script:helpFullViewCultureState.CurrentCultureChanged = $true
+        }
+
+        if ($script:helpFullViewCultureState.CurrentUICulture.LCID -eq $script:helpFullViewInvariantCultureLCID) {
+            [System.Globalization.CultureInfo]::CurrentUICulture = $script:helpFullViewEnUSCulture
+            $script:helpFullViewCultureState.CurrentUICultureChanged = $true
         }
     }
 
-    AfterAll {
-        if ($script:helpFullViewCultureState.Changed) {
+    AfterEach {
+        if ($script:helpFullViewCultureState.CurrentCultureChanged) {
             [System.Globalization.CultureInfo]::CurrentCulture = $script:helpFullViewCultureState.CurrentCulture
+        }
+
+        if ($script:helpFullViewCultureState.CurrentUICultureChanged) {
             [System.Globalization.CultureInfo]::CurrentUICulture = $script:helpFullViewCultureState.CurrentUICulture
         }
 
         $script:helpFullViewCultureState = $null
+    }
+
+    AfterAll {
+        $script:helpFullViewInvariantCultureLCID = $null
+        $script:helpFullViewEnUSCulture = $null
     }
 
     It "help should return full view without -Full switch" {

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -416,6 +416,32 @@ Describe "Get-Help should find pattern alias" -Tags "CI" {
 }
 
 Describe "help function uses full view by default" -Tags "CI" {
+    BeforeAll {
+        $script:helpFullViewCultureState = @{
+            CurrentCulture = [System.Globalization.CultureInfo]::CurrentCulture
+            CurrentUICulture = [System.Globalization.CultureInfo]::CurrentUICulture
+            Changed = $false
+        }
+
+        if ($script:helpFullViewCultureState.CurrentCulture.LCID -eq 127 -or
+            $script:helpFullViewCultureState.CurrentUICulture.LCID -eq 127) {
+            # The full help content used by these assertions is localized for en-US.
+            $enUSCulture = [System.Globalization.CultureInfo]::GetCultureInfo('en-US')
+            [System.Globalization.CultureInfo]::CurrentCulture = $enUSCulture
+            [System.Globalization.CultureInfo]::CurrentUICulture = $enUSCulture
+            $script:helpFullViewCultureState.Changed = $true
+        }
+    }
+
+    AfterAll {
+        if ($script:helpFullViewCultureState.Changed) {
+            [System.Globalization.CultureInfo]::CurrentCulture = $script:helpFullViewCultureState.CurrentCulture
+            [System.Globalization.CultureInfo]::CurrentUICulture = $script:helpFullViewCultureState.CurrentUICulture
+        }
+
+        $script:helpFullViewCultureState = $null
+    }
+
     It "help should return full view without -Full switch" {
         if (Test-IsWindowsArm64) {
             Set-ItResult -Pending -Because "IOException: The handle is invalid."


### PR DESCRIPTION
# PR Summary
Make the `help function uses full view by default` CI tests switch to `en-US` when the process culture or UI culture is invariant, then restore the original cultures after the describe block.

## PR Context
Fixes #27532.

These tests assert against the `PARAMETERS` section from the bundled full help content. On Linux environments where the culture resolves to invariant culture (LCID 127), the localized help content is not selected, so those assertions can fail even though the full-view behavior is not broken. This mirrors the invariant-culture guard already used by the UpdatableHelp tests.

## Validation
- `git diff --check -- test/powershell/engine/Help/HelpSystem.Tests.ps1`
- Parsed `test/powershell/engine/Help/HelpSystem.Tests.ps1` with `System.Management.Automation.Language.Parser`
- Verified the culture guard switches invariant culture to `en-US` and restores the saved cultures
- `Start-PSBuild -Clean -PSModuleRestore -UseNuGetOrg`
- `Start-PSPester -Path test/powershell/engine/Help/HelpSystem.Tests.ps1 -Tag CI -UseNuGetOrg` (local run reached the targeted file but the desktop host hit existing non-interactive Help test failures: invalid console handle in `help` calls plus unrelated help-file lookup misses)

## PR Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md) document.
- [x] If this PR is work in progress, I am opening the PR as a draft.
- [x] The PR is made against the `master` branch.
- [x] My commit messages follow the repository guidelines.
- [x] I have added tests or validation that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation, if appropriate.
