### PR TITLE
[release/v7.6.5] Use .NET SDK and NuGet feed early access for build, package and release pipelines

### DIFF
--- a/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
@@ -5,6 +5,14 @@ parameters:
     displayName: URL to the blob having internal .NET SDK
     type: string
     default: ' '
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
   - name: ReleaseTagVar
     displayName: Release Tag
     type: string
@@ -29,6 +37,17 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: bins-$(BUILD.SOURCEBRANCHNAME)-nonofficial-$(Build.BuildId)
 
@@ -52,6 +71,8 @@ variables:
       SKIP_SIGNING: ${{ parameters.SKIP_SIGNING }}
       ENABLE_MSBUILD_BINLOGS: ${{ parameters.ENABLE_MSBUILD_BINLOGS }}
       FORCE_CODEQL: ${{ parameters.FORCE_CODEQL }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@onebranchTemplates
@@ -96,3 +117,7 @@ extends:
         RUN_WINDOWS: ${{ parameters.RUN_WINDOWS }}
         RUN_TEST_AND_RELEASE: ${{ parameters.RUN_TEST_AND_RELEASE }}
         OfficialBuild: false
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}

--- a/.pipelines/NonOfficial/PowerShell-Packages-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Packages-NonOfficial.yml
@@ -27,6 +27,25 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   - name: disableNetworkIsolation
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-nonofficial-$(Build.BuildId)
 
@@ -37,6 +56,8 @@ variables:
       ForceAzureBlobDelete: ${{ parameters.ForceAzureBlobDelete }}
       ReleaseTagVar: ${{ parameters.ReleaseTagVar }}
       disableNetworkIsolation: ${{ parameters.disableNetworkIsolation }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 resources:
   pipelines:
@@ -95,3 +116,7 @@ extends:
     - template: /.pipelines/templates/stages/PowerShell-Packages-Stages.yml@self
       parameters:
         OfficialBuild: false
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}

--- a/.pipelines/NonOfficial/PowerShell-Release-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Release-NonOfficial.yml
@@ -29,6 +29,24 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip MSIX Publish
     type: boolean
     default: false
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: release-$(BUILD.SOURCEBRANCHNAME)-nonofficial-$(Build.BuildId)
 
@@ -104,3 +122,7 @@ extends:
         SkipPublish: ${{ parameters.SkipPublish }}
         SkipPSInfraInstallers: ${{ parameters.SkipPSInfraInstallers }}
         skipMSIXPublish: ${{ parameters.skipMSIXPublish }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -29,6 +29,25 @@ parameters:
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: bins-$(BUILD.SOURCEBRANCHNAME)-prod-$(Build.BuildId)
 
@@ -52,6 +71,8 @@ variables:
       SKIP_SIGNING: ${{ parameters.SKIP_SIGNING }}
       ENABLE_MSBUILD_BINLOGS: ${{ parameters.ENABLE_MSBUILD_BINLOGS }}
       FORCE_CODEQL: ${{ parameters.FORCE_CODEQL }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
@@ -96,3 +117,7 @@ extends:
         RUN_WINDOWS: ${{ parameters.RUN_WINDOWS }}
         RUN_TEST_AND_RELEASE: ${{ parameters.RUN_TEST_AND_RELEASE }}
         OfficialBuild: true
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}

--- a/.pipelines/PowerShell-Packages-Official.yml
+++ b/.pipelines/PowerShell-Packages-Official.yml
@@ -27,6 +27,25 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   - name: disableNetworkIsolation
     type: boolean
     default: false
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: pkgs-$(BUILD.SOURCEBRANCHNAME)-prod-$(Build.BuildId)
 
@@ -37,6 +56,8 @@ variables:
       ForceAzureBlobDelete: ${{ parameters.ForceAzureBlobDelete }}
       ReleaseTagVar: ${{ parameters.ReleaseTagVar }}
       disableNetworkIsolation: ${{ parameters.disableNetworkIsolation }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
 
 resources:
   pipelines:
@@ -95,3 +116,7 @@ extends:
     - template: templates/stages/PowerShell-Packages-Stages.yml
       parameters:
         OfficialBuild: true
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}

--- a/.pipelines/PowerShell-Release-Official.yml
+++ b/.pipelines/PowerShell-Release-Official.yml
@@ -29,6 +29,24 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     displayName: Skip MSIX Publish
     type: boolean
     default: false
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
 
 name: release-$(BUILD.SOURCEBRANCHNAME)-prod-$(Build.BuildId)
 
@@ -100,3 +118,7 @@ extends:
         SkipPublish: ${{ parameters.SkipPublish }}
         SkipPSInfraInstallers: ${{ parameters.SkipPSInfraInstallers }}
         skipMSIXPublish: ${{ parameters.skipMSIXPublish }}
+        IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+        DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+        EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}

