### PR TITLE
Use .NET SDK and NuGet feed early access for build, package and release pipelines

### DIFF
--- a/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
@@ -5,6 +5,14 @@ parameters:
     displayName: URL to the blob having internal .NET SDK
     type: string
     default: ' '
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
   - name: ReleaseTagVar
     displayName: Release Tag
     type: string
@@ -29,6 +37,17 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: bins-$(BUILD.SOURCEBRANCHNAME)-nonofficial-$(Build.BuildId)
 
@@ -52,6 +71,8 @@ variables:
       SKIP_SIGNING: ${{ parameters.SKIP_SIGNING }}
       ENABLE_MSBUILD_BINLOGS: ${{ parameters.ENABLE_MSBUILD_BINLOGS }}
       FORCE_CODEQL: ${{ parameters.FORCE_CODEQL }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates
@@ -96,3 +117,7 @@ extends:
         RUN_WINDOWS: ${{ parameters.RUN_WINDOWS }}
         RUN_TEST_AND_RELEASE: ${{ parameters.RUN_TEST_AND_RELEASE }}
         OfficialBuild: false
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}

--- a/.pipelines/NonOfficial/PowerShell-Packages-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Packages-NonOfficial.yml
@@ -27,6 +27,25 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   - name: disableNetworkIsolation
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-nonofficial-$(Build.BuildId)
 
@@ -37,6 +56,8 @@ variables:
       ForceAzureBlobDelete: ${{ parameters.ForceAzureBlobDelete }}
       ReleaseTagVar: ${{ parameters.ReleaseTagVar }}
       disableNetworkIsolation: ${{ parameters.disableNetworkIsolation }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 resources:
   pipelines:
@@ -95,3 +116,7 @@ extends:
     - template: /.pipelines/templates/stages/PowerShell-Packages-Stages.yml@self
       parameters:
         OfficialBuild: false
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}

--- a/.pipelines/NonOfficial/PowerShell-Release-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Release-NonOfficial.yml
@@ -29,6 +29,24 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip MSIX Publish
     type: boolean
     default: false
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: release-$(BUILD.SOURCEBRANCHNAME)-nonofficial-$(Build.BuildId)
 
