### PR TITLE
Update 7.5 changelog for v7.5.10

### DIFF
--- a/CHANGELOG/7.5.md
+++ b/CHANGELOG/7.5.md
@@ -1,5 +1,31 @@
 # 7.5 Changelog
 
+## [7.5.10]
+
+### Engine Updates and Fixes
+
+- Fix the dot-sourcing behavior of `pwsh -file` for advanced-function scripts (#27761)
+
+### Build and Packaging Improvements
+
+<details>
+
+<summary>
+
+<p>Update to .NET SDK 9.0.317</p>
+
+</summary>
+
+<ul>
+<li>Update branch for release (#27831)</li>
+<li>Backport Windows build pipeline fixes (#27813)</li>
+<li>Update Microsoft.PowerShell.Archive version to 1.2.6 (#27801)</li>
+</ul>
+
+</details>
+
+[7.5.10]: https://github.com/PowerShell/PowerShell/compare/v7.5.9...v7.5.10
+
 ## [7.5.9]
 
 ### Tests


### PR DESCRIPTION
Manual cherry-pick of #27832

Automated changelog update for v7.5.10 (changes since v7.5.9).

## :warning: Changelog Validation Warnings

The following potential issues were found in `CHANGELOG/7.5.md`. These do not block this PR — review and decide whether a follow-up edit to the changelog is needed.

### Pre-existing duplicate PR refs in older sections (legacy entries)

- #20999 in: [7.5.0-preview.5]
- #24304 in: [7.5.0-preview.5]

### Duplicate dependency bump entries

- `<code>actions/checkout</code>` in: [7.5.0-preview.3], [7.5.0-preview.4]
- `<code>actions/dependency-review-action</code>` in: [7.5.0-preview.3], [7.5.0-preview.4]
- `<code>actions/upload-artifact</code>` in: [7.5.0-preview.3], [7.5.0-preview.4]
- `<code>github/codeql-action</code>` in: [7.5.0-preview.3], [7.5.0-preview.4], [7.5.6]
- `<code>ossf/scorecard-action</code>` in: [7.5.0-preview.3], [7.5.0-preview.4]
- `XunitXml.TestLogger` in: [7.5.0-preview.1], [7.5.0-preview.2]