### PR TITLE
[release/v7.4.19] Fix TimeZone test with duplicate names

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -97,11 +97,20 @@ Describe "Get-Timezone test cases" -Tags "CI" {
         Assert-ListsSame $selectedTZ $result
     }
 
-    It "Call Get-TimeZone using Name param and singe item" {
-        $timezoneList = Get-TimeZone -ListAvailable
-        $timezoneName = $timezoneList[0].StandardName
-        $observed = Get-TimeZone -Name $timezoneName
-        $observed.StandardName | Should -Be $timezoneName
+    It "Call Get-TimeZone using Name param and single item" {
+        $timezone = $TimeZonesAvailable |
+            Group-Object -Property StandardName |
+            Where-Object Count -EQ 1 |
+            Select-Object -First 1 -ExpandProperty Group
+
+        if ($null -eq $timezone) {
+            Set-ItResult -Skipped -Because "No available time zone has a unique StandardName on this platform."
+            return
+        }
+
+        $observed = Get-TimeZone -Name $timezone.StandardName
+        $observed.Id | Should -Be $timezone.Id
+        $observed.StandardName | Should -Be $timezone.StandardName
     }
 
     It "Call Get-TimeZone using Name param with wild card" {


### PR DESCRIPTION
Backport of #27525 to release/v7.4.19

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27525$$$
-->

Triggered by @jshigetomi on behalf of @KirtiRamchandani

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Stabilizes the TimeZone test on systems where timezone StandardName values have aliases.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Ran the targeted TimeZone.Tests.ps1 suite successfully with Start-PSPester, validated PowerShell syntax, and confirmed the diff has no whitespace errors or conflict markers.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

This is a test-only change that selects a unique StandardName before asserting Get-TimeZone behavior; it does not change product code.
