### PR TITLE
Fix Set-Variable mutating variable when -Option Constant fails on existing variable

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -991,8 +991,22 @@ namespace Microsoft.PowerShell.Commands
                                     wasReadOnly = true;
                                 }
 
-                                // Now change the value, options, or description
-                                // and set the variable
+                                // Set options first so that if setting options fails (e.g. trying to make
+                                // an existing variable Constant), the value and description remain unchanged.
+                                // See issue #27679: Set-Variable should not mutate a variable when -Option results in an error.
+                                if (_options != null)
+                                {
+                                    matchingVariable.Options = (ScopedItemOptions)_options;
+                                }
+                                else
+                                {
+                                    if (wasReadOnly)
+                                    {
+                                        matchingVariable.SetOptions(matchingVariable.Options | ScopedItemOptions.ReadOnly, true);
+                                    }
+                                }
+
+                                // Now change the value and description.
 
                                 if (varValue != AutomationNull.Value)
                                 {
@@ -1012,18 +1026,6 @@ namespace Microsoft.PowerShell.Commands
                                 if (Description != null)
                                 {
                                     matchingVariable.Description = Description;
-                                }
-
-                                if (_options != null)
-                                {
-                                    matchingVariable.Options = (ScopedItemOptions)_options;
-                                }
-                                else
-                                {
-                                    if (wasReadOnly)
-                                    {
-                                        matchingVariable.SetOptions(matchingVariable.Options | ScopedItemOptions.ReadOnly, true);
-                                    }
                                 }
 
                                 // If visibility was specified, set it on the variable

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -163,6 +163,56 @@ Describe "Set-Variable" -Tags "CI" {
         }
     }
 
+    Context "Set-Variable should not mutate variable when -Option Constant fails on existing variable" {
+        It "Writable variable: value and options should remain unchanged when -Option Constant fails" {
+            & {
+                New-Variable -Name x -Value 1
+                Set-Variable -Name x -Value 2 -Option Constant -ErrorVariable setError -ErrorAction SilentlyContinue
+
+                $var = Get-Variable -Name x
+                $var.Value | Should -Be 1
+                $var.Options | Should -BeExactly "None"
+                $setError.FullyQualifiedErrorId | Should -BeExactly "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+            }
+        }
+
+        It "ReadOnly variable with -Force: value and options should remain unchanged when -Option Constant fails" {
+            & {
+                New-Variable -Name x -Value 1 -Option ReadOnly
+                Set-Variable -Name x -Value 2 -Force -Option Constant -ErrorVariable setError -ErrorAction SilentlyContinue
+
+                $var = Get-Variable -Name x
+                $var.Value | Should -Be 1
+                $var.Options | Should -BeExactly "ReadOnly"
+                $setError.FullyQualifiedErrorId | Should -BeExactly "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+            }
+        }
+
+        It "ReadOnly variable without value change: options should remain unchanged when -Option Constant fails" {
+            & {
+                New-Variable -Name x -Value 1 -Option ReadOnly
+                Set-Variable -Name x -Force -Option Constant -ErrorVariable setError -ErrorAction SilentlyContinue
+
+                $var = Get-Variable -Name x
+                $var.Value | Should -Be 1
+                $var.Options | Should -BeExactly "ReadOnly"
+                $setError.FullyQualifiedErrorId | Should -BeExactly "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+            }
+        }
+
+        It "Description should remain unchanged when -Option Constant fails" {
+            & {
+                New-Variable -Name x -Value 1 -Description "original"
+                Set-Variable -Name x -Value 2 -Description "changed" -Option Constant -ErrorVariable setError -ErrorAction SilentlyContinue
+
+                $var = Get-Variable -Name x
+                $var.Value | Should -Be 1
+                $var.Description | Should -BeExactly "original"
+                $var.Options | Should -BeExactly "None"
+            }
+        }
+    }
+
     It "Should create a new variable with no parameters" {
 	{ Set-Variable testVar } | Should -Not -Throw
     }


### PR DESCRIPTION
## Summary

`Set-Variable` mutates an existing variable's value, description, and options even when `-Option Constant` results in an error. This is because the cmdlet sets `Value` and `Description` before attempting to set `Options` — so when `PSVariable.SetOptions()` throws `SessionStateUnauthorizedAccessException` (because an existing variable cannot be made Constant), the earlier mutations are already committed.

This PR reorders the property assignments so that `Options` is set first. If the options assignment fails, the value, description, and visibility remain unchanged.

## Reproduction (from #27679)

**Case 1 — writable variable mutated:**
```powershell
New-Variable -Name x -Value 1
Set-Variable -Name x -Value 2 -Option Constant -ErrorAction SilentlyContinue
Get-Variable -Name x | Select-Object Name, Value, Options
```
Before: `x 2 None` — After: `x 1 None` ✅

**Case 2 — ReadOnly variable with -Force, value and options mutated:**
```powershell
New-Variable -Name x -Value 1 -Option ReadOnly
Set-Variable -Name x -Value 2 -Force -Option Constant -ErrorAction SilentlyContinue
Get-Variable -Name x | Select-Object Name, Value, Options
```
Before: `x 2 None` — After: `x 1 ReadOnly` ✅

**Case 3 — ReadOnly option removed even without value change:**
```powershell
New-Variable -Name x -Value 1 -Option ReadOnly
Set-Variable -Name x -Force -Option Constant -ErrorAction SilentlyContinue
Get-Variable -Name x | Select-Object Name, Value, Options
```
Before: `x 1 None` — After: `x 1 ReadOnly` ✅

## Root cause

In `SetVariableCommand.SetVariable()`, when updating an existing variable, the order of property assignments was:

1. Temporarily remove `ReadOnly` (if `-Force`)
2. Set `Value`
3. Set `Description`
4. Set `Options` ← throws here for `Constant` on existing variable

Since step 4 throws after steps 2–3 have already executed, the variable is left in a partially-updated state.

## Fix

Reorder to set `Options` immediately after the ReadOnly-removal step, before touching `Value` and `Description`. If `Options` assignment fails, the exception propagates to the `catch (SessionStateException)` block and none of the subsequent mutations occur.

This also fixes a secondary bug: when `-Force` temporarily removes `ReadOnly` and then `-Option Constant` fails, the `else` branch (which restores `ReadOnly`) now runs before any value mutation — so the variable's `ReadOnly` flag is correctly preserved.

## Tests

Added 4 regression tests in `Set-Variable.Tests.ps1` covering all three variations from the issue plus a description-mutation case.

Fixes #27679
