### PR TITLE
[release/v7.6.3] Add PMC mappings for debian12 arm64 and debian13 arm64

### DIFF
--- a/tools/packages.microsoft.com/mapping.json
+++ b/tools/packages.microsoft.com/mapping.json
@@ -89,11 +89,25 @@
           "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
       },
       {
+          "url": "microsoft-debian-bookworm-prod",
+          "distribution": [
+              "bookworm"
+          ],
+          "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_arm64.deb"
+      },
+      {
           "url": "microsoft-debian-trixie-prod",
           "distribution": [
               "trixie"
           ],
           "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_amd64.deb"
+      },
+      {
+          "url": "microsoft-debian-trixie-prod",
+          "distribution": [
+              "trixie"
+          ],
+          "PackageFormat": "PACKAGE_NAME_POWERSHELL_RELEASE-1.deb_arm64.deb"
       },
       {
           "url": "microsoft-ubuntu-bionic-prod",


### PR DESCRIPTION
Backport of #27491 to release/v7.6.3

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27491$$$
-->

Triggered by @SeeminglyScience on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds Packages.microsoft.com (PMC) mappings for debian12 arm64 and debian13 arm64, required for packaging support on those platforms.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

This is a packaging configuration change adding new platform mappings. Verified by the original PR which resolved issue #24076. The change is additive and does not affect existing mappings.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Adding new platform mappings is purely additive with no changes to existing functionality or configuration.
