### PR TITLE
Fix Test-Connection to correctly report BufferSize of 0

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -485,9 +485,9 @@ namespace Microsoft.PowerShell.Commands
                                     ? reply.RoundtripTime
                                     : timer.ElapsedMilliseconds,
 
-                                // If we use the empty buffer, then .NET actually uses a 32 byte buffer so we want to show
-                                // as the result object the actual buffer size used instead of 0.
-                                buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length,
+                                // If we use the empty buffer for default size, we want to show
+                                // the requested BufferSize (32) instead of the actual buffer length (0).
+                                BufferSize,
                                 pingNum: i);
                             WriteObject(new TraceStatus(
                                 currentHop,
@@ -732,7 +732,7 @@ namespace Microsoft.PowerShell.Commands
                         resolvedTargetName,
                         reply,
                         reply.RoundtripTime,
-                        buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length,
+                        BufferSize,
                         pingNum: (uint)i));
                 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -218,6 +218,12 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
             $result.BufferSize | Should -Be 2
         }
 
+        It "BufferSize 0 works and returns 0" {
+            $result = Test-Connection $targetName -Count 1 -BufferSize 0
+
+            $result.BufferSize | Should -Be 0
+        }
+
         It "ResolveDestination for address" {
             $result = Test-Connection $targetAddress -ResolveDestination -Count 1
             $resolvedName = [System.Net.DNS]::GetHostEntry($targetAddress).HostName


### PR DESCRIPTION
 ## Summary

This PR fixes a bug in `Test-Connection` where specifying `-BufferSize 0` incorrectly reports a buffer size of `32` in the output object and the CLI
formatting tables, even though a 0-byte payload was actually sent.

## What was broken & Root Cause

Previously, when creating the output `PingStatus` objects (both for standard pings and traceroutes), the cmdlet calculated the reported buffer size using this expression:
    ```csharp
    buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length

This logic was added in the past to support non-Windows platforms (like Linux/macOS), where  Test-Connection  sends a 0-length buffer under the hood
when using the default size of 32 (to run without requiring administrative/root privileges).

However, checking  buffer.Length == 0  meant the code couldn't distinguish between:

1. The default 32-byte size (which is sent as 0-length under the hood).
2. An explicit user request for a 0-byte buffer size via  -BufferSize 0 .

Because of this, both scenarios ended up reporting a buffer size of 32.

## What changed

Instead of checking the underlying  buffer.Length  on the fly, we now pass the cmdlet's  BufferSize  property directly to the  PingStatus  constructor.

This works perfectly because:

• When using the default settings,  BufferSize  is  32 , so the output reports  32 .
• When the user specifies  -BufferSize 0 ,  BufferSize  is  0 , so the output correctly reports  0 .
• Any other custom buffer size is also reported exactly as requested.

## How it was tested

1. Added a new Pester test under  test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1  to assert that  -BufferSize 0 correctly returns a reported buffer size of  0 .
2. Verified that the test fails on the old codebase and passes perfectly after applying the fix, alongside the other 26 tests in the test suite.

Fixes #27656