### PR TITLE
Preserve source directories for wildcard Move-Item destinations

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -3000,8 +3000,24 @@ namespace Microsoft.PowerShell.Commands
                     out destinationProvider,
                     out destinationDrive);
             }
-            catch (Exception e) when (WritePathResolutionError(e))
+            catch (PSNotSupportedException notSupported)
             {
+                WritePathResolutionError(notSupported);
+                return false;
+            }
+            catch (DriveNotFoundException driveNotFound)
+            {
+                WritePathResolutionError(driveNotFound);
+                return false;
+            }
+            catch (ProviderNotFoundException providerNotFound)
+            {
+                WritePathResolutionError(providerNotFound);
+                return false;
+            }
+            catch (ItemNotFoundException pathNotFound)
+            {
+                WritePathResolutionError(pathNotFound);
                 return false;
             }
 
@@ -3246,24 +3262,22 @@ namespace Microsoft.PowerShell.Commands
         }
         #endregion Command code
 
-        private bool WritePathResolutionError(Exception exception)
+        private void WritePathResolutionError(Exception exception)
         {
             switch (exception)
             {
                 case PSNotSupportedException notSupported:
                     WriteError(new ErrorRecord(notSupported.ErrorRecord, notSupported));
-                    return true;
+                    break;
                 case DriveNotFoundException driveNotFound:
                     WriteError(new ErrorRecord(driveNotFound.ErrorRecord, driveNotFound));
-                    return true;
+                    break;
                 case ProviderNotFoundException providerNotFound:
                     WriteError(new ErrorRecord(providerNotFound.ErrorRecord, providerNotFound));
-                    return true;
+                    break;
                 case ItemNotFoundException pathNotFound:
                     WriteError(new ErrorRecord(pathNotFound.ErrorRecord, pathNotFound));
-                    return true;
-                default:
-                    return false;
+                    break;
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2998,24 +2998,8 @@ namespace Microsoft.PowerShell.Commands
                     out destinationProvider,
                     out destinationDrive);
             }
-            catch (PSNotSupportedException notSupported)
+            catch (Exception e) when (WritePathResolutionError(e))
             {
-                WriteError(new ErrorRecord(notSupported.ErrorRecord, notSupported));
-                return false;
-            }
-            catch (DriveNotFoundException driveNotFound)
-            {
-                WriteError(new ErrorRecord(driveNotFound.ErrorRecord, driveNotFound));
-                return false;
-            }
-            catch (ProviderNotFoundException providerNotFound)
-            {
-                WriteError(new ErrorRecord(providerNotFound.ErrorRecord, providerNotFound));
-                return false;
-            }
-            catch (ItemNotFoundException pathNotFound)
-            {
-                WriteError(new ErrorRecord(pathNotFound.ErrorRecord, pathNotFound));
                 return false;
             }
 
@@ -3261,6 +3245,27 @@ namespace Microsoft.PowerShell.Commands
         #endregion Command code
 
         private bool _destinationContainerCreated;
+
+        private bool WritePathResolutionError(Exception exception)
+        {
+            switch (exception)
+            {
+                case PSNotSupportedException notSupported:
+                    WriteError(new ErrorRecord(notSupported.ErrorRecord, notSupported));
+                    return true;
+                case DriveNotFoundException driveNotFound:
+                    WriteError(new ErrorRecord(driveNotFound.ErrorRecord, driveNotFound));
+                    return true;
+                case ProviderNotFoundException providerNotFound:
+                    WriteError(new ErrorRecord(providerNotFound.ErrorRecord, providerNotFound));
+                    return true;
+                case ItemNotFoundException pathNotFound:
+                    WriteError(new ErrorRecord(pathNotFound.ErrorRecord, pathNotFound));
+                    return true;
+                default:
+                    return false;
+            }
+        }
 
     }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2979,6 +2979,105 @@ namespace Microsoft.PowerShell.Commands
             return results;
         }
 
