### PR TITLE
Fix the dot-sourcing behavior of `pwsh -file` for advanced-function scripts

### DIFF
--- a/src/System.Management.Automation/engine/CommandProcessor.cs
+++ b/src/System.Management.Automation/engine/CommandProcessor.cs
@@ -778,7 +778,9 @@ namespace System.Management.Automation
             InitCommon();
 
             // If the script has been dotted, throw an error if it's from a different language mode.
-            if (!this.UseLocalScope)
+            // Unless it was a script loaded through -File, in which case the danger of dotting other
+            // language modes (getting internal functions in the user's state) isn't a danger.
+            if (!this.UseLocalScope && !scriptCmdlet.ShouldRethrowExitException)
             {
                 ValidateCompatibleLanguageMode(scriptCommandInfo.ScriptBlock, _context, Command.MyInvocation);
             }

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2191,6 +2191,8 @@ namespace System.Management.Automation
         private bool _exitWasCalled;
         private bool _anyClauseExecuted;
 
+        internal bool ShouldRethrowExitException => _rethrowExitException;
+
         public PSScriptCmdlet(ScriptBlock scriptBlock, bool useNewScope, bool fromScriptFile, ExecutionContext context)
         {
             _scriptBlock = scriptBlock;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

### Context

The behavior between signed advanced script and signed simple script is inconsistent in a WDAC enforced environment -- signed advanced script is rejected when running with `pwsh.exe -f` while the signed simple script works fine.

It turns out advanced script and simple script take different code paths to calling `ValidateCompatibleLanguageMode`, and they use different condition checks to decide whether they will actually call into that method.

**For simple script**, PowerShell uses the `DlrScriptCommandProcessor`, which calls `ValidateCompatibleLanguageMode` at [this location](https://github.com/PowerShell/PowerShell/blob/0c226762e2580cd7853c058dd03fc32638a73971/src/System.Management.Automation/engine/ScriptCommandProcessor.cs#L120-L126) with the following check:

```c#
// If the script has been dotted, throw an error if it's from a different language mode.
// Unless it was a script loaded through -File, in which case the danger of dotting other
// language modes (getting internal functions in the user's state) isn't a danger
if ((!this.UseLocalScope) && (!this._rethrowExitException))
{
    ValidateCompatibleLanguageMode(_scriptBlock, context, Command.MyInvocation);
}
```

**For advanced script**, PowerShell uses `CommandProcessor`, which calls `ValidateCompatibleLanguageMode` at [this location](https://github.com/PowerShell/PowerShell/blob/0c226762e2580cd7853c058dd03fc32638a73971/src/System.Management.Automation/engine/CommandProcessor.cs#L780-L784), with the following check:

```c#
// If the script has been dotted, throw an error if it's from a different language mode.
if (!this.UseLocalScope)
{
    ValidateCompatibleLanguageMode(scriptCommandInfo.ScriptBlock, _context, Command.MyInvocation);
}
```

As you can see, the check for simple script code path has `&& !this._rethrowExitException`, but **that is missing from the advance script code path**. `_rethrowExitException` gets set at startup in [ConsoleHost](https://github.com/PowerShell/PowerShell/blob/0c226762e2580cd7853c058dd03fc32638a73971/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs#L1990-L1995), as follows:

```c#
// If we're not going to continue, then get the exit code out of the runspace and
// and indicate that it should be returned...
if (!_noExit && this.Runspace is not RemoteRunspace)
{
    this.Runspace.ExecutionContext.ScriptCommandProcessorShouldRethrowExit = true;
}
```

The value of `_rethrowExitException` will be `true` if it's just `pwsh -file xxx.ps1`. **In this case**, even though the global scope is CLM, there is no harm to dot-source the FLM script file, because the process will be gone right after the script finishes execution, so cross boundary is fine in this case. We believe that's why the `DlrScriptCommandProcessor` code path has that check.

So, for a simple script, the check returns `false` for `pwsh -file xxx.ps1`, and thus it never calls to `ValidateCompatibleLanguageMode`. While for an advanced script, it always calls to `ValidateCompatibleLanguageMode`. This is why in a WDAC enforced environment, `pwsh -file` allows a signed simple script to work but errors out for a signed advanced script.

### Fix

Given the above, the fix should be adding the `&& !this._rethrowExitException` check to the [CommandProcessor](https://github.com/PowerShell/PowerShell/blob/0c226762e2580cd7853c058dd03fc32638a73971/src/System.Management.Automation/engine/CommandProcessor.cs#L780-L784) code path too (the advance script code path). With such a fix,

- The existing behavior in FLM environment will be kept.
- In WDAC enforced environment, `pwsh -file xxx.ps1` will work for both signed advanced script and simple script.
- In WDAC enforced environment, `pwsh -noexit -file xxx.ps1` will continue to fail for signed scripts as it is today.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
