### PR TITLE
Guard null-reference on `methods[0].method` in `FindBestMethodImpl`

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1639,9 +1639,10 @@ namespace System.Management.Automation
                 else if (genericParamTypes is not null)
                 {
                     errorId = "MethodCountCouldNotFindBestGeneric";
+                    string methodName = methods.Length > 0 && methods[0].method != null ? methods[0].method.Name : "<unknown>";
                     errorMsg = string.Format(
                         ExtendedTypeSystem.MethodGenericArgumentCountException,
-                        methods[0].method.Name,
+                        methodName,
                         genericParamTypes.Length,
                         arguments.Length);
                     return null;


### PR DESCRIPTION
## PR Summary

Guard against null-reference when accessing `methods[0].method.Name` in the error path of `FindBestMethodImpl`.

## PR Context

When `candidates.Count == 0` and the first condition (all methods are static generic type definitions) is false, the else-if branch on line 1639 accesses `methods[0].method.Name`. This can throw a `NullReferenceException` if `methods[0].method` is null or if `methods.Length` is 0. Add a null check and fall back to `"<unknown>"`.

## PR Checklist

- [x] PR title is meaningful and in present tense, imperative mood
- [x] Changes are summarized in the PR description
- [x] All files have the Microsoft copyright header
- [x] **Ready for review** -- this is not a Draft PR
- [x] Breaking changes: **None**
- [x] User-facing changes: **No**
- [ ] Testing: **N/A** -- defensive null check only, no functional change