@@ -104,3 +122,7 @@ extends:
         SkipPublish: ${{ parameters.SkipPublish }}
         SkipPSInfraInstallers: ${{ parameters.SkipPSInfraInstallers }}
         skipMSIXPublish: ${{ parameters.skipMSIXPublish }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -29,6 +29,25 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: bins-$(BUILD.SOURCEBRANCHNAME)-prod-$(Build.BuildId)
 
@@ -52,6 +71,8 @@ variables:
       SKIP_SIGNING: ${{ parameters.SKIP_SIGNING }}
       ENABLE_MSBUILD_BINLOGS: ${{ parameters.ENABLE_MSBUILD_BINLOGS }}
       FORCE_CODEQL: ${{ parameters.FORCE_CODEQL }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
@@ -96,3 +117,8 @@ extends:
         RUN_WINDOWS: ${{ parameters.RUN_WINDOWS }}
         RUN_TEST_AND_RELEASE: ${{ parameters.RUN_TEST_AND_RELEASE }}
         OfficialBuild: true
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -27,6 +27,25 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   - name: disableNetworkIsolation
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod-$(Build.BuildId)
 
@@ -37,6 +56,8 @@ variables:
       ForceAzureBlobDelete: ${{ parameters.ForceAzureBlobDelete }}
       ReleaseTagVar: ${{ parameters.ReleaseTagVar }}
       disableNetworkIsolation: ${{ parameters.disableNetworkIsolation }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 resources:
   pipelines:
@@ -95,3 +116,8 @@ extends:
     - template: templates/stages/PowerShell-Packages-Stages.yml
       parameters:
         OfficialBuild: true
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -29,6 +29,24 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip MSIX Publish
     type: boolean
     default: false
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: release-$(BUILD.SOURCEBRANCHNAME)-prod-$(Build.BuildId)
 
@@ -100,3 +118,7 @@ extends:
         SkipPublish: ${{ parameters.SkipPublish }}
         SkipPSInfraInstallers: ${{ parameters.SkipPSInfraInstallers }}
         skipMSIXPublish: ${{ parameters.skipMSIXPublish }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}

--- a/.pipelines/templates/downloadDotnetEarlyAccess.yml
+++ b/.pipelines/templates/downloadDotnetEarlyAccess.yml
@@ -1,0 +1,59 @@
+parameters:
+- name: DotnetRuntimeVersion
+  type: string
+- name: DotnetSdkVersion
+  type: string
+
+jobs:
+- job: download_dotnet_early_access
+  displayName: Download DotNet Early Access
+  variables:
+  - group: dotnet-early-access
+  - name: DOTNET_RUNTIME_VERSION
+    value: ${{ parameters.DotnetRuntimeVersion }}
+  - name: DOTNET_SDK_VERSION
+    value: ${{ parameters.DotnetSdkVersion }}
+  - name: destinationPath
+    value: '$(Build.ArtifactStagingDirectory)/pkgs'
+
+  pool:
+    name: PowerShell1ES
+    type: windows
+    isCustom: true
+    demands:
+    - ImageOverride -equals PSMMS2019-Secure
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - pwsh: |
+      Get-ChildItem Env: | Out-String -Width 9999 -Stream | Write-Verbose -Verbose
+    displayName: Capture environment
+
+  - task: AzurePowerShell@5
+    inputs:
+      azureSubscription: powershell-net-early-access
+      azurePowerShellVersion: LatestVersion
+      ScriptType: InlineScript
+      pwsh: true
+      inline: |
+        $DOTNET_PRIVATE_SAS = Get-AzKeyVaultSecret -VaultName $env:DOTNET_AZ_KV_NAME -Name $env:DOTNET_AZ_SECRET_NAME -AsPlainText
+
+        Write-Verbose -Message "DOTNET_PRIVATE_SAS acquired" -Verbose
+
+        Import-Module "$env:BUILD_SOURCESDIRECTORY/build.psm1" -Force
+
+        if (-not (Test-Path '$(destinationPath)'))
+        {
+            New-Item -ItemType Directory -Path '$(destinationPath)' -Force -Verbose | Out-Null
+        }
+
+        Get-DotnetEarlyAccess -DestinationPath '$(destinationPath)' -Architecture all -DOTNET_PRIVATE_SAS $DOTNET_PRIVATE_SAS
+
+        Get-ChildItem -Path '$(destinationPath)' -Recurse | ForEach-Object {
+            Write-Verbose -verbose "Uploading $($_.FullName) to 'dotnet-packages'"
+            Write-Host "##vso[artifact.upload containerfolder=dotnet-packages;artifactname=dotnet-packages]$($_.FullName)"
+        }
+
+    displayName: 'Download DotNet Early Access'

--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -16,8 +16,20 @@ steps:
       $configPath = "${env:NugetConfigDir}/nuget.config"
       Import-Module ${{ parameters.repoRoot }}/build.psm1 -Force
 
-      Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'"
-      Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'
+      $earlyAccess = $env:ISEARLYACCESS -eq 'true'
+
+      Write-Verbose -Verbose "Is Early access: $earlyAccess"
+
+      if (-not $earlyAccess)
+      {
+        Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'"
+        Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'
+      }
+      else
+      {
+        Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source EarlyAccess"
+        Switch-PSNugetConfig -Source EarlyAccess
+      }
 
       if(-not (Test-Path $configPath))
       {
@@ -33,6 +45,55 @@ steps:
   env:
     NugetConfigDir: ${{ parameters.repoRoot }}/src/Modules
     ob_restore_phase: ${{ parameters.ob_restore_phase }}
+
+- task: AzurePowerShell@5
+  inputs:
+    azureSubscription: powershell-net-early-access
+    azurePowerShellVersion: LatestVersion
+    ScriptType: InlineScript
+    pwsh: true
+    inline: |
+      Write-Verbose -Verbose "Getting an Azure DevOps access token"
+      # Microsoft's well-known Entra resource ID for the Azure DevOps token audience.
+      $azureDevOpsResourceUrl = '499b84ac-1321-427f-aa17-267ca6975798'
+      $azt = (Get-AzAccessToken -ResourceUrl $azureDevOpsResourceUrl).Token | ConvertFrom-SecureString -AsPlainText
+
+      Write-Host "##vso[task.setsecret]$azt"
+      Write-Verbose -Verbose "Setting up Azure Artifacts Credential Provider token"
+
+      $earlyAccessFeed = '$(EARLY_ACCESS_FEED)'
+      $ADORepoUri = switch ($earlyAccessFeed) {
+            'net8' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-8-early-access/nuget/v3/index.json' }
+            'net9' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-9-early-access/nuget/v3/index.json' }
+            'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
+            default { throw "Unknown early access feed URL: $earlyAccessFeed" }
+        }
+      $galleryRepoUri = 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-psgallery/nuget/v2'
+
+      Write-Verbose -Verbose "ADORepoUri == $ADORepoUri"
+
+      if ([string]::IsNullOrEmpty($ADORepoUri) -eq $false)
+      {
+        $endpointCredsObj = @{ endpointCredentials = @(
+          @{ endpoint = $ADORepoUri; password = $azt }
+          @{ endpoint = $galleryRepoUri; password = $azt }
+        )}
+        $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $endpointCredsObj | ConvertTo-Json -Compress
+
+        Write-Verbose -Verbose "Setting VSS_NUGET_EXTERNAL_FEED_ENDPOINTS environment variable"
+
+        $vstsCommandString = "vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS]$VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"
+        Write-Host "##$vstsCommandString"
+      }
+      else
+      {
+        Write-Verbose -Verbose "EARLY_ACCESS_FEED_URL is not set"
+      }
+  displayName: 'Setup Azure Artifacts Credential Provider secret'
+  condition: eq(variables['ISEARLYACCESS'], 'true')
+  env:
+    ob_restore_phase: ${{ parameters.ob_restore_phase }}
+
 
 - pwsh: |
     Get-ChildItem ${{ parameters.repoRoot }}/nuget.config -Recurse | Foreach-Object {

--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -68,7 +68,7 @@ steps:
             'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
             default { throw "Unknown early access feed URL: $earlyAccessFeed" }
         }
-      $galleryRepoUri = 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-psgallery/nuget/v2'
+      $galleryRepoUri = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-psgallery/nuget/v2'
 
       Write-Verbose -Verbose "ADORepoUri == $ADORepoUri"
 
@@ -76,7 +76,6 @@ steps:
       {
         $endpointCredsObj = @{ endpointCredentials = @(
           @{ endpoint = $ADORepoUri; password = $azt }
-          @{ endpoint = $galleryRepoUri; password = $azt }
         )}
         $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $endpointCredsObj | ConvertTo-Json -Compress
 

--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -68,7 +68,7 @@ steps:
             'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
             default { throw "Unknown early access feed URL: $earlyAccessFeed" }
         }
-      $galleryRepoUri = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-psgallery/nuget/v2'
+      $galleryRepoUri = 'https://www.powershellgallery.com/api/v2'
 
       Write-Verbose -Verbose "ADORepoUri == $ADORepoUri"
 

--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -81,8 +81,7 @@ steps:
 
         Write-Verbose -Verbose "Setting VSS_NUGET_EXTERNAL_FEED_ENDPOINTS environment variable"
 
-        $vstsCommandString = "vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS]$VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"
-        Write-Host "##$vstsCommandString"
+        Write-Host "##vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS;issecret=true]$VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"
       }
       else
       {

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -2,6 +2,19 @@ parameters:
 - name: ob_restore_phase
   type: boolean
   default: true
+- name: architecture
+  type: string
+  default: 'win-x64'
+  values:
+      - 'win-x64'
+      - 'win-x86'
+      - 'win-arm64'
+      - 'linux-x64'
+      - 'linux-arm64'
+      - 'linux-musl-x64'
+      - 'linux-musl-arm64'
+      - 'osx-x64'
+      - 'osx-arm64'
 
 steps:
   - pwsh: |
@@ -19,6 +32,70 @@ steps:
 
     displayName: 'Install dotnet SDK'
     workingDirectory: $(RepoRoot)
+    condition: ne(variables['ISEARLYACCESS'], 'true')
     env:
       ob_restore_phase: ${{ parameters.ob_restore_phase }}
 
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifactName: 'dotnet-packages'
+      targetPath: '$(Pipeline.Workspace)/dotnet-packages'
+      displayName: "Download dotnet-packages artifact"
+      condition: eq(variables['ISEARLYACCESS'], 'true')
+    env:
+      ob_restore_phase: ${{ parameters.ob_restore_phase }}
+
+  - pwsh: |
+      $arch = '${{ parameters.architecture }}'
+      $sdkFilePattern = "dotnet-sdk-*-${arch}.*"
+
+      if (-not (Test-Path '$(Pipeline.Workspace)/dotnet-packages')) {
+        New-Item -Path '$(Pipeline.Workspace)/dotnet-packages' -ItemType Directory -Force -Verbose | Out-Null
+      }
+
+      $filePath = Get-ChildItem '$(Pipeline.Workspace)/dotnet-packages' -Recurse -File | Where-Object { $_.Name -like $sdkFilePattern } | Select-Object -First 1 -ExpandProperty FullName
+
+      if (-not $filePath) {
+        Get-ChildItem -Path '$(Pipeline.Workspace)/dotnet-packages' -Recurse
+        throw "SDK file matching pattern $sdkFilePattern not found in $(Pipeline.Workspace)/dotnet-packages"
+      }
+
+      $dotnetLocation = if ($IsWindows) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
+
+      if (-not (Test-Path $dotnetLocation)) {
+        New-Item -ItemType Directory -Path $dotnetLocation -Force -Verbose | Out-Null
+      }
+
+      Write-Verbose -Verbose "Extracting SDK from $filePath to $dotnetLocation"
+
+      if ($filePath -match '\.(tar\.gz|tgz)$') {
+        & tar -xzf $filePath -C $dotnetLocation
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to extract $filePath with tar (exit code $LASTEXITCODE)"
+        }
+      } elseif ($filePath -match '\.zip$') {
+        Expand-Archive -Path $filePath -DestinationPath $dotnetLocation -Force
+      } else {
+        throw "Unsupported SDK archive format: $filePath"
+      }
+
+      Write-Verbose -Verbose "Expand dotnet package complete."
+
+      $dotnetExe = if ($IsWindows) {
+        "$dotnetLocation\dotnet.exe"
+      } else {
+        "$dotnetLocation/dotnet"
+      }
+
+      if (-not (Test-Path $dotnetExe)) {
+        throw "dotnet executable not found at $dotnetExe"
+      }
+
+      Get-ChildItem -Path $dotnetLocation -Recurse
+
+      & $dotnetExe --info
+    workingDirectory: $(RepoRoot)
+    displayName: Install dotnet early access
+    condition: eq(variables['ISEARLYACCESS'], 'true')
+    env:
+      ob_restore_phase: ${{ parameters.ob_restore_phase }}

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -38,7 +38,7 @@ steps:
 
   - task: DownloadPipelineArtifact@2
     displayName: "Download dotnet-packages artifact"
-    condition: or(eq(variables['ISEARLYACCESS'], 'true'), eq(variables['ISEARLYACCESS'], 'True'))
+    condition: eq(variables['ISEARLYACCESS'], 'true')
     inputs:
       artifactName: 'dotnet-packages'
       targetPath: '$(Pipeline.Workspace)/dotnet-packages'

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -32,7 +32,7 @@ steps:
 
     displayName: 'Install dotnet SDK'
     workingDirectory: $(RepoRoot)
-    condition: ne(variables['ISEARLYACCESS'], 'true')
+    condition: and(ne(variables['ISEARLYACCESS'], 'true'), ne(variables['ISEARLYACCESS'], 'True'))
     env:
       ob_restore_phase: ${{ parameters.ob_restore_phase }}
 

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -37,14 +37,13 @@ steps:
       ob_restore_phase: ${{ parameters.ob_restore_phase }}
 
   - task: DownloadPipelineArtifact@2
+    displayName: "Download dotnet-packages artifact"
+    condition: or(eq(variables['ISEARLYACCESS'], 'true'), eq(variables['ISEARLYACCESS'], 'True'))
     inputs:
       artifactName: 'dotnet-packages'
       targetPath: '$(Pipeline.Workspace)/dotnet-packages'
-      displayName: "Download dotnet-packages artifact"
-      condition: eq(variables['ISEARLYACCESS'], 'true')
     env:
       ob_restore_phase: ${{ parameters.ob_restore_phase }}
-
   - pwsh: |
       $arch = '${{ parameters.architecture }}'
       $sdkFilePattern = "dotnet-sdk-*-${arch}.*"

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -3,6 +3,7 @@ parameters:
   signedDrop: 'drop_linux_sign_linux_x64'
   packageType: deb
   jobName: 'deb'
+  dotnetArch: 'linux-x64'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -95,6 +96,8 @@ jobs:
       ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $packageType = '$(PackageType)'

--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -2,6 +2,7 @@ parameters:
   Runtime: 'linux-x64'
   BuildConfiguration: 'release'
   JobName: 'build_linux'
+  dotnetArch: 'linux-x64'
 
 jobs:
 - job: build_${{ parameters.JobName }}
@@ -63,6 +64,8 @@ jobs:
       Language: csharp
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $runtime = $env:RUNTIME

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -1,5 +1,6 @@
 parameters:
   buildArchitecture: 'x64'
+  dotnetArch: 'osx-x64'
 jobs:
 - job: build_macOS_${{ parameters.buildArchitecture }}
   displayName: Build macOS ${{ parameters.buildArchitecture }}
@@ -39,6 +40,8 @@ jobs:
 
     ## We cross compile for arm64, so the arch is always x64
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       Import-Module $(PowerShellRoot)/build.psm1 -Force

--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -1,5 +1,6 @@
 parameters:
   runtime: x64
+  dotnetArch: 'win-x64'
 
 jobs:
 - job: build_win_${{ parameters.runtime }}
@@ -80,6 +81,7 @@ jobs:
   - template: /.pipelines/templates/install-dotnet.yml@self
     parameters:
       ob_restore_phase: false
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $runtime = '$(Runtime)'

--- a/.pipelines/templates/release-validate-fxdpackages.yml
+++ b/.pipelines/templates/release-validate-fxdpackages.yml
@@ -20,6 +20,20 @@ parameters:
   - name: enableCredScan
     type: boolean
     default: true
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: dotnetArch
+    type: string
+    default: 'win-x64'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -36,6 +50,8 @@ jobs:
     value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
   - name: ob_sdl_credscan_enabled
     value: ${{ parameters.enableCredScan }}
+  - name: ISEARLYACCESS
+    value: ${{ parameters.IsEarlyAccess }}
 
   pool:
     type: ${{ parameters.jobtype }}
@@ -62,6 +78,9 @@ jobs:
       displayName: 'Capture Downloaded Artifacts'
 
     - template: /.pipelines/templates/install-dotnet.yml@self
+      parameters:
+        architecture: ${{ parameters.dotnetArch }}
+        ob_restore_phase: false
 
     - pwsh: |
         $artifactName = '$(artifactName)'

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -1,10 +1,33 @@
 parameters:
-  jobName: ""
-  displayName: ""
-  jobtype: "windows"
-  globalToolExeName: 'pwsh.exe'
-  globalToolPackageName: 'PowerShell.Windows.x64'
-
+  - name: jobName
+    type: string
+    default: ""
+  - name: displayName
+    type: string
+    default: ""
+  - name: jobtype
+    type: string
+    default: "windows"
+  - name: globalToolExeName
+    type: string
+    default: 'pwsh.exe'
+  - name: globalToolPackageName
+    type: string
+    default: 'PowerShell.Windows.x64'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: dotnetArch
+    type: string
+    default: 'win-x64'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -19,6 +42,8 @@ jobs:
       value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
     - name: ob_sdl_tsa_configFile
       value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
+    - name: ISEARLYACCESS
+      value: ${{ parameters.IsEarlyAccess }}
 
   steps:
     - checkout: self
@@ -39,6 +64,9 @@ jobs:
       displayName: 'Capture Downloaded Artifacts'
 
     - template: /.pipelines/templates/install-dotnet.yml@self
+      parameters:
+        architecture: ${{ parameters.dotnetArch }}
+        ob_restore_phase: false
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -1,8 +1,33 @@
 parameters:
-  jobName: ""
-  displayName: ""
-  poolName: "windows"
-  imageName: 'none'
+  - name: jobName
+    type: string
+    default: ""
+  - name: displayName
+    type: string
+    default: ""
+  - name: poolName
+    type: string
+    default: "windows"
+  - name: imageName
+    type: string
+    default: 'none'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: dotnetArch
+    type: string
+    default: 'win-x64'
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -22,15 +47,19 @@ jobs:
   - group: mscodehub-feed-read-general
   - group: mscodehub-feed-read-akv
   - group: DotNetPrivateBuildAccess
+  - name: ISEARLYACCESS
+    value: ${{ parameters.IsEarlyAccess }}
+  - name: EARLY_ACCESS_FEED
+    value: ${{ parameters.EarlyAccessFeed }}
 
   steps:
     - checkout: self
       clean: true
       lfs: false
 
-    - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
+    - template: /.pipelines/templates/SetVersionVariables.yml@self
       parameters:
-        repoRoot: "$(Build.SourcesDirectory)"
+        ReleaseTagVar: $(ReleaseTagVar)
 
     - template: release-SetReleaseTagandContainerName.yml@self
 
@@ -47,6 +76,11 @@ jobs:
       displayName: 'Capture Downloaded Artifacts'
 
     - template: /.pipelines/templates/install-dotnet.yml@self
+      parameters:
+        ob_restore_phase: false
+        architecture: ${{ parameters.dotnetArch }}
+
+    - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)"
@@ -56,10 +90,28 @@ jobs:
 
         $env:DOTNET_NOLOGO=1
 
+        $isEarlyAccess = '$(ISEARLYACCESS)'
+
+        $ADORepoUri = if ($isEarlyAccess -eq 'True')
+          {
+            $earlyAccessFeed = '$(EARLY_ACCESS_FEED)'
+            switch ($earlyAccessFeed) {
+                  'net8' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-8-early-access/nuget/v3/index.json' }
+                  'net9' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-9-early-access/nuget/v3/index.json' }
+                  'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
+                  default { throw "Unknown early access feed URL: $earlyAccessFeed" }
+              }
+          }
+          else {
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json"
+          }
+
+        Write-Verbose -Verbose "ADO Repo URI: $ADORepoUri"
+
         $localLocation = "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg"
         $xmlElement = @"
           <add key=`"local`" value=`"$localLocation`" />
-          <add key="dotnet" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v2" />
+          <add key=`"dotnet`" value=`"$ADORepoUri`" />
         </packageSources>
         "@
 

--- a/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
@@ -7,6 +7,20 @@ parameters:
     default: true
   - name: OfficialBuild
     type: boolean
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 stages:
 - stage: prep
@@ -31,6 +45,8 @@ stages:
         value: false
       - name: ob_sdl_sbom_enabled
         value: false
+      - name: IsEarlyAccess
+        value: ${{ parameters.IsEarlyAccess }}
 
     steps:
     - checkout: self
@@ -49,12 +65,20 @@ stages:
         ReleaseTagVar: $(ReleaseTagVar)
         CreateJson: yes
 
+  - ${{ if eq(parameters.IsEarlyAccess, true) }}:
+    - template: /.pipelines/templates/downloadDotnetEarlyAccess.yml@self
+      parameters:
+        DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
+
 - stage: macos
   displayName: macOS - build and sign
   dependsOn: ['prep']
   variables:
     - name: ps_official_build
       value: ${{ parameters.OfficialBuild }}
+    - name: IsEarlyAccess
+      value: ${{ parameters.IsEarlyAccess }}
   jobs:
   - template: /.pipelines/templates/mac.yml@self
     parameters:
@@ -69,6 +93,8 @@ stages:
   variables:
     - name: ps_official_build
       value: ${{ parameters.OfficialBuild }}
+    - name: IsEarlyAccess
+      value: ${{ parameters.IsEarlyAccess }}
   jobs:
   - template: /.pipelines/templates/linux.yml@self
     parameters:
@@ -129,6 +155,8 @@ stages:
   variables:
     - name: ps_official_build
       value: ${{ parameters.OfficialBuild }}
+    - name: IsEarlyAccess
+      value: ${{ parameters.IsEarlyAccess }}
   jobs:
   - template: /.pipelines/templates/windows-hosted-build.yml@self
     parameters:
@@ -149,6 +177,7 @@ stages:
     parameters:
       Architecture: x86
       JobName: build_windows_x86_release
+      dotnetArch: 'win-x86'
   - template: /.pipelines/templates/windows-hosted-build.yml@self
     parameters:
       Architecture: arm64

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -1,6 +1,20 @@
 parameters:
   - name: OfficialBuild
     type: boolean
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 stages:
 - stage: prep
@@ -8,9 +22,21 @@ stages:
   jobs:
   - template: /.pipelines/templates/checkAzureContainer.yml@self
 
+- stage: EarlyDotnet
+  displayName: 'Early .NET Setup'
+  dependsOn: []
+  condition: always()
+
+  jobs:
+  - ${{ if eq(parameters.IsEarlyAccess, true) }}:
+    - template: /.pipelines/templates/downloadDotnetEarlyAccess.yml@self
+      parameters:
+        DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
+
 - stage: mac_package
   displayName: 'macOS Pkg+Sign'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/mac-package-build.yml@self
     parameters:
@@ -22,7 +48,7 @@ stages:
 
 - stage: windows_package_build
   displayName: 'Win Pkg (unsigned)'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/packaging/windows/package.yml@self
     parameters:
@@ -86,7 +112,7 @@ stages:
 
 - stage: linux_package
   displayName: 'Linux Pkg+Sign'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/linux-package-build.yml@self
     parameters:
@@ -181,13 +207,13 @@ stages:
 
 - stage: nupkg
   displayName: 'NuGet Pkg+Sign'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/nupkg.yml@self
 
 - stage: msixbundle
   displayName: 'MSIX Bundle+Sign'
-  dependsOn: [windows_package_build]  # Only depends on unsigned packages
+  dependsOn: [EarlyDotnet, windows_package_build]  # Only depends on unsigned packages
   jobs:
   - template: /.pipelines/templates/package-create-msix.yml@self
     parameters:
@@ -201,7 +227,7 @@ stages:
 
 - stage: upload
   displayName: 'Upload'
-  dependsOn: [prep, mac_package, windows_package_sign, linux_package, nupkg, msixbundle]  # prep needed for BuildInfo JSON
+  dependsOn: [EarlyDotnet, prep, mac_package, windows_package_sign, linux_package, nupkg, msixbundle]  # prep needed for BuildInfo JSON
   jobs:
   - template: /.pipelines/templates/uploadToAzure.yml@self
 

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -33,7 +33,13 @@ stages:
       parameters:
         DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
         DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
-
+  - ${{ else }}:
+    - job: skip_early_dotnet
+      displayName: 'Skip early access .NET setup'
+      pool:
+        type: windows
+      steps:
+      - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET setup.'
 - stage: mac_package
   displayName: 'macOS Pkg+Sign'
   dependsOn: [EarlyDotnet]

--- a/.pipelines/templates/stages/PowerShell-Release-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Release-Stages.yml
@@ -36,7 +36,13 @@ stages:
       parameters:
         DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
         DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
-
+  - ${{ else }}:
+    - job: skip_download_dotnet_early_access
+      displayName: 'Skip early access .NET download'
+      pool:
+        type: windows
+      steps:
+      - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET download.'
 - stage: validateSdk
   displayName: 'Validate SDK'
   dependsOn: [downloadDotnetEarlyAccess]

--- a/.pipelines/templates/stages/PowerShell-Release-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Release-Stages.yml
@@ -7,6 +7,20 @@ parameters:
     type: boolean
   - name: skipMSIXPublish
     type: boolean
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 stages:
 - stage: setReleaseTagAndChangelog
@@ -14,9 +28,18 @@ stages:
   jobs:
   - template: /.pipelines/templates/release-SetTagAndChangelog.yml@self
 
+- stage: downloadDotnetEarlyAccess
+  displayName: 'Download Early release .NET'
+  jobs:
+  - ${{ if eq(parameters.IsEarlyAccess, true) }}:
+    - template: /.pipelines/templates/downloadDotnetEarlyAccess.yml@self
+      parameters:
+        DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
+
 - stage: validateSdk
   displayName: 'Validate SDK'
-  dependsOn: []
+  dependsOn: [downloadDotnetEarlyAccess]
   jobs:
   - template: /.pipelines/templates/release-validate-sdk.yml@self
     parameters:
@@ -24,6 +47,11 @@ stages:
       displayName: "Windows SDK Validation"
       imageName: PSMMS2019-Secure
       poolName: $(windowsPool)
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-sdk.yml@self
     parameters:
@@ -31,6 +59,10 @@ stages:
       displayName: "MacOS SDK Validation"
       imageName: macOS-latest
       poolName: Azure Pipelines
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'osx-x64'
 
   - template: /.pipelines/templates/release-validate-sdk.yml@self
     parameters:
@@ -38,16 +70,24 @@ stages:
       displayName: "Linux SDK Validation"
       imageName: PSMMSUbuntu22.04-Secure
       poolName: $(ubuntuPool)
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-x64'
 
 - stage: gbltool
   displayName: 'Validate Global tools'
-  dependsOn: []
+  dependsOn: [downloadDotnetEarlyAccess]
   jobs:
   - template: /.pipelines/templates/release-validate-globaltools.yml@self
     parameters:
       jobName: "WindowsGlobalTools"
       displayName: "Windows Global Tools Validation"
       jobtype: windows
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-globaltools.yml@self
     parameters:
@@ -56,10 +96,14 @@ stages:
       jobtype: linux
       globalToolExeName: 'pwsh'
       globalToolPackageName: 'PowerShell.Linux.x64'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-x64'
 
 - stage: fxdpackages
   displayName: 'Validate FXD Packages'
-  dependsOn: []
+  dependsOn: [downloadDotnetEarlyAccess]
   jobs:
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -68,6 +112,10 @@ stages:
       jobtype: 'windows'
       artifactName: 'drop_windows_package_package_win_fxdependent'
       packageNamePattern: '**/*win-fxdependent.zip'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -76,6 +124,10 @@ stages:
       jobtype: 'windows'
       artifactName: 'drop_windows_package_package_win_fxdependentWinDesktop'
       packageNamePattern: '**/*win-fxdependentwinDesktop.zip'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -84,6 +136,10 @@ stages:
       jobtype: 'linux'
       artifactName: 'drop_linux_package_fxdependent'
       packageNamePattern: '**/*linux-x64-fxdependent.tar.gz'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-x64'
 
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -95,6 +151,10 @@ stages:
       packageNamePattern: '**/*linux-x64-fxdependent.tar.gz'
       arm64: 'yes'
       enableCredScan: false
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-arm64'
 
 - stage: ManualValidation
   dependsOn: []

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -33,6 +33,8 @@ jobs:
       ob_restore_phase: true
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: 'win-x64'
 
   - pwsh: |
       New-Item -Path '$(ob_outputDirectory)' -ItemType Directory -Force
@@ -96,6 +98,8 @@ jobs:
       ob_restore_phase: true
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: 'linux-x64'
 
   - pwsh: |
       New-Item -Path '$(ob_outputDirectory)' -ItemType Directory -Force

--- a/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
@@ -2,6 +2,13 @@ parameters:
   - name: InternalSDKBlobURL
     type: string
     default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
   - name: ReleaseTagVar
     type: string
     default: 'fromBranch'
@@ -12,6 +19,9 @@ parameters:
     type: boolean
     default: false
   - name: FORCE_CODEQL
+    type: boolean
+    default: false
+  - name: IsEarlyAccess
     type: boolean
     default: false
 
@@ -65,3 +75,7 @@ variables:
   # Disable BinSkim at job level to override NonOfficial template defaults
   - name: ob_sdl_binskim_enabled
     value: false
+  - name: EARLY_ACCESS_FEED
+    value: ${{ parameters.EarlyAccessFeed }}
+  - name: IsEarlyAccess
+    value: ${{ parameters.IsEarlyAccess }}

--- a/.pipelines/templates/variables/PowerShell-Packages-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-Packages-Variables.yml
@@ -11,6 +11,16 @@ parameters:
   - name: disableNetworkIsolation
     type: boolean
     default: false
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -48,3 +58,7 @@ variables:
   - group: MSIXSigningProfile
   - name: disableNetworkIsolation
     value: ${{ parameters.disableNetworkIsolation }}
+  - name: EARLY_ACCESS_FEED
+    value: ${{ parameters.EarlyAccessFeed }}
+  - name: IsEarlyAccess
+    value: ${{ parameters.IsEarlyAccess }}

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -2,6 +2,7 @@ parameters:
   Architecture: 'x64'
   BuildConfiguration: 'release'
   JobName: 'build_windows'
+  dotnetArch: 'win-x64'
 
 jobs:
 - job: build_windows_${{ parameters.Architecture }}_${{ parameters.BuildConfiguration }}
@@ -64,6 +65,8 @@ jobs:
       Language: csharp
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $runtime = switch ($env:Architecture)

--- a/build.psm1
+++ b/build.psm1
@@ -920,7 +920,7 @@ function Switch-PSNugetConfig {
     }
 
     $dotnetSdk = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v2'; Name = 'dotnet' }
-    $gallery = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-psgallery/nuget/v2'; Name = 'psgallery' }
+    $gallery = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-psgallery/nuget/v2'; Name = 'psgallery' }
     $nugetorg = [NugetPackageSource] @{Url = 'https://api.nuget.org/v3/index.json'; Name = 'nuget.org' }
     if ( $Source -eq 'Public') {
         New-NugetConfigFile -NugetPackageSource $nugetorg, $dotnetSdk   -Destination "$PSScriptRoot/" @extraParams

--- a/build.psm1
+++ b/build.psm1
@@ -899,7 +899,7 @@ function Switch-PSNugetConfig {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'user')]
         [Parameter(Mandatory = $true, ParameterSetName = 'nouser')]
-        [ValidateSet('Public', 'Private', 'NuGetOnly')]
+        [ValidateSet('Public', 'Private', 'NuGetOnly', 'EarlyAccess')]
         [string] $Source,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'user')]
