### PR TITLE
Handle MSIX installation specially when prepend to PATH

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -59,6 +59,81 @@ namespace Microsoft.PowerShell
         internal const string DECCKM_OFF = "\x1b[?1l";
 #endif
 
+        private static string GetPSExecutableHome()
+        {
+#if UNIX
+            const string pwshName = "pwsh";
+            const string dotnetToolPathSegment = "/.store/powershell/";
+#else
+            const string pwshName = "pwsh.exe";
+            const string dotnetToolPathSegment = @"\.store\powershell\";
+#endif
+
+            string psExePath = Environment.ProcessPath;
+            string psExeHome = Path.GetDirectoryName(psExePath);
+            string processName = Path.GetFileName(psExePath);
+
+            // Use 'Environment.ProcessPath' if it points to 'pwsh.exe' or 'pwsh'.
+            if (pwshName.Equals(processName, StringComparison.Ordinal))
+            {
+#if !UNIX
+                psExeHome = ResolveStablePathIfMsix(psExeHome);
+#endif
+                return psExeHome;
+            }
+
+            psExeHome = Utils.DefaultPowerShellAppBase;
+
+            int index = psExeHome.IndexOf(dotnetToolPathSegment, StringComparison.Ordinal);
+            if (index > 0)
+            {
+                // We're running PowerShell dotnet tool. In this case the real entry executable should be the 'pwsh'
+                // or 'pwsh.exe' within the tool folder which should be the path right before the '\.store', because
+                // the pwsh executable under $PSHOME is an x86-64 binary that won't work on non-x86/64 platforms.
+                return psExeHome[0..index];
+            }
+
+            return psExeHome;
+        }
+
+#if !UNIX
+        /// <summary>
+        /// Handle the MSIX package scenario where <paramref name="psExeHome"/> points to the MSIX package folder under "Program Files".
+        ///
+        /// That path contains a version string and will change with every update. Prepend that path to the PATH environment variable
+        /// caused a problem to the cmake-based build system, where cmake cached the path to 'pwsh.exe' when running for the 1st time
+        /// from the MSIX PowerShell. That cached path became invalid after the MSIX PowerShell got updated, which broke cmake.
+        ///
+        /// So, instead of using the "Program Files" package folder path, we need to use the path that contains the execution alias for
+        /// the specific MSIX package family name, e.g. %LOCALAPPDATA%\Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe.
+        /// </summary>
+        /// <param name="psExeHome"></param>
+        private static string ResolveStablePathIfMsix(string psExeHome)
+        {
+            const string msixPublisherSuffix = "_8wekyb3d8bbwe";
+            const string msixPackageBaseName = "Microsoft.PowerShell";
+
+            if (psExeHome.EndsWith(msixPublisherSuffix, StringComparison.Ordinal))
+            {
+                string programFileDir = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                string prefix = $"{programFileDir}\\WindowsApps\\{msixPackageBaseName}";
+                if (psExeHome.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    int startIndex = prefix.Length;
+                    int underbarIndex = psExeHome.IndexOf('_', startIndex);
+                    if (underbarIndex > 0)
+                    {
+                        ReadOnlySpan<char> channelSuffix = psExeHome.AsSpan(startIndex, underbarIndex - startIndex);
+                        string localAppDataDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                        psExeHome = $"{localAppDataDir}\\Microsoft\\WindowsApps\\{msixPackageBaseName}{channelSuffix}{msixPublisherSuffix}";
+                    }
+                }
+            }
+
+            return psExeHome;
+        }
+#endif
+
         /// <summary>
         /// Internal Entry point in msh console host implementation.
         /// </summary>
@@ -118,31 +193,21 @@ namespace Microsoft.PowerShell
                 throw new ConsoleHostStartupException(ConsoleHostStrings.ShellCannotBeStartedWithConfigConflict);
             }
 
-            // Put PSHOME in front of PATH so that calling `pwsh` within `pwsh` always starts the same running version.
+            // Put pwsh executable home in front of PATH so that calling `pwsh` within `pwsh` always starts the same running version.
+            string psExeHome = GetPSExecutableHome();
             string path = Environment.GetEnvironmentVariable("PATH");
-            string pshome = Utils.DefaultPowerShellAppBase;
-            string dotnetToolsPathSegment = $"{Path.DirectorySeparatorChar}.store{Path.DirectorySeparatorChar}powershell{Path.DirectorySeparatorChar}";
 
