### PR TITLE
Fix progress bar stacking when removing items

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2975,7 +2975,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                if (Stopping || _removedFiles == _totalFiles)
+                if (Stopping || _removedFiles >= _totalFiles)
                 {
                     _removeStopwatch.Stop();
                     var progress = new ProgressRecord(REMOVE_FILE_ACTIVITY_ID, " ", " ")


### PR DESCRIPTION
# PR Summary

Fixes the `Remove-Item` progress bar stacking issue when the number of removed files exceeds the initially calculated total.

The file count is calculated concurrently with file removal. Because of this race, `_removedFiles` can advance beyond `_totalFiles`. Requiring both values to be exactly equal prevents the completed progress record from being emitted, leaving the progress bar visible and causing subsequent progress records to stack.

This change completes the progress activity when `_removedFiles` is greater than or equal to `_totalFiles`.

This PR only fixes the progress bar stacking issue. The total file calculation can still be off by one and is not addressed by this change.

Fixes progress bar stacking only in #23875.

## PR Context

`Remove-Item` can report more removed files than the calculated total, for example, `Removed 11 of 10 files`. In this situation, the existing equality check is never satisfied, so the progress activity remains active after the removal operation completes.

Using `>=` ensures that the progress record is completed even when concurrent file counting and removal cause the removed-file count to exceed the calculated total. This prevents stale `Remove-Item` progress bars from remaining visible and stacking with later progress output.

The underlying off-by-one issue in the total calculation remains and should be addressed separately.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s):
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed:
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)