### PR TITLE
Add fallback to session state if function definition in Ast is broken in PseudoBinding

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1198,7 +1198,17 @@ namespace System.Management.Automation.Language
             string commandName = null;
             try
             {
-                processor = PrepareFromAst(context, out commandName) ?? context.CreateCommand(commandName, dotSource, forCompletion:true);
+                processor = PrepareFromAst(context, out commandName);
+            }
+            catch (RuntimeException)
+            {
+                // There's an issue with the function definition.
+                // We ignore it because an older working definition can have been loaded into the session state already.
+            }
+
+            try
+            {
+                processor ??= context.CreateCommand(commandName, dotSource, forCompletion: true);
             }
             catch (RuntimeException)
             {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -3893,6 +3893,10 @@ function MyFunction ($param1, $param2)
             }
         }
 
+        AfterAll {
+            Remove-Item function:BrokenFunctionTest -ErrorAction SilentlyContinue
+        }
+
         It 'Should complete parameters of a function with missing types' {
             $res = TabExpansion2 -inputScript @'
 function BrokenFunctionTest
@@ -3908,7 +3912,7 @@ function BrokenFunctionTest
 
 BrokenFunctionTest -Param
 '@
-            $res.CompletionMatches[0].CompletionText | Should -Be '-Param1'
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly '-Param1'
         }
 
         It 'Should complete output members from a function with missing types' {
@@ -3926,7 +3930,7 @@ function BrokenFunctionTest
 
 (BrokenFunctionTest).Lengt
 '@
-            $res.CompletionMatches[0].CompletionText | Should -Be 'Length'
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Length'
         }
     }
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -3877,6 +3877,58 @@ function MyFunction ($param1, $param2)
         $res = TabExpansion2 -inputScript $Text -cursorColumn ($Text.Length - 1)
         $res.CompletionMatches | Should -HaveCount 0
     }
+
+    Context "Tab completion with broken function definition" {
+        BeforeAll {
+            # First define and load a working version of the function
+            function BrokenFunctionTest
+            {
+                [OutputType([string])]
+                param
+                (
+                    [Parameter()]
+                    [string]
+                    $Param1
+                )
+            }
+        }
+
+        It 'Should complete parameters of a function with missing types' {
+            $res = TabExpansion2 -inputScript @'
+function BrokenFunctionTest
+{
+    [OutputType([THISTYPEDOESNOTEXIST])]
+    param
+    (
+        [Parameter()]
+        [THISTYPEDOESNOTEXIST]
+        $Param1
+    )
+}
+
+BrokenFunctionTest -Param
+'@
+            $res.CompletionMatches[0].CompletionText | Should -Be '-Param1'
+        }
+
+        It 'Should complete output members from a function with missing types' {
+            $res = TabExpansion2 -inputScript @'
+function BrokenFunctionTest
+{
+    [OutputType([THISTYPEDOESNOTEXIST])]
+    param
+    (
+        [Parameter()]
+        [THISTYPEDOESNOTEXIST]
+        $Param1
+    )
+}
+
+(BrokenFunctionTest).Lengt
+'@
+            $res.CompletionMatches[0].CompletionText | Should -Be 'Length'
+        }
+    }
 }
 
 Describe "TabCompletion elevated tests" -Tags CI, RequireAdminOnWindows {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR updates the PseudoBinding logic so there is a fallback to the session state if a function definition in the script text is broken for whatever reason.
This is intended as a workaround for the issue where you can't tab complete function parameters inside a script if the function uses a PowerShell class. Like in this scenario:
```
enum Animals
{
    Dog    = 0
    Cat    = 1
}
function Demo
{
    [OutputType([string])]
    Param
    (
        [Parameter()]
        [Animals]
        $Param1
    )
}

Demo -<Tab>
# or
(Demo).<Tab>
```
After this change you can load the class and function definitions into the session state (select them and press F8 in ISE/VS code) and now the tab completion will use the definitions found in the session state.

Ideally the PseudoBinding would be able to handle PowerShell classes in a scenario like this, but it relies on compiling the function definition, and when it does that it can't find the class.
I believe a proper fix would be to revamp the PseudoBinding so it doesn't have to compile the function definitions it finds, and can instead use static analysis of the function definition ast to determine the available parameters and output type. However, in the interest of reducing the workload for both me and the reviewer(s) <Looks at the 276 pending PRs> I have opted for this simple approach that can hopefully get through the process a little quicker.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
This fixes one of my main issues when working with PowerShell classes.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [X] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
