### PR TITLE
Add support for inline XML format data in Update-FormatData

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -978,8 +978,13 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (ShouldProcess("Inline XML", action))
                     {
-                        var doc = new System.Xml.XmlDocument();
-                        doc.LoadXml(PrependFormatData[i]);
+                        var doc = new System.Xml.XmlDocument() { XmlResolver = null };
+                        var settings = new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null };
+                        using (var reader = System.Xml.XmlReader.Create(new System.IO.StringReader(PrependFormatData[i]), settings))
+                        {
+                            doc.Load(reader);
+                        }
+
                         newFormats.Add(new SessionStateFormatEntry(doc));
                     }
                 }
@@ -1018,8 +1023,13 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (ShouldProcess("Inline XML", action))
                     {
-                        var doc = new System.Xml.XmlDocument();
-                        doc.LoadXml(appendFormatDataItem);
+                        var doc = new System.Xml.XmlDocument() { XmlResolver = null };
+                        var settings = new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null };
+                        using (var reader = System.Xml.XmlReader.Create(new System.IO.StringReader(appendFormatDataItem), settings))
+                        {
+                            doc.Load(reader);
+                        }
+
                         newFormats.Add(new SessionStateFormatEntry(doc));
                     }
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -270,6 +270,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         private bool _force = false;
+
         /// <summary>
         /// True if we should overwrite a possibly existing member.
         /// </summary>
@@ -287,6 +288,7 @@ namespace Microsoft.PowerShell.Commands
         #region strong type data set
 
         private TypeData[] _typeData;
+
         /// <summary>
         /// The TypeData instances.
         /// </summary>
@@ -890,25 +892,26 @@ namespace Microsoft.PowerShell.Commands
     public class UpdateFormatDataCommand : UpdateData
     {
         private string[] _prependFormatData = Array.Empty<string>();
+        private string[] _appendFormatData = Array.Empty<string>();
+
         /// <summary>
-        /// The format xml data to prepend.
+        /// Gets or sets the format xml data to prepend.
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
-        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] PrependFormatData
         {
             get { return _prependFormatData; }
             set { _prependFormatData = value ?? Array.Empty<string>(); }
         }
 
-        private string[] _appendFormatData = Array.Empty<string>();
         /// <summary>