@@ -920,7 +920,7 @@ function Switch-PSNugetConfig {
     }
 
     $dotnetSdk = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v2'; Name = 'dotnet' }
-    $gallery = [NugetPackageSource] @{Url = 'https://www.powershellgallery.com/api/v2/'; Name = 'psgallery' }
+    $gallery = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-psgallery/nuget/v2'; Name = 'psgallery' }
     $nugetorg = [NugetPackageSource] @{Url = 'https://api.nuget.org/v3/index.json'; Name = 'nuget.org' }
     if ( $Source -eq 'Public') {
         New-NugetConfigFile -NugetPackageSource $nugetorg, $dotnetSdk   -Destination "$PSScriptRoot/" @extraParams
@@ -936,6 +936,23 @@ function Switch-PSNugetConfig {
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/" @extraParams
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/src/Modules/" @extraParams
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
+    } elseif ($Source -eq 'EarlyAccess') {
+        $earlyAccess = $env:EARLY_ACCESS_FEED
+
+        $earlyAccessFeedUrl = switch ($earlyAccess) {
+            'net8' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-8-early-access/nuget/v3/index.json' }
+            'net9' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-9-early-access/nuget/v3/index.json' }
+            'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
+            default { throw "Unknown early access feed URL: $earlyAccess" }
+        }
+
+        Set-PipelineVariable -Name 'EARLY_ACCESS_FEED_URL' -Value $earlyAccessFeedUrl
+
+        $earlyAccessFeed = [NugetPackageSource] @{Url = $earlyAccessFeedUrl; Name = 'earlyaccess' }
+
+        New-NugetConfigFile -NugetPackageSource $earlyAccessFeed -Destination "$PSScriptRoot/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $gallery -Destination "$PSScriptRoot/src/Modules/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $gallery -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
     } else {
         throw "Unknown source: $Source"
     }
@@ -2574,6 +2591,55 @@ function Start-PSxUnit {
     finally {
         $env:DOTNET_ROOT = $originalDOTNET_ROOT
         Pop-Location
+    }
+}
+
+function Get-DotnetEarlyAccess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DestinationPath,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('win-x64', 'win-x86', 'win-arm64', 'linux-x64', 'linux-arm64', 'linux-alpine-x64', 'linux-alpine-arm64', 'osx-x64', 'osx-arm64', 'all')]
+        [string]$Architecture,
+
+        [Parameter(Mandatory)]
+        [string]$DOTNET_PRIVATE_SAS
+    )
+
+    $baseUrl = $env:DOTNET_PRIVATE_BLOB_BASE_URL
+    $DOTNET_RUNTIME_VERSION = $env:DOTNET_RUNTIME_VERSION
+    $DOTNET_SDK_VERSION = $env:DOTNET_SDK_VERSION
+
+    $fileName = switch ($Architecture) {
+        'win-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-win-x64.zip" }
+        'win-x86' { "dotnet-sdk-$DOTNET_SDK_VERSION-win-x86.zip" }
+        'win-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-win-arm64.zip" }
+        'linux-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz" }
+        'linux-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz" }
+        'linux-alpine-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz" }
+        'linux-alpine-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-arm64.tar.gz" }
+        'osx-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-osx-x64.tar.gz" }
+        'osx-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-osx-arm64.tar.gz" }
+        'all' { @(
+            "dotnet-sdk-$DOTNET_SDK_VERSION-win-x64.zip"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-win-x86.zip"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-win-arm64.zip"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-arm64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-osx-x64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-osx-arm64.tar.gz"
+        ) }
+        default { throw "Unsupported architecture: $Architecture" }
+    }
+
+    $fileName | ForEach-Object {
+        $destFile = "$DestinationPath/$_"
+        Write-Verbose -Verbose "Downloading $_ from $baseUrl/$DOTNET_RUNTIME_VERSION to $destFile"
+        Invoke-WebRequest -Uri "$baseUrl/$DOTNET_RUNTIME_VERSION/$_$DOTNET_PRIVATE_SAS" -OutFile $destFile
     }
 }
 

