### PR TITLE
[release/v7.6.5] Update branch for release

### DIFF
--- a/CHANGELOG/v7.6/dependencychanges.json
+++ b/CHANGELOG/v7.6/dependencychanges.json
@@ -6,10 +6,10 @@
     "FromVersion": "10.0.5",
     "ToVersion": "10.0.6",
     "VulnerabilityId": [
-      "GHSA-W3X6-4M5H-CXQF",
       "CVE-2026-26171",
+      "CVE-2026-33116",
       "GHSA-37GX-XXP4-5RGX",
-      "CVE-2026-33116"
+      "GHSA-W3X6-4M5H-CXQF"
     ],
     "Severity": [
       "high"
@@ -18,11 +18,11 @@
       "[10.0.0, 10.0.5]"
     ],
     "AdvisoryUrls": [
-      "https://github.com/advisories/GHSA-w3x6-4m5h-cxqf",
-      "https://github.com/advisories/GHSA-37gx-xxp4-5rgx"
+      "https://github.com/advisories/GHSA-37gx-xxp4-5rgx",
+      "https://github.com/advisories/GHSA-w3x6-4m5h-cxqf"
     ],
-    "Justification": null,
-    "TimestampUtc": "2026-04-16T23:13:21.4575733Z"
+    "Justification": "",
+    "TimestampUtc": "04/16/2026 23:13:21"
   },
   {
     "ChangeType": "NonSecurity",
@@ -35,7 +35,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "2026-04-16T23:13:22.4500098Z"
+    "TimestampUtc": "04/16/2026 23:13:22"
   },
   {
     "ChangeType": "NonSecurity",
@@ -48,7 +48,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Required dependency of System.Security.Cryptography.Xml.",
-    "TimestampUtc": "2026-04-16T23:13:22.4500098Z"
+    "TimestampUtc": "04/16/2026 23:13:22"
   },
   {
     "ChangeType": "NonSecurity",
@@ -61,7 +61,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "2026-05-14T17:53:01.1430124Z"
+    "TimestampUtc": "05/14/2026 17:53:01"
   },
   {
     "ChangeType": "NonSecurity",
@@ -74,7 +74,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "2026-06-09T20:21:29.3313254Z"
+    "TimestampUtc": "06/09/2026 20:21:29"
   },
   {
     "ChangeType": "NonSecurity",
@@ -87,6 +87,53 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "2026-07-15T15:01:47.0062032Z"
+    "TimestampUtc": "07/15/2026 15:01:47"
+  },
+  {
+    "ChangeType": "Security",
+    "Branch": "release/v7.6.5",
+    "PackageId": "System.Security.Cryptography.Xml",
+    "FromVersion": "10.0.6",
+    "ToVersion": "10.0.10",
+    "VulnerabilityId": [
+      "CVE-2026-47302",
+      "CVE-2026-47304",
+      "CVE-2026-50525",
+      "CVE-2026-50527",
+      "CVE-2026-50648",
+      "GHSA-23RF-6693-G89P",
+      "GHSA-8Q5V-6PQQ-X66H",
+      "GHSA-CVVH-RHRC-WG4Q",
+      "GHSA-G8R8-53C2-PM3F",
+      "GHSA-MMJF-RQRV-855V"
+    ],
+    "Severity": [
+      "high"
+    ],
+    "VulnerableRanges": [
+      "[10.0.0, 10.0.9]"
+    ],
+    "AdvisoryUrls": [
+      "https://github.com/advisories/GHSA-23rf-6693-g89p",
+      "https://github.com/advisories/GHSA-8q5v-6pqq-x66h",
+      "https://github.com/advisories/GHSA-cvvh-rhrc-wg4q",
+      "https://github.com/advisories/GHSA-g8r8-53c2-pm3f",
+      "https://github.com/advisories/GHSA-mmjf-rqrv-855v"
+    ],
+    "Justification": "",
+    "TimestampUtc": "2026-08-06T18:28:20.7094880Z"
+  },
+  {
+    "ChangeType": "NonSecurity",
+    "Branch": "release/v7.6.5",
+    "PackageId": "System.Security.Cryptography.Pkcs",
+    "FromVersion": "10.0.6",
+    "ToVersion": "10.0.10",
+    "VulnerabilityId": [],
+    "Severity": [],
+    "VulnerableRanges": [],
+    "AdvisoryUrls": [],
+    "Justification": "Required by System.Security.Cryptography.Xml 10.0.10 dependency constraint '[10.0.10, )'.",
+    "TimestampUtc": "2026-08-06T18:28:20.7227205Z"
   }
 ]

