### PR TITLE
Get-Command: resolve noun-only names with the default verb

### DIFF
--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -935,6 +935,30 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
 
+                    // Command discovery retries noun-only names with the default verb prepended.
+                    // Do the same here after an exact lookup fails.
+                    if (!resultFound && !isDuplicate && !isPattern && !commandName.Contains('-') && !commandName.Contains('\\'))
+                    {
+                        string defaultVerbCommandName =
+                            StringLiterals.DefaultCommandVerb + StringLiterals.CommandVerbNounSeparator + commandName;
+                        string tempCommandName = defaultVerbCommandName;
+                        if (!string.IsNullOrEmpty(moduleName))
+                        {
+                            tempCommandName = moduleName + "\\" + defaultVerbCommandName;
+                        }
+
+                        try
+                        {
+                            CommandDiscovery.LookupCommandInfo(tempCommandName, this.MyInvocation.CommandOrigin, this.Context);
+                        }
+                        catch (CommandNotFoundException)
+                        {
+                            // Ignore and let the regular Get-Command error handling report the original name.
+                        }
+
+                        resultFound = FindCommandForName(options, defaultVerbCommandName, isPattern: false, emitErrors: false, ref count, out isDuplicate);
+                    }
+
                     // If we are trying to match a single specific command name (no glob characters)
                     // then we need to write an error if we didn't find it.
                     if (!isDuplicate)

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -86,6 +86,37 @@ Describe "Command Discovery tests" -Tags "CI" {
         (& 'location').Path | Should -Be (Get-Location).Path
     }
 
+    It "Get-Command prepends Get- to noun-only command names" {
+        function Get-DefaultVerbCommandTest {}
+
+        (Get-Command DefaultVerbCommandTest).Name | Should -BeExactly 'Get-DefaultVerbCommandTest'
+    }
+
+    It "Get-Command prefers an exact noun-only command name" {
+        function DefaultVerbCommandTest {}
+        function Get-DefaultVerbCommandTest {}
+
+        (Get-Command DefaultVerbCommandTest).Name | Should -BeExactly 'DefaultVerbCommandTest'
+    }
+
+    It "Get-Command applies command type filtering before the default verb fallback" {
+        Set-Alias DefaultVerbCommandTest Get-Date
+        function Get-DefaultVerbCommandTest {}
+
+        (Get-Command DefaultVerbCommandTest -CommandType Function).Name | Should -BeExactly 'Get-DefaultVerbCommandTest'
+    }
+
+    It "Get-Command does not prepend Get- to wildcard command names" {
+        function Get-DefaultVerbCommandTest {}
+
+        Get-Command 'DefaultVerbCommand*' | Should -BeNullOrEmpty
+    }
+
+    It "Get-Command reports the original noun-only name when no command is found" {
+        { Get-Command DefaultVerbMissingCommandTest -ErrorAction Stop } |
+            Should -Throw -ErrorId 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+    }
+
     Context "Use literal path first when executing scripts" {
         BeforeAll {
             $firstFileName = '[test1].ps1'


### PR DESCRIPTION
# PR Summary

Make `Get-Command` retry a literal noun-only name with the default `Get-` verb when the exact lookup fails, matching normal command invocation.

Exact command names still take precedence. Wildcard, fuzzy, abbreviated, path, and module-qualified lookups keep their existing behavior, and the retry uses the same command type and module filters as the original lookup.

## PR Context

Command discovery already prepends `Get-` when a noun-only command cannot be found. `Get-Command` performs its own enumeration and did not apply that fallback, so invoking `location` worked while `Get-Command location` returned `CommandNotFoundException`.

Fixes #17438

## Testing

- `Start-PSBuild -UseNuGetOrg -SkipRoslynAnalyzers`
- `Start-PSPester -Path test/powershell/engine/Basic/CommandDiscovery.Tests.ps1 -UseNuGetOrg`
  - 40 passed, 0 failed, 2 inconclusive pre-existing tests

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Existing files retain their copyright headers
- [x] Added regression tests
- [x] No breaking changes
