### PR TITLE
Replace `lock(this)` with private lock object in `CompiledScriptBlockData`

### DIFF
--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -84,7 +84,7 @@ namespace System.Management.Automation
 
         private void InitializeMetadata()
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_attributes != null)
                 {
@@ -132,7 +132,7 @@ namespace System.Management.Automation
 
         private void CompileUnoptimized()
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_compiledUnoptimized)
                 {
@@ -147,7 +147,7 @@ namespace System.Management.Automation
 
         private void CompileOptimized()
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_compiledOptimized)
                 {
@@ -291,7 +291,7 @@ namespace System.Management.Automation
 
         private IParameterMetadataProvider DelayParseScriptText()
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_ast != null)
                 {
@@ -345,6 +345,8 @@ namespace System.Management.Automation
         #endregion Named Blocks
 
         internal IScriptExtent[] SequencePoints { get; set; }
+
+        private readonly object _lock = new object();
 
         private RuntimeDefinedParameterDictionary _runtimeDefinedParameterDictionary;
         private Attribute[] _attributes;
@@ -473,7 +475,7 @@ namespace System.Management.Automation
             {
                 if (_expAttribute == ExperimentalAttribute.None)
                 {
-                    lock (this)
+                    lock (_lock)
                     {
                         if (_expAttribute == ExperimentalAttribute.None)
                         {
@@ -492,7 +494,7 @@ namespace System.Management.Automation
         {
             if (_parameterMetadata == null)
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (_parameterMetadata == null)
                     {


### PR DESCRIPTION
## PR Summary

Replace six instances of `lock(this)` with `lock(_lock)` using a dedicated private readonly object field to avoid synchronizing on the instance itself.

## PR Context

Using `this` as a synchronization object is dangerous because external code could also lock on the same instance, leading to deadlocks or unexpected contention. This is a common threading anti-pattern flagged by static analysis.

## PR Checklist

- [x] PR title is meaningful and in present tense, imperative mood
- [x] Changes are summarized in the PR description
- [x] All files have the Microsoft copyright header
- [x] **Ready for review** -- this is not a Draft PR
- [x] Breaking changes: **None**
- [x] User-facing changes: **No**
- [ ] Testing: **N/A** -- refactoring only, no behavioral change