### PR TITLE
Add API for getting signature help

### DIFF
--- a/src/System.Management.Automation/engine/COM/ComMethod.cs
+++ b/src/System.Management.Automation/engine/COM/ComMethod.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation.Internal;
 using System.Reflection;
@@ -72,6 +73,29 @@ namespace System.Management.Automation
                 COM.FUNCDESC funcdesc = Marshal.PtrToStructure<COM.FUNCDESC>(pFuncDesc);
 
                 string signature = ComUtil.GetMethodSignatureFromFuncDesc(_typeInfo, funcdesc, false);
+                result.Add(signature);
+
+                _typeInfo.ReleaseFuncDesc(pFuncDesc);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the following information about each method overload:
+        /// Method name, Return type, and parameters (name and type)
+        /// </summary>
+        /// <returns></returns>
+        internal List<Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>>> MethodDefinitionsAsTuples()
+        {
+            var result = new List<Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>>>();
+
+            foreach (int index in _methods)
+            {
+                _typeInfo.GetFuncDesc(index, out nint pFuncDesc);
+                COM.FUNCDESC funcdesc = Marshal.PtrToStructure<COM.FUNCDESC>(pFuncDesc);
+
+                var signature = ComUtil.GetMethodSignatureFromFuncDescAsTuple(_typeInfo, funcdesc);
                 result.Add(signature);
 
                 _typeInfo.ReleaseFuncDesc(pFuncDesc);

--- a/src/System.Management.Automation/engine/COM/ComMethod.cs
+++ b/src/System.Management.Automation/engine/COM/ComMethod.cs
@@ -81,21 +81,16 @@ namespace System.Management.Automation
             return result;
         }
 
-        /// <summary>
-        /// Returns the following information about each method overload:
-        /// Method name, Return type, and parameters (name and type)
-        /// </summary>
-        /// <returns></returns>
-        internal List<Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>>> MethodDefinitionsAsTuples()
+        internal List<engine.SignatureHelp.SignatureInformation> MethodDefinitionsAsSignatureInformation()
         {
-            var result = new List<Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>>>();
+            var result = new List<engine.SignatureHelp.SignatureInformation>();
 
             foreach (int index in _methods)
             {
                 _typeInfo.GetFuncDesc(index, out nint pFuncDesc);
                 COM.FUNCDESC funcdesc = Marshal.PtrToStructure<COM.FUNCDESC>(pFuncDesc);
 
-                var signature = ComUtil.GetMethodSignatureFromFuncDescAsTuple(_typeInfo, funcdesc);
+                var signature = ComUtil.GetMethodSignatureFromFuncDescAsSignatureInformation(_typeInfo, funcdesc);
                 result.Add(signature);
 
                 _typeInfo.ReleaseFuncDesc(pFuncDesc);

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation.ComInterop;
 using System.Runtime.InteropServices;
@@ -100,6 +101,55 @@ namespace System.Management.Automation
             builder.Append(')');
 
             return builder.ToString();
+        }
+
+        /// <summary>
+        /// Gets Method Signature info from FuncDesc describing the method.
+        /// </summary>
+        /// <param name="typeinfo">ITypeInfo interface of the object.</param>
+        /// <param name="funcdesc">FuncDesc which defines the method.</param>
+        /// <returns>A tuple that contains Method name, Return type, and parameters (name and type) for the method.</returns>
+        internal static Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>> GetMethodSignatureFromFuncDescAsTuple(COM.ITypeInfo typeinfo, COM.FUNCDESC funcdesc)
+        {
+            // First value is function name
+            int namesCount = funcdesc.cParams + 1;
+            string[] names = new string[funcdesc.cParams + 1];
+            typeinfo.GetNames(funcdesc.memid, names, namesCount, out _);
+            string methodName = names[0];
+
+            // Get the return type.
+            string retstring = GetStringFromTypeDesc(typeinfo, funcdesc.elemdescFunc.tdesc);
+            PSTypeName returnType = new(retstring);
+
+            IntPtr ElementDescriptionArrayPtr = funcdesc.lprgelemdescParam;
+            int ElementDescriptionSize = Marshal.SizeOf<COM.ELEMDESC>();
+            var paramList = new List<Tuple<string, PSTypeName>>();
+            for (int i = 0; i < funcdesc.cParams; i++)
+            {
+                int ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
+                IntPtr ElementDescriptionPointer;
+                // Disable PRefast warning for converting to int32 and converting back into intptr.
+                // Code below takes into account 32 bit vs 64 bit conversions
+#pragma warning disable 56515
+                if (IntPtr.Size == 4)
+                {
+                    ElementDescriptionPointer = (IntPtr)(ElementDescriptionArrayPtr.ToInt32() + ElementDescriptionArrayByteOffset);
+                }
+                else
+                {
+                    ElementDescriptionPointer = (IntPtr)(ElementDescriptionArrayPtr.ToInt64() + ElementDescriptionArrayByteOffset);
+                }
+#pragma warning restore 56515
+
+                COM.ELEMDESC ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
+
+                string paramName = names[i + 1];
+                string paramTypeAsString = GetStringFromTypeDesc(typeinfo, ElementDescription.tdesc);
+                PSTypeName parameterType = new(paramTypeAsString);
+                paramList.Add(new Tuple<string, PSTypeName>(paramName, parameterType));
+            }
+
+            return new Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>>(returnType, methodName, paramList);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -108,26 +108,33 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="typeinfo">ITypeInfo interface of the object.</param>
         /// <param name="funcdesc">FuncDesc which defines the method.</param>
-        /// <returns>A tuple that contains Method name, Return type, and parameters (name and type) for the method.</returns>
-        internal static Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>> GetMethodSignatureFromFuncDescAsTuple(COM.ITypeInfo typeinfo, COM.FUNCDESC funcdesc)
+        internal static engine.SignatureHelp.SignatureInformation GetMethodSignatureFromFuncDescAsSignatureInformation(COM.ITypeInfo typeinfo, COM.FUNCDESC funcdesc)
         {
+            StringBuilder builder = new();
+
             // First value is function name
             int namesCount = funcdesc.cParams + 1;
             string[] names = new string[funcdesc.cParams + 1];
             typeinfo.GetNames(funcdesc.memid, names, namesCount, out _);
-            string methodName = names[0];
 
-            // Get the return type.
+            // First get the string for return type.
             string retstring = GetStringFromTypeDesc(typeinfo, funcdesc.elemdescFunc.tdesc);
-            PSTypeName returnType = new(retstring);
+            _ = builder.Append(retstring + " ");
+
+            // Append the function name
+            _ = builder.Append(names[0]);
+            _ = builder.Append(" (");
 
             IntPtr ElementDescriptionArrayPtr = funcdesc.lprgelemdescParam;
             int ElementDescriptionSize = Marshal.SizeOf<COM.ELEMDESC>();
-            var paramList = new List<Tuple<string, PSTypeName>>();
+
+            var parameters = new engine.SignatureHelp.ParameterInformation[funcdesc.cParams];
             for (int i = 0; i < funcdesc.cParams; i++)
             {
+                int signatureStartOffset = builder.Length;
                 int ElementDescriptionArrayByteOffset = i * ElementDescriptionSize;
                 IntPtr ElementDescriptionPointer;
+
                 // Disable PRefast warning for converting to int32 and converting back into intptr.
                 // Code below takes into account 32 bit vs 64 bit conversions
 #pragma warning disable 56515
@@ -143,13 +150,26 @@ namespace System.Management.Automation
 
                 COM.ELEMDESC ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 
-                string paramName = names[i + 1];
-                string paramTypeAsString = GetStringFromTypeDesc(typeinfo, ElementDescription.tdesc);
-                PSTypeName parameterType = new(paramTypeAsString);
-                paramList.Add(new Tuple<string, PSTypeName>(paramName, parameterType));
+                string paramstring = GetStringFromTypeDesc(typeinfo, ElementDescription.tdesc);
+
+                _ = builder.Append(paramstring);
+                _ = builder.Append(" " + names[i + 1]);
+
+                parameters[i] = new engine.SignatureHelp.ParameterInformation(
+                    new PSTypeName(paramstring),
+                    signatureStartOffset,
+                    signatureLength: builder.Length - signatureStartOffset);
+
+                if (i < funcdesc.cParams - 1)
+                {
+                    _ = builder.Append(", ");
+                }
             }
 
-            return new Tuple<PSTypeName, string, List<Tuple<string, PSTypeName>>>(returnType, methodName, paramList);
+            _ = builder.Append(')');
+
+            typeinfo.GetDocumentation(funcdesc.memid, out _, out string documentation, out _, out _);
+            return new engine.SignatureHelp.SignatureInformation(builder.ToString(), parameters, documentation);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -3873,7 +3873,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="parameterInfo">ParameterInfo containing the parameter's default value.</param>
         /// <returns>String representation of the parameter's default value.</returns>
-        private static string GetDefaultValueStringRepresentation(ParameterInfo parameterInfo)
+        internal static string GetDefaultValueStringRepresentation(ParameterInfo parameterInfo)
         {
             var parameterType = parameterInfo.ParameterType;
             var parameterDefaultValue = parameterInfo.DefaultValue;

--- a/src/System.Management.Automation/engine/SignatureHelp.cs
+++ b/src/System.Management.Automation/engine/SignatureHelp.cs
@@ -2,42 +2,56 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.PowerShell;
 
 namespace System.Management.Automation.engine
 {
     /// <summary>
-    /// 
+    /// Class intended to be used by editors to get signature info from methods used in a script.
     /// </summary>
     public sealed class SignatureHelp
     {
         /// <summary>
-        /// 
+        /// An array of the found signatures. This is never null or empty.
         /// </summary>
-        public InvokeMemberExpressionAst InvokeExpression { get; }
+        public SignatureInformation[] Signatures { get; }
 
         /// <summary>
-        /// 
+        /// An index for <see cref="Signatures"/> for the most likely signature of the analyzed statement.
+        /// Will return -1 if the input doesn't seem to match any of the signatures.
         /// </summary>
-        public MethodOverload[] Overloads { get; }
+        public int ActiveSignature { get; }
 
-        private SignatureHelp(InvokeMemberExpressionAst invokeExpression, MethodOverload[] overloads)
+        private static readonly Dictionary<string, string> typeToDocFileTable = new();
+
+        private static readonly char[] s_methodStartChars = new char[] { '(', '{' };
+
+        private SignatureHelp(SignatureInformation[] signatures, int activeSignature)
         {
-            InvokeExpression = invokeExpression;
-            Overloads = overloads;
+            Signatures = signatures;
+            ActiveSignature = activeSignature;
         }
 
         /// <summary>
-        /// 
+        /// Gets <see cref="SignatureHelp"/> from the provided script and curor position.
         /// </summary>
-        /// <param name="scriptText"></param>
-        /// <param name="cursorPosition"></param>
-        /// <returns></returns>
-        public static SignatureHelp GetSignatureHelp(string scriptText, int cursorPosition)
+        /// <param name="scriptText">The script content that should be analyzed.</param>
+        /// <param name="cursorPosition">The position of the cursor inside the script.</param>
+        /// <param name="includeUnusableSignatures">Set to true to include all signatures.
+        /// By default unusable signatures (ones that use pointer parameters) will not be shown.</param>
+        /// <returns> Returns <see cref="SignatureHelp"/> if the cursor is within a valid type signature that can be analyzed.
+        /// Otherwise it returns null.</returns>
+        public static SignatureHelp GetSignatureHelp(string scriptText, int cursorPosition, bool includeUnusableSignatures = false)
         {
-            ScriptBlockAst baseAst = Parser.ParseInput(scriptText, out _, out ParseError[] parseErrors);
+            ScriptBlockAst baseAst = Parser.ParseInput(scriptText, out Token[] parsedTokens, out ParseError[] parseErrors);
             int incompleteInputOffset = -1;
             foreach (ParseError error in parseErrors)
             {
@@ -52,13 +66,202 @@ namespace System.Management.Automation.engine
             baseAst.Visit(signatureFinder);
             if (signatureFinder.foundAst is InvokeMemberExpressionAst invokeMemberExpression)
             {
-                return GetSignatureHelpForMethod(invokeMemberExpression);
+                int argumentIndex = GetCurrentArgIndex(invokeMemberExpression, parsedTokens, cursorPosition);
+                return GetSignatureHelpForMethod(invokeMemberExpression, argumentIndex, includeUnusableSignatures);
             }
 
             return null;
         }
 
-        private static SignatureHelp GetSignatureHelpForMethod(InvokeMemberExpressionAst methodInvokeExpression)
+        /// <summary>
+        /// Sets the folder where PowerShell gets type documentation from for use in the signaturehelp.
+        /// </summary>
+        /// <param name="path">The folder that contains the .XML files with the help documentation.</param>
+        /// <param name="clearOldEntries">Set to true to remove old XML documentation references that were previously loaded.</param>
+        public static void SetDotNetReferenceDir(string path, bool clearOldEntries)
+        {
+            if (clearOldEntries)
+            {
+                typeToDocFileTable.Clear();
+            }
+
+            DirectoryInfo docDir = new(path);
+            foreach (FileInfo file in docDir.EnumerateFiles("*.xml"))
+            {
+
+                XDocument doc;
+                try
+                {
+                    doc = XDocument.Load(file.FullName);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                IEnumerable<XElement> members = doc.Root.Element("members")?.Elements("member");
+                if (members is not null)
+                {
+                    foreach (var member in members)
+                    {
+                        string memberName = member.Attribute("name").Value;
+                        if (memberName.StartsWith("T:"))
+                        {
+                            typeToDocFileTable[memberName] = file.FullName;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the index of the argument that the user is currently typing.
+        /// </summary>
+        /// <returns>
+        /// The index of the argument the cursor is at or 0 if there's no arguments.
+        /// The index may exceed the number of arguments if the cursor is after a trailing comma like: $Var.Method("Arg1", ^
+        /// </returns>
+        private static int GetCurrentArgIndex(InvokeMemberExpressionAst invokeMemberExpression, Token[] parsedTokens, int cursorPosition)
+        {
+            if (invokeMemberExpression.Arguments is null)
+            {
+                return 0;
+            }
+
+            ReadOnlyCollection<ExpressionAst> arguments = invokeMemberExpression.Arguments;
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                IScriptExtent currentArg = arguments[i].Extent;
+                if ((currentArg.StartOffset <= cursorPosition && currentArg.EndOffset >= cursorPosition)
+                    || (cursorPosition < currentArg.StartOffset))
+                {
+                    // Cursor is within, or before an argument like: $Var.Method( ^ "Arg1, "Arg2"
+                    return i;
+                }
+
+                if (i + 1 == arguments.Count)
+                {
+                    // The cursor is past the last argument.
+                    // Check for a trailing comma indicating that the user is entering the next parameter.
+                    foreach (Token token in parsedTokens)
+                    {
+                        if (token.Extent.StartOffset < currentArg.EndOffset)
+                        {
+                            continue;
+                        }
+
+                        if (token.Extent.StartOffset > invokeMemberExpression.Extent.EndOffset)
+                        {
+                            return i;
+                        }
+
+                        if (token.Kind == TokenKind.Comma)
+                        {
+                            return i + 1;
+                        }
+                    }
+                }
+
+                IScriptExtent nextArg = arguments[i + 1].Extent;
+                if (cursorPosition >= nextArg.StartOffset)
+                {
+                    continue;
+                }
+
+                // The cursor is in the whitespace between one of the arguments like this: $Var.Method("Arg1" ^ , "Arg2", "Arg3"
+                // Need to check the tokens to see if we are before or after the comma.
+                foreach (Token token in parsedTokens)
+                {
+                    if (token.Extent.StartOffset < currentArg.EndOffset)
+                    {
+                        continue;
+                    }
+
+                    if (token.Kind == TokenKind.Comma)
+                    {
+                        return token.Extent.StartOffset > cursorPosition ? i : i + 1;
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        private static SignatureDocumentation GetSignatureDocumentation(MethodBase methodBase)
+        {
+            Type declaringType = methodBase.DeclaringType;
+            string typeName;
+            MethodBase methodToGetDocsFor;
+            if (declaringType.IsGenericType)
+            {
+                Type genericType = declaringType.GetGenericTypeDefinition();
+                typeName = genericType.FullName;
+                methodToGetDocsFor = MethodBase.GetMethodFromHandle(methodBase.MethodHandle, genericType.TypeHandle);
+            }
+            else
+            {
+                typeName = declaringType.FullName;
+                methodToGetDocsFor = methodBase;
+            }
+
+            if (!typeToDocFileTable.TryGetValue($"T:{typeName}", out string docFilePath))
+            {
+                string assemblyLocation = declaringType.Assembly.Location;
+                if (string.IsNullOrEmpty(assemblyLocation))
+                {
+                    return null;
+                }
+
+                docFilePath = Path.ChangeExtension(assemblyLocation, ".xml");
+            }
+
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Load(docFilePath);
+            }
+            catch
+            {
+                return null;
+            }
+
+            string lookupKey = GetMemberId(methodToGetDocsFor);
+
+            var members = doc.Root.Element("members")?.Elements("member");
+            if (members is not null)
+            {
+                foreach (var member in members)
+                {
+                    string memberName = member.Attribute("name")?.Value;
+                    if (memberName.Equals(lookupKey, StringComparison.Ordinal))
+                    {
+                        Dictionary<string, string> parameterDocs = new(StringComparer.Ordinal);
+                        IEnumerable<XElement> documentedParameters = member.Elements("param");
+                        if (documentedParameters is not null)
+                        {
+                            foreach (XElement parameter in documentedParameters)
+                            {
+                                string parameterName = parameter.Attribute("name")?.Value;
+                                if (string.IsNullOrEmpty(parameterName))
+                                {
+                                    continue;
+                                }
+
+                                parameterDocs[parameterName] = parameter.Value;
+                            }
+                        }
+
+                        return new SignatureDocumentation(
+                            summary: member.Element("summary")?.Value,
+                            parameters: parameterDocs);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static SignatureHelp GetSignatureHelpForMethod(InvokeMemberExpressionAst methodInvokeExpression, int argumentIndex, bool includeUnusableSignatures)
         {
             if (methodInvokeExpression.Member is not ExpressionAst memberExpression)
             {
@@ -66,6 +269,7 @@ namespace System.Management.Automation.engine
                 return null;
             }
 
+            bool isStatic = methodInvokeExpression.Static;
             using (PowerShell powershell = PowerShell.Create(RunspaceMode.CurrentRunspace))
             {
                 ExecutionContext context = LocalPipeline.GetExecutionContextFromTLS();
@@ -78,11 +282,11 @@ namespace System.Management.Automation.engine
                     return null;
                 }
 
-                var methodOverloads = new List<MethodOverload>();
+                List<SignatureInformation> foundSignatures = [];
                 if (SafeExprEvaluator.TrySafeEval(methodInvokeExpression.Expression, context, out object value))
                 {
                     PSMemberInfoCollection<PSMemberInfo> members;
-                    if (methodInvokeExpression.Static)
+                    if (isStatic)
                     {
                         if (PSObject.Base(value) is not Type type)
                         {
@@ -108,19 +312,18 @@ namespace System.Management.Automation.engine
 
                         if (method.adapterData is DotNetAdapter.MethodCacheEntry cacheEntry)
                         {
-                            methodOverloads.AddRange(GetMethodOverloadsFromDotNetCacheEntry(cacheEntry, member.Name));
+                            foundSignatures.AddRange(GetSignaturesFromDotNetCacheEntry(cacheEntry, member.Name, includeUnusableSignatures));
                         }
                         else if (method.adapterData is ComMethod comMethod)
                         {
-                            methodOverloads.AddRange(GetMethodOverloadsFromComMethod(comMethod));
+                            foundSignatures.AddRange(comMethod.MethodDefinitionsAsSignatureInformation());
                         }
                     }
                 }
 
-                if (methodOverloads.Count == 0)
+                if (foundSignatures.Count == 0)
                 {
                     IList<PSTypeName> typesToGetMembersFrom;
-                    bool isStatic = methodInvokeExpression.Static;
                     if (isStatic)
                     {
                         if (methodInvokeExpression.Expression is not TypeExpressionAst typeExpression)
@@ -152,7 +355,7 @@ namespace System.Management.Automation.engine
                                     continue;
                                 }
 
-                                methodOverloads.AddRange(GetMethodOverloadsFromDotNetCacheEntry(cacheEntry, methodName));
+                                foundSignatures.AddRange(GetSignaturesFromDotNetCacheEntry(cacheEntry, methodName, includeUnusableSignatures));
                             }
                             else if (member is CompilerGeneratedMemberFunctionAst constructorInfo)
                             {
@@ -162,72 +365,222 @@ namespace System.Management.Automation.engine
                                     continue;
                                 }
 
-                                PSTypeName implementingType = new(constructorInfo.DefiningType);
-                                methodOverloads.Add(new MethodOverload(
-                                    implementingType,
-                                    implementingType,
-                                    methodName: "new",
-                                    parameters: null,
-                                    genericArgs: null
-                                    ));
+                                foundSignatures.Add(new SignatureInformation(signature: $"{constructorInfo.DefiningType.Name} new()", parameters: []));
                             }
-                            else if (member is FunctionMemberAst PsClassMethod)
+                            else if (member is FunctionMemberAst psClassMethod)
                             {
-                                string methodName = PsClassMethod.IsConstructor ? "new" : PsClassMethod.Name;
+                                string methodName = psClassMethod.IsConstructor ? "new" : psClassMethod.Name;
                                 if (!inputMethodName.EqualsOrdinalIgnoreCase(methodName))
                                 {
                                     continue;
                                 }
 
-                                PSTypeName implementingType = new((TypeDefinitionAst)PsClassMethod.Parent);
-                                PSTypeName returnType;
-                                if (PsClassMethod.IsConstructor)
-                                {
-                                    returnType = implementingType;
-                                }
-                                else if (PsClassMethod.ReturnType is null)
-                                {
-                                    returnType = new PSTypeName(typeof(void));
-                                }
-                                else
-                                {
-                                    returnType = new PSTypeName(PsClassMethod.ReturnType.TypeName);
-                                }
-
-                                MethodParameter[] parameters = GetMethodParametersFromParameterAsts(PsClassMethod.Parameters);
-                                methodOverloads.Add(new MethodOverload(
-                                    returnType,
-                                    implementingType,
-                                    methodName,
-                                    parameters,
-                                    genericArgs: null));
+                                foundSignatures.Add(GetSignatureFromPsClassMethod(psClassMethod));
                             }
                         }
                     }
                 }
 
-                if (methodOverloads.Count != 0)
+                if (foundSignatures.Count != 0)
                 {
-                    return new SignatureHelp(methodInvokeExpression, methodOverloads.ToArray());
+                    return GetSignatureHelpFromFoundSignatures(ref foundSignatures, methodInvokeExpression, argumentIndex, powershell);
                 }
             }
 
             return null;
         }
 
-        private static IEnumerable<MethodOverload> GetMethodOverloadsFromDotNetCacheEntry(DotNetAdapter.MethodCacheEntry cacheEntry, string methodName)
+        private static SignatureHelp GetSignatureHelpFromFoundSignatures(
+            ref List<SignatureInformation> foundSignatures,
+            InvokeMemberExpressionAst invokeExpression,
+            int argumentIndex,
+            PowerShell powerShell)
         {
+            int inputArgCount;
+            IList<PSTypeName>[] argumentInputTypes;
+            if (invokeExpression.Arguments is not null)
+            {
+                inputArgCount = argumentIndex == invokeExpression.Arguments.Count
+                    ? argumentIndex + 1
+                    : invokeExpression.Arguments.Count;
+                argumentInputTypes = new IList<PSTypeName>[invokeExpression.Arguments.Count];
+                for (int i = 0; i < argumentInputTypes.Length; i++)
+                {
+                    argumentInputTypes[i] = AstTypeInference.InferTypeOf(invokeExpression.Arguments[i], powerShell);
+                }
+            }
+            else
+            {
+                inputArgCount = 0;
+                argumentInputTypes = null;
+            }
+
+            int activeSignature = -1;
+            for (int i = 0; i < foundSignatures.Count; i++)
+            {
+                if (foundSignatures[i].Parameters.Length == 0)
+                {
+                    foundSignatures[i].ActiveParameter = -1;
+                }
+                else if (argumentIndex >= foundSignatures[i].Parameters.Length)
+                {
+                    foundSignatures[i].ActiveParameter = foundSignatures[i].Parameters[^1].IsParams
+                        ? foundSignatures[i].Parameters.Length - 1
+                        : -1;
+                }
+                else
+                {
+                    foundSignatures[i].ActiveParameter = argumentIndex;
+                }
+
+                if (activeSignature != -1)
+                {
+                    continue;
+                }
+
+                if (inputArgCount == 0)
+                {
+                    if (foundSignatures[i].Parameters.Length == 0)
+                    {
+                        activeSignature = i;
+                    }
+
+                    continue;
+                }
+
+                if (inputArgCount > foundSignatures[i].Parameters.Length
+                    && !foundSignatures[i].Parameters[^1].IsParams)
+                {
+                    continue;
+                }
+
+                for (int j = 0; j < foundSignatures[i].Parameters.Length; j++)
+                {
+                    if (foundSignatures[i].Parameters[j].IsPointer)
+                    {
+                        goto nextSignature;
+                    }
+
+                    if (argumentInputTypes.Length > j)
+                    {
+                        PSTypeName paramType = foundSignatures[i].Parameters[j].Type;
+                        Type realParamType = paramType.Type;
+                        bool typeMatched = false;
+                        foreach (PSTypeName inferredType in argumentInputTypes[j])
+                        {
+                            if (realParamType is null)
+                            {
+                                // No type info loaded. Can only compare by name.
+                                if (string.Equals(inferredType.Name, paramType.Name, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    typeMatched = true;
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                Type realInferredType = inferredType.Type;
+                                if (realInferredType is null)
+                                {
+                                    continue;
+                                }
+
+                                if (realParamType.IsAssignableFrom(realInferredType)
+                                    || (realParamType.IsArray && realParamType.GetElementType().IsAssignableFrom(realInferredType))
+                                    || (foundSignatures[i].Parameters[j].IsRef && realInferredType == typeof(PSReference)))
+                                {
+                                    typeMatched = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!typeMatched)
+                        {
+                            goto nextSignature;
+                        }
+                    }
+                }
+
+                activeSignature = i;
+
+            nextSignature:
+                ;
+            }
+
+            return new SignatureHelp(foundSignatures.ToArray(), activeSignature);
+        }
+
+        private static List<SignatureInformation> GetSignaturesFromDotNetCacheEntry(DotNetAdapter.MethodCacheEntry cacheEntry, string methodName, bool includeSigsWithPointers)
+        {
+            List<SignatureInformation> outputList = new(cacheEntry.methodInformationStructures.Length);
+            StringBuilder signatureBuilder = new();
             foreach (MethodInformation methodInfo in cacheEntry.methodInformationStructures)
             {
+                signatureBuilder.Length = 0;
+
                 MethodBase methodBase = methodInfo.method;
+                if (methodBase.IsStatic)
+                {
+                    _ = signatureBuilder.Append("static ");
+                }
+
+                if (methodBase is MethodInfo methodEntry)
+                {
+                    _ = signatureBuilder.Append(ToStringCodeMethods.Type(methodEntry.ReturnType));
+                    _ = signatureBuilder.Append(' ');
+                }
+                else if (methodBase is ConstructorInfo constructor)
+                {
+                    _ = signatureBuilder.Append(ToStringCodeMethods.Type(constructor.DeclaringType));
+                    _ = signatureBuilder.Append(' ');
+                }
+
+                if (methodBase.DeclaringType.IsInterface)
+                {
+                    _ = signatureBuilder.Append(ToStringCodeMethods.Type(methodBase.DeclaringType, dropNamespaces: true));
+                    _ = signatureBuilder.Append('.');
+                }
+
+                _ = signatureBuilder.Append(methodName);
+                if (methodBase.IsGenericMethodDefinition || methodBase.IsGenericMethod)
+                {
+                    _ = signatureBuilder.Append('[');
+                    Type[] genericArgs = methodBase.GetGenericArguments();
+                    for (int i = 0; i < genericArgs.Length; i++)
+                    {
+                        if (i > 0)
+                        {
+                            _ = signatureBuilder.Append(", ");
+                        }
+
+                        _ = signatureBuilder.Append(ToStringCodeMethods.Type(genericArgs[i]));
+                    }
+
+                    _ = signatureBuilder.Append(']');
+                }
+
+                SignatureDocumentation signatureDocumentation = GetSignatureDocumentation(methodBase);
+                _ = signatureBuilder.Append('(');
                 ParameterInfo[] methodParamsToProcess = methodBase.GetParameters();
-                var methodParams = new MethodParameter[methodParamsToProcess.Length];
+                var methodParams = new ParameterInformation[methodParamsToProcess.Length];
                 for (int i = 0; i < methodParams.Length; i++)
                 {
+                    int paramStartOffset = signatureBuilder.Length;
                     bool byRef = methodInfo.parameters[i].isByRef;
                     Type paramType = byRef
                         ? methodParamsToProcess[i].ParameterType.GetElementType()
                         : methodParamsToProcess[i].ParameterType;
+
+                    if (!includeSigsWithPointers && paramType.IsPointer)
+                    {
+                        goto nextSignature;
+                    }
+
+                    if (byRef)
+                    {
+                        _ = signatureBuilder.Append("[ref] ");
+                    }
 
                     bool isParams = false;
                     if (paramType.IsArray && i == methodParams.Length - 1)
@@ -236,83 +589,95 @@ namespace System.Management.Automation.engine
                         if (paramAttributes is not null && paramAttributes.Length != 0)
                         {
                             isParams = true;
+                            _ = signatureBuilder.Append("Params ");
                         }
                     }
 
-                    methodParams[i] = new MethodParameter(methodParamsToProcess[i].Name, new PSTypeName(paramType), byRef, isParams);
-                }
+                    _ = signatureBuilder.Append(ToStringCodeMethods.Type(paramType));
+                    _ = signatureBuilder.Append(' ');
+                    _ = signatureBuilder.Append(methodParamsToProcess[i].Name);
 
-                PSTypeName returnType;
-                if (methodBase is MethodInfo methodEntry)
-                {
-                    returnType = new PSTypeName(methodEntry.ReturnType);
-                }
-                else if (methodBase is ConstructorInfo constructor)
-                {
-                    returnType = new PSTypeName(constructor.DeclaringType);
-                }
-                else
-                {
-                    // Should never happen because it should always be either a method or constructor
-                    continue;
-                }
-
-                PSTypeName[] genericArguments;
-                if (methodBase.IsGenericMethodDefinition || methodBase.IsGenericMethod)
-                {
-                    Type[] genericArgs = methodBase.GetGenericArguments();
-                    genericArguments = new PSTypeName[genericArgs.Length];
-                    for (int i = 0; i < genericArgs.Length; i++)
+                    bool hasDefaultValue = methodParamsToProcess[i].HasDefaultValue;
+                    if (hasDefaultValue)
                     {
-                        genericArguments[i] = new PSTypeName(genericArgs[i]);
+                        _ = signatureBuilder.Append(" = ");
+                        _ = signatureBuilder.Append(DotNetAdapter.GetDefaultValueStringRepresentation(methodParamsToProcess[i]));
+                    }
+
+                    string parameterDocumentation = signatureDocumentation?.Parameters.TryGetValue(methodParamsToProcess[i].Name, out string doc) == true
+                        ? doc
+                        : null;
+
+                    methodParams[i] = new ParameterInformation(
+                        new PSTypeName(paramType),
+                        paramStartOffset,
+                        signatureLength: signatureBuilder.Length - paramStartOffset,
+                        documentationText: parameterDocumentation,
+                        byRef,
+                        isParams,
+                        paramType.IsPointer,
+                        hasDefaultValue);
+
+                    if (i < methodParams.Length - 1)
+                    {
+                        _ = signatureBuilder.Append(", ");
                     }
                 }
+
+                _ = signatureBuilder.Append(')');
+
+                outputList.Add(new SignatureInformation(
+                    signatureBuilder.ToString(),
+                    methodParams,
+                    documentationText: signatureDocumentation?.Summary
+                    ));
+            
+            nextSignature:
+                ;
+            }
+
+            return outputList;
+        }
+
+        private static SignatureInformation GetSignatureFromPsClassMethod(FunctionMemberAst psClassMethod)
+        {
+            PSTypeName implementingType = new((TypeDefinitionAst)psClassMethod.Parent);
+            StringBuilder signatureBuilder = new();
+            if (psClassMethod.IsStatic)
+            {
+                _ = signatureBuilder.Append("static ");
+            }
+
+            if (psClassMethod.IsConstructor)
+            {
+                _ = signatureBuilder.Append($"{implementingType.Name} ");
+            }
+            else
+            {
+                string returnTypeString;
+                if (psClassMethod.ReturnType is null)
+                {
+                    returnTypeString = ToStringCodeMethods.Type(typeof(void));
+                }
                 else
                 {
-                    genericArguments = null;
+                    ITypeName typeName = psClassMethod.ReturnType.TypeName;
+                    Type reflectionType = typeName.GetReflectionType();
+                    returnTypeString = reflectionType is null
+                        ? typeName.Name
+                        : ToStringCodeMethods.Type(reflectionType);
                 }
 
-                var implementingType = new PSTypeName(methodBase.DeclaringType);
-                yield return new MethodOverload(returnType, implementingType, methodName, methodParams, genericArguments);
-            }
-        }
-
-        private static IEnumerable<MethodOverload> GetMethodOverloadsFromComMethod(ComMethod comMethod)
-        {
-            var data = comMethod.MethodDefinitionsAsTuples();
-            foreach (var item in data)
-            {
-                var methods = new MethodParameter[item.Item3.Count];
-                for (int i = 0; i < methods.Length; i++)
-                {
-                    methods[i] = new MethodParameter(
-                        item.Item3[i].Item1,
-                        item.Item3[i].Item2,
-                        isRef: false,
-                        isParams: false);
-                }
-
-                yield return new MethodOverload(
-                    item.Item1,
-                    implementingType: null, // Is there a way for me to get this for COM objects?
-                    item.Item2,
-                    methods,
-                    genericArgs: null
-                    );
-            }
-        }
-
-        private static MethodParameter[] GetMethodParametersFromParameterAsts(IList<ParameterAst> parameters)
-        {
-            if (parameters is null || parameters.Count == 0)
-            {
-                return null;
+                _ = signatureBuilder.Append(returnTypeString);
+                _ = signatureBuilder.Append(' ');
             }
 
-            var result = new MethodParameter[parameters.Count];
-            for (int i = 0; i < result.Length; i++)
+            _ = signatureBuilder.Append('(');
+            var methodParams = new ParameterInformation[psClassMethod.Parameters.Count];
+            for (int i = 0; i < methodParams.Length; i++)
             {
-                ParameterAst parameter = parameters[i];
+                int paramStartOffset = signatureBuilder.Length;
+                ParameterAst parameter = psClassMethod.Parameters[i];
                 PSTypeName parameterType = null;
                 if (parameter.Attributes is not null && parameter.Attributes.Count > 0)
                 {
@@ -327,102 +692,144 @@ namespace System.Management.Automation.engine
                 }
 
                 parameterType ??= new PSTypeName(typeof(object));
-                result[i] = new MethodParameter(
-                    parameter.Name.VariablePath.UnqualifiedPath,
+                Type reflectionType = parameterType.Type;
+                string parameterTypeString = reflectionType is null
+                    ? parameterType.Name
+                    : ToStringCodeMethods.Type(reflectionType);
+                _ = signatureBuilder.Append(parameterTypeString);
+                _ = signatureBuilder.Append(' ');
+                _ = signatureBuilder.Append(parameter.Name.VariablePath.UnqualifiedPath);
+
+                methodParams[i] = new ParameterInformation(
                     parameterType,
-                    isRef: false,
-                    isParams: false);
+                    signatureStartOffset: paramStartOffset,
+                    signatureLength: signatureBuilder.Length - paramStartOffset);
+
+                _ = signatureBuilder.Append(", ");
             }
 
-            return result;
+            if (methodParams.Length > 0)
+            {
+                // Remove trailing ", " from parameters
+                signatureBuilder.Length -= 2;
+            }
+
+            _ = signatureBuilder.Append(')');
+
+            return new SignatureInformation(signatureBuilder.ToString(), methodParams);
         }
 
         /// <summary>
-        /// 
+        /// Represents a signature for <see cref="SignatureHelp"/>
         /// </summary>
-        public sealed class MethodOverload
+        public sealed class SignatureInformation
         {
             /// <summary>
-            /// 
+            /// A string representation of a method and its parameters.
             /// </summary>
-            public PSTypeName ReturnType { get; }
-            
-            /// <summary>
-            /// 
-            /// </summary>
-            public PSTypeName ImplementingType { get; }
+            public string SignatureString { get; }
 
             /// <summary>
-            /// 
+            /// Help text for the signature. May be null if no documentation is available.
             /// </summary>
-            public string Name { get; }
+            public string Documentation { get; }
 
             /// <summary>
-            /// 
+            /// The parameters for this signature. This is never null.
             /// </summary>
-            public MethodParameter[] Parameters { get; }
+            public ParameterInformation[] Parameters { get; }
 
             /// <summary>
-            /// 
+            /// An index for <see cref="Parameters"/> that represents the parameter that the cursor is at.
             /// </summary>
-            public PSTypeName[] GenericArguments { get; }
+            public int ActiveParameter { get; internal set; } = -1;
 
-            /// <summary>
-            /// 
-            /// </summary>
-            /// <param name="returnType"></param>
-            /// <param name="implementingType"></param>
-            /// <param name="methodName"></param>
-            /// <param name="parameters"></param>
-            /// <param name="genericArgs"></param>
-            public MethodOverload(PSTypeName returnType, PSTypeName implementingType, string methodName, MethodParameter[] parameters, PSTypeName[] genericArgs)
+            internal SignatureInformation(string signature, ParameterInformation[] parameters, string documentationText = null)
             {
-                ReturnType = returnType;
-                ImplementingType = implementingType;
-                Name = methodName;
+                SignatureString = signature;
+                Documentation = documentationText;
                 Parameters = parameters;
-                GenericArguments = genericArgs;
+            }
+
+            /// <summary>
+            /// Returns <see cref="SignatureString"/>
+            /// </summary>
+            public override string ToString()
+            {
+                return SignatureString;
             }
         }
 
         /// <summary>
-        /// 
+        /// Represents a parameter for <see cref="SignatureInformation"/>
         /// </summary>
-        public sealed class MethodParameter
+        public sealed class ParameterInformation
         {
             /// <summary>
-            /// 
+            /// The index within <see cref="SignatureInformation.SignatureString"/> where this parameter definition starts.
             /// </summary>
-            public string Name { get; }
+            public int SignatureStartOffset { get; }
 
             /// <summary>
-            /// 
+            /// The length of the parameter definition within <see cref="SignatureInformation.SignatureString"/>.
+            /// Can be used in combination with <see cref="SignatureStartOffset"/> to get a string representation of the parameter definition.
             /// </summary>
-            public PSTypeName Type { get; }
+            public int SignatureLength { get; }
 
             /// <summary>
-            /// 
+            /// Help text for the parameter. May be null if no documentation is available.
             /// </summary>
-            public bool IsRef { get; }
+            public string Documentation { get; }
 
-            /// <summary>
-            /// 
-            /// </summary>
-            public bool IsParams { get; }
+            internal PSTypeName Type { get; }
 
-            /// <summary>
-            /// 
-            /// </summary>
-            /// <param name="name"></param>
-            /// <param name="type"></param>
-            /// <param name="isRef"></param>
-            /// <param name="isParams"></param>
-            public MethodParameter(string name, PSTypeName type, bool isRef, bool isParams)
+            internal bool IsRef { get; }
+
+            internal bool IsParams { get; }
+
+            internal bool IsPointer { get; }
+
+            internal bool HasDefaultValue { get; }
+
+            internal ParameterInformation(
+                PSTypeName type,
+                int signatureStartOffset,
+                int signatureLength,
+                string documentationText = null,
+                bool isRef = false,
+                bool isParams = false,
+                bool isPointer = false,
+                bool hasDefaultValue = false)
             {
-                Name = name;
+                SignatureStartOffset = signatureStartOffset;
+                SignatureLength = signatureLength;
+                Documentation = documentationText;
                 Type = type;
                 IsRef = isRef;
                 IsParams = isParams;
+                IsPointer = isPointer;
+                HasDefaultValue = hasDefaultValue;
+            }
+
+            /// <summary>
+            /// Returns the type name for the parameter.
+            /// </summary>
+            public override string ToString()
+            {
+                return Type.Name;
+            }
+        }
+
+        private sealed class SignatureDocumentation
+        {
+            public string Summary { get; }
+
+            public Dictionary<string, string> Parameters { get; }
+
+            public SignatureDocumentation(string summary, Dictionary<string, string> parameters)
+            {
+                Summary = summary;
+                Parameters = parameters;
             }
         }
 
@@ -440,8 +847,20 @@ namespace System.Management.Automation.engine
 
             public override AstVisitAction VisitInvokeMemberExpression(InvokeMemberExpressionAst methodCallAst)
             {
+                int argumentStartOffset;
+                if (methodCallAst.GenericTypeArguments is null || methodCallAst.GenericTypeArguments.Count == 0)
+                {
+                    argumentStartOffset = methodCallAst.Member.Extent.EndOffset + 1;
+                }
+                else
+                {
+                    argumentStartOffset = methodCallAst.GenericTypeArguments[^1].Extent.EndOffset;
+                    int parenStart = methodCallAst.Extent.Text.IndexOfAny(s_methodStartChars, argumentStartOffset - methodCallAst.Extent.StartOffset);
+                    argumentStartOffset = methodCallAst.Extent.StartOffset + parenStart + 1;
+                }
+
                 IScriptExtent extent = methodCallAst.Extent;
-                if (methodCallAst.Member.Extent.EndOffset < cursorOffset
+                if (argumentStartOffset <= cursorOffset
                     && (extent.EndOffset > cursorOffset || (extent.EndOffset == cursorOffset && !extent.Text.EndsWith(')', StringComparison.Ordinal))
                     || (incompleteInputOffset < cursorOffset && incompleteInputOffset == extent.EndOffset && !extent.Text.EndsWith(')', StringComparison.Ordinal))))
                 {
@@ -451,17 +870,17 @@ namespace System.Management.Automation.engine
                 return AstVisitAction.Continue;
             }
 
-            public override AstVisitAction VisitAttribute(AttributeAst attributeAst)
-            {
-                IScriptExtent extent = attributeAst.Extent;
-                if (extent.StartOffset < cursorOffset
-                    && (extent.EndOffset > cursorOffset || (extent.EndOffset == cursorOffset && !extent.Text.EndsWith(']', StringComparison.Ordinal))))
-                {
-                    foundAst = attributeAst;
-                }
+            //public override AstVisitAction VisitAttribute(AttributeAst attributeAst)
+            //{
+            //    IScriptExtent extent = attributeAst.Extent;
+            //    if (extent.StartOffset < cursorOffset
+            //        && (extent.EndOffset > cursorOffset || (extent.EndOffset == cursorOffset && !extent.Text.EndsWith(']', StringComparison.Ordinal))))
+            //    {
+            //        foundAst = attributeAst;
+            //    }
 
-                return AstVisitAction.Continue;
-            }
+            //    return AstVisitAction.Continue;
+            //}
 
             public override AstVisitAction DefaultVisit(Ast ast)
             {
@@ -476,6 +895,93 @@ namespace System.Management.Automation.engine
 
                 return AstVisitAction.Continue;
             }
+        }
+
+        private static string GetMemberId(MethodBase method)
+        {
+            var sb = new StringBuilder("M:");
+
+            _ = sb.Append(GetTypeName(method.DeclaringType));
+            _ = sb.Append('.');
+
+            if (method.IsConstructor)
+            {
+                _ = sb.Append(method.IsStatic ? "#cctor" : "#ctor");
+            }
+            else
+            {
+                _ = sb.Append(method.Name);
+            }
+
+            // Generic method arity (open generic method -> ``N)
+            if (method.IsGenericMethod)
+            {
+                _ = sb.Append("``").Append(method.GetGenericArguments().Length);
+            }
+
+            var parameters = method.GetParameters();
+            if (parameters.Length > 0)
+            {
+                _ = sb.Append('(');
+                _ = sb.Append(string.Join(",", parameters.Select(p => GetParamTypeName(p.ParameterType))));
+                _ = sb.Append(')');
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GetTypeName(Type type)
+        {
+            // Use generic type definition so open params show as `0, `1, etc.
+            var t = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+            return GetRawFullName(t);
+        }
+
+        private static string GetRawFullName(Type type)
+        {
+            string name = type.FullName ?? $"{type.Namespace}.{type.Name}";
+            return name.Replace('+', '.'); // nested types
+        }
+
+        private static string GetParamTypeName(Type type)
+        {
+            if (type.IsByRef)
+                return GetParamTypeName(type.GetElementType()) + "@";
+
+            if (type.IsPointer)
+                return GetParamTypeName(type.GetElementType()) + "*";
+
+            if (type.IsArray)
+            {
+                int rank = type.GetArrayRank();
+                string elem = GetParamTypeName(type.GetElementType());
+                return rank == 1
+                    ? elem + "[]"
+                    : elem + "[" + string.Join(",", Enumerable.Repeat("0:", rank)) + "]";
+            }
+
+            if (type.IsGenericParameter)
+            {
+                return type.DeclaringMethod != null
+                    ? "``" + type.GenericParameterPosition   // method-level generic param
+                    : "`" + type.GenericParameterPosition;   // type-level generic param
+            }
+
+            if (type.IsGenericType)
+            {
+                var def = type.GetGenericTypeDefinition();
+                string baseName = StripGenericArity(GetRawFullName(def));
+                string args = string.Join(",", type.GetGenericArguments().Select(GetParamTypeName));
+                return baseName + "{" + args + "}";
+            }
+
+            return GetRawFullName(type);
+        }
+
+        private static string StripGenericArity(string typeName)
+        {
+            int backtickIndex = typeName.LastIndexOf('`');
+            return backtickIndex >= 0 ? typeName.Substring(0, backtickIndex) : typeName;
         }
     }
 }

--- a/src/System.Management.Automation/engine/SignatureHelp.cs
+++ b/src/System.Management.Automation/engine/SignatureHelp.cs
@@ -1,0 +1,481 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+using System.Management.Automation.Runspaces;
+using System.Reflection;
+
+namespace System.Management.Automation.engine
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed class SignatureHelp
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public InvokeMemberExpressionAst InvokeExpression { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public MethodOverload[] Overloads { get; }
+
+        private SignatureHelp(InvokeMemberExpressionAst invokeExpression, MethodOverload[] overloads)
+        {
+            InvokeExpression = invokeExpression;
+            Overloads = overloads;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="scriptText"></param>
+        /// <param name="cursorPosition"></param>
+        /// <returns></returns>
+        public static SignatureHelp GetSignatureHelp(string scriptText, int cursorPosition)
+        {
+            ScriptBlockAst baseAst = Parser.ParseInput(scriptText, out _, out ParseError[] parseErrors);
+            int incompleteInputOffset = -1;
+            foreach (ParseError error in parseErrors)
+            {
+                if (error.Extent.EndOffset <= cursorPosition
+                    && error.ErrorId.Equals(nameof(ParserStrings.MissingEndParenthesisInMethodCall), StringComparison.Ordinal))
+                {
+                    incompleteInputOffset = error.Extent.EndOffset;
+                }
+            }
+
+            var signatureFinder = new SignatureAstFinder(cursorPosition, incompleteInputOffset);
+            baseAst.Visit(signatureFinder);
+            if (signatureFinder.foundAst is InvokeMemberExpressionAst invokeMemberExpression)
+            {
+                return GetSignatureHelpForMethod(invokeMemberExpression);
+            }
+
+            return null;
+        }
+
+        private static SignatureHelp GetSignatureHelpForMethod(InvokeMemberExpressionAst methodInvokeExpression)
+        {
+            if (methodInvokeExpression.Member is not ExpressionAst memberExpression)
+            {
+                // Should never happen because the only CommandElement that isn't also an Expression is a CommandParameter
+                return null;
+            }
+
+            using (PowerShell powershell = PowerShell.Create(RunspaceMode.CurrentRunspace))
+            {
+                ExecutionContext context = LocalPipeline.GetExecutionContextFromTLS();
+
+                if (!SafeExprEvaluator.TrySafeEval(memberExpression, context, out object memberValue)
+                    || memberValue is not string inputMethodName
+                    || string.IsNullOrEmpty(inputMethodName))
+                {
+                    // Can't determine the name of the method being called.
+                    return null;
+                }
+
+                var methodOverloads = new List<MethodOverload>();
+                if (SafeExprEvaluator.TrySafeEval(methodInvokeExpression.Expression, context, out object value))
+                {
+                    PSMemberInfoCollection<PSMemberInfo> members;
+                    if (methodInvokeExpression.Static)
+                    {
+                        if (PSObject.Base(value) is not Type type)
+                        {
+                            // Trying to invoke a static method on something that isn't a type, which is not possible.
+                            return null;
+                        }
+
+                        members = PSObject.DotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type);
+                    }
+                    else
+                    {
+                        members = PSObject.AsPSObject(value).Members;
+                    }
+
+                    foreach (var member in members)
+                    {
+                        if (!inputMethodName.EqualsOrdinalIgnoreCase(member.Name)
+                            || member is not PSMethod method
+                            || method.IsSpecial)
+                        {
+                            continue;
+                        }
+
+                        if (method.adapterData is DotNetAdapter.MethodCacheEntry cacheEntry)
+                        {
+                            methodOverloads.AddRange(GetMethodOverloadsFromDotNetCacheEntry(cacheEntry, member.Name));
+                        }
+                        else if (method.adapterData is ComMethod comMethod)
+                        {
+                            methodOverloads.AddRange(GetMethodOverloadsFromComMethod(comMethod));
+                        }
+                    }
+                }
+
+                if (methodOverloads.Count == 0)
+                {
+                    IList<PSTypeName> typesToGetMembersFrom;
+                    bool isStatic = methodInvokeExpression.Static;
+                    if (isStatic)
+                    {
+                        if (methodInvokeExpression.Expression is not TypeExpressionAst typeExpression)
+                        {
+                            // Safe eval couldn't figure out the type, and it's not a type expression
+                            // So we have no idea what type to invoke static methods for.
+                            return null;
+                        }
+
+                        typesToGetMembersFrom = new PSTypeName[] { new(typeExpression.TypeName) };
+                    }
+                    else
+                    {
+                        typesToGetMembersFrom = AstTypeInference.InferTypeOf(methodInvokeExpression.Expression, powershell);
+                    }
+
+                    var inferenceContext = new TypeInferenceContext(powershell);
+                    foreach (PSTypeName typename in typesToGetMembersFrom)
+                    {
+                        IList<object> inferredMembers = inferenceContext.GetMembersByInferredType(typename, isStatic, filter: null);
+                        foreach (object member in inferredMembers)
+                        {
+                            if (member is DotNetAdapter.MethodCacheEntry cacheEntry)
+                            {
+                                MethodBase methodBase = cacheEntry.methodInformationStructures[0].method;
+                                string methodName = methodBase.IsConstructor ? "new" : methodBase.Name;
+                                if (!inputMethodName.EqualsOrdinalIgnoreCase(methodName))
+                                {
+                                    continue;
+                                }
+
+                                methodOverloads.AddRange(GetMethodOverloadsFromDotNetCacheEntry(cacheEntry, methodName));
+                            }
+                            else if (member is CompilerGeneratedMemberFunctionAst constructorInfo)
+                            {
+                                // This is a default constructor generated when the class author hasn't defined one themself.
+                                if (!inputMethodName.EqualsOrdinalIgnoreCase("new"))
+                                {
+                                    continue;
+                                }
+
+                                PSTypeName implementingType = new(constructorInfo.DefiningType);
+                                methodOverloads.Add(new MethodOverload(
+                                    implementingType,
+                                    implementingType,
+                                    methodName: "new",
+                                    parameters: null,
+                                    genericArgs: null
+                                    ));
+                            }
+                            else if (member is FunctionMemberAst PsClassMethod)
+                            {
+                                string methodName = PsClassMethod.IsConstructor ? "new" : PsClassMethod.Name;
+                                if (!inputMethodName.EqualsOrdinalIgnoreCase(methodName))
+                                {
+                                    continue;
+                                }
+
+                                PSTypeName implementingType = new((TypeDefinitionAst)PsClassMethod.Parent);
+                                PSTypeName returnType;
+                                if (PsClassMethod.IsConstructor)
+                                {
+                                    returnType = implementingType;
+                                }
+                                else if (PsClassMethod.ReturnType is null)
+                                {
+                                    returnType = new PSTypeName(typeof(void));
+                                }
+                                else
+                                {
+                                    returnType = new PSTypeName(PsClassMethod.ReturnType.TypeName);
+                                }
+
+                                MethodParameter[] parameters = GetMethodParametersFromParameterAsts(PsClassMethod.Parameters);
+                                methodOverloads.Add(new MethodOverload(
+                                    returnType,
+                                    implementingType,
+                                    methodName,
+                                    parameters,
+                                    genericArgs: null));
+                            }
+                        }
+                    }
+                }
+
+                if (methodOverloads.Count != 0)
+                {
+                    return new SignatureHelp(methodInvokeExpression, methodOverloads.ToArray());
+                }
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<MethodOverload> GetMethodOverloadsFromDotNetCacheEntry(DotNetAdapter.MethodCacheEntry cacheEntry, string methodName)
+        {
+            foreach (MethodInformation methodInfo in cacheEntry.methodInformationStructures)
+            {
+                MethodBase methodBase = methodInfo.method;
+                ParameterInfo[] methodParamsToProcess = methodBase.GetParameters();
+                var methodParams = new MethodParameter[methodParamsToProcess.Length];
+                for (int i = 0; i < methodParams.Length; i++)
+                {
+                    bool byRef = methodInfo.parameters[i].isByRef;
+                    Type paramType = byRef
+                        ? methodParamsToProcess[i].ParameterType.GetElementType()
+                        : methodParamsToProcess[i].ParameterType;
+
+                    bool isParams = false;
+                    if (paramType.IsArray && i == methodParams.Length - 1)
+                    {
+                        var paramAttributes = paramType.GetCustomAttributes(typeof(ParamArrayAttribute), inherit: false);
+                        if (paramAttributes is not null && paramAttributes.Length != 0)
+                        {
+                            isParams = true;
+                        }
+                    }
+
+                    methodParams[i] = new MethodParameter(methodParamsToProcess[i].Name, new PSTypeName(paramType), byRef, isParams);
+                }
+
+                PSTypeName returnType;
+                if (methodBase is MethodInfo methodEntry)
+                {
+                    returnType = new PSTypeName(methodEntry.ReturnType);
+                }
+                else if (methodBase is ConstructorInfo constructor)
+                {
+                    returnType = new PSTypeName(constructor.DeclaringType);
+                }
+                else
+                {
+                    // Should never happen because it should always be either a method or constructor
+                    continue;
+                }
+
+                PSTypeName[] genericArguments;
+                if (methodBase.IsGenericMethodDefinition || methodBase.IsGenericMethod)
+                {
+                    Type[] genericArgs = methodBase.GetGenericArguments();
+                    genericArguments = new PSTypeName[genericArgs.Length];
+                    for (int i = 0; i < genericArgs.Length; i++)
+                    {
+                        genericArguments[i] = new PSTypeName(genericArgs[i]);
+                    }
+                }
+                else
+                {
+                    genericArguments = null;
+                }
+
+                var implementingType = new PSTypeName(methodBase.DeclaringType);
+                yield return new MethodOverload(returnType, implementingType, methodName, methodParams, genericArguments);
+            }
+        }
+
+        private static IEnumerable<MethodOverload> GetMethodOverloadsFromComMethod(ComMethod comMethod)
+        {
+            var data = comMethod.MethodDefinitionsAsTuples();
+            foreach (var item in data)
+            {
+                var methods = new MethodParameter[item.Item3.Count];
+                for (int i = 0; i < methods.Length; i++)
+                {
+                    methods[i] = new MethodParameter(
+                        item.Item3[i].Item1,
+                        item.Item3[i].Item2,
+                        isRef: false,
+                        isParams: false);
+                }
+
+                yield return new MethodOverload(
+                    item.Item1,
+                    implementingType: null, // Is there a way for me to get this for COM objects?
+                    item.Item2,
+                    methods,
+                    genericArgs: null
+                    );
+            }
+        }
+
+        private static MethodParameter[] GetMethodParametersFromParameterAsts(IList<ParameterAst> parameters)
+        {
+            if (parameters is null || parameters.Count == 0)
+            {
+                return null;
+            }
+
+            var result = new MethodParameter[parameters.Count];
+            for (int i = 0; i < result.Length; i++)
+            {
+                ParameterAst parameter = parameters[i];
+                PSTypeName parameterType = null;
+                if (parameter.Attributes is not null && parameter.Attributes.Count > 0)
+                {
+                    foreach (var attribute in parameter.Attributes)
+                    {
+                        if (attribute is TypeConstraintAst typeConstraint)
+                        {
+                            parameterType = new PSTypeName(typeConstraint.TypeName);
+                            break;
+                        }
+                    }
+                }
+
+                parameterType ??= new PSTypeName(typeof(object));
+                result[i] = new MethodParameter(
+                    parameter.Name.VariablePath.UnqualifiedPath,
+                    parameterType,
+                    isRef: false,
+                    isParams: false);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public sealed class MethodOverload
+        {
+            /// <summary>
+            /// 
+            /// </summary>
+            public PSTypeName ReturnType { get; }
+            
+            /// <summary>
+            /// 
+            /// </summary>
+            public PSTypeName ImplementingType { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public string Name { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public MethodParameter[] Parameters { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public PSTypeName[] GenericArguments { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="returnType"></param>
+            /// <param name="implementingType"></param>
+            /// <param name="methodName"></param>
+            /// <param name="parameters"></param>
+            /// <param name="genericArgs"></param>
+            public MethodOverload(PSTypeName returnType, PSTypeName implementingType, string methodName, MethodParameter[] parameters, PSTypeName[] genericArgs)
+            {
+                ReturnType = returnType;
+                ImplementingType = implementingType;
+                Name = methodName;
+                Parameters = parameters;
+                GenericArguments = genericArgs;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public sealed class MethodParameter
+        {
+            /// <summary>
+            /// 
+            /// </summary>
+            public string Name { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public PSTypeName Type { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public bool IsRef { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public bool IsParams { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="name"></param>
+            /// <param name="type"></param>
+            /// <param name="isRef"></param>
+            /// <param name="isParams"></param>
+            public MethodParameter(string name, PSTypeName type, bool isRef, bool isParams)
+            {
+                Name = name;
+                Type = type;
+                IsRef = isRef;
+                IsParams = isParams;
+            }
+        }
+
+        private sealed class SignatureAstFinder : AstVisitor2
+        {
+            internal Ast foundAst;
+            private readonly int cursorOffset;
+            private readonly int incompleteInputOffset;
+
+            public SignatureAstFinder(int cursorPosition, int incompleteInputOffset)
+            {
+                cursorOffset = cursorPosition;
+                this.incompleteInputOffset = incompleteInputOffset;
+            }
+
+            public override AstVisitAction VisitInvokeMemberExpression(InvokeMemberExpressionAst methodCallAst)
+            {
+                IScriptExtent extent = methodCallAst.Extent;
+                if (methodCallAst.Member.Extent.EndOffset < cursorOffset
+                    && (extent.EndOffset > cursorOffset || (extent.EndOffset == cursorOffset && !extent.Text.EndsWith(')', StringComparison.Ordinal))
+                    || (incompleteInputOffset < cursorOffset && incompleteInputOffset == extent.EndOffset && !extent.Text.EndsWith(')', StringComparison.Ordinal))))
+                {
+                    foundAst = methodCallAst;
+                }
+
+                return AstVisitAction.Continue;
+            }
+
+            public override AstVisitAction VisitAttribute(AttributeAst attributeAst)
+            {
+                IScriptExtent extent = attributeAst.Extent;
+                if (extent.StartOffset < cursorOffset
+                    && (extent.EndOffset > cursorOffset || (extent.EndOffset == cursorOffset && !extent.Text.EndsWith(']', StringComparison.Ordinal))))
+                {
+                    foundAst = attributeAst;
+                }
+
+                return AstVisitAction.Continue;
+            }
+
+            public override AstVisitAction DefaultVisit(Ast ast)
+            {
+                if (ast.Extent.StartOffset > cursorOffset)
+                {
+                    // When visiting do while/until statements, the condition will be visited before the statement block.
+                    // The condition itself may not be interesting if it's after the cursor, but the statement block could be.
+                    return ast is PipelineBaseAst && ast.Parent is DoUntilStatementAst or DoWhileStatementAst
+                        ? AstVisitAction.SkipChildren
+                        : AstVisitAction.StopVisit;
+                }
+
+                return AstVisitAction.Continue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This PR adds a new API for getting signature help for the method at the cursor, similar to the completion API. See this example for use and output:
```
PS C:\> $ScriptText = "[System.Management.Automation.Language.Parser]::ParseFile('C:\MyScript.ps1', "
PS C:\> $SigHelp = [System.Management.Automation.engine.SignatureHelp]::GetSignatureHelp($ScriptText, $ScriptText.Length - 1)
PS C:\> $SigHelp | fl

Signatures      : {static System.Management.Automation.Language.ScriptBlockAst ParseFile(string fileName, [ref] System.Management.Automation.Language.Token[] tokens, [ref] System.Management.Automation.Language.ParseError[] errors)}
ActiveSignature : 0

PS C:\> $SigHelp.Signatures[0] | fl

SignatureString : static System.Management.Automation.Language.ScriptBlockAst ParseFile(string fileName, [ref] System.Management.Automation.Language.Token[] tokens, [ref] System.Management.Automation.Language.ParseError[] errors)
Documentation   :
                              Parse input from the specified file.

Parameters      : {System.String, System.Management.Automation.Language.Token[], System.Management.Automation.Language.ParseError[]}
ActiveParameter : 1

PS C:\> $SigHelp.Signatures[0].Parameters[1] | fl

SignatureStartOffset : 87
SignatureLength      : 58
Documentation        : Returns the tokens from parsing the script.

PS C:\> $SigHelp.Signatures[0].SignatureString.Substring(87, 58)
[ref] System.Management.Automation.Language.Token[] tokens
PS C:\>
```
<!-- Summarize your PR between here and the checklist. -->

I took inspiration from the LSP spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_signatureHelp which defines these interfaces:

```
export interface SignatureHelp {
	signatures: SignatureInformation[];
	activeSignature?: uinteger;
	activeParameter?: uinteger | null;
}

export interface SignatureInformation {
	label: string;
	documentation?: string | MarkupContent;
	parameters?: ParameterInformation[];
	activeParameter?: uinteger | null;
}

export interface ParameterInformation {
	label: string | [uinteger, uinteger];
	documentation?: string | MarkupContent;
}
```

My class names and public properties mostly match these interfaces, but instead of using uints and null I use ints and -1.
For `SignatureHelp` I left out `activeParameter` because it's redundant when `SignatureInformation` already has that info.
For `ParameterInformation` I defined two properties `SignatureStartOffset` and `SignatureLength` rather than start/end offsets because it's easier to use with .NETs Substring method.

For the documentation text there are 2 possible sources depending on what is being analyzed.
1: For COM object methods it's whatever output comes from `typeinfo.GetDocumentation()`.  
2: For .NET methods the user can specify a folder that contains the .xml files with the documentation like this: `[System.Management.Automation.engine.SignatureHelp]::SetDotNetReferenceDir("C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\11.0.0-preview.5.26302.115\ref\net11.0", $false)`
Then it will look for the documentation in the .xml files in that folder. If it doesn't find any documentation there it tries to look for an .xml that matches the assembly in the same folder as the assembly. For example for `C:\Program Files\PowerShell\7-preview\System.Management.Automation.dll` it will look for `C:\Program Files\PowerShell\7-preview\System.Management.Automation.xml`

## PR Context
Fixes: https://github.com/PowerShell/PowerShell/issues/19619 (this issue also describes why I want it).

Right now this only supports method invocations, but the plan is to also support attributes in another PR (this one is big enough already).
Since the main users of this API would be PSReadLine and editor services, those SMEs should probably take a look /cc @daxian-dbw @andyleejordan @SeeminglyScience @JustinGrote

Marked as draft because I haven't added any tests yet.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [X] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
