### PR TITLE
[release/v7.6.4] PMC: Download deb_arm artifact to ensure package is available for PMC publish flow

### DIFF
--- a/.pipelines/templates/release-prep-for-ev2.yml
+++ b/.pipelines/templates/release-prep-for-ev2.yml
@@ -18,6 +18,9 @@ stages:
           artifactName: drop_linux_package_deb
         - input: pipelineArtifact
           pipeline: PSPackagesOfficial
+          artifactName: drop_linux_package_deb_arm64
+        - input: pipelineArtifact
+          pipeline: PSPackagesOfficial
           artifactName: drop_linux_package_rpm
         - input: pipelineArtifact
           pipeline: PSPackagesOfficial


### PR DESCRIPTION
Backport of #27635 to release/v7.6.4

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27635$$$
-->

Triggered by @SeeminglyScience on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds the `drop_linux_package_deb_arm64` artifact to the PMC release prep pipeline so the ARM64 deb package is available during the PMC publish flow. Required to ensure the ARM64 package is published to PMC for the 7.6.4 release.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Pipeline-only change. Verified by reviewing the YAML diff — adds a single artifact entry to the list in `release-prep-for-ev2.yml`. No runtime code affected. Can only be validated by running the actual release pipeline.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Minor pipeline artifact addition. Only adds the `drop_linux_package_deb_arm64` artifact to the release prep template — no runtime or logic changes, no removals.
