### PR TITLE
[release/v7.6.5] Produce min-size package for arm64 architecture

### DIFF
--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -136,7 +136,8 @@ jobs:
         'rpm-fxdependent' { 'Signed-fxdependent-linux-x64', 'powershell*.rpm' }
         'rpm-fxdependent-arm64' { 'Signed-fxdependent-linux-arm64', 'powershell*.rpm' }
         'rpm' { 'Signed-linux-x64', 'powershell*.rpm' }
-        'min-size' { 'Signed-linux-x64', 'powershell*.tar.gz' }
+        'min-size-x64' { 'Signed-linux-x64', 'powershell*.tar.gz' }
+        'min-size-arm64' { 'Signed-linux-arm64', 'powershell*.tar.gz' }
       }
 
       $signedFilesPath = "$(Pipeline.Workspace)/CoOrdinatedBuildPipeline/${signedDrop}/${signedFolder}"
@@ -173,7 +174,7 @@ jobs:
 
       Start-PSPackage -Type $packageType -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath
 
-      if ($LTS) {
+      if ($LTS -and ($packageType -like 'deb*' -or $packageType -like 'rpm*')) {
         Write-Verbose -Message "LTS Release: $LTS" -Verbose
         Start-PSPackage -Type $packageType -ReleaseTag $(ReleaseTagVar) -PackageBinPath $signedFilesPath -LTS
       }

--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -63,16 +63,16 @@ jobs:
   - download: CoOrdinatedBuildPipeline
     artifact: drop_windows_build_windows_${{ parameters.runtime }}_release
     displayName: Download signed artifacts
-    condition: ${{ ne(parameters.runtime, 'minSize') }}
+    condition: ${{ not(contains(parameters.runtime, 'minsize')) }}
 
   - download: CoOrdinatedBuildPipeline
-    artifact: drop_windows_build_windows_x64_${{ parameters.runtime }}
+    artifact: drop_windows_build_windows_${{ parameters.runtime }}
     displayName: Download minsize signed artifacts
-    condition: ${{ eq(parameters.runtime, 'minSize') }}
+    condition: ${{ contains(parameters.runtime, 'minsize') }}
 
   - pwsh: |
       Write-Verbose -Verbose "signed artifacts"
-      Get-ChildItem "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_${{ parameters.runtime }}_release" -Recurse
+      Get-ChildItem "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline" -Recurse
     displayName: 'Capture Downloaded Artifacts'
     # Diagnostics is not critical it passes every time it runs
     continueOnError: true
@@ -91,7 +91,8 @@ jobs:
         'arm64' { 'Signed-win-arm64' }
         'fxdependent' { 'Signed-fxdependent' }
         'fxdependentWinDesktop' { 'Signed-fxdependent-win-desktop' }
-        'minsize' { 'Signed-win7-x64' }
+        'x64_minsize' { 'Signed-win7-x64' }
+        'arm64_minsize' { 'Signed-win-arm64' }
       }
 
       Write-Verbose -Message "Init..." -Verbose
@@ -104,9 +105,9 @@ jobs:
 
       Find-Dotnet
 