--- a/CHANGELOG/v7.6/dependencychanges.json
+++ b/CHANGELOG/v7.6/dependencychanges.json
@@ -6,10 +6,10 @@
     "FromVersion": "10.0.5",
     "ToVersion": "10.0.6",
     "VulnerabilityId": [
+      "GHSA-W3X6-4M5H-CXQF",
       "CVE-2026-26171",
-      "CVE-2026-33116",
       "GHSA-37GX-XXP4-5RGX",
-      "GHSA-W3X6-4M5H-CXQF"
+      "CVE-2026-33116"
     ],
     "Severity": [
       "high"
@@ -18,11 +18,11 @@
       "[10.0.0, 10.0.5]"
     ],
     "AdvisoryUrls": [
-      "https://github.com/advisories/GHSA-37gx-xxp4-5rgx",
-      "https://github.com/advisories/GHSA-w3x6-4m5h-cxqf"
+      "https://github.com/advisories/GHSA-w3x6-4m5h-cxqf",
+      "https://github.com/advisories/GHSA-37gx-xxp4-5rgx"
     ],
-    "Justification": "",
-    "TimestampUtc": "04/16/2026 23:13:21"
+    "Justification": null,
+    "TimestampUtc": "2026-04-16T23:13:21.4575733Z"
   },
   {
     "ChangeType": "NonSecurity",
@@ -35,7 +35,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "04/16/2026 23:13:22"
+    "TimestampUtc": "2026-04-16T23:13:22.4500098Z"
   },
   {
     "ChangeType": "NonSecurity",
@@ -48,7 +48,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Required dependency of System.Security.Cryptography.Xml.",
-    "TimestampUtc": "04/16/2026 23:13:22"
+    "TimestampUtc": "2026-04-16T23:13:22.4500098Z"
   },
   {
     "ChangeType": "NonSecurity",
@@ -61,7 +61,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "05/14/2026 17:53:01"
+    "TimestampUtc": "2026-05-14T17:53:01.1430124Z"
   },
   {
     "ChangeType": "NonSecurity",
@@ -74,7 +74,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "06/09/2026 20:21:29"
+    "TimestampUtc": "2026-06-09T20:21:29.3313254Z"
   },
   {
     "ChangeType": "NonSecurity",
@@ -87,7 +87,7 @@
     "VulnerableRanges": [],
     "AdvisoryUrls": [],
     "Justification": "Updated .NET SDK. Building with the latest SDK is required.",
-    "TimestampUtc": "07/15/2026 15:01:47"
+    "TimestampUtc": "2026-07-15T15:01:47.0062032Z"
   },
   {
     "ChangeType": "Security",

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -58,9 +58,9 @@
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="10.0.5" />
     <PackageReference Include="System.Reflection.Context" Version="10.0.5" />
     <PackageReference Include="System.Runtime.Caching" Version="10.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Security.Permissions" Version="10.0.5" />
     <!-- the following package(s) are from https://github.com/dotnet/wcf -->
     <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />

--- a/test/tools/TestService/TestService.csproj
+++ b/test/tools/TestService/TestService.csproj
@@ -53,9 +53,9 @@
     <PackageReference Include="System.Management" Version="10.0.5" />
     <PackageReference Include="System.Reflection.Context" Version="10.0.5" />
     <PackageReference Include="System.Runtime.Caching" Version="10.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="System.Security.Permissions" Version="10.0.5" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="10.0.5" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.5" />

--- a/tools/cgmanifest/main/cgmanifest.json
+++ b/tools/cgmanifest/main/cgmanifest.json
@@ -626,7 +626,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Security.Cryptography.Pkcs",
-          "Version": "10.0.6"
+          "Version": "10.0.10"
         }
       },
       "DevelopmentDependency": false
@@ -646,7 +646,7 @@
         "Type": "nuget",
         "Nuget": {
           "Name": "System.Security.Cryptography.Xml",
-          "Version": "10.0.6"
+          "Version": "10.0.10"
         }
       },
       "DevelopmentDependency": false


### PR DESCRIPTION
lts - Automated by PowerShell Bot

> **Note for reviewers:** This PR uses transitive dependency pinning (`transitive=true`, `versionLock=minor`). If this is the first time this workflow has run on this branch, a large number of transitive dependencies may appear pinned. This is expected behavior.

This replaces #27778. The generated dependency log was corrected so all existing records remain unchanged; only the new 7.6.5 Xml and Pkcs records are appended.