### PR TITLE
Bring Changelogs to Master Branch v7.4.17, v7.5.8, v7.6.3

### DIFF
--- a/CHANGELOG/7.4.md
+++ b/CHANGELOG/7.4.md
@@ -1,5 +1,38 @@
 # 7.4 Changelog
 
+## [7.4.17]
+
+### Code Cleanup
+
+<details>
+
+<ul>
+<li>Remove the unused <code>Publish-NugetToMyGet</code> command from packaging module (#27574)</li>
+</ul>
+
+</details>
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 8.0.422</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release (#27580)</li>
+<li>Skip Store Publish when No Channel Selected (#27571)</li>
+<li>Verify Apple codesign immediately after ESRP signing (#27540)</li>
+<li>Remove unused step that clones <code>Internal-PowerShellTeam-Tools</code> repo in PMC publish pipeline (#27497)</li>
+</ul>
+
+</details>
+
+[7.4.17]: https://github.com/PowerShell/PowerShell/compare/v7.4.16...v7.4.17
+
 ## [7.4.16]
 
 ### Engine Updates and Fixes

--- a/CHANGELOG/7.5.md
+++ b/CHANGELOG/7.5.md
@@ -1,5 +1,44 @@
 # 7.5 Changelog
 
+## [7.5.8]
+
+### Code Cleanup
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 9.0.315</p>
+
+</summary>
+
+<ul>
+<li>Remove the unused <code>Publish-NugetToMyGet</code> command from packaging module (#27575)</li>
+</ul>
+
+</details>
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 9.0.315</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release (#27581)</li>
+<li>Skip Store Publish when No Channel Selected (#27572)</li>
+<li>Verify Apple codesign immediately after ESRP signing (#27541)</li>
+<li>Remove unused step that clones <code>Internal-PowerShellTeam-Tools</code> repo in PMC publish pipeline (#27498)</li>
+</ul>
+
+</details>
+
+[7.5.8]: https://github.com/PowerShell/PowerShell/compare/v7.5.7...v7.5.8
+
 ## [7.5.7]
 
 ### Engine Updates and Fixes

--- a/CHANGELOG/7.6.md
+++ b/CHANGELOG/7.6.md
@@ -1,5 +1,27 @@
 # 7.6 Changelog
 
+## [7.6.3]
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 10.0.301</p>
+
+</summary>
+
+<ul>
+<li>Remove the unused <code>Publish-NugetToMyGet</code> command from packaging module (#27576)</li>
+<li>Verify Apple codesign immediately after ESRP signing (#27542)</li>
+<li>Remove unused step to clone Internal-PowerShellTeam-Tools repo in PMC publish pipeline (#27496)</li>
+</ul>
+
+</details>
+
+[7.6.3]: https://github.com/PowerShell/PowerShell/compare/v7.6.2...v7.6.3
+
 ## [7.6.2]
 
 ### Engine Updates and Fixes


### PR DESCRIPTION
- **Update 7.4 changelog for v7.4.17 (#27590)**
- **Update 7.5 changelog for v7.5.8 (#27589)**
- **Update CHANGELOG for v7.6.3 (#27593)**

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates the changelogs for versions 7.4.17, 7.5.8, and 7.6.3 to document recent code cleanup and build/packaging improvements. The main changes include removing unused commands and steps from the packaging process, updating the .NET SDK versions, and improving the Apple codesigning verification process.

Build and Packaging Improvements:
* Updated to newer .NET SDK versions in each release: 8.0.422 for 7.4.17, 9.0.315 for 7.5.8, and 10.0.301 for 7.6.3. [[1]](diffhunk://#diff-40aa312efa433f92e80795d4c6d41ef27587e14e0533ff7c7c1fc3a940a6bb89R3-R35) [[2]](diffhunk://#diff-be20ddee0e7ceba662992c80e10decc95d152de059de46b82fca98008cfcc1e3R3-R41) [[3]](diffhunk://#diff-4c1ba42ccc2cfa42937ff5c2d5d150940d6e0de657c0a18d7349c0b99c11a30fR3-R24)
* Improved the Apple codesigning process by verifying the codesign immediately after ESRP signing. [[1]](diffhunk://#diff-40aa312efa433f92e80795d4c6d41ef27587e14e0533ff7c7c1fc3a940a6bb89R3-R35) [[2]](diffhunk://#diff-be20ddee0e7ceba662992c80e10decc95d152de059de46b82fca98008cfcc1e3R3-R41) [[3]](diffhunk://#diff-4c1ba42ccc2cfa42937ff5c2d5d150940d6e0de657c0a18d7349c0b99c11a30fR3-R24)
* Removed unused steps that cloned the `Internal-PowerShellTeam-Tools` repository in the PMC publish pipeline. [[1]](diffhunk://#diff-40aa312efa433f92e80795d4c6d41ef27587e14e0533ff7c7c1fc3a940a6bb89R3-R35) [[2]](diffhunk://#diff-be20ddee0e7ceba662992c80e10decc95d152de059de46b82fca98008cfcc1e3R3-R41) [[3]](diffhunk://#diff-4c1ba42ccc2cfa42937ff5c2d5d150940d6e0de657c0a18d7349c0b99c11a30fR3-R24)
* Added logic to skip Store Publish when no channel is selected. [[1]](diffhunk://#diff-40aa312efa433f92e80795d4c6d41ef27587e14e0533ff7c7c1fc3a940a6bb89R3-R35) [[2]](diffhunk://#diff-be20ddee0e7ceba662992c80e10decc95d152de059de46b82fca98008cfcc1e3R3-R41)

Code Cleanup:
* Removed the unused `Publish-NugetToMyGet` command from the packaging module. [[1]](diffhunk://#diff-40aa312efa433f92e80795d4c6d41ef27587e14e0533ff7c7c1fc3a940a6bb89R3-R35) [[2]](diffhunk://#diff-be20ddee0e7ceba662992c80e10decc95d152de059de46b82fca98008cfcc1e3R3-R41) [[3]](diffhunk://#diff-4c1ba42ccc2cfa42937ff5c2d5d150940d6e0de657c0a18d7349c0b99c11a30fR3-R24)

## PR Context

This is bringing the changelogs from the recent releases to the master branch.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