-        /// The format xml data to append.
+        /// Gets or sets the format xml data to append.
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
-        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] AppendFormatData
         {
             get { return _appendFormatData; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -889,6 +889,32 @@ namespace Microsoft.PowerShell.Commands
         DefaultParameterSetName = FileParameterSet, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=2097135")]
     public class UpdateFormatDataCommand : UpdateData
     {
+        private string[] _prependFormatData = Array.Empty<string>();
+        /// <summary>
+        /// The format xml data to prepend.
+        /// </summary>
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public string[] PrependFormatData
+        {
+            get { return _prependFormatData; }
+            set { _prependFormatData = value ?? Array.Empty<string>(); }
+        }
+
+        private string[] _appendFormatData = Array.Empty<string>();
+        /// <summary>
+        /// The format xml data to append.
+        /// </summary>
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public string[] AppendFormatData
+        {
+            get { return _appendFormatData; }
+            set { _appendFormatData = value ?? Array.Empty<string>(); }
+        }
+
         /// <summary>
         /// This method verify if the Format database manager is shared and cannot be updated.
         /// </summary>
@@ -911,7 +937,7 @@ namespace Microsoft.PowerShell.Commands
 
             // There are file path input but they did not pass the validation in the method Glob
             if ((PrependPath.Length > 0 || AppendPath.Length > 0) &&
-                prependPathTotal.Count == 0 && appendPathTotal.Count == 0)
+                prependPathTotal.Count == 0 && appendPathTotal.Count == 0 && PrependFormatData.Length == 0 && AppendFormatData.Length == 0)
             { return; }
 
             string action = UpdateDataStrings.UpdateFormatDataAction;
@@ -945,6 +971,16 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
+                for (int i = PrependFormatData.Length - 1; i >= 0; i--)
+                {
+                    if (ShouldProcess("Inline XML", action))
+                    {
+                        var doc = new System.Xml.XmlDocument();
+                        doc.LoadXml(PrependFormatData[i]);
+                        newFormats.Add(new SessionStateFormatEntry(doc));
+                    }
+                }
+
                 // Always add InitialSessionState.Formats to the new list
                 foreach (SessionStateFormatEntry entry in Context.InitialSessionState.Formats)
                 {
@@ -975,6 +1011,16 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
+                foreach (string appendFormatDataItem in AppendFormatData)
+                {
+                    if (ShouldProcess("Inline XML", action))
+                    {
+                        var doc = new System.Xml.XmlDocument();
+                        doc.LoadXml(appendFormatDataItem);
+                        newFormats.Add(new SessionStateFormatEntry(doc));
+                    }
+                }
+
                 var originalFormats = Context.InitialSessionState.Formats;
                 try
                 {
@@ -1001,6 +1047,10 @@ namespace Microsoft.PowerShell.Commands
                         else if (ssfe.FormatData != null)
                         {
                             entries.Add(new PSSnapInTypeAndFormatErrors(name, ssfe.FormatData));
+                        }
+                        else if (ssfe.FormatDataXml != null)
+                        {
+                            entries.Add(new PSSnapInTypeAndFormatErrors(name ?? "Inline", ssfe.FormatDataXml, true));
                         }
                         else
                         {

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
@@ -409,6 +409,28 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     continue;
                 }
 
+                if (file.FormatDataXml != null)
+                {
+                    XmlFileLoadInfo info =
+                        new XmlFileLoadInfo("Inline", "Inline XML", file.Errors, file.PSSnapinName);
+                    using (TypeInfoDataBaseLoader loader = new TypeInfoDataBaseLoader())
+                    {
+                        if (!loader.LoadXmlString(file.FormatDataXml, info, db, expressionFactory, preValidated))
+                            success = false;
+
+                        foreach (XmlLoaderLoggerEntry entry in loader.LogEntries)
+                        {
+                            if (entry.entryType == XmlLoaderLoggerEntry.EntryType.Error)
+                            {
+                                string mshsnapinMessage = StringUtil.Format(FormatAndOutXmlLoadingStrings.MshSnapinQualifiedError, info.psSnapinName, entry.message);
+                                info.errors.Add(mshsnapinMessage);
+                            }
+                        }
+                        logEntries.AddRange(loader.LogEntries);
+                    }
+                    continue;
+                }
+
                 if (etwEnabled)
                 {
                     RunspaceEventSource.Log.ProcessFormatFileStart(file.FullPath);

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -304,11 +304,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             this.SetDatabaseLoadingInfo(info);
             this.ReportTrace("loading xml string started");
 
-            XmlDocument newDocument = new XmlDocument();
+            var newDocument = new XmlDocument() { XmlResolver = null };
             try
             {
-                // To safely load from string without resolving external entities
-                using (var reader = XmlReader.Create(new System.IO.StringReader(xmlData), new XmlReaderSettings { XmlResolver = null }))
+                // Load from string without resolving external entities
+                var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
+                using (var reader = XmlReader.Create(new System.IO.StringReader(xmlData), settings))
                 {
                     newDocument.Load(reader);
                 }

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -304,20 +304,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             this.SetDatabaseLoadingInfo(info);
             this.ReportTrace("loading xml string started");
 
-XmlDocument newDocument;
-try
-{
-    // Match the file-loading path: untrusted XML parsing with hardened defaults.
-    newDocument = InternalDeserializer.LoadUnsafeXmlDocument(
-        xmlData,
-        true, /* preserve whitespace, comments, etc. */
-        null); /* default maxCharacters */
-}
-catch (XmlException e)
-{
-    this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, FilePath, e.Message));
-    return false;
-}
+            XmlDocument newDocument;
+            try
+            {
+                // Match the file-loading path: untrusted XML parsing with hardened defaults.
+                newDocument = InternalDeserializer.LoadUnsafeXmlDocument(
+                    xmlData,
+                    true, /* preserve whitespace, comments, etc. */
+                    null); /* default maxCharacters */
+            }
+            catch (XmlException e)
+            {
+                this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, FilePath, e.Message));
+                return false;
+            }
 
             bool previousSuppressValidation = _suppressValidation;
             try

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -334,7 +334,7 @@ catch (XmlException e)
                 }
                 catch (Exception e)
                 {
-                    this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, "Inline XML", e.Message));
+                    this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, FilePath, e.Message));
                     throw;
                 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -304,21 +304,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             this.SetDatabaseLoadingInfo(info);
             this.ReportTrace("loading xml string started");
 
