### PR TITLE
[release/v7.4.18] Update CI workflow to also target servicing-* branches

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -10,6 +10,7 @@ on:
       - master
       - release/**
       - github-mirror
+      - "servicing-*"
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -21,6 +22,7 @@ on:
       - master
       - release/**
       - github-mirror
+      - "servicing-*"
       - "*-feature"
 # Path filters for PRs need to go into the changes job
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -8,6 +8,7 @@ on:
       - master
       - release/**
       - github-mirror
+      - "servicing-*"
     paths:
       - "**"
       - "!.github/ISSUE_TEMPLATE/**"
@@ -19,6 +20,7 @@ on:
       - master
       - release/**
       - github-mirror
+      - "servicing-*"
       - "*-feature"
 # Path filters for PRs need to go into the changes job
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -6,6 +6,7 @@ on:
       - master
       - release/**
       - github-mirror
+      - "servicing-*"
     paths:
       - "**"
       - "!.vsts-ci/misc-analysis.yml"
@@ -18,6 +19,7 @@ on:
       - master
       - release/**
       - github-mirror
+      - "servicing-*"
       - "*-feature"
 
 # Path filters for PRs need to go into the changes job


### PR DESCRIPTION
Backport of #27612 to release/v7.4.18

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27612$$$
-->

Triggered by @SeeminglyScience on behalf of @anamnavi

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates the CI workflow to also trigger on servicing-* branches, ensuring CI coverage for servicing branch work.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

This is a CI workflow-only change. The update adds servicing-* branch targeting to ensure CI runs on those branches. PR #27617 (revert) was closed without merging, confirming the change is stable. No product tests apply to workflow YAML changes.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

CI workflow-only change that adds servicing-* branch targeting. No product code is modified. The revert PR #27617 was closed without merging, confirming the change is intentional and stable.