--- a/build.psm1
+++ b/build.psm1
@@ -2639,7 +2639,14 @@ function Get-DotnetEarlyAccess {
     $fileName | ForEach-Object {
         $destFile = "$DestinationPath/$_"
         Write-Verbose -Verbose "Downloading $_ from $baseUrl/$DOTNET_RUNTIME_VERSION to $destFile"
-        Invoke-WebRequest -Uri "$baseUrl/$DOTNET_RUNTIME_VERSION/$_$DOTNET_PRIVATE_SAS" -OutFile $destFile
+
+        try {
+            Invoke-WebRequest -Uri "$baseUrl/$DOTNET_RUNTIME_VERSION/$_$DOTNET_PRIVATE_SAS" -OutFile $destFile -RetryIntervalSec 5 -MaximumRetryCount 3
+        }
+        catch {
+            Write-Error "Failed to download $_ from $baseUrl/$DOTNET_RUNTIME_VERSION"
+            throw
+        }
     }
 }
 

--- a/build.psm1
+++ b/build.psm1
@@ -920,7 +920,7 @@ function Switch-PSNugetConfig {
     }
 
     $dotnetSdk = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v2'; Name = 'dotnet' }
-    $gallery = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell-psgallery/nuget/v2'; Name = 'psgallery' }
+    $gallery = [NugetPackageSource] @{Url = 'https://www.powershellgallery.com/api/v2/'; Name = 'psgallery' }
     $nugetorg = [NugetPackageSource] @{Url = 'https://api.nuget.org/v3/index.json'; Name = 'nuget.org' }
     if ( $Source -eq 'Public') {
         New-NugetConfigFile -NugetPackageSource $nugetorg, $dotnetSdk   -Destination "$PSScriptRoot/" @extraParams


### PR DESCRIPTION
# PR Summary

This pull request introduces early access .NET build support into the PowerShell build and release pipelines. It adds new parameters and logic to allow builds to target early access .NET SDK and runtime versions, select specific early access feeds, and handle their installation and authentication securely. The changes are spread across official and non-official pipeline YAMLs, as well as supporting templates.

**Key changes include:**

### Early Access Build Parameterization

* Added new parameters (`IsEarlyAccess`, `EarlyAccessFeed`, `DOTNET_RUNTIME_VERSION`, `DOTNET_SDK_VERSION`) to all relevant pipeline YAMLs for both official and non-official builds, enabling selection of early access .NET feeds and versions at queue time. [[1]](diffhunk://#diff-bb6823a9ef9ed62d250d5176d035352b36640f2a6718c4e30f3ed07d17acedd7R8-R15) [[2]](diffhunk://#diff-bb6823a9ef9ed62d250d5176d035352b36640f2a6718c4e30f3ed07d17acedd7R40-R50) [[3]](diffhunk://#diff-83daa6f221082383b5dada59d9b9f21860fe3f3cf3f0e39aaa83c0c25b92d5f8R30-R48) [[4]](diffhunk://#diff-c83a1b4379a5e89cd4ac030b60e7db1fa17d48cf6eb0cc6c805f9d25ed4ad5c2R32-R49) [[5]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR32-R50) [[6]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R30-R48) [[7]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR32-R49)

* Propagated these parameters into pipeline variables and downstream template parameters to ensure early access settings flow throughout the build and release process. [[1]](diffhunk://#diff-bb6823a9ef9ed62d250d5176d035352b36640f2a6718c4e30f3ed07d17acedd7R74-R75) [[2]](diffhunk://#diff-bb6823a9ef9ed62d250d5176d035352b36640f2a6718c4e30f3ed07d17acedd7R120-R123) [[3]](diffhunk://#diff-83daa6f221082383b5dada59d9b9f21860fe3f3cf3f0e39aaa83c0c25b92d5f8R59-R60) [[4]](diffhunk://#diff-83daa6f221082383b5dada59d9b9f21860fe3f3cf3f0e39aaa83c0c25b92d5f8R119-R122) [[5]](diffhunk://#diff-c83a1b4379a5e89cd4ac030b60e7db1fa17d48cf6eb0cc6c805f9d25ed4ad5c2R125-R128) [[6]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR74-R75) [[7]](diffhunk://#diff-b4a2090e3664c911fbfe10b93d8703cba9141cabb8707085b1b6885a4ee8653aR120-R124) [[8]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R59-R60) [[9]](diffhunk://#diff-94820840eb18ab110a6244f06a5d156e757c980ceebcfe03a4f2591bb67bc859R119-R123) [[10]](diffhunk://#diff-b25fb4a8cfad5e36ba1c9c9c7cbe494fce4eed0067878610ebb12ffcab7e41cdR121-R124)

### Early Access .NET SDK/Runtime Download and Installation

* Introduced a new template (`downloadDotnetEarlyAccess.yml`) to securely download early access .NET SDK/runtime artifacts using Azure credentials and upload them as pipeline artifacts.

* Enhanced the `install-dotnet.yml` template to support conditional installation of early access SDKs by extracting from downloaded artifacts, with support for multiple architectures. [[1]](diffhunk://#diff-7570e585001d4b7fba396c24c2ea2100dd94bd8c7961bd39a665e68a1c747f18R5-R17) [[2]](diffhunk://#diff-7570e585001d4b7fba396c24c2ea2100dd94bd8c7961bd39a665e68a1c747f18R35-R101) [[3]](diffhunk://#diff-c4deeac235a73bb18401801ffa4dbcba3977cfb09599cd432e2a5940de12734eR6) [[4]](diffhunk://#diff-c4deeac235a73bb18401801ffa4dbcba3977cfb09599cd432e2a5940de12734eR99-R100)

### NuGet Feed and Credential Management for Early Access

* Updated the `insert-nuget-config-azfeed.yml` template to switch NuGet config sources based on the early access flag and to securely set up credentials for Azure Artifacts feeds using Azure DevOps tokens. [[1]](diffhunk://#diff-69953bf967d1671c7627e0bd3fffcd1bc77812827be14a74c3fcc8b15d16213eR19-R32) [[2]](diffhunk://#diff-69953bf967d1671c7627e0bd3fffcd1bc77812827be14a74c3fcc8b15d16213eR49-R97)

These enhancements enable the build system to flexibly and securely consume early access .NET builds, supporting advanced development and testing scenarios.

## PR Context

These changes to the pipelines allow us to consume .NET SDK and NuGet feeds early.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
