### PR TITLE
Declare native execution in macOS .app bundle Info.plist

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1242,7 +1242,7 @@ function New-UnixPackage {
             if ($PSCmdlet.ShouldProcess("Add macOS launch application"))
             {
                 # Generate launcher app folder
-                $AppsFolder = New-MacOSLauncher -Version $Version
+                $AppsFolder = New-MacOSLauncher -Version $Version -HostArchitecture $HostArchitecture
             }
         }
 
@@ -2369,7 +2369,13 @@ function New-MacOSLauncher
         [Parameter(Mandatory)]
         [String]$Version,
 
-        [switch]$LTS
+        [switch]$LTS,
+
+        # When "arm64", emits LSRequiresNativeExecution in the app's Info.plist so
+        # Apple Silicon Launch Services does not offer Rosetta when launching
+        # /Applications/PowerShell.app. Leave empty / non-arm64 to preserve the
+        # ability to launch x86_64 builds under Rosetta on Apple Silicon.
+        [string]$HostArchitecture
     )
 
     $packageInfo = Get-MacOSPackageIdentifierInfo -Version $Version -LTS:$LTS
@@ -2398,9 +2404,18 @@ function New-MacOSLauncher
     # Copy icns file.
     Copy-Item -Force -Path $iconfile -Destination "$macosapp/Contents/Resources"
 
+    # On arm64 builds, declare native execution so Launch Services does not
+    # offer Rosetta for the bundle. Omitted on x86_64 so that build remains
+    # launchable under Rosetta if installed on Apple Silicon.
+    $nativeExecutionKey = if ($HostArchitecture -eq "arm64") {
+        "    <key>LSRequiresNativeExecution</key>`n    <true/>`n"
+    } else {
+        ""
+    }
+
     # Create plist file.
     $plist = "$macosapp/Contents/Info.plist"
-    $plistcontent = $packagingStrings.MacOSLauncherPlistTemplate -f $packageId, $Version, $iconfilebase
+    $plistcontent = $packagingStrings.MacOSLauncherPlistTemplate -f $packageId, $Version, $iconfilebase, $nativeExecutionKey
     $plistcontent | Out-File -Force -Path $plist -Encoding utf8
 
     # Create shell script.

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2371,10 +2371,12 @@ function New-MacOSLauncher
 
         [switch]$LTS,
 
-        # When "arm64", emits LSRequiresNativeExecution in the app's Info.plist so
-        # Apple Silicon Launch Services does not offer Rosetta when launching
-        # /Applications/PowerShell.app. Leave empty / non-arm64 to preserve the
-        # ability to launch x86_64 builds under Rosetta on Apple Silicon.
+        # The CPU architecture of the target package ("arm64" or "x86_64").
+        # Because the bundle executable is a shell script rather than a Mach-O binary,
+        # Launch Services cannot infer the supported architecture and defaults to
+        # offering Rosetta translation. When "arm64", LSRequiresNativeExecution is
+        # added to Info.plist to suppress the Rosetta prompt on Apple Silicon. Omitted
+        # for x86_64 so that build remains launchable under Rosetta on Apple Silicon.
         [string]$HostArchitecture
     )
 
@@ -2404,9 +2406,10 @@ function New-MacOSLauncher
     # Copy icns file.
     Copy-Item -Force -Path $iconfile -Destination "$macosapp/Contents/Resources"
 
-    # On arm64 builds, declare native execution so Launch Services does not
-    # offer Rosetta for the bundle. Omitted on x86_64 so that build remains
-    # launchable under Rosetta if installed on Apple Silicon.
+    # Launch Services cannot infer CPU architecture from a shell script launcher
+    # and defaults to offering Rosetta translation. LSRequiresNativeExecution
+    # suppresses that prompt for arm64 builds; the key is omitted for x86_64
+    # so that build remains launchable under Rosetta on Apple Silicon.
     $nativeExecutionKey = if ($HostArchitecture -eq "arm64") {
         "    <key>LSRequiresNativeExecution</key>`n    <true/>`n"
     } else {

--- a/tools/packaging/packaging.strings.psd1
+++ b/tools/packaging/packaging.strings.psd1
@@ -116,9 +116,7 @@ open {0}
     </array>
     <key>CFBundleVersion</key>
     <string>{1}</string>
-    <key>LSRequiresNativeExecution</key>
-    <true/>
-</dict>
+{3}</dict>
 </plist>
 '@
 

--- a/tools/packaging/packaging.strings.psd1
+++ b/tools/packaging/packaging.strings.psd1
@@ -116,6 +116,8 @@ open {0}
     </array>
     <key>CFBundleVersion</key>
     <string>{1}</string>
+    <key>LSRequiresNativeExecution</key>
+    <true/>
 </dict>
 </plist>
 '@


### PR DESCRIPTION
# PR Summary

Adds `LSRequiresNativeExecution = true` to the macOS launcher app `Info.plist` template so opening `/Applications/PowerShell.app` on Apple Silicon does not trigger a Rosetta prompt.

## PR Context

On Apple Silicon, double-clicking `/Applications/PowerShell.app` from the `osx-arm64.pkg` produces a "To open PowerShell, you need to install Rosetta" prompt, even though the underlying `pwsh` binary is arm64-native and running `pwsh` from a terminal works without any prompt. This has been reported repeatedly (#18548, #27587, and historical #17130 whose original dylib root cause no longer applies — `libmi.dylib` / `libpsrpclient.dylib` were removed and all remaining dylibs in the arm64 package are arm64 or universal).

The surviving root cause is in the static bundle metadata generated from `tools/packaging/packaging.strings.psd1`:

- `CFBundleExecutable` is a shell script (`PowerShell.sh`), not a Mach-O binary, so Launch Services cannot infer architecture from the executable.
- The bundle is unsigned.
- The `Info.plist` has no `LSRequiresNativeExecution` key.

With nothing telling Launch Services the bundle is native, Apple Silicon defaults to offering Rosetta. Ironically the actual `pwsh` that ends up running is arm64 either way — Rosetta would only be wrapping the launcher script.

Setting `LSRequiresNativeExecution = true` tells Launch Services explicitly that the bundle must run natively, which suppresses the Rosetta prompt on Apple Silicon. The key is a no-op on Intel Macs (no Rosetta translates Intel binaries on Intel hardware), so it is safe to add to the shared template used for both `osx-arm64.pkg` and `osx-x64.pkg` builds without conditional logic.

Verified on a fresh install of `powershell-7.6.2-osx-arm64.pkg`:

```
$ file /usr/local/microsoft/powershell/7/pwsh
/usr/local/microsoft/powershell/7/pwsh: Mach-O 64-bit executable arm64

$ /usr/libexec/PlistBuddy -c "Print" /Applications/PowerShell.app/Contents/Info.plist
# (no LSRequiresNativeExecution key)

$ codesign -dvv /Applications/PowerShell.app
/Applications/PowerShell.app: code object is not signed at all
```

The existing macOS package validation tests in `test/packaging/macos/package-validation.tests.ps1` verify that the plist exists and the bundle structure is correct, but do not assert on plist contents, so no test changes are required.

Fixes #18548

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively