### PR TITLE
fix(web-cmdlets): use response charset instead of ASCII in WebResponseObject.ToString()

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebResponseObject.Common.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PowerShell.Commands
         {
             StringBuilder raw = ContentHelper.GetRawContentHeader(baseResponse);
 
-            // Use ASCII encoding for the RawContent visual view of the content.
+            // Use the response encoding for the RawContent visual view of the content.
             if (Content?.Length > 0)
             {
                 raw.Append(ToString());
@@ -184,7 +184,13 @@ namespace Microsoft.PowerShell.Commands
                 return string.Empty;
             }
 
-            char[] stringContent = Encoding.ASCII.GetChars(Content);
+            // Decode using the response's character set when available so non-ASCII
+            // content is preserved. Fall back to UTF-8, which is a safe superset of
+            // ASCII and the default encoding used elsewhere in the web cmdlets.
+            string? characterSet = WebResponseHelper.GetCharacterSet(BaseResponse);
+            StreamHelper.TryGetEncoding(characterSet, out Encoding encoding);
+
+            char[] stringContent = encoding.GetChars(Content);
             for (int counter = 0; counter < stringContent.Length; counter++)
             {
                 if (!IsPrintable(stringContent[counter]))

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1534,6 +1534,19 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
             $result.Output.RawContent | Should -Match ([regex]::Escape('Content-Length: 2'))
         }
 
+        It "Verifies Invoke-WebRequest ToString preserves non-ASCII characters when charset is declared" {
+            $query = @{
+                contenttype = 'text/plain; charset=utf-8'
+                body        = 'café'
+            }
+            $uri = Get-WebListenerUrl -Test 'Response' -Query $query
+            $response = ExecuteWebRequest -Uri $uri -UseBasicParsing
+
+            $response.Error | Should -BeNullOrEmpty
+            # ToString() should preserve the non-ASCII 'é' instead of replacing it with '?'.
+            $response.Output.ToString() | Should -Match 'café'
+        }
+
         It "Verifies Invoke-WebRequest Supports Multiple response headers with same name" {
             $query = @{
                 contenttype = 'text/plain'


### PR DESCRIPTION
# PR Summary

WebResponseObject.ToString() hardcoded Encoding.ASCII to decode the response body bytes, so any non-ASCII character came out as '?' (or '.' after the printable-char filter). This affects both the direct .ToString() call and the RawContent property that is built from it.

This change resolves the encoding from the response Content-Type charset via WebResponseHelper.GetCharacterSet / StreamHelper.TryGetEncoding, falling back to UTF-8 (ContentHelper.GetDefaultEncoding) when no charset is declared. UTF-8 is a strict superset of ASCII, so existing pure-ASCII responses are unchanged. I also updated the now-stale 'Use ASCII encoding' comment in InitializeRawContent.

Added a Pester test that serves a UTF-8 body containing 'café' and asserts the non-ASCII character survives ToString().

## PR Context

Fixes #27154 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [] Issue filed: 
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