-            int index = pshome.IndexOf(dotnetToolsPathSegment, StringComparison.Ordinal);
-            if (index > 0)
-            {
-                // We're running PowerShell global tool. In this case the real entry executable should be the 'pwsh'
-                // or 'pwsh.exe' within the tool folder which should be the path right before the '\.store', not what
-                // PSHome is pointing to.
-                pshome = pshome[0..index];
-            }
-
-            pshome += Path.PathSeparator;
+            psExeHome += Path.PathSeparator;
 
             // To not impact startup perf, we don't remove duplicates, but we avoid adding a duplicate to the front
             // we also don't handle the edge case where PATH only contains $PSHOME
             if (string.IsNullOrEmpty(path))
             {
-                Environment.SetEnvironmentVariable("PATH", pshome);
+                Environment.SetEnvironmentVariable("PATH", psExeHome);
             }
-            else if (!path.StartsWith(pshome, StringComparison.Ordinal))
+            else if (!path.StartsWith(psExeHome, StringComparison.Ordinal))
             {
-                Environment.SetEnvironmentVariable("PATH", pshome + path);
+                Environment.SetEnvironmentVariable("PATH", psExeHome + path);
             }
 
             try

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -443,8 +443,9 @@ namespace Microsoft.PowerShell
         /// caused a problem for CMake-based build systems: CMake cached the path to 'pwsh.exe' when running for the first time from the
         /// MSIX PowerShell. That cached path became invalid after the MSIX PowerShell was updated, which broke CMake.
         ///
-        /// So, instead of using the "Program Files" package folder path, we need to use the path that contains the execution alias for
-        /// the specific MSIX package family name, e.g. %LOCALAPPDATA%\Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe.
+        /// So, instead of using the "Program Files" package folder path, we need to use the stable path that contains the execution alias
+        /// for the specific MSIX package, e.g. use "%LOCALAPPDATA%\Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe" instead of
+        /// "%ProgramFiles%\WindowsApps\Microsoft.PowerShell_7.x.x.0_x64__8wekyb3d8bbwe".
         /// </summary>
         /// <param name="psExeHome">Path to the directory that contains the pwsh executable.</param>
         private static string ResolveStablePathIfMsix(string psExeHome)
