### PR TITLE
fix(filesystem): report clear error for junction creation on non-NTFS platforms

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2464,6 +2464,25 @@ namespace Microsoft.PowerShell.Commands
                 string action = FileSystemProviderStrings.NewItemActionJunction;
                 string resource = StringUtil.Format(FileSystemProviderStrings.NewItemActionTemplate, path);
 
+                // Junctions are an NTFS-specific feature. On non-Windows platforms CreateJunction()
+                // is a no-op, so fail fast before performing any filesystem mutations (deleting an
+                // existing path, creating a directory) that would otherwise leave the caller's path in
+                // a different state than they requested.
+                if (!Platform.IsWindows)
+                {
+                    if (ShouldProcess(resource, action))
+                    {
+                        string message = FileSystemProviderStrings.JunctionNotSupported;
+                        WriteError(new ErrorRecord(
+                            new PlatformNotSupportedException(message),
+                            "JunctionNotSupported",
+                            ErrorCategory.NotImplemented,
+                            path));
+                    }
+
+                    return;
+                }
+
                 if (ShouldProcess(resource, action))
                 {
                     bool isDirectory = false;
@@ -2572,19 +2591,6 @@ namespace Microsoft.PowerShell.Commands
                             if (!pathExists)
                             {
                                 pathDirInfo.Delete();
-                            }
-
-                            // On non-Windows platforms, CreateJunction returns false because
-                            // junctions are an NTFS-specific feature. Report a clear error instead
-                            // of silently doing nothing.
-                            if (!Platform.IsWindows)
-                            {
-                                string message = FileSystemProviderStrings.JunctionNotSupported;
-                                WriteError(new ErrorRecord(
-                                    new PlatformNotSupportedException(message),
-                                    "JunctionNotSupported",
-                                    ErrorCategory.NotImplemented,
-                                    path));
                             }
                         }
                     }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2573,6 +2573,19 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 pathDirInfo.Delete();
                             }
+
+                            // On non-Windows platforms, CreateJunction returns false because
+                            // junctions are an NTFS-specific feature. Report a clear error instead
+                            // of silently doing nothing.
+                            if (!Platform.IsWindows)
+                            {
+                                string message = FileSystemProviderStrings.JunctionNotSupported;
+                                WriteError(new ErrorRecord(
+                                    new PlatformNotSupportedException(message),
+                                    "JunctionNotSupported",
+                                    ErrorCategory.NotImplemented,
+                                    path));
+                            }
                         }
                     }
                     catch (Exception exception)

--- a/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
+++ b/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
@@ -354,4 +354,7 @@
   <data name="JunctionAbsolutePath" xml:space="preserve">
     <value>Creating a junction requires an absolute path for the target.</value>
   </data>
+  <data name="JunctionNotSupported" xml:space="preserve">
+    <value>Junctions are only supported on NTFS file systems. The current platform does not support creating junctions.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -703,6 +703,12 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             Test-Path $junctionToDir | Should -BeTrue
         }
 
+        It "New-Item junction fails with clear error on non-Windows" -Skip:$IsWindows {
+            $targetDir = New-Item -ItemType Directory -Path "$TestDrive/target"
+            { New-Item -ItemType Junction -Path "$TestDrive/junction" -Target $targetDir.FullName -ErrorAction Stop } |
+                Should -Throw -ErrorId "JunctionNotSupported,Microsoft.PowerShell.Commands.NewItemCommand"
+        }
+
         It 'New-Item fails creating junction with relative path' -Skip:(!$IsWindows) {
             try {
                 Push-Location $TestDrive

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -703,10 +703,15 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             Test-Path $junctionToDir | Should -BeTrue
         }
 
-        It "New-Item junction fails with clear error on non-Windows" -Skip:$IsWindows {
+        It "New-Item junction fails with clear error on non-Windows and leaves no item behind" -Skip:$IsWindows {
             $targetDir = New-Item -ItemType Directory -Path "$TestDrive/target"
-            { New-Item -ItemType Junction -Path "$TestDrive/junction" -Target $targetDir.FullName -ErrorAction Stop } |
+            $junctionPath = "$TestDrive/junction"
+            { New-Item -ItemType Junction -Path $junctionPath -Target $targetDir.FullName -ErrorAction Stop } |
                 Should -Throw -ErrorId "JunctionNotSupported,Microsoft.PowerShell.Commands.NewItemCommand"
+
+            # The early-return on non-Windows must not create a directory or leave any filesystem
+            # artefact at the requested path.
+            Test-Path -LiteralPath $junctionPath | Should -BeFalse
         }
 
         It 'New-Item fails creating junction with relative path' -Skip:(!$IsWindows) {


### PR DESCRIPTION
## Summary

On non-Windows platforms, `New-Item -ItemType Junction` was a quiet no-op: `CreateJunction()` returns `false` (junctions are NTFS-specific), the code rolled back the temporary directory it created, and no error was reported to the user.

This adds an explicit `PlatformNotSupportedException` via `WriteError` with error id `JunctionNotSupported` so the user gets an actionable message instead of silence.

## Reproduction

```powershell
# On Linux/macOS
New-Item foo -Target $HOME -ItemType Junction
```

**Before:** No output, no error, no item created (quiet no-op).

**After:**
```
New-Item: Junctions are only supported on NTFS file systems. The current platform does not support creating junctions.
```

## Changes

- `FileSystemProvider.cs`: In the `WinCreateJunction` failure branch, check `!Platform.IsWindows` and emit a `PlatformNotSupportedException` error record instead of silently returning.
- `FileSystemProviderStrings.resx`: Add `JunctionNotSupported` resource string.
- `FileSystem.Tests.ps1`: Add Pester test verifying the error on non-Windows.

Fixes #27252.
