### PR TITLE
Add non-recursive trace to empty catch blocks in `StructuredTraceSource.TraceScope`

### DIFF
--- a/src/System.Management.Automation/utils/StructuredTraceSource.cs
+++ b/src/System.Management.Automation/utils/StructuredTraceSource.cs
@@ -437,7 +437,10 @@ namespace System.Management.Automation
                 {
                     return new ScopeTracer(this, PSTraceSourceOptions.Scope, null, null, string.Empty, msg);
                 }
-                catch { }
+                catch (Exception e)
+                {
+                    System.Diagnostics.Trace.WriteLine("ScopeTracer(string) threw: " + e);
+                }
             }
 
             return null;
@@ -451,7 +454,10 @@ namespace System.Management.Automation
                 {
                     return new ScopeTracer(this, PSTraceSourceOptions.Scope, null, null, string.Empty, format, arg1);
                 }
-                catch { }
+                catch (Exception e)
+                {
+                    System.Diagnostics.Trace.WriteLine("ScopeTracer(string,object) threw: " + e);
+                }
             }
 
             return null;
@@ -465,7 +471,10 @@ namespace System.Management.Automation
                 {
                     return new ScopeTracer(this, PSTraceSourceOptions.Scope, null, null, string.Empty, format, arg1, arg2);
                 }
-                catch { }
+                catch (Exception e)
+                {
+                    System.Diagnostics.Trace.WriteLine("ScopeTracer(string,object,object) threw: " + e);
+                }
             }
 
             return null;


### PR DESCRIPTION
## PR Summary

Add `System.Diagnostics.Trace.WriteLine` calls to three empty catch blocks in `StructuredTraceSource.TraceScope` methods that were silently swallowing exceptions from the `ScopeTracer` constructor.

## PR Context

The `TraceScope` overloads contained empty catch blocks that caught all exceptions from the `ScopeTracer` constructor. While the original intent was to ensure trace methods never throw, silently swallowing all exceptions hides infrastructure failures. Using `System.Diagnostics.Trace.WriteLine` (which bypasses PSTraceSource) provides diagnostics without risk of recursion.

## PR Checklist

- [x] PR title is meaningful and in present tense, imperative mood
- [x] Changes are summarized in the PR description
- [x] All files have the Microsoft copyright header
- [x] **Ready for review** -- this is not a Draft PR
- [x] Breaking changes: **None**
- [x] User-facing changes: **No**
- [ ] Testing: **N/A** -- logging only, no behavioral change