### PR TITLE
Update changelogs for v7.4.18, v7.5.9, and v7.6.4

### DIFF
--- a/CHANGELOG/7.4.md
+++ b/CHANGELOG/7.4.md
@@ -1,5 +1,35 @@
 # 7.4 Changelog
 
+## [7.4.18]
+
+### Engine Updates and Fixes
+
+- Merged PR 40624: Validate CAB path before expansion
+
+### Tests
+
+- Update CI workflow to also target servicing-* branches (#27649)
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 8.0.423</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release (#27690)</li>
+<li>Avoid calling credential provider for public feed for Wix (#27664)</li>
+<li>Separate NuGet publish into its own stage after pushing the git tag (#27648)</li>
+</ul>
+
+</details>
+
+[7.4.18]: https://github.com/PowerShell/PowerShell/compare/v7.4.17...v7.4.18
+
 ## [7.4.17]
 
 ### Code Cleanup

--- a/CHANGELOG/7.5.md
+++ b/CHANGELOG/7.5.md
@@ -2,6 +2,10 @@
 
 ## [7.5.9]
 
+### Engine Updates and Fixes
+
+- Merged PR 40624: Validate CAB path before expansion
+
 ### Tests
 
 - Update CI workflow to also target servicing-* branches (#27651)

--- a/CHANGELOG/7.5.md
+++ b/CHANGELOG/7.5.md
@@ -1,5 +1,31 @@
 # 7.5 Changelog
 
+## [7.5.9]
+
+### Tests
+
+- Update CI workflow to also target servicing-* branches (#27651)
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 9.0.316</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release (#27682)</li>
+<li>Avoid calling credential provider for public feed for Wix (#27665)</li>
+<li>Separate NuGet publish into its own stage after pushing the git tag (#27650)</li>
+</ul>
+
+</details>
+
+[7.5.9]: https://github.com/PowerShell/PowerShell/compare/v7.5.8...v7.5.9
+
 ## [7.5.8]
 
 ### Code Cleanup

--- a/CHANGELOG/7.6.md
+++ b/CHANGELOG/7.6.md
@@ -2,6 +2,10 @@
 
 ## [7.6.4]
 
+### Engine Updates and Fixes
+
+- Merged PR 40624: Validate CAB path before expansion
+
 ### Build and Packaging Improvements
 
 <details>

--- a/CHANGELOG/7.6.md
+++ b/CHANGELOG/7.6.md
@@ -1,5 +1,28 @@
 # 7.6 Changelog
 
+## [7.6.4]
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 10.0.302</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release (#27685)</li>
+<li>Avoid calling credential provider for public feed for Wix (#27666)</li>
+<li>Separate NuGet publish into its own stage after pushing the git tag (#27652)</li>
+<li>PMC: Download deb_arm artifact to ensure package is available for PMC publish flow (#27653)</li>
+</ul>
+
+</details>
+
+[7.6.4]: https://github.com/PowerShell/PowerShell/compare/v7.6.3...v7.6.4
+
 ## [7.6.3]
 
 ### Build and Packaging Improvements


### PR DESCRIPTION
## Summary

Bring the published changelog entries from the three July servicing releases into `master`:

- v7.4.18 from #27691
- v7.5.9 from #27684
- v7.6.4 from #27687

This PR contains changelog updates only; it does not bring release-branch code or pipeline changes into `master`.