### PR TITLE
[release/v7.6.5] Fix OneBranch output variables for early .NET jobs

### DIFF
--- a/.pipelines/templates/downloadDotnetEarlyAccess.yml
+++ b/.pipelines/templates/downloadDotnetEarlyAccess.yml
@@ -13,8 +13,10 @@ jobs:
     value: ${{ parameters.DotnetRuntimeVersion }}
   - name: DOTNET_SDK_VERSION
     value: ${{ parameters.DotnetSdkVersion }}
-  - name: destinationPath
+  - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/pkgs'
+  - name: destinationPath
+    value: '$(ob_outputDirectory)'
 
   pool:
     name: PowerShell1ES

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -38,6 +38,9 @@ stages:
       displayName: 'Skip early access .NET setup'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET setup.'
 - stage: mac_package

--- a/.pipelines/templates/stages/PowerShell-Release-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Release-Stages.yml
@@ -41,6 +41,9 @@ stages:
       displayName: 'Skip early access .NET download'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET download.'
 - stage: validateSdk


### PR DESCRIPTION
Backport of #27843 to `release/v7.6.5`.

Defines the OneBranch-required `ob_outputDirectory` variable for the early-access .NET download job and fallback Windows jobs.