@@ -454,7 +455,10 @@ namespace Microsoft.PowerShell
 
             if (psExeHome.EndsWith(msixPublisherSuffix, StringComparison.Ordinal))
             {
-                string programFileDir = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                string programFileDir = Environment.GetFolderPath(
+                    Environment.SpecialFolder.ProgramFiles,
+                    Environment.SpecialFolderOption.DoNotVerify);
+
                 string prefix = $"{programFileDir}\\WindowsApps\\{msixPackageBaseName}";
                 if (psExeHome.StartsWith(prefix, StringComparison.Ordinal))
                 {
@@ -463,7 +467,10 @@ namespace Microsoft.PowerShell
                     if (underbarIndex > 0)
                     {
                         ReadOnlySpan<char> channelSuffix = psExeHome.AsSpan(startIndex, underbarIndex - startIndex);
-                        string localAppDataDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                        string localAppDataDir = Environment.GetFolderPath(
+                            Environment.SpecialFolder.LocalApplicationData,
+                            Environment.SpecialFolderOption.DoNotVerify);
+
                         psExeHome = $"{localAppDataDir}\\Microsoft\\WindowsApps\\{msixPackageBaseName}{channelSuffix}{msixPublisherSuffix}";
                     }
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -59,81 +59,6 @@ namespace Microsoft.PowerShell
         internal const string DECCKM_OFF = "\x1b[?1l";
 #endif
 
-        private static string GetPSExecutableHome()
-        {
-#if UNIX
-            const string pwshName = "pwsh";
-            const string dotnetToolPathSegment = "/.store/powershell/";
-#else
-            const string pwshName = "pwsh.exe";
-            const string dotnetToolPathSegment = @"\.store\powershell\";
-#endif
-
-            string psExePath = Environment.ProcessPath;
-            string psExeHome = Path.GetDirectoryName(psExePath);
-            string processName = Path.GetFileName(psExePath);
-
-            // Use 'Environment.ProcessPath' if it points to 'pwsh.exe' or 'pwsh'.
-            if (pwshName.Equals(processName, StringComparison.Ordinal))
-            {
-#if !UNIX
-                psExeHome = ResolveStablePathIfMsix(psExeHome);
-#endif
-                return psExeHome;
-            }
-
-            psExeHome = Utils.DefaultPowerShellAppBase;
-
-            int index = psExeHome.IndexOf(dotnetToolPathSegment, StringComparison.Ordinal);
-            if (index > 0)
-            {
-                // We're running PowerShell dotnet tool. In this case the real entry executable should be the 'pwsh'
-                // or 'pwsh.exe' within the tool folder which should be the path right before the '\.store', because
-                // the pwsh executable under $PSHOME is an x86-64 binary that won't work on non-x86/64 platforms.
-                return psExeHome[0..index];
-            }
-
-            return psExeHome;
-        }
-
-#if !UNIX
-        /// <summary>
-        /// Handle the MSIX package scenario where <paramref name="psExeHome"/> points to the MSIX package folder under "Program Files".
-        ///
-        /// That path contains a version string and will change with every update. Prepend that path to the PATH environment variable
-        /// caused a problem to the cmake-based build system, where cmake cached the path to 'pwsh.exe' when running for the 1st time
-        /// from the MSIX PowerShell. That cached path became invalid after the MSIX PowerShell got updated, which broke cmake.
-        ///
-        /// So, instead of using the "Program Files" package folder path, we need to use the path that contains the execution alias for
-        /// the specific MSIX package family name, e.g. %LOCALAPPDATA%\Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe.
-        /// </summary>
-        /// <param name="psExeHome"></param>
-        private static string ResolveStablePathIfMsix(string psExeHome)
-        {
-            const string msixPublisherSuffix = "_8wekyb3d8bbwe";
-            const string msixPackageBaseName = "Microsoft.PowerShell";
-
-            if (psExeHome.EndsWith(msixPublisherSuffix, StringComparison.Ordinal))
-            {
-                string programFileDir = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-                string prefix = $"{programFileDir}\\WindowsApps\\{msixPackageBaseName}";
-                if (psExeHome.StartsWith(prefix, StringComparison.Ordinal))
-                {
-                    int startIndex = prefix.Length;
-                    int underbarIndex = psExeHome.IndexOf('_', startIndex);
-                    if (underbarIndex > 0)
-                    {
-                        ReadOnlySpan<char> channelSuffix = psExeHome.AsSpan(startIndex, underbarIndex - startIndex);
-                        string localAppDataDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                        psExeHome = $"{localAppDataDir}\\Microsoft\\WindowsApps\\{msixPackageBaseName}{channelSuffix}{msixPublisherSuffix}";
-                    }
-                }
-            }
-
-            return psExeHome;
-        }
-#endif
-
         /// <summary>
         /// Internal Entry point in msh console host implementation.
         /// </summary>
@@ -445,6 +370,43 @@ namespace Microsoft.PowerShell
 
         private static readonly CommandLineParameterParser s_cpp = new CommandLineParameterParser();
 
+        private static string GetPSExecutableHome()
+        {
+#if UNIX
+            const string pwshName = "pwsh";
+            const string dotnetToolPathSegment = "/.store/powershell/";
+#else
+            const string pwshName = "pwsh.exe";
+            const string dotnetToolPathSegment = @"\.store\powershell\";
+#endif
+
+            string psExePath = Environment.ProcessPath;
+            string psExeHome = Path.GetDirectoryName(psExePath);
+            string processName = Path.GetFileName(psExePath);
+
+            // Use 'Environment.ProcessPath' if it points to 'pwsh.exe' or 'pwsh'.
+            if (pwshName.Equals(processName, StringComparison.Ordinal))
+            {
+#if !UNIX
+                psExeHome = ResolveStablePathIfMsix(psExeHome);
+#endif
+                return psExeHome;
+            }
+
+            psExeHome = Utils.DefaultPowerShellAppBase;
+
+            int index = psExeHome.IndexOf(dotnetToolPathSegment, StringComparison.Ordinal);
+            if (index > 0)
+            {
+                // We're running PowerShell dotnet tool. In this case the real entry executable should be the 'pwsh'
+                // or 'pwsh.exe' within the tool folder which should be the path right before the '\.store', because
+                // the pwsh executable under $PSHOME is an x86-64 binary that won't work on non-x86/64 platforms.
+                return psExeHome[0..index];
+            }
+
+            return psExeHome;
+        }
+
 #if UNIX
         /// <summary>
         /// The break handler for the program.  Dispatches a break event to the current Executor.
@@ -474,6 +436,42 @@ namespace Microsoft.PowerShell
             }
         }
 #else