--- a/.pipelines/templates/downloadDotnetEarlyAccess.yml
+++ b/.pipelines/templates/downloadDotnetEarlyAccess.yml
@@ -1,0 +1,59 @@
+parameters:
+- name: DotnetRuntimeVersion
+  type: string
+- name: DotnetSdkVersion
+  type: string
+
+jobs:
+- job: download_dotnet_early_access
+  displayName: Download DotNet Early Access
+  variables:
+  - group: dotnet-early-access
+  - name: DOTNET_RUNTIME_VERSION
+    value: ${{ parameters.DotnetRuntimeVersion }}
+  - name: DOTNET_SDK_VERSION
+    value: ${{ parameters.DotnetSdkVersion }}
+  - name: destinationPath
+    value: '$(Build.ArtifactStagingDirectory)/pkgs'
+
+  pool:
+    name: PowerShell1ES
+    type: windows
+    isCustom: true
+    demands:
+    - ImageOverride -equals PSMMS2019-Secure
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - pwsh: |
+      Get-ChildItem Env: | Out-String -Width 9999 -Stream | Write-Verbose -Verbose
+    displayName: Capture environment
+
+  - task: AzurePowerShell@5
+    inputs:
+      azureSubscription: powershell-net-early-access
+      azurePowerShellVersion: LatestVersion
+      ScriptType: InlineScript
+      pwsh: true
+      inline: |
+        $DOTNET_PRIVATE_SAS = Get-AzKeyVaultSecret -VaultName $env:DOTNET_AZ_KV_NAME -Name $env:DOTNET_AZ_SECRET_NAME -AsPlainText
+
+        Write-Verbose -Message "DOTNET_PRIVATE_SAS acquired" -Verbose
+
+        Import-Module "$env:BUILD_SOURCESDIRECTORY/build.psm1" -Force
+
+        if (-not (Test-Path '$(destinationPath)'))
+        {
+            New-Item -ItemType Directory -Path '$(destinationPath)' -Force -Verbose | Out-Null
+        }
+
+        Get-DotnetEarlyAccess -DestinationPath '$(destinationPath)' -Architecture all -DOTNET_PRIVATE_SAS $DOTNET_PRIVATE_SAS
+
+        Get-ChildItem -Path '$(destinationPath)' -Recurse | ForEach-Object {
+            Write-Verbose -verbose "Uploading $($_.FullName) to 'dotnet-packages'"
+            Write-Host "##vso[artifact.upload containerfolder=dotnet-packages;artifactname=dotnet-packages]$($_.FullName)"
+        }
+
+    displayName: 'Download DotNet Early Access'

--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -16,8 +16,20 @@ steps:
       $configPath = "${env:NugetConfigDir}/nuget.config"
       Import-Module ${{ parameters.repoRoot }}/build.psm1 -Force
 
