### PR TITLE
[release/v7.5.9] Avoid calling credential provider for public feed for Wix

### DIFF
--- a/tools/wix/wix.psm1
+++ b/tools/wix/wix.psm1
@@ -47,6 +47,7 @@ function Install-Wix
     if (-not $respository) {
         Write-Verbose -Verbose "Registering dotnet-eng repository..."
         Register-PSResourceRepository -Name 'dotnet-eng' -Uri 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json' -Trusted
+        Set-PSResourceRepository -CredentialProvider None -Name 'dotnet-eng' -Trusted
     }
 
     # keep version in sync with Microsoft.PowerShell.Packaging.csproj


### PR DESCRIPTION
Backport of #27663 to release/v7.5.9

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27663$$$
-->

Triggered by @SeeminglyScience on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

This backport updates the Wix packaging helper so the public dotnet-eng feed is marked with CredentialProvider None on release/v7.5.9, preventing unnecessary credential provider prompts during packaging.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated the cherry-pick on release/v7.5.9 and ran PowerShell syntax validation on tools/wix/wix.psm1. The backport is limited to the single Wix helper change from the original PR.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The change is narrowly scoped to a single repository registration path in tools/wix/wix.psm1 and only adjusts how the public feed is configured. It does not alter build logic outside that path.
