### PR TITLE
Update the manifest resource names for the localized resources embedded in satellite assemblies

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/Microsoft.Management.Infrastructure.CimCmdlets.csproj
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/Microsoft.Management.Infrastructure.CimCmdlets.csproj
@@ -10,4 +10,9 @@
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Management.UI.Internal/Microsoft.PowerShell.GraphicalHost.csproj
+++ b/src/Microsoft.Management.UI.Internal/Microsoft.PowerShell.GraphicalHost.csproj
@@ -12,10 +12,6 @@
     <UseWPF>True</UseWPF>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <Resource Include="resources\Graphics\Add16.png" />
     <Resource Include="resources\Graphics\CloseTile16.png" />
@@ -34,5 +30,11 @@
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.Commands.Utility\Microsoft.PowerShell.Commands.Utility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj
@@ -11,10 +11,6 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(IsWindows)' != 'true' ">
     <Compile Remove="GetCounterCommand.cs" />
     <Compile Remove="CounterSample.cs" />
@@ -26,4 +22,9 @@
     <Compile Remove="NewWinEventCommand.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -10,13 +10,14 @@
     <ProjectReference Include="..\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- the following package(s) are from https://github.com/dotnet/corefx -->
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -12,14 +12,15 @@
     <PackageReference Include="Microsoft.PowerShell.MarkdownRender" Version="7.2.1" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="System.Drawing.Common" Version="11.0.0-preview.6.26359.118" />
     <PackageReference Include="JsonSchema.Net" Version="7.4.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
+++ b/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
@@ -10,12 +10,13 @@
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(IsWindows)' != 'true' ">
     <Compile Remove="WindowsTaskbarJumpList\*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -11,4 +11,9 @@
     <PackageReference Include="System.Diagnostics.EventLog" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
+++ b/src/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.csproj
@@ -10,4 +10,9 @@
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
+++ b/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
@@ -13,8 +13,10 @@
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -45,10 +45,6 @@
     <PackageReference Include="Microsoft.Security.Extensions" Version="1.4.0" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- exclude code of source generators from compilation and IDEs (e.g. vscode and visual studio) -->
     <Compile Remove="SourceGenerators\**\*.cs" />
@@ -71,5 +67,11 @@
 
   <ItemGroup Condition=" '$(IsWindows)' == 'true' ">
     <Compile Remove="engine\Interop\Unix\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="resources\*\*.resx">