-      Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'"
-      Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'
+      $earlyAccess = $env:ISEARLYACCESS -eq 'true'
+
+      Write-Verbose -Verbose "Is Early access: $earlyAccess"
+
+      if (-not $earlyAccess)
+      {
+        Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'"
+        Switch-PSNugetConfig -Source Private -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'
+      }
+      else
+      {
+        Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source EarlyAccess"
+        Switch-PSNugetConfig -Source EarlyAccess
+      }
 
       if(-not (Test-Path $configPath))
       {
@@ -33,6 +45,53 @@ steps:
   env:
     NugetConfigDir: ${{ parameters.repoRoot }}/src/Modules
     ob_restore_phase: ${{ parameters.ob_restore_phase }}
+
+- task: AzurePowerShell@5
+  inputs:
+    azureSubscription: powershell-net-early-access
+    azurePowerShellVersion: LatestVersion
+    ScriptType: InlineScript
+    pwsh: true
+    inline: |
+      Write-Verbose -Verbose "Getting an Azure DevOps access token"
+      # Microsoft's well-known Entra resource ID for the Azure DevOps token audience.
+      $azureDevOpsResourceUrl = '499b84ac-1321-427f-aa17-267ca6975798'
+      $azt = (Get-AzAccessToken -ResourceUrl $azureDevOpsResourceUrl).Token | ConvertFrom-SecureString -AsPlainText
+
+      Write-Host "##vso[task.setsecret]$azt"
+      Write-Verbose -Verbose "Setting up Azure Artifacts Credential Provider token"
+
+      $earlyAccessFeed = '$(EARLY_ACCESS_FEED)'
+      $ADORepoUri = switch ($earlyAccessFeed) {
+            'net8' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-8-early-access/nuget/v3/index.json' }
+            'net9' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-9-early-access/nuget/v3/index.json' }
+            'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
+            default { throw "Unknown early access feed URL: $earlyAccessFeed" }
+        }
+      $galleryRepoUri = 'https://www.powershellgallery.com/api/v2'
+
+      Write-Verbose -Verbose "ADORepoUri == $ADORepoUri"
+
+      if ([string]::IsNullOrEmpty($ADORepoUri) -eq $false)
+      {
+        $endpointCredsObj = @{ endpointCredentials = @(
+          @{ endpoint = $ADORepoUri; password = $azt }
+        )}
+        $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $endpointCredsObj | ConvertTo-Json -Compress
+
+        Write-Verbose -Verbose "Setting VSS_NUGET_EXTERNAL_FEED_ENDPOINTS environment variable"
+
+        Write-Host "##vso[task.setvariable variable=VSS_NUGET_EXTERNAL_FEED_ENDPOINTS;issecret=true]$VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"
+      }
+      else
+      {
+        Write-Verbose -Verbose "EARLY_ACCESS_FEED_URL is not set"
+      }
+  displayName: 'Setup Azure Artifacts Credential Provider secret'
+  condition: eq(variables['ISEARLYACCESS'], 'true')
+  env:
+    ob_restore_phase: ${{ parameters.ob_restore_phase }}
+
 
 - pwsh: |
     Get-ChildItem ${{ parameters.repoRoot }}/nuget.config -Recurse | Foreach-Object {

--- a/.pipelines/templates/install-dotnet.yml
+++ b/.pipelines/templates/install-dotnet.yml
@@ -2,6 +2,19 @@ parameters:
 - name: ob_restore_phase
   type: boolean
   default: true
+- name: architecture
+  type: string
+  default: 'win-x64'
+  values:
+      - 'win-x64'
+      - 'win-x86'
+      - 'win-arm64'
+      - 'linux-x64'
+      - 'linux-arm64'
+      - 'linux-musl-x64'
+      - 'linux-musl-arm64'
+      - 'osx-x64'
+      - 'osx-arm64'
 
 steps:
   - pwsh: |
@@ -19,6 +32,69 @@ steps:
 
     displayName: 'Install dotnet SDK'
     workingDirectory: $(RepoRoot)
+    condition: and(ne(variables['ISEARLYACCESS'], 'true'), ne(variables['ISEARLYACCESS'], 'True'))
     env:
       ob_restore_phase: ${{ parameters.ob_restore_phase }}
 
+  - task: DownloadPipelineArtifact@2
+    displayName: "Download dotnet-packages artifact"
+    condition: eq(variables['ISEARLYACCESS'], 'true')
+    inputs:
+      artifactName: 'dotnet-packages'
+      targetPath: '$(Pipeline.Workspace)/dotnet-packages'
+    env:
+      ob_restore_phase: ${{ parameters.ob_restore_phase }}
+  - pwsh: |
+      $arch = '${{ parameters.architecture }}'
+      $sdkFilePattern = "dotnet-sdk-*-${arch}.*"
+
+      if (-not (Test-Path '$(Pipeline.Workspace)/dotnet-packages')) {
+        New-Item -Path '$(Pipeline.Workspace)/dotnet-packages' -ItemType Directory -Force -Verbose | Out-Null
+      }
+
+      $filePath = Get-ChildItem '$(Pipeline.Workspace)/dotnet-packages' -Recurse -File | Where-Object { $_.Name -like $sdkFilePattern } | Select-Object -First 1 -ExpandProperty FullName
+
+      if (-not $filePath) {
+        Get-ChildItem -Path '$(Pipeline.Workspace)/dotnet-packages' -Recurse
+        throw "SDK file matching pattern $sdkFilePattern not found in $(Pipeline.Workspace)/dotnet-packages"
+      }
+
+      $dotnetLocation = if ($IsWindows) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
+
+      if (-not (Test-Path $dotnetLocation)) {
+        New-Item -ItemType Directory -Path $dotnetLocation -Force -Verbose | Out-Null
+      }
+
+      Write-Verbose -Verbose "Extracting SDK from $filePath to $dotnetLocation"
+
+      if ($filePath -match '\.(tar\.gz|tgz)$') {
+        & tar -xzf $filePath -C $dotnetLocation
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to extract $filePath with tar (exit code $LASTEXITCODE)"
+        }
+      } elseif ($filePath -match '\.zip$') {
+        Expand-Archive -Path $filePath -DestinationPath $dotnetLocation -Force
+      } else {
+        throw "Unsupported SDK archive format: $filePath"
+      }
+
+      Write-Verbose -Verbose "Expand dotnet package complete."
+
+      $dotnetExe = if ($IsWindows) {
+        "$dotnetLocation\dotnet.exe"
+      } else {
+        "$dotnetLocation/dotnet"
+      }
+
+      if (-not (Test-Path $dotnetExe)) {
+        throw "dotnet executable not found at $dotnetExe"
+      }
+
+      Get-ChildItem -Path $dotnetLocation -Recurse
+
+      & $dotnetExe --info
+    workingDirectory: $(RepoRoot)
+    displayName: Install dotnet early access
+    condition: eq(variables['ISEARLYACCESS'], 'true')
+    env:
+      ob_restore_phase: ${{ parameters.ob_restore_phase }}

--- a/.pipelines/templates/linux-package-build.yml
+++ b/.pipelines/templates/linux-package-build.yml
@@ -3,6 +3,7 @@ parameters:
   signedDrop: 'drop_linux_sign_linux_x64'
   packageType: deb
   jobName: 'deb'
+  dotnetArch: 'linux-x64'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -95,6 +96,8 @@ jobs:
       ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $packageType = '$(PackageType)'

--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -2,6 +2,7 @@ parameters:
   Runtime: 'linux-x64'
   BuildConfiguration: 'release'
   JobName: 'build_linux'
+  dotnetArch: 'linux-x64'
 
 jobs:
 - job: build_${{ parameters.JobName }}
@@ -63,6 +64,8 @@ jobs:
       Language: csharp
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $runtime = $env:RUNTIME

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -1,5 +1,6 @@
 parameters:
   buildArchitecture: 'x64'
+  dotnetArch: 'osx-x64'
 jobs:
 - job: build_macOS_${{ parameters.buildArchitecture }}
   displayName: Build macOS ${{ parameters.buildArchitecture }}
@@ -39,6 +40,8 @@ jobs:
 
     ## We cross compile for arm64, so the arch is always x64
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       Import-Module $(PowerShellRoot)/build.psm1 -Force

--- a/.pipelines/templates/packaging/windows/package.yml
+++ b/.pipelines/templates/packaging/windows/package.yml
@@ -1,5 +1,6 @@
 parameters:
   runtime: x64
+  dotnetArch: 'win-x64'
 
 jobs:
 - job: build_win_${{ parameters.runtime }}
@@ -80,6 +81,7 @@ jobs:
   - template: /.pipelines/templates/install-dotnet.yml@self
     parameters:
       ob_restore_phase: false
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $runtime = '$(Runtime)'

--- a/.pipelines/templates/release-validate-fxdpackages.yml
+++ b/.pipelines/templates/release-validate-fxdpackages.yml
@@ -20,6 +20,20 @@ parameters:
   - name: enableCredScan
     type: boolean
     default: true
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: dotnetArch
+    type: string
+    default: 'win-x64'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -36,6 +50,8 @@ jobs:
     value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
   - name: ob_sdl_credscan_enabled
     value: ${{ parameters.enableCredScan }}
+  - name: ISEARLYACCESS
+    value: ${{ parameters.IsEarlyAccess }}
 
   pool:
     type: ${{ parameters.jobtype }}
@@ -62,6 +78,9 @@ jobs:
       displayName: 'Capture Downloaded Artifacts'
 
     - template: /.pipelines/templates/install-dotnet.yml@self
+      parameters:
+        architecture: ${{ parameters.dotnetArch }}
+        ob_restore_phase: false
 
     - pwsh: |
         $artifactName = '$(artifactName)'

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -1,10 +1,33 @@
 parameters:
-  jobName: ""
-  displayName: ""
-  jobtype: "windows"
-  globalToolExeName: 'pwsh.exe'
-  globalToolPackageName: 'PowerShell.Windows.x64'
-
+  - name: jobName
+    type: string
+    default: ""
+  - name: displayName
+    type: string
+    default: ""
+  - name: jobtype
+    type: string
+    default: "windows"
+  - name: globalToolExeName
+    type: string
+    default: 'pwsh.exe'
+  - name: globalToolPackageName
+    type: string
+    default: 'PowerShell.Windows.x64'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: dotnetArch
+    type: string
+    default: 'win-x64'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -19,6 +42,8 @@ jobs:
       value: $(Build.SourcesDirectory)\PowerShell\.config\suppress.json
     - name: ob_sdl_tsa_configFile
       value: $(Build.SourcesDirectory)\PowerShell\.config\tsaoptions.json
+    - name: ISEARLYACCESS
+      value: ${{ parameters.IsEarlyAccess }}
 
   steps:
     - checkout: self
@@ -39,6 +64,9 @@ jobs:
       displayName: 'Capture Downloaded Artifacts'
 
     - template: /.pipelines/templates/install-dotnet.yml@self
+      parameters:
+        architecture: ${{ parameters.dotnetArch }}
+        ob_restore_phase: false
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -1,8 +1,33 @@
 parameters:
-  jobName: ""
-  displayName: ""
-  poolName: "windows"
-  imageName: 'none'
+  - name: jobName
+    type: string
+    default: ""
+  - name: displayName
+    type: string
+    default: ""
+  - name: poolName
+    type: string
+    default: "windows"
+  - name: imageName
+    type: string
+    default: 'none'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: dotnetArch
+    type: string
+    default: 'win-x64'
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -22,15 +47,19 @@ jobs:
   - group: mscodehub-feed-read-general
   - group: mscodehub-feed-read-akv
   - group: DotNetPrivateBuildAccess
+  - name: ISEARLYACCESS
+    value: ${{ parameters.IsEarlyAccess }}
+  - name: EARLY_ACCESS_FEED
+    value: ${{ parameters.EarlyAccessFeed }}
 
   steps:
     - checkout: self
       clean: true
       lfs: false
 
-    - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
+    - template: /.pipelines/templates/SetVersionVariables.yml@self
       parameters:
-        repoRoot: "$(Build.SourcesDirectory)"
+        ReleaseTagVar: $(ReleaseTagVar)
 
     - template: release-SetReleaseTagandContainerName.yml@self
 
@@ -47,6 +76,11 @@ jobs:
       displayName: 'Capture Downloaded Artifacts'
 
     - template: /.pipelines/templates/install-dotnet.yml@self
+      parameters:
+        ob_restore_phase: false
+        architecture: ${{ parameters.dotnetArch }}
+
+    - template: /.pipelines/templates/insert-nuget-config-azfeed.yml@self
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)"
@@ -56,10 +90,28 @@ jobs:
 
         $env:DOTNET_NOLOGO=1
 