-            var newDocument = new XmlDocument() { XmlResolver = null };
-            try
-            {
-                // Load from string without resolving external entities
-                var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
-                using (var reader = XmlReader.Create(new System.IO.StringReader(xmlData), settings))
-                {
-                    newDocument.Load(reader);
-                }
-            }
-            catch (XmlException e)
-            {
-                this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, "Inline XML", e.Message));
-                return false;
-            }
+XmlDocument newDocument;
+try
+{
+    // Match the file-loading path: untrusted XML parsing with hardened defaults.
+    newDocument = InternalDeserializer.LoadUnsafeXmlDocument(
+        xmlData,
+        true, /* preserve whitespace, comments, etc. */
+        null); /* default maxCharacters */
+}
+catch (XmlException e)
+{
+    this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, FilePath, e.Message));
+    return false;
+}
 
             bool previousSuppressValidation = _suppressValidation;
             try

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -272,6 +272,87 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
+        /// Entry point for the loader algorithm to load formatting data from an XML string.
+        /// </summary>
+        /// <param name="xmlData">XML string containing format data.</param>
+        /// <param name="info">Information needed to load the file (used for error reporting).</param>
+        /// <param name="db">Database instance to load the file into.</param>
+        /// <param name="expressionFactory">Expression factory to validate script blocks.</param>
+        /// <param name="preValidated">True if pre-validated.</param>
+        /// <returns>True if successful.</returns>
+        internal bool LoadXmlString(
+            string xmlData,
+            XmlFileLoadInfo info,
+            TypeInfoDataBase db,
+            PSPropertyExpressionFactory expressionFactory,
+            bool preValidated)
+        {
+            if (xmlData == null)
+                throw PSTraceSource.NewArgumentNullException(nameof(xmlData));
+
+            if (info == null)
+                throw PSTraceSource.NewArgumentNullException(nameof(info));
+
+            if (db == null)
+                throw PSTraceSource.NewArgumentNullException(nameof(db));
+
+            if (expressionFactory == null)
+                throw PSTraceSource.NewArgumentNullException(nameof(expressionFactory));
+
+            this.displayResourceManagerCache = db.displayResourceManagerCache;
+            this.expressionFactory = expressionFactory;
+            this.SetDatabaseLoadingInfo(info);
+            this.ReportTrace("loading xml string started");
+
+            XmlDocument newDocument = new XmlDocument();
+            try
+            {
+                // To safely load from string without resolving external entities
+                using (var reader = XmlReader.Create(new System.IO.StringReader(xmlData), new XmlReaderSettings { XmlResolver = null }))
+                {
+                    newDocument.Load(reader);
+                }
+            }
+            catch (XmlException e)
+            {
+                this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, "Inline XML", e.Message));
+                return false;
+            }
+
+            bool previousSuppressValidation = _suppressValidation;
+            try
+            {
+                _suppressValidation = preValidated;
+
+                try
+                {
+                    this.LoadData(newDocument, db);
+                }
+                catch (TooManyErrorsException)
+                {
+                    return false;
+                }
+                catch (Exception e)
+                {
+                    this.ReportError(StringUtil.Format(FormatAndOutXmlLoadingStrings.ErrorInFile, "Inline XML", e.Message));
+                    throw;
+                }
+
+                if (this.HasErrors)
+                {
+                    return false;
+                }
+            }
+            finally
+            {
+                _suppressValidation = previousSuppressValidation;
+            }
+
+            this.ReportTrace("xml string loaded with no errors");
+            return true;
+        }
+
+        /// <summary>
         /// Entry point for the loader algorithm to load formatting data from ExtendedTypeDefinition.
         /// </summary>
         /// <param name="typeDefinition">The ExtendedTypeDefinition instance to load formatting data from.</param>

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -19,6 +19,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 
 using Microsoft.PowerShell.Commands;
 
