### PR TITLE
Reject malformed rebuild branches and gate nonofficial Apple signing

### DIFF
--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -1,6 +1,7 @@
 parameters:
   parentJob: ''
   buildArchitecture: x64
+  OfficialBuild: true
 
 jobs:
 - job: package_macOS_${{ parameters.buildArchitecture }}
@@ -84,6 +85,7 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "codesign verification failed for $($_.FullName)" }
       }
     displayName: 'Verify Apple codesign on signed binaries'
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
 
   - pwsh: |
       # Add -SkipReleaseChecks as a mitigation to unblock release.
@@ -191,6 +193,10 @@ jobs:
   - group: certificate_logical_to_actual
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+  - name: ob_signing_setup_enabled
+    value: ${{ parameters.OfficialBuild }}
+  - name: ob_sdl_codeSignValidation_enabled
+    value: ${{ parameters.OfficialBuild }}
   - name: ob_sdl_binskim_enabled
     value: true
   - name: ob_sdl_credscan_suppressionsfileforartifacts
@@ -226,9 +232,11 @@ jobs:
       Write-Verbose -Verbose "Compressed files:"
       Get-ChildItem -Path $(Pipeline.Workspace) -Filter "*.zip" -File | Write-Verbose -Verbose
     displayName: Compress package files for signing
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
 
   - task: onebranch.pipeline.signing@1
     displayName: 'OneBranch CodeSigning Package'
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
     inputs:
       command: 'sign'
       files_to_sign: '**/*-osx-*.zip'
@@ -248,6 +256,7 @@ jobs:
 
   - task: onebranch.pipeline.signing@1
     displayName: 'OneBranch Notarize Package'
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
     inputs:
       command: 'sign'
       files_to_sign: '**/*-osx-*.zip'
@@ -294,3 +303,19 @@ jobs:
       Write-Verbose -Verbose "Expanded pkg file:"
       Get-ChildItem -Path $(ob_outputDirectory) | Write-Verbose -Verbose
     displayName: Expand signed file
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
+
+  - pwsh: |
+      $buildArch = '${{ parameters.buildArchitecture }}'
+      $macosRuntime = "osx-$buildArch"
+      $pkgNameFilter = "powershell-*$macosRuntime.pkg"
+      $pkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $pkgNameFilter -Recurse -File
+
+      if ($pkgPath.Count -eq 0) {
+        throw "No package found for $macosRuntime"
+      }
+
+      $null = New-Item -Path $(ob_outputDirectory) -ItemType Directory -Force
+      $pkgPath | Copy-Item -Destination $(ob_outputDirectory) -Force -Verbose
+    displayName: Copy unsigned package for upload
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'false'))

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -1,5 +1,6 @@
 parameters:
   buildArchitecture: 'x64'
+  OfficialBuild: true
 jobs:
 - job: build_macOS_${{ parameters.buildArchitecture }}
   displayName: Build macOS ${{ parameters.buildArchitecture }}
@@ -101,7 +102,7 @@ jobs:
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: ob_sdl_codeSignValidation_enabled
-    value: true
+    value: ${{ parameters.OfficialBuild }}
   - name: ob_sdl_tsa_configFile
     value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
   - name: ob_sdl_credscan_suppressionsFile
@@ -150,7 +151,7 @@ jobs:
   - template: /.pipelines/templates/obp-file-signing.yml@self
     parameters:
       binPath: $(DropRootPath)
-      OfficialBuild: $(ps_official_build)
+      OfficialBuild: ${{ parameters.OfficialBuild }}
 
   # Apple-sign the Mach-O binaries inside the signed output.
   - pwsh: |
@@ -158,9 +159,11 @@ jobs:
       $zipFile = "$(Pipeline.Workspace)/macho-$(BuildArchitecture).zip"
       Compress-Archive -Path "$signedDir/*" -DestinationPath $zipFile -Force
     displayName: Compress signed folder for Apple signing
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
 
   - task: onebranch.pipeline.signing@1
     displayName: Apple CodeSign Mach-O binaries
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
     inputs:
       command: 'sign'
       files_to_sign: 'macho-$(BuildArchitecture).zip'
@@ -183,6 +186,7 @@ jobs:
       $zipFile = "$(Pipeline.Workspace)/macho-$(BuildArchitecture).zip"
       Expand-Archive -Path $zipFile -DestinationPath $signedDir -Force -Verbose
     displayName: Expand Apple-signed Mach-O binaries into signed output
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
 
   - pwsh: |
       $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
@@ -202,5 +206,6 @@ jobs:
         throw "ESRP did not apply a Developer ID signature to $($missing.Count) file(s): $($missing -join ', ')"
       }
     displayName: 'Verify Developer ID signature on Mach-O binaries'
+    condition: and(succeeded(), eq('${{ parameters.OfficialBuild }}', 'true'))
 
   - template: /.pipelines/templates/step/finalize.yml@self

--- a/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
@@ -59,9 +59,11 @@ stages:
   - template: /.pipelines/templates/mac.yml@self
     parameters:
       buildArchitecture: x64