+        $isEarlyAccess = '$(ISEARLYACCESS)'
+
+        $ADORepoUri = if ($isEarlyAccess -eq 'True')
+          {
+            $earlyAccessFeed = '$(EARLY_ACCESS_FEED)'
+            switch ($earlyAccessFeed) {
+                  'net8' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-8-early-access/nuget/v3/index.json' }
+                  'net9' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-9-early-access/nuget/v3/index.json' }
+                  'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
+                  default { throw "Unknown early access feed URL: $earlyAccessFeed" }
+              }
+          }
+          else {
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json"
+          }
+
+        Write-Verbose -Verbose "ADO Repo URI: $ADORepoUri"
+
         $localLocation = "$(Pipeline.Workspace)/PSPackagesOfficial/drop_nupkg_build_nupkg"
         $xmlElement = @"
           <add key=`"local`" value=`"$localLocation`" />
-          <add key="dotnet" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v2" />
+          <add key=`"dotnet`" value=`"$ADORepoUri`" />
         </packageSources>
         "@
 

--- a/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml
@@ -7,6 +7,20 @@ parameters:
     default: true
   - name: OfficialBuild
     type: boolean
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 stages:
 - stage: prep
@@ -31,6 +45,8 @@ stages:
         value: false
       - name: ob_sdl_sbom_enabled
         value: false
