### PR TITLE
Add Unix-like parameter aliases to core cmdlets for better cross-platform UX

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
@@ -170,6 +170,7 @@ namespace Microsoft.PowerShell.Commands
         /// the existing read-only file. If force is false, the provider should write an error.
         /// </remarks>
         [Parameter]
+        [Alias("a")]
         public override SwitchParameter Force
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -2062,6 +2062,7 @@ namespace Microsoft.PowerShell.Commands
         /// the existing read-only file. If force is false, the provider should write an error.
         /// </remarks>
         [Parameter]
+        [Alias("p")]
         public override SwitchParameter Force
         {
             get => base.Force;
@@ -2435,6 +2436,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the recurse property.
         /// </summary>
         [Parameter]
+        [Alias("r")]
         public SwitchParameter Recurse
         {
             get => _recurse;
@@ -2454,6 +2456,7 @@ namespace Microsoft.PowerShell.Commands
         /// the existing read-only file. If force is false, the provider should write an error.
         /// </remarks>
         [Parameter]
+        [Alias("f")]
         public override SwitchParameter Force
         {
             get => base.Force;
@@ -2847,6 +2850,7 @@ namespace Microsoft.PowerShell.Commands
         /// the existing read-only file. If force is false, the provider should write an error.
         /// </remarks>
         [Parameter]
+        [Alias("f")]
         public override SwitchParameter Force
         {
             get => base.Force;
@@ -3574,6 +3578,7 @@ namespace Microsoft.PowerShell.Commands
         /// the existing read-only file. If force is false, the provider should write an error.
         /// </remarks>
         [Parameter]
+        [Alias("f")]
         public override SwitchParameter Force
         {
             get => base.Force;
@@ -3614,6 +3619,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the recurse property.
         /// </summary>
         [Parameter]
+        [Alias("r")]
         public SwitchParameter Recurse
         {
             get => _recurse;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1321,6 +1321,7 @@ namespace Microsoft.PowerShell.Commands
         /// Equivalent to grep -v/findstr -v.
         /// </summary>
         [Parameter]
+        [Alias("v")]
         public SwitchParameter NotMatch { get; set; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Select-Object.cs
@@ -99,6 +99,7 @@ namespace Microsoft.PowerShell.Commands
         // NTRAID#Windows Out Of Band Releases-927878-2006/03/02
         // Allow zero
         [ValidateRange(0, int.MaxValue)]
+        [Alias("n")]
         public int First
         {
             get { return _first; }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This Pull Request introduces standard Unix-like parameter aliases to several core Management and Utility cmdlets. 

As PowerShell becomes increasingly popular across different platforms, many Linux and Unix administrators use familiar aliases like `ls`, `rm`, `cp`, `mkdir`, and `grep` natively in PowerShell. However, using these aliases with their standard Unix flags (e.g., `rm -rf`, `mkdir -p`, `grep -v`) previously required writing complex wrapper functions or custom modules, which introduced performance overhead and spawned unnecessary processes.

By adding the native `[Alias()]` C# attribute to the relevant properties, this PR allows PowerShell's built-in parser to seamlessly interpret standard Unix flags natively, with zero performance overhead.

**Cmdlets and Parameters modified:**
- `Copy-Item`: Added `[Alias("r")]` to `Recurse`, `[Alias("f")]` to `Force` (enables `cp -r -f`)
- `Move-Item`: Added `[Alias("f")]` to `Force` (enables `mv -f`)
- `New-Item`: Added `[Alias("p")]` to `Force` (enables `mkdir -p` to create missing parents)
- `Remove-Item`: Added `[Alias("r")]` to `Recurse`, `[Alias("f")]` to `Force` (enables `rm -rf`)
- `Get-ChildItem`: Added `[Alias("a")]` to `Force` (enables `ls -a` to display hidden files)
- `Select-String`: Added `[Alias("v")]` to `NotMatch` (enables `grep -v`)
- `Select-Object`: Added `[Alias("n")]` to `First` (enables `head -n 1`)

## PR Context

These additions aim to lower the entry barrier for users migrating from bash/zsh to PowerShell, greatly improving their terminal productivity on macOS and Linux without altering any core behavior of the cmdlets themselves. It makes the transition to PowerShell much more intuitive for Unix veterans.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