+        /// <summary>
+        /// Handle the MSIX package scenario where <paramref name="psExeHome"/> points to the MSIX package folder under "Program Files".
+        ///
+        /// That path contains a version string and will change with every update. Prepend that path to the PATH environment variable
+        /// caused a problem to the cmake-based build system, where cmake cached the path to 'pwsh.exe' when running for the 1st time
+        /// from the MSIX PowerShell. That cached path became invalid after the MSIX PowerShell got updated, which broke cmake.
+        ///
+        /// So, instead of using the "Program Files" package folder path, we need to use the path that contains the execution alias for
+        /// the specific MSIX package family name, e.g. %LOCALAPPDATA%\Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe.
+        /// </summary>
+        /// <param name="psExeHome">Path to the directory that contains the pwsh executable.</param>
+        private static string ResolveStablePathIfMsix(string psExeHome)
+        {
+            const string msixPublisherSuffix = "_8wekyb3d8bbwe";
+            const string msixPackageBaseName = "Microsoft.PowerShell";
+
+            if (psExeHome.EndsWith(msixPublisherSuffix, StringComparison.Ordinal))
+            {
+                string programFileDir = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                string prefix = $"{programFileDir}\\WindowsApps\\{msixPackageBaseName}";
+                if (psExeHome.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    int startIndex = prefix.Length;
+                    int underbarIndex = psExeHome.IndexOf('_', startIndex);
+                    if (underbarIndex > 0)
+                    {
+                        ReadOnlySpan<char> channelSuffix = psExeHome.AsSpan(startIndex, underbarIndex - startIndex);
+                        string localAppDataDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                        psExeHome = $"{localAppDataDir}\\Microsoft\\WindowsApps\\{msixPackageBaseName}{channelSuffix}{msixPublisherSuffix}";
+                    }
+                }
+            }
+
+            return psExeHome;
+        }
+
         /// <summary>
         /// The break handler for the program.  Dispatches a break event to the current Executor.
         /// </summary>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -439,9 +439,9 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Handle the MSIX package scenario where <paramref name="psExeHome"/> points to the MSIX package folder under "Program Files".
         ///
-        /// That path contains a version string and will change with every update. Prepend that path to the PATH environment variable
-        /// caused a problem to the cmake-based build system, where cmake cached the path to 'pwsh.exe' when running for the 1st time
-        /// from the MSIX PowerShell. That cached path became invalid after the MSIX PowerShell got updated, which broke cmake.
+        /// That path contains a version string and will change with every update. Prepending that path to the PATH environment variable
+        /// caused a problem for CMake-based build systems: CMake cached the path to 'pwsh.exe' when running for the first time from the
+        /// MSIX PowerShell. That cached path became invalid after the MSIX PowerShell was updated, which broke CMake.
         ///
         /// So, instead of using the "Program Files" package folder path, we need to use the path that contains the execution alias for
         /// the specific MSIX package family name, e.g. %LOCALAPPDATA%\Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe.

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -745,8 +745,8 @@ $powershell -c '[System.Management.Automation.Platform]::SelectProductNameForDir
     }
 
     Context "PATH environment variable" {
-        It "`$PSHOME should be in front so that pwsh.exe starts current running PowerShell" {
-            & $powershell -v | Should -Match $PSVersionTable.GitCommitId
+        It "Running 'pwsh' should start the currently running PowerShell" {
+            pwsh -v | Should -Match $PSVersionTable.GitCommitId
         }
 
         It "powershell starts if PATH is not set" -Skip:($IsWindows) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## Context

Prepend `$PSHOME` to `PATH` env variable at startup causes a problem to cmake-based build system when it runs in the MSIX PowerShell installation because it caches the location of PowerShell on its first run from within PowerShell.

At startup, PowerShell adds `$PSHOME` to the beginning of `PATH`, and for MSIX installation, `$PSHOME` contains version numbers that change when PowerShell is updated.

When `cmake` is started for the 1st time from MSIX PowerShell, the path it caches will be that `$PSHOME`, which will become invalid after an update of the MSIX PowerShell.

## PR Summary

This PR updated the code that prepend `$PSHOME` to `PATH`. It now handles the MSIX package installation specially -- it uses the directory that contains the `ExecutionAlias` of the MSIX installation instead of `$PSHOME`. For example:
```
Microsoft.PowerShell -> $env:LOCALAPPDATA\Microsoft\WindowsApps\Microsoft.PowerShell_8wekyb3d8bbwe
Microsoft.PowerShell-LTS -> $env:LOCALAPPDATA\Microsoft\WindowsApps\Microsoft.PowerShell-LTS_8wekyb3d8bbwe
Microsoft.PowerShellPreview -> $env:LOCALAPPDATA\Microsoft\WindowsApps\Microsoft.PowerShellPreview_8wekyb3d8bbwe
```
Those are the stable paths that contain the `pwsh.exe` alias pointing to corresponding channels of MSIX. They won't change when the MSIX packages get updated.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
