### PR TITLE
Deduplicate dependency records in release prep PR

### DIFF
--- a/CHANGELOG/v7.6/dependencychanges.json
+++ b/CHANGELOG/v7.6/dependencychanges.json
@@ -124,40 +124,6 @@
     "TimestampUtc": "2026-08-05T19:30:59.6538917Z"
   },
   {
-    "ChangeType": "Security",
-    "Branch": "release/v7.6.5",
-    "PackageId": "System.Security.Cryptography.Xml",
-    "FromVersion": "10.0.6",
-    "ToVersion": "10.0.10",
-    "VulnerabilityId": [
-      "GHSA-G8R8-53C2-PM3F",
-      "CVE-2026-47304",
-      "GHSA-8Q5V-6PQQ-X66H",
-      "CVE-2026-50525",
-      "GHSA-23RF-6693-G89P",
-      "CVE-2026-50648",
-      "GHSA-CVVH-RHRC-WG4Q",
-      "CVE-2026-47302",
-      "GHSA-MMJF-RQRV-855V",
-      "CVE-2026-50527"
-    ],
-    "Severity": [
-      "high"
-    ],
-    "VulnerableRanges": [
-      "[10.0.0, 10.0.9]"
-    ],
-    "AdvisoryUrls": [
-      "https://github.com/advisories/GHSA-g8r8-53c2-pm3f",
-      "https://github.com/advisories/GHSA-8q5v-6pqq-x66h",
-      "https://github.com/advisories/GHSA-23rf-6693-g89p",
-      "https://github.com/advisories/GHSA-cvvh-rhrc-wg4q",
-      "https://github.com/advisories/GHSA-mmjf-rqrv-855v"
-    ],
-    "Justification": null,
-    "TimestampUtc": "2026-08-05T19:30:59.6747647Z"
-  },
-  {
     "ChangeType": "NonSecurity",
     "Branch": "release/v7.6.5",
     "PackageId": "System.Security.Cryptography.Pkcs",
@@ -169,18 +135,5 @@
     "AdvisoryUrls": [],
     "Justification": "Required by System.Security.Cryptography.Xml 10.0.10 dependency constraint '[10.0.10, )'.",
     "TimestampUtc": "2026-08-05T19:30:59.6779359Z"
-  },
-  {
-    "ChangeType": "NonSecurity",
-    "Branch": "release/v7.6.5",
-    "PackageId": "System.Security.Cryptography.Pkcs",
-    "FromVersion": "10.0.6",
-    "ToVersion": "10.0.10",
-    "VulnerabilityId": [],
-    "Severity": [],
-    "VulnerableRanges": [],
-    "AdvisoryUrls": [],
-    "Justification": "Required by System.Security.Cryptography.Xml 10.0.10 dependency constraint '[10.0.10, )'.",
-    "TimestampUtc": "2026-08-05T19:30:59.6787647Z"
   }
 ]


### PR DESCRIPTION
Removes the duplicate package-level dependency change records generated for the SDK and TestService project updates in #27770.

The project files remain updated in both locations. `dependencychanges.json` now contains one security record for `System.Security.Cryptography.Xml` and one companion-dependency record for `System.Security.Cryptography.Pkcs`.