### PR TITLE
[release/v7.6.3] Skip Store Publish when No Channel Seleceted

### DIFF
--- a/.pipelines/templates/package-store-package.yml
+++ b/.pipelines/templates/package-store-package.yml
@@ -79,10 +79,24 @@ jobs:
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
-          else {
-            Write-Error "No valid channel detected"
-            exit 1
+          else { $null }
+
+        if (-not $currentChannel) {
+          Write-Host "##[warning]No release channel selected (LTS/Stable/Preview all false). Skipping Store package creation."
+          Write-Host "##vso[task.setvariable variable=SkipStorePublish]true"
+          # Set channel flags so any downstream conditioned tasks evaluate to skip.
+          Write-Host "##vso[task.setvariable variable=LTS]false"
+          Write-Host "##vso[task.setvariable variable=STABLE]false"
+          Write-Host "##vso[task.setvariable variable=PREVIEW]false"
+          # Ensure the output directory exists so downstream artifact publishing does not fail.
+          $outputDirectory = "$(ob_outputDirectory)"
+          if (-not (Test-Path -LiteralPath $outputDirectory)) {
+            New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
           }
+          return
+        }
+
+        Write-Host "##vso[task.setvariable variable=SkipStorePublish]false"
 
         $config = $channelConfigs[$currentChannel]
         Write-Verbose -Verbose "Selected channel: $currentChannel"
@@ -242,3 +256,4 @@ jobs:
           exit 1
         }
       displayName: 'Upload StoreBroker Package'
+      condition: and(succeeded(), ne(variables['SkipStorePublish'], 'true'))

--- a/.pipelines/templates/release-MSIX-Publish.yml
+++ b/.pipelines/templates/release-MSIX-Publish.yml
@@ -34,6 +34,7 @@ jobs:
     displayName: 'Capture ReleaseTag and Downloaded Packages'
 
   - task: PowerShell@2
+    condition: or(eq(variables['LTS'], 'true'), eq(variables['STABLE'], 'true'), eq(variables['PREVIEW'], 'true'))
     inputs:
       targetType: inline
       script: |
@@ -70,12 +71,13 @@ jobs:
     displayName: 'Add Changelog Link and Version Number to SBJSON'
 
   - task: PowerShell@2
+    condition: or(eq(variables['LTS'], 'true'), eq(variables['STABLE'], 'true'), eq(variables['PREVIEW'], 'true'))
     inputs:
       targetType: inline
       script: |
         # Convert ADO variables to PowerShell boolean variables
         $IsLTS = '$(LTS)' -eq 'true'
-        $IsStable = '$(STABLE)' -eq 'true' 
+        $IsStable = '$(STABLE)' -eq 'true'
         $IsPreview = '$(PREVIEW)' -eq 'true'
 
         Write-Verbose -Verbose "Channel Selection - LTS: $(LTS), Stable: $(STABLE), Preview: $(PREVIEW)"
@@ -83,10 +85,12 @@ jobs:
         $currentChannel = if ($IsLTS) { 'LTS' }
           elseif ($IsStable) { 'Stable' }
           elseif ($IsPreview) { 'Preview' }
-          else { 
-            Write-Error "No valid channel detected"
-            exit 1
-          }
+          else { $null }
+
+        if (-not $currentChannel) {
+          Write-Host "##[warning]No release channel selected (LTS/Stable/Preview all false). Skipping Store publish."
+          return
+        }
 
         # Assign AppID for Store-Publish Task
         $appID = $null


### PR DESCRIPTION
Backport of #27334 to release/v7.6.3

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27334$$$
-->

Triggered by @TravisEz13 on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Prevents pipeline failure when no release channel (LTS/Stable/Preview) is selected by skipping Store package creation and publish steps gracefully.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Pipeline tested by running without a channel selection to verify it skips gracefully instead of failing.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Pipeline-only change that adds graceful skip logic when no channel is selected. No runtime code changes.
