### PR TITLE
[release/v7.6.5] Update Microsoft.PowerShell.Archive version to 1.2.6

### DIFF
--- a/src/Modules/PSGalleryModules.csproj
+++ b/src/Modules/PSGalleryModules.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="PowerShellGet" Version="2.2.5" />
     <PackageReference Include="PackageManagement" Version="1.4.8.1" />
     <PackageReference Include="Microsoft.PowerShell.PSResourceGet" Version="1.2.0" />
-    <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.5" />
+    <PackageReference Include="Microsoft.PowerShell.Archive" Version="1.2.6" />
     <PackageReference Include="PSReadLine" Version="2.4.5" />
     <PackageReference Include="Microsoft.PowerShell.ThreadJob" Version="2.2.0" />   
   </ItemGroup>

--- a/tools/packaging/boms/windows.json
+++ b/tools/packaging/boms/windows.json
@@ -1102,11 +1102,6 @@
     "Architecture": null
   },
   {
-    "Pattern": "Modules/Microsoft.PowerShell.Archive/*.cat",
-    "FileType": "NonProduct",
-    "Architecture": null
-  },
-  {
     "Pattern": "Modules/Microsoft.PowerShell.Archive/*.ps?1",
     "FileType": "NonProduct",
     "Architecture": null
@@ -1220,6 +1215,10 @@
     "Pattern": "Modules\\Microsoft.PowerShell.PSResourceGet\\.signature.p7s",
     "FileType": "NonProduct",
     "Architecture": null
+  },
+  {
+    "Pattern": "Modules\\Microsoft.PowerShell.Archive\\.signature.p7s",
+    "FileType": "NonProduct"
   },
   {
     "Pattern": "Modules\\Microsoft.PowerShell.PSResourceGet\\Microsoft.PowerShell.PSResourceGet.pdb",


### PR DESCRIPTION
Backport of #27784 to release/v7.6.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27784$$$
-->

Triggered by @jshigetomi on behalf of @anamnavi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Updates the Microsoft.PowerShell.Archive module bundled by the release build to version 1.2.6.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Parsed PSGalleryModules.csproj as XML, verified Microsoft.PowerShell.Archive resolves to version 1.2.6, and confirmed the diff has no whitespace errors. dotnet restore was unavailable because the host does not have the repository-required .NET SDK 10.0.302.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

The backport changes a single bundled module package reference from 1.2.5 to 1.2.6 and preserves all other release-branch dependency versions.

## Merge Conflicts

Preserved the release/v7.6.5 Microsoft.PowerShell.PSResourceGet version (1.2.0) while updating only Microsoft.PowerShell.Archive from 1.2.5 to 1.2.6.
