### PR TITLE
Skip locked files in Clean task instead of prompting (build script)

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -528,6 +528,7 @@ function Start-PSBuild {
             } elseif ([System.IO.File]::Exists($path)) {
                 [System.IO.File]::Delete($path)
             } else {
+                Write-Information "Removing directory '$path'."
                 [System.IO.Directory]::Delete($path, $true)
             }
         }

--- a/build.psm1
+++ b/build.psm1
@@ -495,7 +495,7 @@ function Start-PSBuild {
             # Excluded sqlite3 folder is due to this Roslyn issue: https://github.com/dotnet/roslyn/issues/23060
             # Excluded src/Modules/nuget.config as this is required for release build.
             # Excluded nuget.config as this is required for release build.
-            git clean -fdX --exclude .vs/PowerShell/v16/Server/sqlite3 --exclude src/Modules/nuget.config  --exclude nuget.config
+            measure-command { Start-Process -Wait -NoNewWindow git "clean -fdX --exclude .vs/PowerShell/v16/Server/sqlite3 --exclude src/Modules/nuget.config  --exclude nuget.config" }
         } finally {
             Write-LogGroupEnd -Title "Cleaning your working directory"
             Pop-Location

--- a/build.psm1
+++ b/build.psm1
@@ -488,14 +488,65 @@ function Start-PSBuild {
         Stop-Process -Verbose
     }
 
+    function CleanLenient {
+        [CmdletBinding()]
+        param()
+        $failed = $false
+        # `git clean` may keep returning different sets of paths.
+        while (-not $failed -and (git clean --dry-run -dX | Select-Object -First 1)) {
+            # `git clean` will prompt if it can't unlink files, so we delete in PS to skip errors.
+            foreach ($line in git clean --dry-run -dX) {
+                if (-not $line.StartsWith('Would remove ')) {
+                    Write-Warning "Expected git clean --dry-run prefix 'Would remove ' not found in git output '$line'. The clean operation may be unreliable. The build script may need updating."
+                    continue
+                }
+                $path = Join-Path $PSScriptRoot $line.Substring('Would remove '.Length)
+                Write-Verbose "Cleaning path '$path'..."
+                # Visual Studio is Windows-only. Use backslashes.
+                # git clean will return '.vs/' and Join-Path (Windows) will normalize to '.vs\'.
+                if ($path.Contains('\.vs\')) {
+                    # VS may take locks on files while it's open. Skip them.
+                    if ([System.IO.Directory]::Exists($path)) {
+                        $failedDir = $false
+                        foreach ($filePath in [System.IO.Directory]::EnumerateFiles($path, '*.*', [System.IO.SearchOption]::AllDirectories)) {
+                            Write-Verbose "Removing file '$filePath'."
+                            try {
+                                [System.IO.File]::Delete($filePath)
+                            } catch {
+                                $failed = $true
+                                $failedDir = $true
+                                Write-Warning "Clean operation could not remove file '$filePath'."
+                            }
+                        }
+                        if (-not $failedDir) {
+                            Write-Information "Removing directory 1 '$path'."
+                            [System.IO.Directory]::Delete($path, $true)
+                        }
+                    } else {
+                        Write-Verbose "Removing file '$path'."
+                        try {
+                            [System.IO.File]::Delete($path)
+                        } catch {
+                            $failed = $true
+                            Write-Warning "Clean operation could not remove file '$path'."
+                        }
+                    }
+                } elseif ([System.IO.File]::Exists($path)) {
+                    [System.IO.File]::Delete($path)
+                } else {
+                    Write-Information "Removing directory '$path'."
+                    # Delete recursively.
+                    [System.IO.Directory]::Delete($path, $true)
+                }
+            }
+        }
+    }
+
     if ($Clean) {
         Write-LogGroupStart -Title "Cleaning your working directory"
         Push-Location $PSScriptRoot
         try {
-            # Excluded sqlite3 folder is due to this Roslyn issue: https://github.com/dotnet/roslyn/issues/23060
-            # Excluded src/Modules/nuget.config as this is required for release build.
-            # Excluded nuget.config as this is required for release build.
-            git clean -fdX --exclude .vs/PowerShell/v16/Server/sqlite3 --exclude src/Modules/nuget.config  --exclude nuget.config
+            CleanLenient
         } finally {
             Write-LogGroupEnd -Title "Cleaning your working directory"
             Pop-Location

--- a/build.psm1
+++ b/build.psm1
@@ -538,7 +538,7 @@ function Start-PSBuild {
         Write-LogGroupStart -Title "Cleaning your working directory"
         Push-Location $PSScriptRoot
         try {
-            CleanLenient
+            Measure-Command { CleanLenient }
         } finally {
             Write-LogGroupEnd -Title "Cleaning your working directory"
             Pop-Location

--- a/build.psm1
+++ b/build.psm1
@@ -495,9 +495,10 @@ function Start-PSBuild {
         foreach ($line in git clean --dry-run -dX) {
             if (-not $line.StartsWith("Would remove ")) {
                 Write-Warning "Expected git clean --dry-run prefix 'Would remove' not found. The clean operation may be unreliable. The build script may need updating."
+            if (-not $line.StartsWith('Would remove ')) {
                 continue
             }
-            $path = Join-Path $PSScriptRoot $line.Substring("Would remove ".Length)
+            $path = Join-Path $PSScriptRoot $line.Substring('Would remove '.Length)
             Write-Verbose "Cleaning path '$path'..."
             # Visual Studio is Windows only.
             if ($path.Contains('\.vs\')) {

--- a/build.psm1
+++ b/build.psm1
@@ -488,14 +488,62 @@ function Start-PSBuild {
         Stop-Process -Verbose
     }
 
+    function CleanLenient {
+        [CmdletBinding()]
+        param()
+        $failed = $false
+        # `git clean` may keep returning different sets of paths.
+        while (-not $failed -and (git clean --dry-run -dX | Select-Object -First 1)) {
+            # `git clean` will prompt if it can't unlink files, so we delete in PS to skip errors.
+            foreach ($line in git clean --dry-run -dX) {
+                if (-not $line.StartsWith("Would remove ")) {
+                    Write-Warning "Expected git clean --dry-run prefix 'Would remove' not found. The clean operation may be unreliable. The build script may need updating."
+                    continue
+                }
+                $path = Join-Path $PSScriptRoot $line.Substring("Would remove ".Length)
+                Write-Verbose "Cleaning path '$path'..."
+                # Visual Studio is Windows only.
+                if ($path.Contains('\.vs\')) {
+                    # VS may take locks on files while it's open. Skip them.
+                    if ([System.IO.Directory]::Exists($path)) {
+                        $failedDir = $false
+                        foreach ($filePath in [System.IO.Directory]::EnumerateFiles($path, "*.*", [System.IO.SearchOption]::AllDirectories)) {
+                            Write-Verbose "Removing file '$filePath'."
+                            try {
+                                [System.IO.File]::Delete($filePath)
+                            } catch {
+                                $failed = $true
+                                $failedDir = $true
+                                Write-Warning "Clean operation could not remove file '$filePath'."
+                            }
+                        }
+                        if (-not $failedDir) {
+                            Write-Information "Removing directory '$path'."
+                            [System.IO.Directory]::Delete($path, $true)
+                        }
+                    } else {
+                        Write-Verbose "Removing file '$path'."
+                        try {
+                            [System.IO.File]::Delete($path)
+                        } catch {
+                            $failed = $true
+                            Write-Warning "Clean operation could not remove file '$path'."
+                        }
+                    }
+                } elseif ([System.IO.File]::Exists($path)) {
+                    [System.IO.File]::Delete($path)
+                } else {
+                    [System.IO.Directory]::Delete($path, $true)
+                }
+            }
+        }
+    }
+
     if ($Clean) {
         Write-LogGroupStart -Title "Cleaning your working directory"
         Push-Location $PSScriptRoot
         try {
-            # Excluded sqlite3 folder is due to this Roslyn issue: https://github.com/dotnet/roslyn/issues/23060
-            # Excluded src/Modules/nuget.config as this is required for release build.
-            # Excluded nuget.config as this is required for release build.
-            measure-command { Start-Process -Wait -NoNewWindow git "clean -fdX --exclude .vs/PowerShell/v16/Server/sqlite3 --exclude src/Modules/nuget.config  --exclude nuget.config" }
+            CleanLenient
         } finally {
             Write-LogGroupEnd -Title "Cleaning your working directory"
             Pop-Location

--- a/build.psm1
+++ b/build.psm1
@@ -491,50 +491,44 @@ function Start-PSBuild {
     function CleanLenient {
         [CmdletBinding()]
         param()
-        $failed = $false
-        # `git clean` may keep returning different sets of paths.
-        while (-not $failed -and (git clean --dry-run -dX | Select-Object -First 1)) {
-            # `git clean` will prompt if it can't unlink files, so we delete in PS to skip errors.
-            foreach ($line in git clean --dry-run -dX) {
-                if (-not $line.StartsWith("Would remove ")) {
-                    Write-Warning "Expected git clean --dry-run prefix 'Would remove' not found. The clean operation may be unreliable. The build script may need updating."
-                    continue
-                }
-                $path = Join-Path $PSScriptRoot $line.Substring("Would remove ".Length)
-                Write-Verbose "Cleaning path '$path'..."
-                # Visual Studio is Windows only.
-                if ($path.Contains('\.vs\')) {
-                    # VS may take locks on files while it's open. Skip them.
-                    if ([System.IO.Directory]::Exists($path)) {
-                        $failedDir = $false
-                        foreach ($filePath in [System.IO.Directory]::EnumerateFiles($path, "*.*", [System.IO.SearchOption]::AllDirectories)) {
-                            Write-Verbose "Removing file '$filePath'."
-                            try {
-                                [System.IO.File]::Delete($filePath)
-                            } catch {
-                                $failed = $true
-                                $failedDir = $true
-                                Write-Warning "Clean operation could not remove file '$filePath'."
-                            }
-                        }
-                        if (-not $failedDir) {
-                            Write-Information "Removing directory '$path'."
-                            [System.IO.Directory]::Delete($path, $true)
-                        }
-                    } else {
-                        Write-Verbose "Removing file '$path'."
+        # `git clean` will prompt if it can't unlink files, so we delete in PS to skip errors.
+        foreach ($line in git clean --dry-run -dX) {
+            if (-not $line.StartsWith("Would remove ")) {
+                Write-Warning "Expected git clean --dry-run prefix 'Would remove' not found. The clean operation may be unreliable. The build script may need updating."
+                continue
+            }
+            $path = Join-Path $PSScriptRoot $line.Substring("Would remove ".Length)
+            Write-Verbose "Cleaning path '$path'..."
+            # Visual Studio is Windows only.
+            if ($path.Contains('\.vs\')) {
+                # VS may take locks on files while it's open. Skip them.
+                if ([System.IO.Directory]::Exists($path)) {
+                    $failedDir = $false
+                    foreach ($filePath in [System.IO.Directory]::EnumerateFiles($path, "*.*", [System.IO.SearchOption]::AllDirectories)) {
+                        Write-Verbose "Removing file '$filePath'."
                         try {
-                            [System.IO.File]::Delete($path)
+                            [System.IO.File]::Delete($filePath)
                         } catch {
-                            $failed = $true
-                            Write-Warning "Clean operation could not remove file '$path'."
+                            $failedDir = $true
+                            Write-Warning "Clean operation could not remove file '$filePath'."
                         }
                     }
-                } elseif ([System.IO.File]::Exists($path)) {
-                    [System.IO.File]::Delete($path)
+                    if (-not $failedDir) {
+                        Write-Information "Removing directory '$path'."
+                        [System.IO.Directory]::Delete($path, $true)
+                    }
                 } else {
-                    [System.IO.Directory]::Delete($path, $true)
+                    Write-Verbose "Removing file '$path'."
+                    try {
+                        [System.IO.File]::Delete($path)
+                    } catch {
+                        Write-Warning "Clean operation could not remove file '$path'."
+                    }
                 }
+            } elseif ([System.IO.File]::Exists($path)) {
+                [System.IO.File]::Delete($path)
+            } else {
+                [System.IO.Directory]::Delete($path, $true)
             }
         }
     }

--- a/build.psm1
+++ b/build.psm1
@@ -493,9 +493,8 @@ function Start-PSBuild {
         param()
         # `git clean` will prompt if it can't unlink files, so we delete in PS to skip errors.
         foreach ($line in git clean --dry-run -dX) {
-            if (-not $line.StartsWith("Would remove ")) {
-                Write-Warning "Expected git clean --dry-run prefix 'Would remove' not found. The clean operation may be unreliable. The build script may need updating."
             if (-not $line.StartsWith('Would remove ')) {
+                Write-Warning "Expected git clean --dry-run prefix 'Would remove ' not found. The clean operation may be unreliable. The build script may need updating."
                 continue
             }
             $path = Join-Path $PSScriptRoot $line.Substring('Would remove '.Length)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Avoid `git clean` prompting during build when Visual Studio is open.

This is the problem in the old implementation when Visual Studio has a lock on a file to be cleaned (interactive prompt):

<img width="986" height="52" alt="image" src="https://github.com/user-attachments/assets/dfbff027-7214-4855-bd1b-41ba35d4514f" />

This is what happens in the new implementation (no interactive prompt):

<img width="1222" height="106" alt="image" src="https://github.com/user-attachments/assets/0ca4c511-0beb-44ed-956a-1a8214fbebf9" />

The files being left uncleaned doesn't appear to affect the build.

## PR Context

- Closes #27745
- #27758 

## Details

Measurements for the **Clean** step after a successful build follow based on 

```powershell
Start-PSBuild -Clean -PSModuleRestore -UseNuGetOrg -InformationAction continue
```

Measurements taken with `[System.Diagnostics.Stopwatch]`.

#### Before

```
00:00:02.7059009
00:00:02.9417162
00:00:02.8136674
```

#### After

>[!NOTE]
> The **After** implementation cleans _more_ files than the **Before** implementation.

```
00:00:03.0110610
00:00:03.3722993
00:00:03.2672085
```

## Notes

The script says it must support Windows PowerShell, but it doesn't run?

The old implementation calls `git clean` naively, and residual files/directories are left behind. The new implementation cleans more exhaustively.

> [!NOTE]
> The new implementation still doesn't clean all items reported by `git clean` because we bail early if we hit an IO error. This can be improved in a future PR by keeping track of deletion attempts and proceeding with items not attempted yet.

> [!NOTE]
> It might be possible to use `git ls-file --cached --others --ignore --exclude-standard`, but the returned files are not obviously the same, and directory removal might require additional work. However, there would be less dumb string parsing than using `git clean --dry-run` and hence localized git messages would not prevent a clean build.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