@@ -320,6 +321,21 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
+        /// Loads all the format data specified in the xmlDocument.
+        /// </summary>
+        /// <param name="xmlDocument">The XmlDocument containing format data.</param>
+        public SessionStateFormatEntry(XmlDocument xmlDocument)
+            : base("*")
+        {
+            if (xmlDocument == null)
+            {
+                throw PSTraceSource.NewArgumentNullException(nameof(xmlDocument));
+            }
+
+            FormatDataXml = xmlDocument.OuterXml;
+        }
+
+        /// <summary>
         /// Loads all the format data specified in the typeDefinition.
         /// </summary>
         /// <param name="typeDefinition"></param>
@@ -350,6 +366,12 @@ namespace System.Management.Automation.Runspaces
             {
                 entry = new SessionStateFormatEntry(Formattable);
             }
+            else if (FormatDataXml != null)
+            {
+                var doc = new XmlDocument();
+                doc.LoadXml(FormatDataXml);
+                entry = new SessionStateFormatEntry(doc);
+            }
             else
             {
                 entry = new SessionStateFormatEntry(FormatData);
@@ -376,6 +398,12 @@ namespace System.Management.Automation.Runspaces
         /// This can be null if the FileName or FormatTable constructors are used.
         /// </summary>
         public ExtendedTypeDefinition FormatData { get; }
+
+        /// <summary>
+        /// The FormatData XML string specified with constructor.
+        /// This can be null if other constructors are used.
+        /// </summary>
+        public string FormatDataXml { get; }
 
         // So that we can specify the format information on the fly,
         // without using Format.ps1xml file

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -368,8 +368,13 @@ namespace System.Management.Automation.Runspaces
             }
             else if (FormatDataXml != null)
             {
-                var doc = new XmlDocument();
-                doc.LoadXml(FormatDataXml);
+                var doc = new XmlDocument() { XmlResolver = null };
+                var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
+                using (var reader = XmlReader.Create(new System.IO.StringReader(FormatDataXml), settings))
+                {
+                    doc.Load(reader);
+                }
+
                 entry = new SessionStateFormatEntry(doc);
             }
             else

--- a/src/System.Management.Automation/utils/FormatAndTypeDataHelper.cs
+++ b/src/System.Management.Automation/utils/FormatAndTypeDataHelper.cs
@@ -45,7 +45,16 @@ namespace System.Management.Automation.Runspaces
             Errors = new ConcurrentBag<string>();
         }
 
+        internal PSSnapInTypeAndFormatErrors(string psSnapinName, string formatDataXml, bool isXml)
+        {
+            this.psSnapinName = psSnapinName;
+            FormatDataXml = formatDataXml;
+            Errors = new ConcurrentBag<string>();
+        }
+
         internal ExtendedTypeDefinition FormatData { get; }
+
+        internal string FormatDataXml { get; }
 
         internal TypeData TypeData { get; }
 