+      - name: IsEarlyAccess
+        value: ${{ parameters.IsEarlyAccess }}
 
     steps:
     - checkout: self
@@ -49,12 +65,20 @@ stages:
         ReleaseTagVar: $(ReleaseTagVar)
         CreateJson: yes
 
+  - ${{ if eq(parameters.IsEarlyAccess, true) }}:
+    - template: /.pipelines/templates/downloadDotnetEarlyAccess.yml@self
+      parameters:
+        DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
+
 - stage: macos
   displayName: macOS - build and sign
   dependsOn: ['prep']
   variables:
     - name: ps_official_build
       value: ${{ parameters.OfficialBuild }}
+    - name: IsEarlyAccess
+      value: ${{ parameters.IsEarlyAccess }}
   jobs:
   - template: /.pipelines/templates/mac.yml@self
     parameters:
@@ -69,6 +93,8 @@ stages:
   variables:
     - name: ps_official_build
       value: ${{ parameters.OfficialBuild }}
+    - name: IsEarlyAccess
+      value: ${{ parameters.IsEarlyAccess }}
   jobs:
   - template: /.pipelines/templates/linux.yml@self
     parameters:
@@ -129,6 +155,8 @@ stages:
   variables:
     - name: ps_official_build
       value: ${{ parameters.OfficialBuild }}
+    - name: IsEarlyAccess
+      value: ${{ parameters.IsEarlyAccess }}
   jobs:
   - template: /.pipelines/templates/windows-hosted-build.yml@self
     parameters:
@@ -149,6 +177,7 @@ stages:
     parameters:
       Architecture: x86
       JobName: build_windows_x86_release