-      $signedFilesPath, $psoptionsFilePath = if ($env:RUNTIME -eq 'minsize') {
-          "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_x64_${runtime}\$signedFolder"
-          "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_x64_${runtime}\psoptions\psoptions.json"
+      $signedFilesPath, $psoptionsFilePath = if ($runtime.Contains('minsize')) {
+          "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_${runtime}\$signedFolder"
+          "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_${runtime}\psoptions\psoptions.json"
         }
         else {
           "$(Pipeline.Workspace)\CoOrdinatedBuildPipeline\drop_windows_build_windows_${runtime}_release\$signedFolder"
@@ -157,7 +158,8 @@ jobs:
         'arm64' { 'win-arm64' }
         'fxdependent' { 'win7-x64' }
         'fxdependentWinDesktop' { 'win7-x64' }
-        'minsize' { 'win7-x64' }
+        'x64_minsize' { 'win7-x64' }
+        'arm64_minsize' { 'win-arm64' }
       }
 
       $packageTypes = switch ($runtime) {
@@ -166,7 +168,8 @@ jobs:
         'arm64' { @('msi', 'zip', 'msix') }
         'fxdependent' { 'fxdependent' }
         'fxdependentWinDesktop' { 'fxdependent-win-desktop' }
-        'minsize' { 'min-size' }
+        'x64_minsize' { 'min-size-x64' }
+        'arm64_minsize' { 'min-size-arm64' }
       }
 
       if (-not (Test-Path $(ob_outputDirectory))) {
@@ -198,7 +201,8 @@ jobs:
         'arm64' { @('msi', 'zip', 'msix') }
         'fxdependent' { 'fxdependent' }
         'fxdependentWinDesktop' { 'fxdependent-win-desktop' }
-        'minsize' { 'min-size' }
+        'x64_minsize' { 'min-size-x64' }
+        'arm64_minsize' { 'min-size-arm64' }
       }
 
       if (-not (Test-Path $(ob_outputDirectory))) {
@@ -212,7 +216,7 @@ jobs:
         Copy-Item -Path $msiPkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose
       }
 
-      if ($packageTypes -contains 'zip' -or $packageTypes -contains 'fxdependent' -or $packageTypes -contains 'min-size' -or $packageTypes -contains 'fxdependent-win-desktop') {
+      if ($packageTypes -contains 'zip' -or $packageTypes -like 'fxdependent*' -or $packageTypes -like 'min-size*') {
         $zipPkgNameFilter = "powershell-*.zip"
         $zipPkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $zipPkgNameFilter -Recurse -File | Select-Object -ExpandProperty FullName
         Write-Verbose -Verbose "unsigned zipPkgPath: $zipPkgPath"

--- a/.pipelines/templates/packaging/windows/sign.yml
+++ b/.pipelines/templates/packaging/windows/sign.yml
@@ -173,7 +173,8 @@ jobs:
         'arm64' { @('msi', 'zip', 'msix', 'exe') }
         'fxdependent' { 'fxdependent' }
         'fxdependentWinDesktop' { 'fxdependent-win-desktop' }
-        'minsize' { 'min-size' }
+        'x64_minsize' { 'min-size-x64' }
+        'arm64_minsize' { 'min-size-arm64' }
       }
 
       if (-not (Test-Path $(ob_outputDirectory))) {
@@ -194,9 +195,7 @@ jobs:
         Copy-Item -Path $exePkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose
       }
 
-      if ($packageTypes -contains 'zip' -or $packageTypes -contains 'fxdependent' -or $packageTypes -contains 'min-size' -or $packageTypes -contains 'fxdependent-win-desktop') {
-        $zipPkgNameFilter = "powershell-*.zip"
-        $zipPkgPath = Get-ChildItem -Path $(Pipeline.Workspace) -Filter $zipPkgNameFilter -Recurse -File | Select-Object -ExpandProperty FullName
+      if ($packageTypes -contains 'zip' -or $packageTypes -like 'fxdependent*' -or $packageTypes -like 'min-size*') {
         Write-Verbose -Verbose "signed zipPkgPath: $zipPkgPath"
         Copy-Item -Path $zipPkgPath -Destination '$(ob_outputDirectory)' -Force -Verbose
       }

--- a/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
@@ -83,6 +83,12 @@ stages:
 
   - template: /.pipelines/templates/linux.yml@self
     parameters:
+      Runtime: 'linux-arm64'
+      JobName: 'linux_arm64_minSize'
+      BuildConfiguration: 'minSize'
+
+  - template: /.pipelines/templates/linux.yml@self
+    parameters:
       Runtime: 'linux-arm'
       JobName: 'linux_arm'
 
@@ -134,6 +140,11 @@ stages:
       Architecture: x64
       BuildConfiguration: minSize
       JobName: build_windows_x64_minSize_release
+  - template: /.pipelines/templates/windows-hosted-build.yml@self
+    parameters:
+      Architecture: arm64
+      BuildConfiguration: minSize
+      JobName: build_windows_arm64_minSize_release
   - template: /.pipelines/templates/windows-hosted-build.yml@self
     parameters:
       Architecture: x86

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -46,7 +46,11 @@ stages:
 
   - template: /.pipelines/templates/packaging/windows/package.yml@self
     parameters:
-      runtime: minsize
+      runtime: x64_minsize
+
+  - template: /.pipelines/templates/packaging/windows/package.yml@self
+    parameters:
+      runtime: arm64_minsize
 
 - stage: windows_package_sign
   displayName: 'Win Pkg Sign'
@@ -74,7 +78,11 @@ stages:
 
   - template: /.pipelines/templates/packaging/windows/sign.yml@self
     parameters:
-      runtime: minsize
+      runtime: x64_minsize
+
+  - template: /.pipelines/templates/packaging/windows/sign.yml@self
+    parameters:
+      runtime: arm64_minsize
 
 - stage: linux_package
   displayName: 'Linux Pkg+Sign'
@@ -161,8 +169,15 @@ stages:
     parameters:
       unsignedDrop: 'drop_linux_build_linux_x64_minSize'
       signedDrop: 'drop_linux_sign_linux_x64_minSize'
-      packageType: min-size
-      jobName: minSize
+      packageType: min-size-x64
+      jobName: minSize_x64
+
+  - template: /.pipelines/templates/linux-package-build.yml@self
+    parameters:
+      unsignedDrop: 'drop_linux_build_linux_arm64_minSize'
+      signedDrop: 'drop_linux_sign_linux_arm64_minSize'
+      packageType: min-size-arm64
+      jobName: minSize_arm64
 
 - stage: nupkg
   displayName: 'NuGet Pkg+Sign'

--- a/.pipelines/templates/uploadToAzure.yml
+++ b/.pipelines/templates/uploadToAzure.yml
@@ -59,6 +59,14 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       buildType: 'current'
+      artifact: drop_linux_package_deb_arm64
+      itemPattern: '**/*.deb'
+      targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
+    displayName: Download deb arm64 package
+
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      buildType: 'current'
       artifact: drop_linux_package_fxdependent
       itemPattern: '**/*.tar.gz'
       targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
@@ -83,10 +91,18 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       buildType: 'current'
-      artifact: drop_linux_package_minSize
+      artifact: drop_linux_package_minSize_x64
       itemPattern: '**/*.tar.gz'
       targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
-    displayName: Download linux minSize package
+    displayName: Download linux minSize x64 package
+
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      buildType: 'current'
+      artifact: drop_linux_package_minSize_arm64
+      itemPattern: '**/*.tar.gz'
+      targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
+    displayName: Download linux minSize arm64 package
 
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -175,10 +191,18 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       buildType: 'current'
-      artifact: drop_windows_package_package_win_minsize
+      artifact: drop_windows_package_package_win_x64_minsize
       itemPattern: '**/*.zip'
       targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
-    displayName: Download windows minsize packages
+    displayName: Download windows x64 minsize packages
+
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      buildType: 'current'
+      artifact: drop_windows_package_package_win_arm64_minsize
+      itemPattern: '**/*.zip'
+      targetPath: '$(Build.ArtifactStagingDirectory)/downloads'
+    displayName: Download windows arm64 minsize packages
 
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/build.psm1
+++ b/build.psm1
@@ -463,8 +463,8 @@ function Start-PSBuild {
     }
 
     if ($ForMinimalSize) {
-        if ($Runtime -and "linux-x64", "win7-x64", "osx-x64" -notcontains $Runtime) {
-            throw "Build for the minimal size is enabled only for following runtimes: 'linux-x64', 'win7-x64', 'osx-x64'"
+        if ($Runtime -and "linux-x64", "linux-arm64", "win7-x64", "win-arm64", "osx-x64", "osx-arm64" -notcontains $Runtime) {
+            throw "Build for the minimal size is enabled only for following runtimes: 'linux-x64', 'linux-arm64', 'win7-x64', 'win-arm64', 'osx-x64', 'osx-arm64'"
         }
     }
 
@@ -3197,7 +3197,7 @@ function Start-TypeGen
 
     Push-Location "$PSScriptRoot/src/TypeCatalogGen"
     try {
-        Start-NativeExecution { dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $IncFileName }
+        Start-NativeExecution { dotnet run -- ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $IncFileName }
     } finally {
         Pop-Location
     }

--- a/tools/packaging/packaging.psd1
+++ b/tools/packaging/packaging.psd1
@@ -10,8 +10,6 @@
         'Compress-ExePackageEngine'
         'Expand-ExePackageEngine'
         'Expand-PSSignedBuild'
-        'Invoke-AzDevOpsLinuxPackageBuild'
-        'Invoke-AzDevOpsLinuxPackageCreation'
         'New-DotnetSdkContainerFxdPackage'
         'New-ExePackage'
         'Start-PrepForGlobalToolNupkg'

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -52,7 +52,7 @@ function Start-PSPackage {
         [string]$Name = "powershell",
 
         # Ubuntu, CentOS, Fedora, macOS, and Windows packages are supported
-        [ValidateSet("msix", "deb", "deb-arm64", "osxpkg", "rpm", "rpm-fxdependent", "rpm-fxdependent-arm64", "msi", "zip", "zip-pdb", "tar", "tar-arm", "tar-arm64", "tar-alpine", "fxdependent", "fxdependent-win-desktop", "min-size", "tar-alpine-fxdependent")]
+        [ValidateSet("msix", "deb", "deb-arm64", "osxpkg", "rpm", "rpm-fxdependent", "rpm-fxdependent-arm64", "msi", "zip", "zip-pdb", "tar", "tar-arm", "tar-arm64", "tar-alpine", "fxdependent", "fxdependent-win-desktop", "min-size-x64", "min-size-arm64", "tar-alpine-fxdependent")]
         [string[]]$Type,
 
         # Generate windows downlevel package
@@ -77,8 +77,8 @@ function Start-PSPackage {
     )
 
     DynamicParam {
-        if ($Type -in ('zip', 'min-size') -or $Type -like 'fxdependent*') {
-            # Add a dynamic parameter '-IncludeSymbols' when the specified package type is 'zip' only.
+        if ($Type -contains 'zip' -or $Type -like 'min-size*' -or $Type -like 'fxdependent*') {
+            # Add a dynamic parameter '-IncludeSymbols' when the specified package type is essentially a 'zip' package.
             # The '-IncludeSymbols' parameter can be used to indicate that the package should only contain powershell binaries and symbols.
             $ParameterAttr = New-Object "System.Management.Automation.ParameterAttribute"
             $Attributes = New-Object "System.Collections.ObjectModel.Collection``1[System.Attribute]"
@@ -102,16 +102,16 @@ function Start-PSPackage {
         ($Runtime, $Configuration) = if ($WindowsRuntime) {
             $WindowsRuntime, "Release"
         } elseif ($MacOSRuntime) {
-           $MacOSRuntime, "Release"
+            $MacOSRuntime, "Release"
         } elseif ($Type.Count -eq 1 -and $Type[0] -eq "tar-alpine") {
             New-PSOptions -Configuration "Release" -Runtime "linux-musl-x64" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
         } elseif ($Type.Count -eq 1 -and $Type[0] -eq "tar-arm") {
-            New-PSOptions -Configuration "Release" -Runtime "Linux-ARM" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
+            New-PSOptions -Configuration "Release" -Runtime "linux-arm" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
         } elseif ($Type.Count -eq 1 -and $Type[0] -eq "tar-arm64") {
             if ($IsMacOS) {
                 New-PSOptions -Configuration "Release" -Runtime "osx-arm64" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
             } else {
-                New-PSOptions -Configuration "Release" -Runtime "Linux-ARM64" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
+                New-PSOptions -Configuration "Release" -Runtime "linux-arm64" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
             }
         } elseif ($Type.Count -eq 1 -and $Type[0] -eq "rpm-fxdependent") {
             New-PSOptions -Configuration "Release" -Runtime 'fxdependent-linux-x64' -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
@@ -123,6 +123,10 @@ function Start-PSPackage {
         }
         elseif ($Type.Count -eq 1 -and $Type[0] -eq "deb-arm64") {
             New-PSOptions -Configuration "Release" -Runtime 'linux-arm64' -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
+        }
+        elseif ($Type.Count -eq 1 -and $Type[0] -eq "min-size-arm64") {
+            $runtimeToUse = if ($IsMacOS) { "osx-arm64" } elseif ($IsLinux) { "linux-arm64" } else { "win-arm64" }
+            New-PSOptions -Configuration "Release" -Runtime $runtimeToUse -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
         }
         else {
             New-PSOptions -Configuration "Release" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
@@ -409,7 +413,7 @@ function Start-PSPackage {
                     New-PdbZipPackage @Arguments
                 }
             }
-            "min-size" {
+            { $_ -like "min-size*" } {
                 # Add suffix '-gc' because this package is for the Guest Config team.
                 if ($Environment.IsWindows) {
                     $Arguments = @{
@@ -419,12 +423,10 @@ function Start-PSPackage {
                         Force = $Force
                         R2RVerification = [R2RVerification]@{
                             R2RState = 'SdkOnly'
-                            OperatingSystem = "Windows"
-                            Architecture = "amd64"
                         }
                     }
 
-                    if ($PSCmdlet.ShouldProcess("Create Zip Package")) {
+                    if ($PSCmdlet.ShouldProcess("Create min-size Zip Package")) {
                         New-ZipPackage @Arguments
                     }
                 }
@@ -433,6 +435,7 @@ function Start-PSPackage {
                         PackageSourcePath = $Source
                         Name = $Name
                         PackageNameSuffix = 'gc'
+                        Architecture = $Runtime.Split('-')[1]
                         Version = $Version
                         Force = $Force
                         R2RVerification = [R2RVerification]@{
@@ -440,12 +443,15 @@ function Start-PSPackage {
                         }
                     }
 
-                    if ($PSCmdlet.ShouldProcess("Create tar.gz Package")) {
+                    if ($PSCmdlet.ShouldProcess("Create min-size tar.gz Package")) {
                         New-TarballPackage @Arguments
                     }
                 }
+                else {
+                    throw "The 'min-size*' package types are supported only on Windows and Linux."
+                }
             }
-            { $_ -like "fxdependent*"} {
+            { $_ -like "fxdependent*" } {
                 if ($Environment.IsWindows) {
                     $Arguments = @{
                         PackageNameSuffix = $NameSuffix
@@ -4989,272 +4995,6 @@ function New-GlobalToolNupkgFromSource
         return
     }
     Remove-Item -Path $CGManifestPath -Recurse -Force -ErrorAction SilentlyContinue
-}
-
-${mainLinuxBuildFolder} = 'pwshLinuxBuild'
-${minSizeLinuxBuildFolder} = 'pwshLinuxBuildMinSize'
-${arm32LinuxBuildFolder} = 'pwshLinuxBuildArm32'
-${arm64LinuxBuildFolder} = 'pwshLinuxBuildArm64'
-${amd64MarinerBuildFolder} = 'pwshMarinerBuildAmd64'
-${amd64AlpineFxdBuildFolder} = 'pwshAlpineFxdBuildAmd64'
-${arm64MarinerBuildFolder} = 'pwshMarinerBuildArm64'
-
-<#
-    Used in Azure DevOps Yaml to package all the linux packages for a channel.
-#>
-function Invoke-AzDevOpsLinuxPackageCreation {
-    param(
-        [switch]
-        $LTS,
-
-        [Parameter(Mandatory)]
-        [ValidatePattern("^v\d+\.\d+\.\d+(-\w+(\.\d{1,2})?)?$")]
-        [ValidateNotNullOrEmpty()]
-        [string]$ReleaseTag,
-
-        [Parameter(Mandatory)]
-        [ValidateSet('fxdependent', 'alpine', 'deb', 'rpm')]
-        [String]$BuildType
-    )
-
-    if (!${env:SYSTEM_ARTIFACTSDIRECTORY}) {
-        throw "Must be run in Azure DevOps"
-    }
-
-    try {
-        Write-Verbose "Packaging '$BuildType'; LTS:$LTS for $ReleaseTag ..." -Verbose
-
-        Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}-meta\psoptions.json"
-
-        $releaseTagParam = @{ 'ReleaseTag' = $ReleaseTag }
-
-        switch ($BuildType) {
-            'fxdependent' {
-                $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}-meta\linuxFilePermission.json"
-                Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}"
-                Start-PSPackage -Type 'fxdependent' @releaseTagParam -LTS:$LTS
-            }
-            'alpine' {
-                $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}-meta\linuxFilePermission.json"
-                Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}"
-                Start-PSPackage -Type 'tar-alpine' @releaseTagParam -LTS:$LTS
-            }
-            'rpm' {
-                Start-PSPackage -Type 'rpm' @releaseTagParam -LTS:$LTS
-            }
-            default {
-                $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}-meta\linuxFilePermission.json"
-                Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${mainLinuxBuildFolder}"
-                Start-PSPackage @releaseTagParam -LTS:$LTS -Type 'deb', 'tar'
-            }
-        }
-
-        if ($BuildType -eq 'deb') {
-            Start-PSPackage -Type tar @releaseTagParam -LTS:$LTS
-
-            Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${minSizeLinuxBuildFolder}-meta\psoptions.json"
-
-            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${minSizeLinuxBuildFolder}-meta\linuxFilePermission.json"
-            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${minSizeLinuxBuildFolder}"
-
-            Write-Verbose -Verbose "---- Min-Size ----"
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-
-            Start-PSPackage -Type min-size @releaseTagParam -LTS:$LTS
-
-            ## Create 'linux-arm' 'tar.gz' package.
-            ## Note that 'linux-arm' can only be built on Ubuntu environment.
-            Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm32LinuxBuildFolder}-meta\psoptions.json"
-            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm32LinuxBuildFolder}-meta\linuxFilePermission.json"
-            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm32LinuxBuildFolder}"
-            Start-PSPackage -Type tar-arm @releaseTagParam -LTS:$LTS
-
-            ## Create 'linux-arm64' 'tar.gz' package.
-            ## Note that 'linux-arm64' can only be built on Ubuntu environment.
-            Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64LinuxBuildFolder}-meta\psoptions.json"
-            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64LinuxBuildFolder}-meta\linuxFilePermission.json"
-            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64LinuxBuildFolder}"
-            Start-PSPackage -Type tar-arm64 @releaseTagParam -LTS:$LTS
-        } elseif ($BuildType -eq 'rpm') {
-            # Generate mariner amd64 package
-            Write-Verbose -Verbose "Generating mariner amd64 package"
-            Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64MarinerBuildFolder}-meta\psoptions.json"
-            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64MarinerBuildFolder}-meta\linuxFilePermission.json"
-            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64MarinerBuildFolder}"
-
-            Write-Verbose -Verbose "---- rpm-fxdependent ----"
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-
-            Start-PSPackage -Type rpm-fxdependent @releaseTagParam -LTS:$LTS
-
-            # Generate mariner arm64 package
-            Write-Verbose -Verbose "Generating mariner arm64 package"
-            Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64MarinerBuildFolder}-meta\psoptions.json"
-            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64MarinerBuildFolder}-meta\linuxFilePermission.json"
-            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${arm64MarinerBuildFolder}"
-
-            Write-Verbose -Verbose "---- rpm-fxdependent-arm64 ----"
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-
-            Start-PSPackage -Type rpm-fxdependent-arm64 @releaseTagParam -LTS:$LTS
-        } elseif ($BuildType -eq 'alpine') {
-            Restore-PSOptions -PSOptionsPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64AlpineFxdBuildFolder}-meta\psoptions.json"
-            $filePermissionFile = "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64AlpineFxdBuildFolder}-meta\linuxFilePermission.json"
-            Set-LinuxFilePermission -FilePath $filePermissionFile -RootPath "${env:SYSTEM_ARTIFACTSDIRECTORY}\${amd64AlpineFxdBuildFolder}"
-
-            Write-Verbose -Verbose "---- tar-alpine-fxdependent ----"
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-
-            Start-PSPackage -Type tar-alpine-fxdependent @releaseTagParam -LTS:$LTS
-        }
-    }
-    catch {
-        Get-Error -InputObject $_
-        throw
-    }
-}
-
-<#
-    Used in Azure DevOps Yaml to do all the builds needed for all Linux packages for a channel.
-#>
-function Invoke-AzDevOpsLinuxPackageBuild {
-    param (
-        [Parameter(Mandatory)]
-        [ValidatePattern("^v\d+\.\d+\.\d+(-\w+(\.\d{1,2})?)?$")]
-        [ValidateNotNullOrEmpty()]
-        [string]$ReleaseTag,
-
-        [Parameter(Mandatory)]
-        [ValidateSet('fxdependent', 'alpine', 'deb', 'rpm')]
-        [String]$BuildType
-    )
-
-    if (!${env:SYSTEM_ARTIFACTSDIRECTORY}) {
-        throw "Must be run in Azure DevOps"
-    }
-
-    try {
-
-        Write-Verbose "Building '$BuildType' for $ReleaseTag ..." -Verbose
-
-        $releaseTagParam = @{ 'ReleaseTag' = $ReleaseTag }
-
-        $buildParams = @{ Configuration = 'Release'; PSModuleRestore = $true; Restore = $true }
-
-        switch ($BuildType) {
-            'fxdependent' {
-                $buildParams.Add("Runtime", "fxdependent")
-            }
-            'alpine' {
-                $buildParams.Add("Runtime", 'linux-musl-x64')
-            }
-        }
-
-        $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${mainLinuxBuildFolder}"
-        Start-PSBuild @buildParams @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
-        Get-ChildItem -Path $buildFolder -Recurse -File | Export-LinuxFilePermission -FilePath "${buildFolder}-meta/linuxFilePermission.json" -RootPath ${buildFolder} -Force
-
-        # Remove symbol files.
-        Remove-Item "${buildFolder}\*.pdb" -Force
-
-        if ($BuildType -eq 'deb') {
-            ## Build 'min-size'
-            $options = Get-PSOptions
-            Write-Verbose -Verbose "---- Min-Size ----"
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-            $binDir = Join-Path -Path $options.Top -ChildPath 'bin'
-            if (Test-Path -Path $binDir) {
-                Write-Verbose -Verbose "Remove $binDir, to get a clean build for min-size package"
-                Remove-Item -Path $binDir -Recurse -Force
-            }
-
-            $buildParams['ForMinimalSize'] = $true
-            $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${minSizeLinuxBuildFolder}"
-            Start-PSBuild -Clean @buildParams @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
-            # Remove symbol files, xml document files.
-            Remove-Item "${buildFolder}\*.pdb", "${buildFolder}\*.xml" -Force
-            Get-ChildItem -Path $buildFolder -Recurse -File | Export-LinuxFilePermission -FilePath "${buildFolder}-meta/linuxFilePermission.json" -RootPath ${buildFolder} -Force
-
-            ## Build 'linux-arm' and create 'tar.gz' package for it.
-            ## Note that 'linux-arm' can only be built on Ubuntu environment.
-            $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${arm32LinuxBuildFolder}"
-            Start-PSBuild -Configuration Release -Restore -Runtime linux-arm -PSModuleRestore @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
-            # Remove symbol files.
-            Remove-Item "${buildFolder}\*.pdb" -Force
-            Get-ChildItem -Path $buildFolder -Recurse -File | Export-LinuxFilePermission -FilePath "${buildFolder}-meta/linuxFilePermission.json" -RootPath ${buildFolder} -Force
-
-            $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${arm64LinuxBuildFolder}"
-            Start-PSBuild -Configuration Release -Restore -Runtime linux-arm64 -PSModuleRestore @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
-            # Remove symbol files.
-            Remove-Item "${buildFolder}\*.pdb" -Force
-            Get-ChildItem -Path $buildFolder -Recurse -File | Export-LinuxFilePermission -FilePath "${buildFolder}-meta/linuxFilePermission.json" -RootPath ${buildFolder} -Force
-        } elseif ($BuildType -eq 'rpm') {
-            ## Build for Mariner amd64
-            $options = Get-PSOptions
-            Write-Verbose -Verbose "---- Mariner x64 ----"
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-            $binDir = Join-Path -Path $options.Top -ChildPath 'bin'
-            if (Test-Path -Path $binDir) {
-                Write-Verbose -Verbose "Remove $binDir, to get a clean build for Mariner x64 package"
-                Remove-Item -Path $binDir -Recurse -Force
-            }
-
-            $buildParams['Runtime'] = 'fxdependent-linux-x64'
-            $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${amd64MarinerBuildFolder}"
-            Start-PSBuild -Clean @buildParams @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
-            # Remove symbol files, xml document files.
-            Remove-Item "${buildFolder}\*.pdb", "${buildFolder}\*.xml" -Force
-            Get-ChildItem -Path $buildFolder -Recurse -File | Export-LinuxFilePermission -FilePath "${buildFolder}-meta/linuxFilePermission.json" -RootPath ${buildFolder} -Force
-
-            ## Build for Mariner arm64
-            $options = Get-PSOptions
-            Write-Verbose -Verbose "---- Mariner arm64 ----"
-
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-            $binDir = Join-Path -Path $options.Top -ChildPath 'bin'
-            if (Test-Path -Path $binDir) {
-                Write-Verbose -Verbose "Remove $binDir, to get a clean build for Mariner arm64 package"
-                Remove-Item -Path $binDir -Recurse -Force
-            }
-
-            $buildParams['Runtime'] = 'fxdependent-linux-arm64'
-            $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${arm64MarinerBuildFolder}"
-
-            Start-PSBuild -Clean @buildParams @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
-            # Remove symbol files, xml document files.
-            Remove-Item "${buildFolder}\*.pdb", "${buildFolder}\*.xml" -Force
-            Get-ChildItem -Path $buildFolder -Recurse -File | Export-LinuxFilePermission -FilePath "${buildFolder}-meta/linuxFilePermission.json" -RootPath ${buildFolder} -Force
-        } elseif ($BuildType -eq 'alpine') {
-            ## Build for alpine fxdependent
-            $options = Get-PSOptions
-            Write-Verbose -Verbose "---- fxdependent alpine x64 ----"
-            Write-Verbose -Verbose "options.Output: $($options.Output)"
-            Write-Verbose -Verbose "options.Top $($options.Top)"
-            $binDir = Join-Path -Path $options.Top -ChildPath 'bin'
-            if (Test-Path -Path $binDir) {
-                Write-Verbose -Verbose "Remove $binDir, to get a clean build for Mariner package"
-                Remove-Item -Path $binDir -Recurse -Force
-            }
-
-            $buildParams['Runtime'] = 'fxdependent-noopt-linux-musl-x64'
-            $buildFolder = "${env:SYSTEM_ARTIFACTSDIRECTORY}/${amd64AlpineFxdBuildFolder}"
-            Start-PSBuild -Clean @buildParams @releaseTagParam -Output $buildFolder -PSOptionsPath "${buildFolder}-meta/psoptions.json"
-            # Remove symbol files, xml document files.
-            Remove-Item "${buildFolder}\*.pdb", "${buildFolder}\*.xml" -Force
-            Get-ChildItem -Path $buildFolder -Recurse -File | Export-LinuxFilePermission -FilePath "${buildFolder}-meta/linuxFilePermission.json" -RootPath ${buildFolder} -Force
-        }
-    }
-    catch {
-        Get-Error -InputObject $_
-        throw
-    }
 }
 
 <#


### PR DESCRIPTION
Backport of #27646 to release/v7.6.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27646$$$
-->

Triggered by @jshigetomi on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Release build and packaging pipelines must produce, sign, stage, and upload the new arm64 min-size artifacts.

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Adds the requested arm64 min-size package and ensures the arm64 Debian package is downloaded for release publishing.

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Imported tools/packaging/packaging.psd1 and resolved Start-PSPackage successfully; validated PowerShell syntax and confirmed the backport diff has no whitespace errors or conflict markers.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

The change updates shared cross-platform packaging pipelines and package type dispatch, but is a direct backport of the merged master change with conflicts limited to preserving existing release-branch Windows package handling.

## Merge Conflicts

Resolved conflicts in Windows package/sign templates by preserving release/v7.6.5 MSI and EXE artifact handling while using wildcard matching for architecture-specific fxdependent and min-size package types. Preserved MSI as an accepted packaging type while replacing min-size with min-size-x64 and min-size-arm64.