+        private bool EnsureDestinationContainerForMultipleMoves(Collection<PathInfo> resolvedPaths)
+        {
+            if (_destinationContainerCreated || resolvedPaths.Count < 2)
+            {
+                return true;
+            }
+
+            CmdletProviderContext currentContext = CmdletProviderContext;
+            ProviderInfo destinationProvider;
+            PSDriveInfo destinationDrive;
+
+            try
+            {
+                _ = SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+                    Destination,
+                    currentContext,
+                    out destinationProvider,
+                    out destinationDrive);
+            }
+            catch (PSNotSupportedException notSupported)
+            {
+                WriteError(new ErrorRecord(notSupported.ErrorRecord, notSupported));
+                return false;
+            }
+            catch (DriveNotFoundException driveNotFound)
+            {
+                WriteError(new ErrorRecord(driveNotFound.ErrorRecord, driveNotFound));
+                return false;
+            }
+            catch (ProviderNotFoundException providerNotFound)
+            {
+                WriteError(new ErrorRecord(providerNotFound.ErrorRecord, providerNotFound));
+                return false;
+            }
+            catch (ItemNotFoundException pathNotFound)
+            {
+                WriteError(new ErrorRecord(pathNotFound.ErrorRecord, pathNotFound));
+                return false;
+            }
+
+            if (!destinationProvider.Name.Equals(FileSystemProvider.ProviderName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            foreach (PathInfo resolvedPath in resolvedPaths)
+            {
+                if (!resolvedPath.Provider.Name.Equals(destinationProvider.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            if (InvokeProvider.Item.Exists(Destination, currentContext))
+            {
+                if (!InvokeProvider.Item.IsContainer(Destination, currentContext))
+                {
+                    ArgumentException argException =
+                        PSTraceSource.NewArgumentException(
+                            "Destination",
+                            SessionStateStrings.MoveItemPathMultipleDestinationNotContainer);
+
+                    WriteError(
+                        new ErrorRecord(
+                            argException,
+                            argException.GetType().FullName,
+                            ErrorCategory.InvalidArgument,
+                            Destination));
+
+                    return false;
+                }
+
+                return true;
+            }
+
+            string destinationRoot = destinationDrive != null ? destinationDrive.Root : string.Empty;
+            string parent = SessionState.Path.ParseParent(Destination, destinationRoot, currentContext);
+            if (!string.IsNullOrEmpty(parent) &&
+                (!InvokeProvider.Item.Exists(parent, currentContext) ||
+                 !InvokeProvider.Item.IsContainer(parent, currentContext)))
+            {
+                return true;
+            }
+
+            bool passThru = currentContext.PassThru;
+            try
+            {
+                currentContext.PassThru = false;
+                InvokeProvider.Item.New(Destination, null, "Directory", null, currentContext);
+            }
+            finally
+            {
+                currentContext.PassThru = passThru;
+            }
+
+            _destinationContainerCreated = true;
+            return true;
+        }
+
         /// <summary>
         /// Moves the specified item to the specified destination.
         /// </summary>
@@ -2993,6 +3092,10 @@ namespace Microsoft.PowerShell.Commands
                 else
                 {
                     Collection<PathInfo> resolvedPaths = GetResolvedPaths(path);
+                    if (!EnsureDestinationContainerForMultipleMoves(resolvedPaths))
+                    {
+                        continue;
+                    }
 
                     foreach (PathInfo resolvedPathInfo in resolvedPaths)
                     {
@@ -3156,6 +3259,8 @@ namespace Microsoft.PowerShell.Commands
             }
         }
         #endregion Command code
+
+        private bool _destinationContainerCreated;
 
     }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2936,6 +2936,8 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private bool _passThrough;
 
+        private bool _destinationContainerCreated;
+
         #endregion Command data
 
         #region Command code
@@ -3243,8 +3245,6 @@ namespace Microsoft.PowerShell.Commands
             }
         }
         #endregion Command code
-
-        private bool _destinationContainerCreated;
 
         private bool WritePathResolutionError(Exception exception)
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -152,6 +152,25 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             "$destDir/$testDir/$testFile" | Should -Exist
         }
 
+        It "Verify Move-Item with wildcard preserves source directories when creating destination container" {
+            $installDir = Join-Path $TestDrive "install"
+            $copyDir = Join-Path $TestDrive "copy"
+            $destination = Join-Path $copyDir "app"
+
+            $null = New-Item -ItemType Directory -Path (Join-Path $installDir "bin") -ErrorAction Stop
+            $null = New-Item -ItemType File -Path (Join-Path (Join-Path $installDir "bin") "test.dll") -ErrorAction Stop
+            $null = New-Item -ItemType Directory -Path (Join-Path $installDir "lib") -ErrorAction Stop
+            $null = New-Item -ItemType File -Path (Join-Path $installDir "ReadMe.md") -ErrorAction Stop
+            $null = New-Item -ItemType Directory -Path $copyDir -ErrorAction Stop
+
+            Move-Item -Path (Join-Path $installDir "*") -Destination $destination -ErrorAction Stop
+
+            (Join-Path (Join-Path $destination "bin") "test.dll") | Should -Exist
+            (Join-Path $destination "lib") | Should -Exist
+            (Join-Path $destination "ReadMe.md") | Should -Exist
+            (Join-Path $destination "test.dll") | Should -Not -Exist
+        }
+
         It "Verify Move-Item across devices for directory" {
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('ThrowExdevErrorOnMoveDirectory', $true)
             try


### PR DESCRIPTION
## Summary
- Create the missing FileSystem destination container before moving multiple wildcard-expanded sources.
- Add regression coverage for `Move-Item -Path install/* -Destination copy/app` so the first source directory is preserved.

## Root cause
`Move-Item` resolves wildcard sources and moves each resolved item one at a time. When the shared destination did not exist yet, the first directory source could be renamed to that destination, which flattened that directory's contents instead of creating `copy/app/bin`.

## Tests
- `pwsh -NoProfile -Command '$parseErrors = $null; $tokens = $null; [System.Management.Automation.Language.Parser]::ParseFile("test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1", [ref]$tokens, [ref]$parseErrors) > $null; if ($parseErrors) { $parseErrors | Format-List | Out-String; exit 1 }'`
- `git diff --check`
- `dotnet build src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj -c Debug -p:SkipExperimentalFeatureGeneration=true -nodeReuse:false`
- `dotnet build src/powershell-win-core/powershell-win-core.csproj -c Debug -p:SkipExperimentalFeatureGeneration=true -nodeReuse:false`
- Built `pwsh.dll` manual regression for the issue repro with relative paths: `Move-Item -Path "install/*" -Destination "copy/app"`
- Built `pwsh.dll` `-WhatIf` sanity check confirmed no destination was created
- `Invoke-Pester -Script test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1 -PassThru` confirmed the new regression passes; the full file also reports unrelated local failures for Appx/symlink/admin-dependent tests on this non-elevated Windows environment.

Fixes #24837