+      dotnetArch: 'win-x86'
   - template: /.pipelines/templates/windows-hosted-build.yml@self
     parameters:
       Architecture: arm64

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -1,6 +1,20 @@
 parameters:
   - name: OfficialBuild
     type: boolean
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 stages:
 - stage: prep
@@ -8,9 +22,27 @@ stages:
   jobs:
   - template: /.pipelines/templates/checkAzureContainer.yml@self
 
+- stage: EarlyDotnet
+  displayName: 'Early .NET Setup'
+  dependsOn: []
+  condition: always()
+
+  jobs:
+  - ${{ if eq(parameters.IsEarlyAccess, true) }}:
+    - template: /.pipelines/templates/downloadDotnetEarlyAccess.yml@self
+      parameters:
+        DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
+  - ${{ else }}:
+    - job: skip_early_dotnet
+      displayName: 'Skip early access .NET setup'
+      pool:
+        type: windows
+      steps:
+      - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET setup.'
 - stage: mac_package
   displayName: 'macOS Pkg+Sign'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/mac-package-build.yml@self
     parameters:
@@ -22,7 +54,7 @@ stages:
 
 - stage: windows_package_build
   displayName: 'Win Pkg (unsigned)'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/packaging/windows/package.yml@self
     parameters:
@@ -86,7 +118,7 @@ stages:
 
 - stage: linux_package
   displayName: 'Linux Pkg+Sign'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/linux-package-build.yml@self
     parameters:
@@ -181,13 +213,13 @@ stages:
 
 - stage: nupkg
   displayName: 'NuGet Pkg+Sign'
-  dependsOn: []
+  dependsOn: [EarlyDotnet]
   jobs:
   - template: /.pipelines/templates/nupkg.yml@self
 
 - stage: msixbundle
   displayName: 'MSIX Bundle+Sign'
-  dependsOn: [windows_package_build]  # Only depends on unsigned packages
+  dependsOn: [EarlyDotnet, windows_package_build]  # Only depends on unsigned packages
   jobs:
   - template: /.pipelines/templates/package-create-msix.yml@self
     parameters:
@@ -201,7 +233,7 @@ stages:
 
 - stage: upload
   displayName: 'Upload'
-  dependsOn: [prep, mac_package, windows_package_sign, linux_package, nupkg, msixbundle]  # prep needed for BuildInfo JSON
+  dependsOn: [EarlyDotnet, prep, mac_package, windows_package_sign, linux_package, nupkg, msixbundle]  # prep needed for BuildInfo JSON
   jobs:
   - template: /.pipelines/templates/uploadToAzure.yml@self
 

--- a/.pipelines/templates/stages/PowerShell-Release-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Release-Stages.yml
@@ -7,6 +7,20 @@ parameters:
     type: boolean
   - name: skipMSIXPublish
     type: boolean
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
 
 stages:
 - stage: setReleaseTagAndChangelog
@@ -14,9 +28,24 @@ stages:
   jobs:
   - template: /.pipelines/templates/release-SetTagAndChangelog.yml@self
 
+- stage: downloadDotnetEarlyAccess
+  displayName: 'Download Early release .NET'
+  jobs:
+  - ${{ if eq(parameters.IsEarlyAccess, true) }}:
+    - template: /.pipelines/templates/downloadDotnetEarlyAccess.yml@self
+      parameters:
+        DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+        DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
+  - ${{ else }}:
+    - job: skip_download_dotnet_early_access
+      displayName: 'Skip early access .NET download'
+      pool:
+        type: windows
+      steps:
+      - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET download.'
 - stage: validateSdk
   displayName: 'Validate SDK'
-  dependsOn: []
+  dependsOn: [downloadDotnetEarlyAccess]
   jobs:
   - template: /.pipelines/templates/release-validate-sdk.yml@self
     parameters:
@@ -24,6 +53,11 @@ stages:
       displayName: "Windows SDK Validation"
       imageName: PSMMS2019-Secure
       poolName: $(windowsPool)
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-sdk.yml@self
     parameters:
@@ -31,6 +65,10 @@ stages:
       displayName: "MacOS SDK Validation"
       imageName: macOS-latest
       poolName: Azure Pipelines
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'osx-x64'
 
   - template: /.pipelines/templates/release-validate-sdk.yml@self
     parameters:
@@ -38,16 +76,24 @@ stages:
       displayName: "Linux SDK Validation"
       imageName: PSMMSUbuntu22.04-Secure
       poolName: $(ubuntuPool)
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-x64'
 
 - stage: gbltool
   displayName: 'Validate Global tools'
-  dependsOn: []
+  dependsOn: [downloadDotnetEarlyAccess]
   jobs:
   - template: /.pipelines/templates/release-validate-globaltools.yml@self
     parameters:
       jobName: "WindowsGlobalTools"
       displayName: "Windows Global Tools Validation"
       jobtype: windows
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-globaltools.yml@self
     parameters:
