### PR TITLE
Fix the condition check for signing EXE

### DIFF
--- a/.pipelines/templates/packaging/windows/sign.yml
+++ b/.pipelines/templates/packaging/windows/sign.yml
@@ -100,7 +100,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      if ($runtime -like '*fxdependent*' -or $runtime -like '*minsize*') {
+      if ($runtime -notin @('x64', 'x86', 'arm64')) {
         Write-Verbose -Verbose "No EXE generated for $runtime"
         return
       }
@@ -138,7 +138,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      if ($runtime -like '*fxdependent*' -or $runtime -like '*minsize*') {
+      if ($runtime -notin @('x64', 'x86', 'arm64')) {
         Write-Verbose -Verbose "No EXE generated for $runtime"
         return
       }

--- a/.pipelines/templates/packaging/windows/sign.yml
+++ b/.pipelines/templates/packaging/windows/sign.yml
@@ -100,9 +100,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      $noExeRuntimes = @('fxdependent', 'fxdependentWinDesktop', 'minsize')
-
-      if ($runtime -in $noExeRuntimes) {
+      if ($runtime -like '*fxdependent*' -or $runtime -like '*minsize*') {
         Write-Verbose -Verbose "No EXE generated for $runtime"
         return
       }
@@ -140,9 +138,7 @@ jobs:
       Import-Module "$repoRoot\build.psm1"
       Import-Module "$repoRoot\tools\packaging"
 
-      $noExeRuntimes = @('fxdependent', 'fxdependentWinDesktop', 'minsize')
-
-      if ($runtime -in $noExeRuntimes) {
+      if ($runtime -like '*fxdependent*' -or $runtime -like '*minsize*') {
         Write-Verbose -Verbose "No EXE generated for $runtime"
         return
       }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix the condition check for signing EXE.
The MSI and EXE related code was removed from GitHub master, so the min-size package change didn't account for them. The conditional check for creating exe is still using `minsize` in the check. Update the check in this PR.