### PR TITLE
Update metadata.json for July releases

### DIFF
--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -1,10 +1,10 @@
 {
-  "StableReleaseTag": "v7.6.3",
-  "PreviewReleaseTag": "v7.7.0-preview.2",
+  "StableReleaseTag": "v7.6.4",
+  "PreviewReleaseTag": "v7.7.0-preview.3",
   "ServicingReleaseTag": "v7.0.13",
-  "ReleaseTag": "v7.6.3",
-  "LTSReleaseTag": ["v7.4.17", "v7.6.3"],
-  "NextReleaseTag": "v7.7.0-preview.3",
+  "ReleaseTag": "v7.6.4",
+  "LTSReleaseTag": ["v7.4.18", "v7.6.4"],
+  "NextReleaseTag": "v7.7.0-preview.4",
   "LTSRelease": { "PublishToChannels": false, "Package": false },
   "StableRelease":  { "PublishToChannels": false, "Package": false }
 }


### PR DESCRIPTION
###

Update `metadata.json` for v7.4.18, v7.6.4, and v7.7.0-preview.3 releases.