--- a/src/System.Management.Automation/utils/FormatAndTypeDataHelper.cs
+++ b/src/System.Management.Automation/utils/FormatAndTypeDataHelper.cs
@@ -49,6 +49,7 @@ namespace System.Management.Automation.Runspaces
         {
             this.psSnapinName = psSnapinName;
             FormatDataXml = formatDataXml;
+            _ = isXml;
             Errors = new ConcurrentBag<string>();
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
@@ -84,7 +84,7 @@ Describe "Update-FormatData" -Tags "CI" {
 "@
 
         It "Should load inline XML using PrependFormatData" {
-            $null = $ps.AddScript("Update-FormatData -PrependFormatData `$xmlContent")
+            $null = $ps.AddScript('param($xml) Update-FormatData -PrependFormatData $xml').AddArgument($xmlContent)
             $ps.Invoke()
             $ps.HadErrors | Should -BeFalse
             $ps.Commands.Clear()
@@ -96,7 +96,7 @@ Describe "Update-FormatData" -Tags "CI" {
         }
 
         It "Should load inline XML using AppendFormatData" {
-            $null = $ps.AddScript("Update-FormatData -AppendFormatData `$xmlContent")
+            $null = $ps.AddScript('param($xml) Update-FormatData -AppendFormatData $xml').AddArgument($xmlContent)
             $ps.Invoke()
             $ps.HadErrors | Should -BeFalse
             $ps.Commands.Clear()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
@@ -57,6 +57,56 @@ Describe "Update-FormatData" -Tags "CI" {
             $formatData.FormatViewDefinition.Name | Should -BeExactly "Test"
         }
     }
+
+    Context "Validate inline XML format data" {
+        $xmlContent = @"
+    <Configuration>
+        <ViewDefinitions>
+            <View>
+                <Name>InlineTest</Name>
+                <ViewSelectedBy>
+                    <TypeName>InlineTestType</TypeName>
+                </ViewSelectedBy>
+                <ListControl>
+                    <ListEntries>
+                        <ListEntry>
+                            <ListItems>
+                                <ListItem>
+                                    <PropertyName>TestProp</PropertyName>
+                                </ListItem>
+                            </ListItems>
+                        </ListEntry>
+                    </ListEntries>
+                </ListControl>
+            </View>
+        </ViewDefinitions>
+    </Configuration>
+"@
+
+        It "Should load inline XML using PrependFormatData" {
+            $null = $ps.AddScript("Update-FormatData -PrependFormatData `$xmlContent")
+            $ps.Invoke()
+            $ps.HadErrors | Should -BeFalse
+            $ps.Commands.Clear()
+            $null = $ps.AddScript("Get-FormatData InlineTestType")
+            $formatData = $ps.Invoke()
+            $formatData | Should -HaveCount 1
+            $formatData.TypeNames | Should -BeExactly "InlineTestType"
+            $formatData.FormatViewDefinition.Name | Should -BeExactly "InlineTest"
+        }
+
+        It "Should load inline XML using AppendFormatData" {
+            $null = $ps.AddScript("Update-FormatData -AppendFormatData `$xmlContent")
+            $ps.Invoke()
+            $ps.HadErrors | Should -BeFalse
+            $ps.Commands.Clear()
+            $null = $ps.AddScript("Get-FormatData InlineTestType")
+            $formatData = $ps.Invoke()
+            $formatData | Should -HaveCount 1
+            $formatData.TypeNames | Should -BeExactly "InlineTestType"
+            $formatData.FormatViewDefinition.Name | Should -BeExactly "InlineTest"
+        }
+    }
 }
 
 Describe "Update-FormatData basic functionality" -Tags "CI" {


### PR DESCRIPTION
# PR Summary

This PR allows the `Update-FormatData` cmdlet to accept formatting configuration (PS1XML) directly from an in-memory string. It introduces two new string array parameters: `-PrependFormatData` and `-AppendFormatData`. 

Under the hood:
- Adds a new `FormatDataXml` property and an `XmlDocument` constructor to `SessionStateFormatEntry` for secure encapsulation of the raw string.
- Updates `TypeInfoDataBaseLoader` to parse inline XML strings without requiring physical disk I/O.
- Plumbs the inline XML capabilities into `UpdateFormatDataCommand` via the `TypeInfoDataBaseManager`.
- Adds Pester unit tests to ensure that `-PrependFormatData` and `-AppendFormatData` correctly load views.

## PR Context

Resolves #7845 

Currently, module authors who use tools like `ModuleBuilder` to pack their modules into a single `.psm1` file for better performance cannot easily embed their format data (`.ps1xml` file contents). They are forced to ship external `.ps1xml` files alongside the module, which also complicates code signing (since the XML file must be signed separately). 

By allowing `Update-FormatData` to accept raw XML strings, module authors can now natively store and apply formatting rules entirely in memory.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Будет здорово, если вы создадите Issue в репозитории MicrosoftDocs/PowerShell-Docs и вставите сюда ссылку, чтобы документацию обновили -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
