### PR TITLE
Add trace logging to empty catch blocks in `CommandDiscovery`

### DIFF
--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -688,8 +688,9 @@ namespace System.Management.Automation
 
                     discoveryTracer.WriteLine("PreCommandLookupAction returned: {0}", eventArgs.Command);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
+                    discoveryTracer.TraceError("PreCommandLookupAction threw: {0}", e.Message);
                 }
                 finally { context.CommandDiscovery.UnregisterLookupCommandInfoAction("ActivePreLookup", commandName); }
             }
@@ -1041,8 +1042,9 @@ namespace System.Management.Automation
                 }
             }
             catch (CommandNotFoundException) { throw; }
-            catch (Exception)
+            catch (Exception e)
             {
+                discoveryTracer.TraceError("Module auto-discovery threw: {0}", e.Message);
             }
             finally
             {

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -690,7 +690,7 @@ namespace System.Management.Automation
                 }
                 catch (Exception e)
                 {
-                    discoveryTracer.TraceError("PreCommandLookupAction threw: {0}", e.Message);
+                    discoveryTracer.TraceError("PreCommandLookupAction for '{0}' threw: {1}", commandName, e);
                 }
                 finally { context.CommandDiscovery.UnregisterLookupCommandInfoAction("ActivePreLookup", commandName); }
             }
@@ -1044,7 +1044,7 @@ namespace System.Management.Automation
             catch (CommandNotFoundException) { throw; }
             catch (Exception e)
             {
-                discoveryTracer.TraceError("Module auto-discovery threw: {0}", e.Message);
+                discoveryTracer.TraceError("Module auto-discovery for '{0}' threw: {1}", commandName, e);
             }
             finally
             {


### PR DESCRIPTION
## PR Summary

Add `discoveryTracer.TraceError()` calls to two empty catch blocks in `CommandDiscovery.LookupCommandInfo` that were silently swallowing all exceptions.

## PR Context

Two catch blocks — one for `PreCommandLookupAction` invoker exceptions and one for module auto-discovery exceptions — were catching `Exception` with an empty body. This hides failures from diagnostic traces and makes debugging difficult. Both handlers are intentional (external event handlers should not crash command lookup, and module discovery failures should degrade gracefully), but the exceptions should still be logged when tracing is enabled.

## PR Checklist

- [x] PR title is meaningful and in present tense, imperative mood
- [x] Changes are summarized in the PR description
- [x] All files have the Microsoft copyright header
- [x] **Ready for review** -- this is not a Draft PR
- [x] Breaking changes: **None**
- [x] User-facing changes: **No**
- [ ] Testing: **N/A** -- logging only, no behavioral change