+      <ManifestResourceName>$(RootNamespace).resources.%(Filename)</ManifestResourceName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/test/powershell/engine/ResourceValidation/LocalizedResource.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/LocalizedResource.Tests.ps1
@@ -1,0 +1,101 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Localized resource files validation" -Tags "CI" {
+
+    BeforeAll {
+        $repoSrcDir = (Resolve-Path (Join-Path $PSScriptRoot ../../../../src)).Path
+
+        # Folders that exist in 'resources' folder but are not a localized resource directory.
+        $excludeDirs = @('Graphics')
+
+        # VS_Main_Languages set, the same as what .NET uses for localization.
+        $langSet = 'cs', 'de', 'es', 'fr', 'it', 'ja', 'ko', 'pl', 'pt-BR', 'ru', 'tr', 'zh-Hans', 'zh-Hant'
+        $asmDirs = @(
+            'Microsoft.Management.Infrastructure.CimCmdlets'
+            'Microsoft.Management.UI.Internal'
+            'Microsoft.PowerShell.Commands.Diagnostics'
+            'Microsoft.PowerShell.Commands.Management'
+            'Microsoft.PowerShell.Commands.Utility'
+            'Microsoft.PowerShell.ConsoleHost'
+            'Microsoft.PowerShell.CoreCLR.Eventing'
+            'Microsoft.PowerShell.Security'
+            'Microsoft.WSMan.Management'
+            'System.Management.Automation'
+        )
+
+        $asmNames = $asmDirs | ForEach-Object {
+            if ($_ -eq 'Microsoft.Management.UI.Internal') {
+                'Microsoft.PowerShell.GraphicalHost'
+            } else {
+                $_
+            }
+        }
+
+        $testCases1 = @(
+            $asmDirs | ForEach-Object { @{ AssemblyDir = $_ } }
+        )
+        $testCases2 = @(
+            $langSet | ForEach-Object { @{ Language = $_ } }
+        )
+    }
+
+    It "Assembly folders with resources should match with records" {
+        try {
+            Push-Location $repoSrcDir
+            $assemblies = Get-ChildItem 'resources' -Recurse -Directory | ForEach-Object { $_.Parent.Name }
+
+            ## Verifies that the assembly folders containing resource files match the expected records in $asmDirs.
+            $result = Compare-Object -ReferenceObject $asmDirs -DifferenceObject $assemblies
+            $result | Should -Be $null -Because "The assembly folders with resources do not match the expected records:`n$($result | Out-String)."
+
+            ## Verifies that the default English resource files exist and match the expected count.
+            $defaultCultureResources = $assemblies | ForEach-Object { Get-ChildItem "$_/resources/*.resx" }
+            $defaultCultureResources | Should -HaveCount 150 -Because "Default English resource files count: $($defaultCultureResources.Count); Expected count: 150."
+        }
+        finally {
+            Pop-Location
+        }
+    }
+
+    It "Localized resource files for '<AssemblyDir>' should match the records" -TestCases $testCases1 {
+        param($AssemblyDir)
+
+        ## Get the full path to the resources directory for the current assembly folder.
+        $resDir = Join-Path $repoSrcDir $AssemblyDir 'resources'
+        ## Get all the localized resource directory names under the resources directory.
+        $locDirNames = @(Get-ChildItem $resDir -Directory | ForEach-Object Name | Where-Object { $_ -notin $excludeDirs })
+
+        ## Verifies that the localized resource directories match the expected language set.
+        $results = Compare-Object -ReferenceObject $langSet -DifferenceObject $locDirNames
+        $results | Should -Be $null -Because "The localized resource directories for '$AssemblyDir' do not match the expected language set:`n$($results | Out-String)."
+
+        ## Get the default English resource file names without extensions.
+        $default = @(Get-ChildItem "$resDir/*.resx" | ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) })
+
+        foreach ($lang in $langSet) {
+            ## Get the full path to the localized resource directory for the current language.
+            $langDir = Join-Path $resDir $lang
+            ## Get all the localized resource file names without extensions for the current language.
+            $langResources = @(Get-ChildItem "$langDir/*.resx" | ForEach-Object { [System.IO.Path]::GetFileNameWithoutExtension($_.Name) })
+
+            ## The localized resource file should have the same base name as the default English resource file, with the language suffix added.
+            $expectedNames = @($default | ForEach-Object { "$_.$lang" })
+            ## Verifies that the localized resource file names match the expected names.
+            $langResults = Compare-Object -ReferenceObject $expectedNames -DifferenceObject $langResources
+            $langResults | Should -Be $null -Because "The names of localized resource files for '$lang' in '$AssemblyDir' do not match the default English files:`n$($langResults | Out-String)."
+        }
+    }
+
+    It "Satellite assemblies should be produced for '<Language>'" -TestCases $testCases2 -Skip:(!$IsWindows) {
+        param($Language)
+
+        $satDir = Join-Path $PSHOME $Language
+        Test-Path $satDir | Should -BeTrue -Because "Satellite directory for language '$Language' should exist."
+
+        foreach ($asmName in $asmNames) {
+            $satAssemblyPath = Join-Path $satDir "$asmName.resources.dll"
+            Test-Path $satAssemblyPath | Should -BeTrue -Because "Satellite assembly '$asmName.resources.dll' for language '$Language' should exist."
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update the manifest resource names for the localized resources embedded in satellite assemblies.

When embedding the English `.resx` resources, .NET SDK uses the manifest resource names `$(RootNamespace).resources.<resx-file-name-without-extension>` by default, e.g. `System.Management.Automation.resources.AuthorizationManagerBase`. The `.resources.` part is because the English `.resx` files are right under the `resources` folder.

The C# binding types we generate from `ResGen` use this exact name (for instance, `System.Management.Automation.resources.AuthorizationManagerBase`) to identify this embedded resource.

With the folder structure of our localized `.resx` resources as `resources\<lang-id>\<name>.<lang-id>.resx`, by default .NET SDK will use the manifest resource names `$(RootNamespace).resources.<lang-id>.<resx-file-name-without-extension>` for the localized resources embedded in the satellite assemblies, e.g. `System.Management.Automation.resources.zh-Hans.AuthorizationManagerBase.zh-Hans`. The `.resources.<lang-id>.` part is because the localized `.resx` files are under the `resources\<lang-id>` folders.

So, the default resource embedding by .NET SDK doesn't work for the folder structure of localized resources we adopt in PowerShell project. 

To make the .NET SDK default work, we will have to put all localized `.resx` files under the same `resources` folder, side-by-side with the English `.resx` files. That will make it hard to look for a `.resx` file for a particular langauge and also make it hard for `ResGen` to reliably find English `.resx` files only. So, I decide to go with the current folder structure and fix the manifest resource names for satellite assemblies by explicitly defining those names.

With this PR, the manifest resource names used in satellite assemblies are like `<RootNamespace>.resources.<Filename>.<Lang-id>`, like `'System.Management.Automation.resources.AuthorizationManagerBase.zh-Hans`, which works fine with the C# binding types we generate today.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
