### PR TITLE
[release/v7.6.5] Fix the dot-sourcing behavior of `pwsh -file` for advanced-function scripts

### DIFF
--- a/src/System.Management.Automation/engine/CommandProcessor.cs
+++ b/src/System.Management.Automation/engine/CommandProcessor.cs
@@ -778,7 +778,9 @@ namespace System.Management.Automation
             InitCommon();
 
             // If the script has been dotted, throw an error if it's from a different language mode.
-            if (!this.UseLocalScope)
+            // Unless it was a script loaded through -File, in which case the danger of dotting other
+            // language modes (getting internal functions in the user's state) isn't a danger.
+            if (!this.UseLocalScope && !scriptCmdlet.ShouldRethrowExitException)
             {
                 ValidateCompatibleLanguageMode(scriptCommandInfo.ScriptBlock, _context, Command.MyInvocation);
             }

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2191,6 +2191,8 @@ namespace System.Management.Automation
         private bool _exitWasCalled;
         private bool _anyClauseExecuted;
 
+        internal bool ShouldRethrowExitException => _rethrowExitException;
+
         public PSScriptCmdlet(ScriptBlock scriptBlock, bool useNewScope, bool fromScriptFile, ExecutionContext context)
         {
             _scriptBlock = scriptBlock;


### PR DESCRIPTION
Backport of #27727 to release/v7.6.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27727$$$
-->

Triggered by @SeeminglyScience on behalf of @daxian-dbw

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes inconsistent WDAC behavior where signed advanced-function scripts failed under pwsh -file while signed simple scripts succeeded. Aligns both code paths so non-noexit file execution behaves consistently.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Validated by original PR scenario coverage for WDAC mode and pwsh -file advanced-function behavior; this backport is a direct cherry-pick with no conflict changes.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Engine behavior change is narrowly scoped to the language-mode compatibility check path for script invocation and keeps existing -noexit behavior intact.