+      OfficialBuild: ${{ parameters.OfficialBuild }}
   - template: /.pipelines/templates/mac.yml@self
     parameters:
       buildArchitecture: arm64
+      OfficialBuild: ${{ parameters.OfficialBuild }}
 
 - stage: linux
   displayName: linux - build and sign

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -15,10 +15,12 @@ stages:
   - template: /.pipelines/templates/mac-package-build.yml@self
     parameters:
       buildArchitecture: x64
+      OfficialBuild: ${{ parameters.OfficialBuild }}
 
   - template: /.pipelines/templates/mac-package-build.yml@self
     parameters:
       buildArchitecture: arm64
+      OfficialBuild: ${{ parameters.OfficialBuild }}
 
 - stage: windows_package_build
   displayName: 'Win Pkg (unsigned)'

--- a/test/infrastructure/SetReleaseTag.Tests.ps1
+++ b/test/infrastructure/SetReleaseTag.Tests.ps1
@@ -4,6 +4,8 @@
 Describe 'setReleaseTag.ps1' {
     BeforeAll {
         $script:setReleaseTagPath = Join-Path $PSScriptRoot '../../tools/releaseBuild/setReleaseTag.ps1'
+        $metadataPath = Join-Path $PSScriptRoot '../../tools/metadata.json'
+        $script:previewVersion = (Get-Content $metadataPath | ConvertFrom-Json).PreviewReleaseTag -replace '-.*$'
     }
 
     It 'rejects malformed rebuild branch <Branch>' -TestCases @(
@@ -34,6 +36,30 @@ Describe 'setReleaseTag.ps1' {
 
         & $script:setReleaseTagPath -ReleaseTag fromBranch -Branch $Branch |
             Should -BeExactly $ExpectedTag
+    }
+
+    It 'derives the release tag from a release branch' {
+        & $script:setReleaseTagPath -ReleaseTag fromBranch -Branch 'refs/heads/release/v7.0.1' |
+            Should -BeExactly 'v7.0.1'
+    }
+
+    It 'does not treat nested <BranchType> paths as release branches' -TestCases @(
+        @{
+            Branch = 'refs/heads/feature/rebuild/v7.0.1-rebuild.1'
+            BranchType = 'rebuild'
+            ReleaseTag = 'v7.0.1-rebuild.1'
+        }
+        @{
+            Branch = 'refs/heads/feature/release/v7.0.1'
+            BranchType = 'release'
+            ReleaseTag = 'v7.0.1'
+        }
+    ) {
+        param($Branch, $ReleaseTag)
+
+        $result = & $script:setReleaseTagPath -ReleaseTag fromBranch -Branch $Branch
+        $result | Should -Match "^$([regex]::Escape($script:previewVersion))-"
+        $result | Should -Not -BeExactly $ReleaseTag
     }
 
     It 'uses an explicit release tag without validating the branch' {

--- a/test/infrastructure/SetReleaseTag.Tests.ps1
+++ b/test/infrastructure/SetReleaseTag.Tests.ps1
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'setReleaseTag.ps1' {
+    BeforeAll {
+        $script:setReleaseTagPath = Join-Path $PSScriptRoot '../../tools/releaseBuild/setReleaseTag.ps1'
+    }
+
+    It 'rejects malformed rebuild branch <Branch>' -TestCases @(
+        @{ Branch = 'refs/heads/rebuild/v7.0.1' }
+        @{ Branch = 'refs/heads/rebuild/v7.0.1-rebuild' }
+        @{ Branch = 'refs/heads/rebuild/v7.0.1-rebuild.one' }
+        @{ Branch = 'refs/heads/rebuild/v7.0.1-rebuild.01' }
+        @{ Branch = 'refs/heads/rebuild/not-a-version-rebuild.1' }
+    ) {
+        param($Branch)
+
+        $expectedMessage = "Malformed rebuild branch '$Branch'. Expected branch name format: 'rebuild/v<major>.<minor>.<patch>-rebuild.<number>'."
+        { & $script:setReleaseTagPath -ReleaseTag fromBranch -Branch $Branch } | Should -Throw -ExpectedMessage $expectedMessage
+    }
+
+    It 'rejects a malformed rebuild branch when ReleaseTag is omitted' {
+        $branch = 'refs/heads/rebuild/v7.0.1'
+        $expectedMessage = "Malformed rebuild branch '$branch'. Expected branch name format: 'rebuild/v<major>.<minor>.<patch>-rebuild.<number>'."
+
+        { & $script:setReleaseTagPath -Branch $branch } | Should -Throw -ExpectedMessage $expectedMessage
+    }
+
+    It 'derives the release tag from valid rebuild branch <Branch>' -TestCases @(
+        @{ Branch = 'refs/heads/rebuild/v7.0.1-rebuild.1'; ExpectedTag = 'v7.0.1-rebuild.1' }
+        @{ Branch = 'refs/heads/rebuild/v7.0.1-rebuild.12'; ExpectedTag = 'v7.0.1-rebuild.12' }
+    ) {
+        param($Branch, $ExpectedTag)
+
+        & $script:setReleaseTagPath -ReleaseTag fromBranch -Branch $Branch |
+            Should -BeExactly $ExpectedTag
+    }
+
+    It 'uses an explicit release tag without validating the branch' {
+        & $script:setReleaseTagPath -ReleaseTag 'v7.0.1-rebuild.1' -Branch 'refs/heads/rebuild/v7.0.1' |
+            Should -BeExactly 'v7.0.1-rebuild.1'
+    }
+}

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -80,18 +80,20 @@ $isDaily = $false
 if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
 {
     $validRebuildBranchRegex = '^refs/heads/rebuild/v[0-9]+\.[0-9]+\.[0-9]+-rebuild\.(?:0|[1-9][0-9]*)$'
-    if ($Branch -match '^refs/heads/rebuild/' -and $Branch -notmatch $validRebuildBranchRegex)
+    $isRebuildBranch = $Branch -match '^refs/heads/rebuild/'
+    $isValidRebuildBranch = $Branch -match $validRebuildBranchRegex
+    if ($isRebuildBranch -and -not $isValidRebuildBranch)
     {
         throw "Malformed rebuild branch '$Branch'. Expected branch name format: 'rebuild/v<major>.<minor>.<patch>-rebuild.<number>'."
     }
 
     # Branch is named release/<semver> or rebuild/v<semver>-rebuild.<number>
-    $releaseBranchRegex = '^.*((release/|rebuild/.*rebuild))'
-    if($Branch -match $releaseBranchRegex)
+    $isReleaseBranch = $Branch -match '^refs/heads/release/'
+    if($isReleaseBranch -or $isValidRebuildBranch)
     {
         $msixType = 'release'
         Write-Verbose "release branch:" -Verbose
-        $releaseTag = $Branch -replace '^.*((release|rebuild)/)'
+        $releaseTag = $Branch -replace '^refs/heads/(?:release|rebuild)/'
         $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
         Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
         Write-Host -Object "##$vstsCommandString"

--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -67,8 +67,8 @@ function New-BuildInfoJson {
 }
 
 # Script to set the release tag based on the branch name if it is not set or it is "fromBranch"
-# the branch name is expected to be release-<semver> or <previewname>
-# VSTS passes it as 'refs/heads/release-v6.0.2'
+# the branch name is expected to be release/<semver>, rebuild/v<semver>-rebuild.<number>, or <previewname>
+# VSTS passes it as 'refs/heads/release/v6.0.2'
 
 $branchOnly = $Branch -replace '^refs/heads/';
 $branchOnly = $branchOnly -replace '[_\-]'
@@ -79,7 +79,13 @@ $isDaily = $false
 
 if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
 {
-    # Branch is named release-<semver>
+    $validRebuildBranchRegex = '^refs/heads/rebuild/v[0-9]+\.[0-9]+\.[0-9]+-rebuild\.(?:0|[1-9][0-9]*)$'
+    if ($Branch -match '^refs/heads/rebuild/' -and $Branch -notmatch $validRebuildBranchRegex)
+    {
+        throw "Malformed rebuild branch '$Branch'. Expected branch name format: 'rebuild/v<major>.<minor>.<patch>-rebuild.<number>'."
+    }
+
+    # Branch is named release/<semver> or rebuild/v<semver>-rebuild.<number>
     $releaseBranchRegex = '^.*((release/|rebuild/.*rebuild))'
     if($Branch -match $releaseBranchRegex)
     {


### PR DESCRIPTION
## PR Summary

- Reject malformed `rebuild/` branch names when `setReleaseTag.ps1` derives the release tag from the source branch.
- Thread `OfficialBuild` through the macOS build and packaging templates.
- Run production Apple signing, notarization, and Developer ID validation only for Official builds.
- Preserve NonOfficial package artifacts by publishing the unsigned `.pkg` files without initializing production signing or code-sign validation.

A branch such as `rebuild/v7.0.1` was previously treated as a preview branch and produced the invalid tag `v7.6.0-rebuild/v7.0.1`. Rebuild branches must now use the existing `rebuild/v<major>.<minor>.<patch>-rebuild.<number>` convention, with a canonical numeric counter. Explicit `ReleaseTag` values remain unaffected.

NonOfficial macOS builds use local test signing for supported binaries, but cannot apply Apple Developer ID signatures or notarize packages. Skipping those production-only operations prevents NonOfficial rebuilds from failing while retaining the complete signing flow for Official builds.

## Validation

- Added Pester coverage for malformed and valid rebuild branch names, omitted `ReleaseTag`, and explicit overrides
- Ran the targeted `SetReleaseTag` infrastructure tests
- Parsed all four modified pipeline templates as YAML
- Ran PSScriptAnalyzer on the release-tag tests and checked the modified script for errors
- Reviewed the staged macOS pipeline changes for job-scoping and OneBranch condition issues