@@ -56,10 +102,14 @@ stages:
       jobtype: linux
       globalToolExeName: 'pwsh'
       globalToolPackageName: 'PowerShell.Linux.x64'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-x64'
 
 - stage: fxdpackages
   displayName: 'Validate FXD Packages'
-  dependsOn: []
+  dependsOn: [downloadDotnetEarlyAccess]
   jobs:
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -68,6 +118,10 @@ stages:
       jobtype: 'windows'
       artifactName: 'drop_windows_package_package_win_fxdependent'
       packageNamePattern: '**/*win-fxdependent.zip'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -76,6 +130,10 @@ stages:
       jobtype: 'windows'
       artifactName: 'drop_windows_package_package_win_fxdependentWinDesktop'
       packageNamePattern: '**/*win-fxdependentwinDesktop.zip'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'win-x64'
 
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -84,6 +142,10 @@ stages:
       jobtype: 'linux'
       artifactName: 'drop_linux_package_fxdependent'
       packageNamePattern: '**/*linux-x64-fxdependent.tar.gz'
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-x64'
 
   - template: /.pipelines/templates/release-validate-fxdpackages.yml@self
     parameters:
@@ -95,6 +157,10 @@ stages:
       packageNamePattern: '**/*linux-x64-fxdependent.tar.gz'
       arm64: 'yes'
       enableCredScan: false
+      IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
+      DOTNET_RUNTIME_VERSION: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+      DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
+      dotnetArch: 'linux-arm64'
 
 - stage: ManualValidation
   dependsOn: []

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -33,6 +33,8 @@ jobs:
       ob_restore_phase: true
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: 'win-x64'
 
   - pwsh: |
       New-Item -Path '$(ob_outputDirectory)' -ItemType Directory -Force
@@ -96,6 +98,8 @@ jobs:
       ob_restore_phase: true
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: 'linux-x64'
 
   - pwsh: |
       New-Item -Path '$(ob_outputDirectory)' -ItemType Directory -Force

--- a/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml
@@ -2,6 +2,13 @@ parameters:
   - name: InternalSDKBlobURL
     type: string
     default: ' '
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
   - name: ReleaseTagVar
     type: string
     default: 'fromBranch'
@@ -12,6 +19,9 @@ parameters:
     type: boolean
     default: false
   - name: FORCE_CODEQL
+    type: boolean
+    default: false
+  - name: IsEarlyAccess
     type: boolean
     default: false
 
@@ -65,3 +75,7 @@ variables:
   # Disable BinSkim at job level to override NonOfficial template defaults
   - name: ob_sdl_binskim_enabled
     value: false
+  - name: EARLY_ACCESS_FEED
+    value: ${{ parameters.EarlyAccessFeed }}
+  - name: IsEarlyAccess
+    value: ${{ parameters.IsEarlyAccess }}

--- a/.pipelines/templates/variables/PowerShell-Packages-Variables.yml
+++ b/.pipelines/templates/variables/PowerShell-Packages-Variables.yml
@@ -11,6 +11,16 @@ parameters:
   - name: disableNetworkIsolation
     type: boolean
     default: false
+  - name: EarlyAccessFeed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
 
 variables:
   - name: CDP_DEFINITION_BUILD_COUNT
@@ -48,3 +58,7 @@ variables:
   - group: MSIXSigningProfile
   - name: disableNetworkIsolation
     value: ${{ parameters.disableNetworkIsolation }}
+  - name: EARLY_ACCESS_FEED
+    value: ${{ parameters.EarlyAccessFeed }}
+  - name: IsEarlyAccess
+    value: ${{ parameters.IsEarlyAccess }}

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -2,6 +2,7 @@ parameters:
   Architecture: 'x64'
   BuildConfiguration: 'release'
   JobName: 'build_windows'
+  dotnetArch: 'win-x64'
 
 jobs:
 - job: build_windows_${{ parameters.Architecture }}_${{ parameters.BuildConfiguration }}
@@ -64,6 +65,8 @@ jobs:
       Language: csharp
 
   - template: /.pipelines/templates/install-dotnet.yml@self
+    parameters:
+      architecture: ${{ parameters.dotnetArch }}
 
   - pwsh: |
       $runtime = switch ($env:Architecture)

--- a/build.psm1
+++ b/build.psm1
@@ -899,7 +899,7 @@ function Switch-PSNugetConfig {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'user')]
         [Parameter(Mandatory = $true, ParameterSetName = 'nouser')]
-        [ValidateSet('Public', 'Private', 'NuGetOnly')]
+        [ValidateSet('Public', 'Private', 'NuGetOnly', 'EarlyAccess')]
         [string] $Source,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'user')]
