### PR TITLE
[release/v7.5.8] Remove the unused `Publish-NugetToMyGet` command from packaging module

### DIFF
--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -21,7 +21,6 @@
         'New-ILNugetPackageFromSource'
         'New-PSBuildZip'
         'New-PSSignedBuildZip'
-        'Publish-NugetToMyGet'
         'Start-PSPackage'
         'Test-PackageManifest'
         'Update-PSSignedBuildFolder'

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -3592,42 +3592,6 @@ function New-NugetPackage
     Pop-Location
 }
 
-<#
-.SYNOPSIS
-Publish the specified Nuget Package to MyGet feed.
-
-.DESCRIPTION
-The specified nuget package is published to the powershell.myget.org/powershell-core feed.
-
-.PARAMETER PackagePath
-Path to the NuGet Package.
-
-.PARAMETER ApiKey
-API key for powershell.myget.org
-#>
-function Publish-NugetToMyGet
-{
-    param(
-        [Parameter(Mandatory = $true)]
-        [string] $PackagePath,
-
-        [Parameter(Mandatory = $true)]
-        [string] $ApiKey
-    )
-
-    $nuget = Get-Command -Type Application nuget -ErrorAction SilentlyContinue
-
-    if ($null -eq $nuget)
-    {
-        throw 'nuget application is not available in PATH'
-    }
-
-    Get-ChildItem $PackagePath | ForEach-Object {
-        Write-Log "Pushing $_ to PowerShell Myget"
-        Start-NativeExecution { nuget push $_.FullName -Source 'https://powershell.myget.org/F/powershell-core/api/v2/package' -ApiKey $ApiKey } > $null
-    }
-}
-
 function New-SubFolder
 {
     [CmdletBinding(SupportsShouldProcess=$true)]


### PR DESCRIPTION
Backport of #27403 to release/v7.5.8

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27403$$$
-->

Triggered by @TravisEz13 on behalf of @daxian-dbw

Original CL Label: CL-CodeCleanup

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Removes unused Publish-NugetToMyGet function from the packaging module. MyGet publishing has been retired for years.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Verified the removed function is not referenced anywhere in the codebase or pipelines.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Removes dead code for a service (MyGet) that hasn't been used in years. No functional impact.
