### PR TITLE
Update 7.4 changelog for v7.4.19

### DIFF
--- a/CHANGELOG/7.4.md
+++ b/CHANGELOG/7.4.md
@@ -1,5 +1,35 @@
 # 7.4 Changelog
 
+## [7.4.19]
+
+### Engine Updates and Fixes
+
+- Fix the dot-sourcing behavior of `pwsh -file` for advanced-function scripts (#27760)
+
+### Tests
+
+- Fix TimeZone test with duplicate names (#27804)
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 8.0.424</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release (#27830)</li>
+<li>Update <code>Microsoft.PowerShell.Archive</code> version to 1.2.6 (#27803)</li>
+<li>Update branch for release (#27780)</li>
+</ul>
+
+</details>
+
+[7.4.19]: https://github.com/PowerShell/PowerShell/compare/v7.4.18...v7.4.19
+
 ## [7.4.18]
 
 ### Engine Updates and Fixes


### PR DESCRIPTION
Automated changelog update for v7.4.19 (changes since v7.4.18).

## :warning: Changelog Validation Warnings

The following potential issues were found in `CHANGELOG/7.4.md`. These do not block this PR — review and decide whether a follow-up edit to the changelog is needed.

### Pre-existing duplicate PR refs in older sections (legacy entries)

- #17856 in: [7.4.0-preview.1], [7.4.2]
- #19215 in: [7.4.0-preview.2]
- #19558 in: [7.4.0-preview.4]
- #24128 in: [7.4.6], [7.4.7]
- #24429 in: [7.4.6], [7.4.7]
- #25401 in: [7.4.10]

### Duplicate dependency bump entries

- `<code>Markdig.Signed</code>` in: [7.4.0-preview.2], [7.4.0-preview.5]
- `<code>Microsoft.CodeAnalysis.CSharp</code>` in: [7.4.0-preview.1], [7.4.0-preview.2], [7.4.0-preview.6]
- `<code>Microsoft.NET.Test.Sdk</code>` in: [7.4.0-preview.2], [7.4.0-preview.6]
- `<code>Microsoft.PowerShell.Native</code>` in: [7.4.0-preview.1], [7.4.0-preview.2]
- `<code>XunitXml.TestLogger</code>` in: [7.4.0-preview.2], [7.4.0-preview.6]
- `JsonSchema.Net` in: [7.4.0-preview.4], [7.4.0-preview.5], [7.4.0-preview.6], [7.4.0-rc.1]
- `Microsoft.CodeAnalysis.CSharp` in: [7.4.0-preview.1], [7.4.0-preview.4]
- `Microsoft.NET.Test.Sdk` in: [7.4.0-preview.1], [7.4.0-preview.4], [7.4.0-preview.5]
- `xunit.runner.visualstudio` in: [7.4.0-preview.5], [7.4.0-rc.1]

Recreates #27833 under a CLA-approved author. The resulting tree matches #27833 exactly.