### PR TITLE
Add parameter capitalization guardrail for PowerShell tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -494,7 +494,7 @@ namespace PowershellTestConfigNamespace
 
                 It "Validate Register-PSSessionConfiguration with ApplicationBase, AssemblyName and ConfigurationTypeName parameter" -Pending {
 
-                    $null = Register-PSSessionConfiguration -Name $TestSessionConfigName -ApplicationBase $script:TestAssemblyDir -AssemblyName $LocalTestAssemblyName -ConfigurationTypeName "PowershellTestConfigNamespace.PowershellTestConfig" -force
+                    $null = Register-PSSessionConfiguration -Name $TestSessionConfigName -ApplicationBase $script:TestAssemblyDir -AssemblyName $LocalTestAssemblyName -ConfigurationTypeName "PowershellTestConfigNamespace.PowershellTestConfig" -Force
 
                     ValidateRemoteEndpoint -TestSessionConfigName $TestSessionConfigName -ScriptToExecute $null -ExpectedOutput $true -ExpectedError $null
                 }
@@ -566,7 +566,7 @@ namespace PowershellTestConfigNamespace
 
                 It "Validate Set-PSSessionConfiguration with ApplicationBase, AssemblyName and ConfigurationTypeName parameter" -Pending {
 
-                    $null = Set-PSSessionConfiguration -Name $TestSessionConfigName -ApplicationBase $script:TestAssemblyDir -AssemblyName $LocalTestAssemblyName -ConfigurationTypeName "PowershellTestConfigNamespace.PowershellTestConfig" -force
+                    $null = Set-PSSessionConfiguration -Name $TestSessionConfigName -ApplicationBase $script:TestAssemblyDir -AssemblyName $LocalTestAssemblyName -ConfigurationTypeName "PowershellTestConfigNamespace.PowershellTestConfig" -Force
 
                     ValidateRemoteEndpoint -TestSessionConfigName $TestSessionConfigName -ScriptToExecute $null -ExpectedOutput $true -ExpectedError $null
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -102,7 +102,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $topPath = Join-Path $TestDrive $longDir
             $longDirPath = Join-Path $topPath $longSubDir
             $longFilePath = Join-Path $longDirPath $fileName
-            $null = New-Item -itemtype file -path $longFilePath -force
+            $null = New-Item -ItemType file -Path $longFilePath -Force
 
             $longFilePath | Should -Exist
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -173,7 +173,7 @@ Describe "Remove-Item" -Tags "CI" {
             $streamfile = Join-Path -Path $testpath -ChildPath $fileName
             $streamdir = Join-Path -Path $testpath -ChildPath $dirName
 
-            $null = New-Item -Path $streamfile -ItemType "File" -force
+            $null = New-Item -Path $streamfile -ItemType "File" -Force
             Add-Content -Path $streamfile -Value $fileContent
             Add-Content -Path $streamfile -Stream $streamName -Value $streamContent
             $null = New-Item -Path $streamdir -ItemType "Directory" -Force

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -158,7 +158,7 @@ Describe "Get-Alias DRT Unit Tests" -Tags "CI" {
 
     It "Get-Alias DisplayName should always show AliasName -> ResolvedCommand for all aliases" {
         Set-Alias -Name Test-MyAlias -Value Get-Command -Force
-        Set-Alias -Name tma -Value Test-MyAlias -force
+        Set-Alias -Name tma -Value Test-MyAlias -Force
         $aliases = Get-Alias Test-MyAlias, tma
         $aliases | ForEach-Object {
             $_.DisplayName | Should -Be "$($_.Name) -> Get-Command"

--- a/test/powershell/engine/Basic/Encoding.Tests.ps1
+++ b/test/powershell/engine/Basic/Encoding.Tests.ps1
@@ -118,7 +118,7 @@ Describe "File encoding tests" -Tag CI {
             )
         }
         BeforeEach {
-            Remove-Item TESTDRIVE:/* -force -ErrorAction Ignore
+            Remove-Item TESTDRIVE:/* -Force -ErrorAction Ignore
         }
         It "'<command> has a warning when '-Encoding utf7' is used" -TestCases $testCases {
             param ($command, $script)

--- a/test/powershell/engine/Basic/ParameterCapitalization.Tests.ps1
+++ b/test/powershell/engine/Basic/ParameterCapitalization.Tests.ps1
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Guardrail for parameter casing in PowerShell tests (see #26614).
+# Parameters are case-insensitive at runtime, but source style prefers PascalCase
+# (e.g. -Force, -ErrorAction) for readability and consistency with docs/examples.
+
+Describe "Parameter capitalization in PowerShell test scripts" -Tags @("CI") {
+    BeforeAll {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+        $scanRoot = Join-Path $repoRoot "test/powershell"
+
+        # High-frequency switches that should appear PascalCase in source.
+        # Intentional lowercase uses (binding case-insensitivity tests, stream fixtures)
+        # are allowlisted by relative path below.
+        $parameterPattern = '(?<=[\s|])-(force|erroraction|warningaction|verbose|debug|whatif|confirm)(?=[\s:\|]|$)'
+
+        $allowlistRelativePaths = @(
+            "test/powershell/Language/Scripting/CommonParameters.Tests.ps1"
+            "test/powershell/Language/Parser/BNotOperator.Tests.ps1"
+            "test/powershell/Language/Parser/RedirectionOperator.Tests.ps1"
+            "test/powershell/engine/Basic/ParameterCapitalization.Tests.ps1"
+        )
+    }
+
+    It "Uses PascalCase for common parameters (no bare lowercase -force / -erroraction / etc.)" {
+        $files = Get-ChildItem -Path $scanRoot -Recurse -Include *.ps1, *.psm1 -File -ErrorAction Stop
+
+        $violations = [System.Collections.Generic.List[string]]::new()
+        foreach ($file in $files) {
+            $rel = $file.FullName.Substring($repoRoot.Length).TrimStart('\', '/').Replace('\', '/')
+            if ($allowlistRelativePaths -contains $rel) {
+                continue
+            }
+
+            $matches = Select-String -Path $file.FullName -Pattern $parameterPattern -CaseSensitive -AllMatches
+            foreach ($m in $matches) {
+                $trim = $m.Line.TrimStart()
+                # Comments that only discuss the switch are fine.
+                if ($trim.StartsWith('#')) {
+                    continue
+                }
+                $violations.Add(("{0}:{1}: {2}" -f $rel, $m.LineNumber, $m.Line.Trim()))
+            }
+        }
+
+        if ($violations.Count -gt 0) {
+            $header = "Found $($violations.Count) lowercase common-parameter(s). Prefer PascalCase (e.g. -Force, -ErrorAction). See PowerShell/PowerShell#26614."
+            throw ($header + [Environment]::NewLine + ($violations -join [Environment]::NewLine))
+        }
+
+        $violations.Count | Should -Be 0
+    }
+}

--- a/test/powershell/engine/Basic/ParameterCapitalization.Tests.ps1
+++ b/test/powershell/engine/Basic/ParameterCapitalization.Tests.ps1
@@ -7,23 +7,24 @@
 
 Describe "Parameter capitalization in PowerShell test scripts" -Tags @("CI") {
     BeforeAll {
-        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+        # test/powershell/engine/Basic -> repo root is four levels up
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../../../..")).Path
         $scanRoot = Join-Path $repoRoot "test/powershell"
 
         # High-frequency switches that should appear PascalCase in source.
         # Intentional lowercase uses (binding case-insensitivity tests, stream fixtures)
         # are allowlisted by relative path below.
-        $parameterPattern = '(?<=[\s|])-(force|erroraction|warningaction|verbose|debug|whatif|confirm)(?=[\s:\|]|$)'
+        # Negative lookbehind allows start-of-line as well as whitespace/pipe.
+        $parameterPattern = '(?<![\w-])-(force|erroraction|warningaction|verbose|debug|whatif|confirm)(?=[\s:\|]|$)'
 
         $allowlistRelativePaths = @(
             "test/powershell/Language/Scripting/CommonParameters.Tests.ps1"
             "test/powershell/Language/Parser/BNotOperator.Tests.ps1"
             "test/powershell/Language/Parser/RedirectionOperator.Tests.ps1"
-            "test/powershell/engine/Basic/ParameterCapitalization.Tests.ps1"
         )
     }
 
-    It "Uses PascalCase for common parameters (no bare lowercase -force / -erroraction / etc.)" {
+    It "Flags fully-lowercase common parameters (e.g. -force / -erroraction)" {
         $files = Get-ChildItem -Path $scanRoot -Recurse -Include *.ps1, *.psm1 -File -ErrorAction Stop
 
         $violations = [System.Collections.Generic.List[string]]::new()
@@ -33,14 +34,15 @@ Describe "Parameter capitalization in PowerShell test scripts" -Tags @("CI") {
                 continue
             }
 
-            $matches = Select-String -Path $file.FullName -Pattern $parameterPattern -CaseSensitive -AllMatches
-            foreach ($m in $matches) {
-                $trim = $m.Line.TrimStart()
+            # Avoid automatic $matches variable
+            $stringHits = Select-String -Path $file.FullName -Pattern $parameterPattern -CaseSensitive -AllMatches
+            foreach ($hit in $stringHits) {
+                $trim = $hit.Line.TrimStart()
                 # Comments that only discuss the switch are fine.
                 if ($trim.StartsWith('#')) {
                     continue
                 }
-                $violations.Add(("{0}:{1}: {2}" -f $rel, $m.LineNumber, $m.Line.Trim()))
+                $violations.Add(("{0}:{1}: {2}" -f $rel, $hit.LineNumber, $hit.Line.Trim()))
             }
         }
 


### PR DESCRIPTION
## Summary

Addresses #26614.

Keep test scripts using PascalCase for common parameters (`-Force`, `-ErrorAction`, etc.).

### Changes
- Fixed a few lowercase `-force` call sites (including the Set-Alias example from the issue)
- Added `ParameterCapitalization.Tests.ps1` (CI) scanning `test/powershell`
- Allowlisted intentional case-insensitivity fixtures

### Testing
Dry-ran the scan over `test/powershell` after fixes (0 violations outside allowlist).