### PR TITLE
Fix OneBranch output variables for early .NET jobs

### DIFF
--- a/.pipelines/templates/downloadDotnetEarlyAccess.yml
+++ b/.pipelines/templates/downloadDotnetEarlyAccess.yml
@@ -13,8 +13,10 @@ jobs:
     value: ${{ parameters.DotnetRuntimeVersion }}
   - name: DOTNET_SDK_VERSION
     value: ${{ parameters.DotnetSdkVersion }}
-  - name: destinationPath
+  - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/pkgs'
+  - name: destinationPath
+    value: '$(ob_outputDirectory)'
 
   pool:
     name: PowerShell1ES

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -38,6 +38,9 @@ stages:
       displayName: 'Skip early access .NET setup'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET setup.'
 - stage: mac_package

--- a/.pipelines/templates/stages/PowerShell-Release-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Release-Stages.yml
@@ -41,6 +41,9 @@ stages:
       displayName: 'Skip early access .NET download'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET download.'
 - stage: validateSdk


### PR DESCRIPTION
## Summary
- define `ob_outputDirectory` for the shared early-access .NET download job
- define `ob_outputDirectory` for the non-early fallback Windows jobs in package and release pipelines
- use the OneBranch output directory as the early-access download destination

## Root cause
PR #27795 introduced new Windows jobs without the `ob_outputDirectory` variable required by the OneBranch Windows job template. This causes pipeline expansion to fail with:

> Variable ob_outputDirectory is not defined

For preview build 707888, `IsEarlyAccess` was false, so the packages pipeline selected the affected `skip_early_dotnet` job. The true early-access path used the shared download job, which was affected as well.

## Preview verification
Build 707888 installed .NET SDK `11.0.100-preview.6.26359.118` from `global.json` on the normal SDK path. The early-access download/install tasks were skipped, as expected with `IsEarlyAccess: false`.

ADO build: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=707888&view=results

## Validation
- parsed all modified files as YAML
- checked the diff for whitespace errors
- verified the shared and fallback Windows jobs define `ob_outputDirectory`