@@ -936,6 +936,23 @@ function Switch-PSNugetConfig {
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/" @extraParams
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/src/Modules/" @extraParams
         New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
+    } elseif ($Source -eq 'EarlyAccess') {
+        $earlyAccess = $env:EARLY_ACCESS_FEED
+
+        $earlyAccessFeedUrl = switch ($earlyAccess) {
+            'net8' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-8-early-access/nuget/v3/index.json' }
+            'net9' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-9-early-access/nuget/v3/index.json' }
+            'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
+            default { throw "Unknown early access feed URL: $earlyAccess" }
+        }
+
+        Set-PipelineVariable -Name 'EARLY_ACCESS_FEED_URL' -Value $earlyAccessFeedUrl
+
+        $earlyAccessFeed = [NugetPackageSource] @{Url = $earlyAccessFeedUrl; Name = 'earlyaccess' }
+
+        New-NugetConfigFile -NugetPackageSource $earlyAccessFeed -Destination "$PSScriptRoot/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $gallery -Destination "$PSScriptRoot/src/Modules/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $gallery -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
     } else {
         throw "Unknown source: $Source"
     }
@@ -2574,6 +2591,62 @@ function Start-PSxUnit {
     finally {
         $env:DOTNET_ROOT = $originalDOTNET_ROOT
         Pop-Location
+    }
+}
+
+function Get-DotnetEarlyAccess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DestinationPath,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('win-x64', 'win-x86', 'win-arm64', 'linux-x64', 'linux-arm64', 'linux-alpine-x64', 'linux-alpine-arm64', 'osx-x64', 'osx-arm64', 'all')]
+        [string]$Architecture,
+
+        [Parameter(Mandatory)]
+        [string]$DOTNET_PRIVATE_SAS
+    )
+
+    $baseUrl = $env:DOTNET_PRIVATE_BLOB_BASE_URL
+    $DOTNET_RUNTIME_VERSION = $env:DOTNET_RUNTIME_VERSION
+    $DOTNET_SDK_VERSION = $env:DOTNET_SDK_VERSION
+
+    $fileName = switch ($Architecture) {
+        'win-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-win-x64.zip" }
+        'win-x86' { "dotnet-sdk-$DOTNET_SDK_VERSION-win-x86.zip" }
+        'win-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-win-arm64.zip" }
+        'linux-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz" }
+        'linux-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz" }
+        'linux-alpine-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz" }
+        'linux-alpine-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-arm64.tar.gz" }
+        'osx-x64' { "dotnet-sdk-$DOTNET_SDK_VERSION-osx-x64.tar.gz" }
+        'osx-arm64' { "dotnet-sdk-$DOTNET_SDK_VERSION-osx-arm64.tar.gz" }
+        'all' { @(
+            "dotnet-sdk-$DOTNET_SDK_VERSION-win-x64.zip"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-win-x86.zip"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-win-arm64.zip"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-arm64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-osx-x64.tar.gz"
+            "dotnet-sdk-$DOTNET_SDK_VERSION-osx-arm64.tar.gz"
+        ) }
+        default { throw "Unsupported architecture: $Architecture" }
+    }
+
+    $fileName | ForEach-Object {
+        $destFile = "$DestinationPath/$_"
+        Write-Verbose -Verbose "Downloading $_ from $baseUrl/$DOTNET_RUNTIME_VERSION to $destFile"
+
+        try {
+            Invoke-WebRequest -Uri "$baseUrl/$DOTNET_RUNTIME_VERSION/$_$DOTNET_PRIVATE_SAS" -OutFile $destFile -RetryIntervalSec 5 -MaximumRetryCount 3
+        }
+        catch {
+            Write-Error "Failed to download $_ from $baseUrl/$DOTNET_RUNTIME_VERSION"
+            throw
+        }
     }
 }
 


### PR DESCRIPTION
Backport of #27795 to release/v7.6.5

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27795$$$
-->

Triggered by @adityapatwardhan on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Enables the PowerShell build, package, and release pipelines to consume approved early access .NET SDK/runtime artifacts and NuGet feeds for release/v7.6.5.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-picked the current authoritative merge commit onto the latest upstream release/v7.6.5 without conflicts. Verified the committed target-to-HEAD diff with git diff --check, confirmed a clean worktree, and validated build.psm1 PowerShell syntax with no errors or conflict markers. Two inherited blank EOF lines in official pipeline YAML files were removed before amending the backport commit. Full pipeline behavior will be validated by required PR CI.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk because this changes shared build, package, and release pipeline templates and credential/feed handling across Windows, Linux, and macOS. The backport is limited to the approved original change, applied cleanly, and is subject to required CI before merge.
