### PR TITLE
Better resolution of file system modules in `Get-Module` – Chapter 1

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -780,12 +780,10 @@ namespace System.Management.Automation
                 moduleNameOrPath = Path.Join(relativeTo, moduleNameOrPath);
             }
 
-            // Use the PowerShell filesystem provider to fully resolve the path
-            // If there is a problem, null could be returned -- so default back to the pre-normalized path
+            // Resolving the path using ModuleCmdletBase.GetResolvedPath() may rarely return null.
             string normalizedPath = ModuleCmdletBase.GetResolvedPath(moduleNameOrPath, executionContext)?.TrimEnd(StringLiterals.DefaultPathSeparator);
 
-            // ModuleCmdletBase.GetResolvePath will return null in the unlikely event that it failed.
-            // If it does, we return the fully qualified path generated before.
+            // If the resolved path is null, just return the fully qualified path generated before.
             return normalizedPath ?? Path.GetFullPath(moduleNameOrPath);
         }
 

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -772,7 +772,9 @@ namespace System.Management.Automation
             //      - Path.IsPathRooted("/some/path") return false on Windows.
             moduleNameOrPath = moduleNameOrPath.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
 
-            // Note: Path.IsFullyQualified("\default\root") is false on Windows, but Path.IsPathRooted returns true
+            // On Windows:
+            //      - Path.IsFullyQualified("\default\root") returns false, but
+            //      - Path.IsPathRooted("\default\root") returns true.
             if (!Path.IsPathRooted(moduleNameOrPath))
             {
                 moduleNameOrPath = Path.Join(relativeTo, moduleNameOrPath);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -724,16 +724,28 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Takes the name of a module as used in a module specification
-        /// and either returns it as a simple name (if it was a simple name)
-        /// or a fully qualified, PowerShell-resolved path.
+        /// Takes a module name from a <strong>module specification</strong> and returns a
+        /// normalized module name.
         /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         A normalized module name is either:
+        ///         <list type="bullet">
+        ///             <item>A simple module name if <paramref name="moduleNameOrPath"/> was a simple name.</item>
+        ///             <item>A fully qualified, PowerShell-resolved path.</item>
+        ///             <item>
+        ///                 A fully qualified path by combination of <paramref name="relativeTo"/> and
+        ///                 <paramref name="moduleNameOrPath"/> if PowerShell could not resolve the path.
+        ///             </item>
+        ///         </list>
+        ///     </para>
+        /// </remarks>
         /// <param name="moduleNameOrPath">The name or path of the module from the specification.</param>
         /// <param name="relativeTo">The path to base relative paths off.</param>
         /// <param name="executionContext">The current execution context.</param>
         /// <returns>
-        /// The simple module name if the given one was simple,
-        /// otherwise a fully resolved, absolute path to the module.
+        /// A simple module name if <paramref name="moduleNameOrPath"/> was a simple module
+        /// name, otherwise a fully qualified path to the module.
         /// </returns>
         /// <remarks>
         /// 2018-11-09 rjmholt:

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -729,7 +729,7 @@ namespace System.Management.Automation
         /// or a fully qualified, PowerShell-resolved path.
         /// </summary>
         /// <param name="moduleNameOrPath">The name or path of the module from the specification.</param>
-        /// <param name="basePath">The path to base relative paths off.</param>
+        /// <param name="relativeTo">The path to base relative paths off.</param>
         /// <param name="executionContext">The current execution context.</param>
         /// <returns>
         /// The simple module name if the given one was simple,
@@ -744,7 +744,7 @@ namespace System.Management.Automation
         /// </remarks>
         internal static string NormalizeModuleName(
             string moduleNameOrPath,
-            string basePath,
+            string relativeTo,
             ExecutionContext executionContext)
         {
             if (moduleNameOrPath == null)
@@ -764,7 +764,7 @@ namespace System.Management.Automation
             // Note: Path.IsFullyQualified("\default\root") is false on Windows, but Path.IsPathRooted returns true
             if (!Path.IsPathRooted(moduleNameOrPath))
             {
-                moduleNameOrPath = Path.Join(basePath, moduleNameOrPath);
+                moduleNameOrPath = Path.Join(relativeTo, moduleNameOrPath);
             }
 
             // Use the PowerShell filesystem provider to fully resolve the path

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -739,6 +739,12 @@ namespace System.Management.Automation
         ///             </item>
         ///         </list>
         ///     </para>
+        ///     <para>
+        ///         2018-11-09 rjmholt:
+        ///         There are several, possibly inconsistent, path handling mechanisms in the module cmdlets.
+        ///         After looking through all of them and seeing they all make some assumptions about their caller
+        ///         I wrote this method. Hopefully we can find a standard path resolution API to settle on.
+        ///     </para>
         /// </remarks>
         /// <param name="moduleNameOrPath">The name or path of the module from the specification.</param>
         /// <param name="relativeTo">The path to base relative paths off.</param>
@@ -747,13 +753,6 @@ namespace System.Management.Automation
         /// A simple module name if <paramref name="moduleNameOrPath"/> was a simple module
         /// name, otherwise a fully qualified path to the module.
         /// </returns>
-        /// <remarks>
-        /// 2018-11-09 rjmholt:
-        /// There are several, possibly inconsistent, path handling mechanisms
-        /// in the module cmdlets. After looking through all of them and seeing
-        /// they all make some assumptions about their caller I wrote this method.
-        /// Hopefully we can find a standard path resolution API to settle on.
-        /// </remarks>
         internal static string NormalizeModuleName(string moduleNameOrPath, string relativeTo, ExecutionContext executionContext)
         {
             ArgumentNullException.ThrowIfNull(moduleNameOrPath);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -762,7 +762,6 @@ namespace System.Management.Automation
             ArgumentNullException.ThrowIfNull(moduleNameOrPath);
             ArgumentNullException.ThrowIfNull(relativeTo);
 
-            // Check whether the module is a path -- if not, it is a simple name and we just return it.
             if (!IsModuleNamePath(moduleNameOrPath))
             {
                 return moduleNameOrPath;

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -767,7 +767,9 @@ namespace System.Management.Automation
                 return moduleNameOrPath;
             }
 
-            // Standardize directory separators -- Path.IsPathRooted() will return false for "\path\here" on *nix and for "/path/there" on Windows
+            // Ensure OS default directory separators because
+            //      - Path.IsPathRooted("\some\path") returns false on *nix, and
+            //      - Path.IsPathRooted("/some/path") return false on Windows.
             moduleNameOrPath = moduleNameOrPath.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
 
             // Note: Path.IsFullyQualified("\default\root") is false on Windows, but Path.IsPathRooted returns true

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -760,6 +760,7 @@ namespace System.Management.Automation
             ExecutionContext executionContext)
         {
             ArgumentNullException.ThrowIfNull(moduleNameOrPath);
+            ArgumentNullException.ThrowIfNull(relativeTo);
 
             // Check whether the module is a path -- if not, it is a simple name and we just return it.
             if (!IsModuleNamePath(moduleNameOrPath))

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -739,12 +739,12 @@ namespace System.Management.Automation
         ///             </item>
         ///         </list>
         ///     </para>
-        ///     <para>
+        ///     <!-- <para>
         ///         2018-11-09 rjmholt:
         ///         There are several, possibly inconsistent, path handling mechanisms in the module cmdlets.
         ///         After looking through all of them and seeing they all make some assumptions about their caller
         ///         I wrote this method. Hopefully we can find a standard path resolution API to settle on.
-        ///     </para>
+        ///     </para> -->
         /// </remarks>
         /// <param name="moduleNameOrPath">The name or path of the module from the specification.</param>
         /// <param name="relativeTo">The path to base relative paths off.</param>

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -728,7 +728,7 @@ namespace System.Management.Automation
         /// and either returns it as a simple name (if it was a simple name)
         /// or a fully qualified, PowerShell-resolved path.
         /// </summary>
-        /// <param name="moduleName">The name or path of the module from the specification.</param>
+        /// <param name="moduleNameOrPath">The name or path of the module from the specification.</param>
         /// <param name="basePath">The path to base relative paths off.</param>
         /// <param name="executionContext">The current execution context.</param>
         /// <returns>
@@ -743,37 +743,37 @@ namespace System.Management.Automation
         /// Hopefully we can find a standard path resolution API to settle on.
         /// </remarks>
         internal static string NormalizeModuleName(
-            string moduleName,
+            string moduleNameOrPath,
             string basePath,
             ExecutionContext executionContext)
         {
-            if (moduleName == null)
+            if (moduleNameOrPath == null)
             {
                 return null;
             }
 
             // Check whether the module is a path -- if not, it is a simple name and we just return it.
-            if (!IsModuleNamePath(moduleName))
+            if (!IsModuleNamePath(moduleNameOrPath))
             {
-                return moduleName;
+                return moduleNameOrPath;
             }
 
             // Standardize directory separators -- Path.IsPathRooted() will return false for "\path\here" on *nix and for "/path/there" on Windows
-            moduleName = moduleName.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
+            moduleNameOrPath = moduleNameOrPath.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
 
             // Note: Path.IsFullyQualified("\default\root") is false on Windows, but Path.IsPathRooted returns true
-            if (!Path.IsPathRooted(moduleName))
+            if (!Path.IsPathRooted(moduleNameOrPath))
             {
-                moduleName = Path.Join(basePath, moduleName);
+                moduleNameOrPath = Path.Join(basePath, moduleNameOrPath);
             }
 
             // Use the PowerShell filesystem provider to fully resolve the path
             // If there is a problem, null could be returned -- so default back to the pre-normalized path
-            string normalizedPath = ModuleCmdletBase.GetResolvedPath(moduleName, executionContext)?.TrimEnd(StringLiterals.DefaultPathSeparator);
+            string normalizedPath = ModuleCmdletBase.GetResolvedPath(moduleNameOrPath, executionContext)?.TrimEnd(StringLiterals.DefaultPathSeparator);
 
             // ModuleCmdletBase.GetResolvePath will return null in the unlikely event that it failed.
             // If it does, we return the fully qualified path generated before.
-            return normalizedPath ?? Path.GetFullPath(moduleName);
+            return normalizedPath ?? Path.GetFullPath(moduleNameOrPath);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -754,10 +754,7 @@ namespace System.Management.Automation
         /// they all make some assumptions about their caller I wrote this method.
         /// Hopefully we can find a standard path resolution API to settle on.
         /// </remarks>
-        internal static string NormalizeModuleName(
-            string moduleNameOrPath,
-            string relativeTo,
-            ExecutionContext executionContext)
+        internal static string NormalizeModuleName(string moduleNameOrPath, string relativeTo, ExecutionContext executionContext)
         {
             ArgumentNullException.ThrowIfNull(moduleNameOrPath);
             ArgumentNullException.ThrowIfNull(relativeTo);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -759,10 +759,7 @@ namespace System.Management.Automation
             string relativeTo,
             ExecutionContext executionContext)
         {
-            if (moduleNameOrPath == null)
-            {
-                return null;
-            }
+            ArgumentNullException.ThrowIfNull(moduleNameOrPath);
 
             // Check whether the module is a path -- if not, it is a simple name and we just return it.
             if (!IsModuleNamePath(moduleNameOrPath))

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>True if the specifications are equal, false otherwise.</returns>
         public bool Equals(ModuleSpecification x, ModuleSpecification y)
         {
-            if (x == y)
+            if (ReferenceEquals(x, y))
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -340,7 +340,7 @@ namespace Microsoft.PowerShell.Commands
     }
 
     /// <summary>
-    /// Compares two ModuleSpecification objects for equality.
+    /// Compares two <see cref="ModuleSpecification"/> objects for structural equality.
     /// </summary>
     internal class ModuleSpecificationComparer : IEqualityComparer<ModuleSpecification>
     {

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -105,7 +105,8 @@ namespace Microsoft.PowerShell.Commands
                     else if (field.Equals("MaximumVersion", StringComparison.OrdinalIgnoreCase))
                     {
                         moduleSpecification.MaximumVersion = LanguagePrimitives.ConvertTo<string>(entry.Value);
-                        ModuleCmdletBase.GetMaximumVersion(moduleSpecification.MaximumVersion);
+                        // Ensure max version is correctly formatted.
+                        _ = ModuleCmdletBase.GetMaximumVersion(moduleSpecification.MaximumVersion);
                     }
                     else if (field.Equals("GUID", StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -90,25 +90,25 @@ namespace Microsoft.PowerShell.Commands
                 {
                     string field = entry.Key.ToString();
 
-                    if (field.Equals("ModuleName", StringComparison.OrdinalIgnoreCase))
+                    if (field.EqualsOrdinalIgnoreCase("ModuleName"))
                     {
                         moduleSpecification.Name = LanguagePrimitives.ConvertTo<string>(entry.Value);
                     }
-                    else if (field.Equals("ModuleVersion", StringComparison.OrdinalIgnoreCase))
+                    else if (field.EqualsOrdinalIgnoreCase("ModuleVersion"))
                     {
                         moduleSpecification.Version = LanguagePrimitives.ConvertTo<Version>(entry.Value);
                     }
-                    else if (field.Equals("RequiredVersion", StringComparison.OrdinalIgnoreCase))
+                    else if (field.EqualsOrdinalIgnoreCase("RequiredVersion"))
                     {
                         moduleSpecification.RequiredVersion = LanguagePrimitives.ConvertTo<Version>(entry.Value);
                     }
-                    else if (field.Equals("MaximumVersion", StringComparison.OrdinalIgnoreCase))
+                    else if (field.EqualsOrdinalIgnoreCase("MaximumVersion"))
                     {
                         moduleSpecification.MaximumVersion = LanguagePrimitives.ConvertTo<string>(entry.Value);
                         // Ensure max version is correctly formatted.
                         _ = ModuleCmdletBase.GetMaximumVersion(moduleSpecification.MaximumVersion);
                     }
-                    else if (field.Equals("GUID", StringComparison.OrdinalIgnoreCase))
+                    else if (field.EqualsOrdinalIgnoreCase("GUID"))
                     {
                         moduleSpecification.Guid = LanguagePrimitives.ConvertTo<Guid?>(entry.Value);
                     }

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -362,7 +362,7 @@ namespace Microsoft.PowerShell.Commands
                 && Guid.Equals(x.Guid, y.Guid)
                 && Version.Equals(x.RequiredVersion, y.RequiredVersion)
                 && Version.Equals(x.Version, y.Version)
-                && string.Equals(x.MaximumVersion, y.MaximumVersion);
+                && string.Equals(x.MaximumVersion, y.MaximumVersion, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -427,6 +427,13 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         }
 
         Context 'Resolves to loose module under $env:PSModule' {
+            # Unclear whether only manifest modules are discovered under $env:PSModulePath.
+            It 'wrongly/correctly returns $null instead of module information' {
+                $path = Join-Path $env:PSModulePath existing-loose.xxx.psm1
+                Test-Path $path | Should -BeTrue
+
+                Get-Module -ListAvailable -FullyQualifiedName existing-loose.xxx | Should -Be $null
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -414,6 +414,8 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     Context 'When path value has unknown extension, such as ''name.xxx''' {
+        Context 'Resolves to non-existing loose or versioned module under $env:PSModulePath' {
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -397,6 +397,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual = Get-Module -ListAvailable -FullyQualifiedName (Join-Path ~ existing*)
             $actual | Should -Be $null
         }
+
+        It 'returns module information for existing script module' {
+            $actual = Get-Module -ListAvailable -Name (Join-Path ~ loose*)
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly (Join-Path $HOME loose.psm1)
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -435,6 +435,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                 Get-Module -ListAvailable -FullyQualifiedName existing-loose.xxx | Should -Be $null
             }
         }
+
+        Context 'Resolves to manifest module under $env:PSModule' {
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -415,6 +415,15 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
 
     Context 'When path value has unknown extension, such as ''name.xxx''' {
         Context 'Resolves to non-existing loose or versioned module under $env:PSModulePath' {
+            It 'wrongly returns $null instead of error' {
+                $path1 = Join-Path $env:PSModulePath missing.xxx.psm1
+                $path2 = Join-Path $env:PSModulePath missing *, missing.xxx.psm1
+                Test-Path $path1 | Should -BeFalse
+                Test-Path $path2 | Should -BeFalse
+
+                Get-Module -ListAvailable -FullyQualifiedName missing.xxx | Should -Be $null
+                Get-Module -ListAvailable -Name missing.xxx | Should -Be $null
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -282,7 +282,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
 Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
     BeforeAll {
-        $psModulePath = ($env:PSModulePath -split ';')[0]
+        $psModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator)[0]
     }
 
     It 'wrongly returns module information instead of $null or error for missing script module' {
@@ -315,7 +315,7 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
 
     Context 'Locating existing script module' {
         BeforeAll {
-            $psModulePath = ($env:PSModulePath -split ';')[0]
+            $psModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator)[0]
 
             # Script modules
             #

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -291,6 +291,13 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }
+
+    It 'wrongly returns module information instead of $null or error for missing script module under $env:PSModulePath' {
+        $path = [System.IO.Path]::GetFullPath("$psModulePath\missing.psm1")
+        Test-Path $path | Should -BeFalse
+        Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+        Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+    }
 }
 
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -304,6 +304,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         { Get-Module -ListAvailable -FullyQualifiedName $path1 -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         { Get-Module -ListAvailable -FullyQualifiedName $path2 -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
     }
+
+    Context 'Locating existing script module' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -283,8 +283,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
     BeforeAll {
         $oldPSModulePath = $env:PSModulePath
-        $psModulePath = New-Item -ItemType Directory (Join-Path $TestDrive modules)
-        $env:PSModulePath = $psModulePath
+        $env:PSModulePath = New-Item -ItemType Directory (Join-Path $TestDrive modules)
     }
 
     AfterAll {
@@ -299,7 +298,7 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     It 'wrongly returns module information instead of $null or error for missing script module under $env:PSModulePath' {
-        $path = [System.IO.Path]::GetFullPath((Join-Path $psModulePath missing.psm1))
+        $path = [System.IO.Path]::GetFullPath((Join-Path $env:PSModulePath missing.psm1))
         Test-Path $path | Should -BeFalse
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
@@ -317,7 +316,7 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     It 'writes error for missing manifest module under $env:PSModulePath' {
-        $path = [System.IO.Path]::GetFullPath((Join-Path $psModulePath missing))
+        $path = [System.IO.Path]::GetFullPath((Join-Path $env:PSModulePath missing))
         Test-Path $path | Should -BeFalse
 
         $err = { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -PassThru
@@ -329,12 +328,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
 
     Context 'Locating existing script module' {
         BeforeAll {
-            $psModulePath = $env:PSModulePath
+            $env:PSModulePath = $env:PSModulePath
 
             # Script modules
             #
             # Under $env:PSModulePath. TODO: Is this a supported scenario?
-            $inPSModulePathLooseFilePath = Join-Path $psModulePath 'loose.psm1'
+            $inPSModulePathLooseFilePath = Join-Path $env:PSModulePath 'loose.psm1'
             New-Item -ItemType File -Force $inPSModulePathLooseFilePath > $null
             #
             # Under $pwd
@@ -349,12 +348,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
 
         # TODO: This looks like a bug.
         It 'wrongly writes error instead of returning module information for existing script module under $env:PSModulePath using basename' {
-            Test-Path (Join-Path $psModulePath loose.psm1) | Should -BeTrue
+            Test-Path (Join-Path $env:PSModulePath loose.psm1) | Should -BeTrue
 
-            $err = { Get-Module -ListAvailable -Name (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err = { Get-Module -ListAvailable -Name (Join-Path $env:PSModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
 
-            $err = { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err = { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $env:PSModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -398,6 +398,61 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     Context 'When argument contains wildcards' {
+        BeforeAll {
+            # Manifest modules under $env:PSModulePath
+            #
+            # Versioned, manifest
+            $inPSModulePathWithManifestFileName = 'existing'
+            $inPSModulePatWithManifestDirectory = Join-Path $env:PSModulePath $inPSModulePathWithManifestFileName '0.0.1'
+            $inPSModulePathWithManifestFilePath = Join-Path $inPSModulePatWithManifestDirectory "$inPSModulePathWithManifestFileName.psm1"
+            New-Item -ItemType File -Force $inPSModulePathWithManifestFilePath > $null
+            New-ModuleManifest -Path (Join-Path $inPSModulePatWithManifestDirectory "$inPSModulePathWithManifestFileName.psd1")
+            #
+            # Versioned, manifest
+            $inPSModulePathWithManifestFileName2 = 'existing2'
+            $inPSModulePatWithManifestDirectory2 = Join-Path $env:PSModulePath $inPSModulePathWithManifestFileName2 '0.0.1'
+            $inPSModulePathWithManifestFilePath2 = Join-Path $inPSModulePatWithManifestDirectory2 "$inPSModulePathWithManifestFileName2.psm1"
+            New-Item -ItemType File -Force $inPSModulePathWithManifestFilePath2 > $null
+            New-ModuleManifest -Path (Join-Path $inPSModulePatWithManifestDirectory2 "$inPSModulePathWithManifestFileName2.psd1")
+
+            # Manifest modules under $pwd
+            #
+            # Versioned, manifest
+            $inCwdhWithManifestFileName = 'existing'
+            $inCwdWithManifestDirectory = Join-Path $pwd $inCwdhWithManifestFileName '0.0.1'
+            $inCwdWithManifestFilePath = Join-Path $inCwdWithManifestDirectory "$inCwdhWithManifestFileName.psm1"
+            New-Item -ItemType File -Force $inCwdWithManifestFilePath > $null
+            New-ModuleManifest -Path (Join-Path $inCwdWithManifestDirectory "$inCwdhWithManifestFileName.psd1")
+            #
+            # Versioned, manifest
+            $inCwdWithManifestFileName2 = 'existing2'
+            $inCwdWithManifestDirectory2 = Join-Path $pwd $inCwdWithManifestFileName2 '0.0.1'
+            $inCwdWithManifestFilePath2 = Join-Path $inCwdWithManifestDirectory2 "$inCwdWithManifestFileName2.psm1"
+            New-Item -ItemType File -Force $inCwdWithManifestFilePath2 > $null
+            New-ModuleManifest -Path (Join-Path $inCwdWithManifestDirectory2 "$inCwdWithManifestFileName2.psd1")
+
+            # Script modules
+            #
+            # Under $env:PSModulePath. TODO: Is this a supported scenario?
+            $inPSModulePathLooseFilePath = Join-Path $env:PSModulePath 'loose.psm1'
+            New-Item -ItemType File -Force $inPSModulePathLooseFilePath > $null
+            #
+            #
+            # Under $pwd
+            $inCwdFilePath = Join-Path $pwd 'loose.psm1'
+            New-Item -ItemType File -Force $inCwdFilePath > $null
+        }
+
+        AfterAll {
+            Remove-Item -Force -Recurse $inPSModulePatWithManifestDirectory
+            Remove-Item -Force -Recurse $inPSModulePatWithManifestDirectory2
+
+            Remove-Item -Force -Recurse $inCwdWithManifestDirectory
+            Remove-Item -Force -Recurse $inCwdWithManifestDirectory2
+
+            Remove-Item $inPSModulePathLooseFilePath
+            Remove-Item $inCwdFilePath
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -418,6 +418,18 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
 
             Remove-Item $inCwdLooseFilePath
         }
+
+        It 'returns existing manifest modules when using the -Name parameter' {
+            $actual = Get-Module -ListAvailable -Name '.\existing*'
+            $actual | Should -HaveCount 2
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('.\existing\0.0.1\existing.psd1'))
+            $actual[1].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('.\existing2\0.0.1\existing2.psd1'))
+
+            $actual = Get-Module -ListAvailable -Name '..\existing*'
+            $actual | Should -HaveCount 2
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('..\existing\0.0.1\existing.psd1'))
+            $actual[1].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('..\existing2\0.0.1\existing2.psd1'))
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -459,6 +459,13 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             }
 
             Context 'Resolves to existing script modules' {
+                It 'wrongly/correctly returns $null' {
+                    $actual = Get-Module -ListAvailable -Name existing-loose*
+                    $actual | Should -Be $null
+
+                    $actual = Get-Module -ListAvailable -FullyQualifiedName existing-loose*
+                    $actual | Should -Be $null
+                }
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -391,6 +391,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual[0].Path | Should -BeExactly (Join-Path $HOME existing 0.0.1, existing.psd1)
             $actual[1].Path | Should -BeExactly (Join-Path $HOME existing2 0.0.1, existing2.psd1)
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly returns $null for existing manifest modules when using the -FullyQualifiedName parameter' {
+            $actual = Get-Module -ListAvailable -FullyQualifiedName (Join-Path ~ existing*)
+            $actual | Should -Be $null
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -280,7 +280,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     }
 }
 
-Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
+Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
     BeforeAll {
         $psModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator)[0]
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -365,6 +365,59 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     Context 'When argument contains wildcards' {
+        BeforeAll {
+            # Manifest modules under '.'
+            #
+            # Versioned, manifest
+            $inCwdWithManifestFileName = 'existing'
+            $inCwdWithManifestDirectory = Join-Path '.' $inCwdWithManifestFileName '0.0.1'
+            $inCwdWithManifestFilePath = Join-Path $inCwdWithManifestDirectory "$inCwdWithManifestFileName.psm1"
+            New-Item -ItemType File -Force $inCwdWithManifestFilePath > $null
+            New-ModuleManifest -Path (Join-Path $inCwdWithManifestDirectory "$inCwdWithManifestFileName.psd1")
+            #
+            # Versioned, manifest
+            $inCwdWithManifestFileName2 = 'existing2'
+            $inCwdWithManifestDirectory2 = Join-Path '.' $inCwdWithManifestFileName2 '0.0.1'
+            $inCwdWithManifestFilePath2 = Join-Path $inCwdWithManifestDirectory2 "$inCwdWithManifestFileName2.psm1"
+            New-Item -ItemType File -Force $inCwdWithManifestFilePath2 > $null
+            New-ModuleManifest -Path (Join-Path $inCwdWithManifestDirectory2 "$inCwdWithManifestFileName2.psd1")
+
+            # Manifest modules under '..'
+            #
+            # Versioned, manifest
+            $inParentWithManifestFileName = 'existing'
+            $inParentWithManifestDirectory = Join-Path '..' $inParentWithManifestFileName '0.0.1'
+            $inParentWithManifestFilePath = Join-Path $inParentWithManifestDirectory "$inParentWithManifestFileName.psm1"
+            New-Item -ItemType File -Force $inParentWithManifestFilePath > $null
+            New-ModuleManifest -Path (Join-Path $inParentWithManifestDirectory "$inParentWithManifestFileName.psd1")
+            #
+            # Versioned, manifest
+            $inParentWithManifestFileName2 = 'existing2'
+            $inParentWithManifestDirectory2 = Join-Path '..' $inParentWithManifestFileName2 '0.0.1'
+            $inParentWithManifestFilePath2 = Join-Path $inParentWithManifestDirectory2 "$inParentWithManifestFileName2.psm1"
+            New-Item -ItemType File -Force $inParentWithManifestFilePath2 > $null
+            New-ModuleManifest -Path (Join-Path $inParentWithManifestDirectory2 "$inParentWithManifestFileName2.psd1")
+
+            # Script modules under '.' and '..'
+            #
+            # Under '.'
+            $inCwdLooseFilePath = Join-Path '.' 'loose.psm1'
+            New-Item -ItemType File -Force $inCwdLooseFilePath > $null
+            #
+            # Under '..'
+            $inParentLooseFilePath = Join-Path '..' 'loose.psm1'
+            New-Item -ItemType File -Force $inParentLooseFilePath > $null
+        }
+
+        AfterAll {
+            Remove-Item -Force -Recurse $inCwdWithManifestDirectory
+            Remove-Item -Force -Recurse $inCwdWithManifestDirectory2
+
+            Remove-Item -Force -Recurse $inParentWithManifestDirectory
+            Remove-Item -Force -Recurse $inParentWithManifestDirectory2
+
+            Remove-Item $inCwdLooseFilePath
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -292,6 +292,18 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         Get-Module -ListAvailable -FullyQualifiedName $path1 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -FullyQualifiedName $path2 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }
+
+    It 'writes error for missing manifest module' {
+        $path1 = Join-Path . missing
+        $path2 = Join-Path .. missing
+        Test-Path $path1 | Should -BeFalse
+        Test-Path $path2 | Should -BeFalse
+
+        { Get-Module -ListAvailable -Name $path1 -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+        { Get-Module -ListAvailable -Name $path2 -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+        { Get-Module -ListAvailable -FullyQualifiedName $path1 -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+        { Get-Module -ListAvailable -FullyQualifiedName $path2 -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -281,6 +281,14 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is home-rooted' -Tags "CI" {
+    It 'wrongly does not expand ''~'' to $HOME' {
+        $path = Join-Path ~ missing.psm1
+        Test-Path $path | Should -BeFalse
+
+        Get-Module -ListAvailable -Name $path | ForEach-Object Path | Should -BeExactly (Join-Path $HOME missing.psm1)
+        # TODO: This is a bug.
+        Get-Module -ListAvailable -FullyQualifiedName $path | ForEach-Object Path | Should -BeExactly (Join-Path $pwd $path)
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -485,6 +485,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                     $actual[3].Name | Should -BeExactly existing2
                 }
             }
+
+            Context 'Resolves to non-existing modules' {
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -375,6 +375,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             Get-Module -ListAvailable -FullyQualifiedName ignore.psm1 | Should -Be $null
             Get-Module -ListAvailable -Name ignore.psm1 | Should -Be $null
         }
+
+        Context 'Resolves to module under $env:PSModulePath' {
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -412,6 +412,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             }
         }
     }
+
+    Context 'When path value has unknown extension, such as ''name.xxx''' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is home-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -339,6 +339,29 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $err = { Get-Module -ListAvailable -Name $name2 -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
+
+        It 'returns module information for existing script module using file name' {
+            $name1 = Join-Path . loose.psm1
+            $name2 = Join-Path .. loose.psm1
+            Test-Path $name1 | Should -BeTrue
+            Test-Path $name2 | Should -BeTrue
+
+            $actual = Get-Module -ListAvailable -Name $name1
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath($name1))
+
+            $actual = Get-Module -ListAvailable -Name $name2
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath($name2))
+
+            $actual = Get-Module -ListAvailable -FullyQualifiedName $name1
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath($name1))
+
+            $actual = Get-Module -ListAvailable -FullyQualifiedName $name2
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath($name2))
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -332,6 +332,13 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
             Remove-Item $inPSModulePathLooseFilePath
             Remove-Item $inPSModulePathLooseFilePathPwd
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly writes error instead of returning module information for existing script module under $env:PSModulePath using basename' {
+            Test-Path "$psModulePath\loose.psm1" | Should -BeTrue
+            { Get-Module -ListAvailable -Name "$psModulePath\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+            { Get-Module -ListAvailable -FullyQualifiedName "$psModulePath\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -322,6 +322,20 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         AfterAll {
             Remove-Item $inHomeLooseFilePath
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly writes error instead of returning module information for existing script module using basename' {
+            $path = Join-Path ~ loose.psm1
+            Test-Path $path | Should -BeTrue
+
+            $name = Join-Path ~ loose
+
+            $err = { Get-Module -ListAvailable -Name $name -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+
+            $err = { Get-Module -ListAvailable -FullyQualifiedName $name -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -382,6 +382,15 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
 
             Remove-Item $inHomeLooseFilePath
         }
+
+        It 'returns existing manifest modules when using the -Name parameter' {
+            $name = Join-Path ~ existing*
+
+            $actual = Get-Module -ListAvailable -Name $name
+            $actual | Should -HaveCount 2
+            $actual[0].Path | Should -BeExactly (Join-Path $HOME existing 0.0.1, existing.psd1)
+            $actual[1].Path | Should -BeExactly (Join-Path $HOME existing2 0.0.1, existing2.psd1)
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -369,6 +369,19 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $err = { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
+
+        It 'returns module information for existing script module using file name' {
+            $path = Join-Path $pwd loose.psm1
+            Test-Path $path | Should -BeTrue
+
+            $actual = Get-Module -ListAvailable -Name $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly $path
+
+            $actual = Get-Module -ListAvailable -FullyQualifiedName $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly $path
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -330,8 +330,6 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
 
     Context 'Locating existing script module' {
         BeforeAll {
-            $env:PSModulePath = $env:PSModulePath
-
             # Script modules
             #
             # Under $env:PSModulePath. TODO: Is this a supported scenario?

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -339,6 +339,13 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
             { Get-Module -ListAvailable -Name "$psModulePath\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
             { Get-Module -ListAvailable -FullyQualifiedName "$psModulePath\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly writes error instead of returning module information for existing script module using basename' {
+            Test-Path "$pwd\loose.psm1" | Should -BeTrue
+            { Get-Module -ListAvailable -Name "$pwd\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+            { Get-Module -ListAvailable -FullyQualifiedName "$pwd\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -280,6 +280,9 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     }
 }
 
+Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {
+}
+
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
     BeforeAll {
         $oldPSModulePath = $env:PSModulePath

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -489,6 +489,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual = Get-Module -ListAvailable -FullyQualifiedName (Join-Path $pwd 'existing*')
             $actual | Should -Be $null
         }
+
+        It 'returns module information for existing script module under $env:PSModulePath' {
+            $actual = Get-Module -ListAvailable -Name (Join-Path $env:PSModulePath 'loose*')
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly (Join-Path $env:PSModulePath loose.psm1)
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -487,6 +487,13 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             }
 
             Context 'Resolves to non-existing modules' {
+                It 'wrongly/correctly returns $null' {
+                    $actual = Get-Module -ListAvailable -Name missing*
+                    $actual | Should -Be $null
+
+                    $actual = Get-Module -ListAvailable -FullyQualifiedName missing*
+                    $actual | Should -Be $null
+                }
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -495,6 +495,19 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual | Should -HaveCount 1
             $actual[0].Path | Should -BeExactly (Join-Path $env:PSModulePath loose.psm1)
         }
+
+        It 'returns module information for existing script module using file name' {
+            $path = Join-Path $pwd loose.psm1
+            Test-Path $path | Should -BeTrue
+
+            $actual = Get-Module -ListAvailable -Name $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly $path
+
+            $actual = Get-Module -ListAvailable -FullyQualifiedName $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly $path
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -384,6 +384,14 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                 Get-Module -ListAvailable -FullyQualifiedName existing-loose.psm1 | Should -Be $null
                 Get-Module -ListAvailable -Name existing-loose.psm1 | Should -Be $null
             }
+
+            # Unclear whether this is correct behavior. Are loose modules allowed under $env:PSModulePath?.
+            # Could resolve to:
+            #   - 'existing2' manifest module
+            It 'wrongly/correctly returns $null instead of module information for versioned module' {
+                Get-Module -ListAvailable -FullyQualifiedName existing2.psm1 | Should -Be $null
+                Get-Module -ListAvailable -Name existing2.psm1 | Should -Be $null
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -446,6 +446,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                 Get-Module -ListAvailable -Name existing.xxx | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
             }
         }
+
+        Context 'When argument has wildcards' {
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -439,6 +439,16 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual = Get-Module -ListAvailable -FullyQualifiedName '..\existing*'
             $actual | Should -Be $null
         }
+
+        It 'returns module information for existing script module' {
+            $actual = Get-Module -ListAvailable -Name '.\loose*'
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('.\loose.psm1'))
+
+            $actual = Get-Module -ListAvailable -FullyQualifiedName '..\loose*'
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('..\loose.psm1'))
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -305,6 +305,13 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
         { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
     }
+
+    It 'writes error for missing manifest module under $env:PSModulePath' {
+        $path = [System.IO.Path]::GetFullPath("$psModulePath\missing")
+        Test-Path $path | Should -BeFalse
+        { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+        { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+    }
 }
 
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -425,6 +425,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                 Get-Module -ListAvailable -Name missing.xxx | Should -Be $null
             }
         }
+
+        Context 'Resolves to loose module under $env:PSModule' {
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -392,6 +392,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                 Get-Module -ListAvailable -FullyQualifiedName existing2.psm1 | Should -Be $null
                 Get-Module -ListAvailable -Name existing2.psm1 | Should -Be $null
             }
+
+            # Finds manifest module 'existing.psm1.psm1'. TODO: Is that correct?
+            It 'wrongly/correctly returns module information for versioned module ending with PS extension' {
+                Get-Module -ListAvailable -FullyQualifiedName existing.psm1 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+                Get-Module -ListAvailable -Name existing.psm1 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -293,6 +293,7 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     It 'wrongly returns module information instead of $null or error for missing script module' {
         $path = [System.IO.Path]::GetFullPath((Join-Path $pwd missing.psm1))
         Test-Path $path | Should -BeFalse
+
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }
@@ -300,6 +301,7 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     It 'wrongly returns module information instead of $null or error for missing script module under $env:PSModulePath' {
         $path = [System.IO.Path]::GetFullPath((Join-Path $env:PSModulePath missing.psm1))
         Test-Path $path | Should -BeFalse
+
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -370,6 +370,11 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     Context 'When path value has PS module extension, such as ''name.psm1''' {
+        # Because non-rooted/non-relative-rooted paths MUST be resolved to modules under $env:PSModulePath.
+        It 'ignores module at current directory' {
+            Get-Module -ListAvailable -FullyQualifiedName ignore.psm1 | Should -Be $null
+            Get-Module -ListAvailable -Name ignore.psm1 | Should -Be $null
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -312,6 +312,9 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
         { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
     }
+
+    Context 'Locating existing script module' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -483,6 +483,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual[0].Path | Should -BeExactly $moduleManifestPath1
             $actual[1].Path | Should -BeExactly $moduleManifestPath2
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly returns $null for existing manifest modules when using the -FullyQualifiedName parameter' {
+            $actual = Get-Module -ListAvailable -FullyQualifiedName (Join-Path $pwd 'existing*')
+            $actual | Should -Be $null
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -297,6 +297,19 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }
+
+    It 'writes error for missing manifest module' {
+        $path = Join-Path ~ missing.psm1
+        Test-Path $path | Should -BeFalse
+
+        $name = Join-Path ~ missing
+
+        $err = { Get-Module -ListAvailable -Name $name -ErrorAction Stop } | Should -Throw -PassThru
+        $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+
+        $err = { Get-Module -ListAvailable -FullyQualifiedName $name -ErrorAction Stop } | Should -Throw -PassThru
+        $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -280,6 +280,9 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     }
 }
 
+Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is home-rooted' -Tags "CI" {
+}
+
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {
     It 'wrongly returns module information instead of $null or error for missing script module' {
         $path1 = Join-Path . missing.psm1

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -430,6 +430,15 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('..\existing\0.0.1\existing.psd1'))
             $actual[1].Path | Should -BeExactly ([System.IO.Path]::GetFullPath('..\existing2\0.0.1\existing2.psd1'))
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly returns $null for existing manifest modules when using the -FullyQualifiedName parameter' {
+            $actual = Get-Module -ListAvailable -FullyQualifiedName '.\existing*'
+            $actual | Should -Be $null
+
+            $actual = Get-Module -ListAvailable -FullyQualifiedName '..\existing*'
+            $actual | Should -Be $null
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -314,6 +314,24 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
     }
 
     Context 'Locating existing script module' {
+        BeforeAll {
+            $psModulePath = ($env:PSModulePath -split ';')[0]
+
+            # Script modules
+            #
+            # Under $env:PSModulePath. TODO: Is this a supported scenario?
+            $inPSModulePathLooseFilePath = Join-Path $psModulePath 'loose.psm1'
+            New-Item -ItemType File -Force $inPSModulePathLooseFilePath > $null
+            #
+            # Under $pwd
+            $inPSModulePathLooseFilePathPwd = Join-Path $pwd 'loose.psm1'
+            New-Item -ItemType File -Force $inPSModulePathLooseFilePathPwd > $null
+        }
+
+        AfterAll {
+            Remove-Item $inPSModulePathLooseFilePath
+            Remove-Item $inPSModulePathLooseFilePathPwd
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -298,6 +298,13 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }
+
+    It 'writes error for missing manifest module' {
+        $path = [System.IO.Path]::GetFullPath("$pwd\missing")
+        Test-Path $path | Should -BeFalse
+        { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+        { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+    }
 }
 
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -353,6 +353,35 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     Context 'When argument contains wildcards' {
+        BeforeAll {
+            # Manifest modules under '~'
+            #
+            # Versioned, manifest
+            $inHomeWithManifestFileName = 'existing'
+            $inHomeWithManifestDirectory = Join-Path '~' $inHomeWithManifestFileName '0.0.1'
+            $inHomeWithManifestFilePath = Join-Path $inHomeWithManifestDirectory "$inHomeWithManifestFileName.psm1"
+            New-Item -ItemType File -Force $inHomeWithManifestFilePath > $null
+            New-ModuleManifest -Path (Join-Path $inHomeWithManifestDirectory "$inHomeWithManifestFileName.psd1")
+            #
+            # Versioned, manifest
+            $inHomeWithManifestFileName2 = 'existing2'
+            $inHomeWithManifestDirectory2 = Join-Path '~' $inHomeWithManifestFileName2 '0.0.1'
+            $inHomeWithManifestFilePath2 = Join-Path $inHomeWithManifestDirectory2 "$inHomeWithManifestFileName2.psm1"
+            New-Item -ItemType File -Force $inHomeWithManifestFilePath2 > $null
+            New-ModuleManifest -Path (Join-Path $inHomeWithManifestDirectory2 "$inHomeWithManifestFileName2.psd1")
+
+            # Script modules under '~'
+            #
+            $inHomeLooseFilePath = Join-Path '~' 'loose.psm1'
+            New-Item -ItemType File -Force $inHomeLooseFilePath > $null
+        }
+
+        AfterAll {
+            Remove-Item -Force -Recurse $inHomeWithManifestDirectory
+            Remove-Item -Force -Recurse $inHomeWithManifestDirectory2
+
+            Remove-Item $inHomeLooseFilePath
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -280,6 +280,9 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     }
 }
 
+Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is module name or filename-like' -Tags "CI" {
+}
+
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is home-rooted' -Tags "CI" {
     It 'wrongly does not expand ''~'' to $HOME' {
         $path = Join-Path ~ missing.psm1

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -363,6 +363,11 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         Get-Module -ListAvailable -FullyQualifiedName existing | ForEach-Object Path | Should -BeExactly (Join-Path $env:PSModulePath existing '0.0.1','existing.psd1')
         Get-Module -ListAvailable -Name existing | ForEach-Object Path | Should -BeExactly (Join-Path $env:PSModulePath existing '0.0.1','existing.psd1')
     }
+
+    It 'ignores module at current directory' {
+        Get-Module -ListAvailable -FullyQualifiedName ignore | Should -Be $null
+        Get-Module -ListAvailable -Name ignore | Should -Be $null
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is home-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -306,6 +306,22 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     Context 'Locating existing script module' {
+        BeforeAll {
+            # Script modules
+            #
+            # Under $env:PSModulePath. TODO: Is this a supported scenario?
+            $inPSModulePathLooseFilePath = Join-Path . loose.psm1
+            New-Item -ItemType File -Force $inPSModulePathLooseFilePath > $null
+            #
+            # Under $pwd
+            $inPSModulePathLooseFilePathParent = Join-Path .. loose.psm1
+            New-Item -ItemType File -Force $inPSModulePathLooseFilePathParent > $null
+        }
+
+        AfterAll {
+            Remove-Item $inPSModulePathLooseFilePath
+            Remove-Item $inPSModulePathLooseFilePathParent
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -351,6 +351,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual[0].Path | Should -BeExactly (Join-Path $pwd $path)
         }
     }
+
+    Context 'When argument contains wildcards' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -399,6 +399,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                 Get-Module -ListAvailable -Name existing.psm1 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
             }
         }
+
+        Context 'Resolves to non-existing loose or versioned module under $env:PSModulePath' {
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -401,6 +401,15 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         }
 
         Context 'Resolves to non-existing loose or versioned module under $env:PSModulePath' {
+            It 'wrongly returns $null instead of error' {
+                $path1 = Join-Path $env:PSModulePath missing.psm1
+                $path2 = Join-Path $env:PSModulePath missing.psm1 *, missing.psm1
+                Test-Path $path1 | Should -BeFalse
+                Test-Path $path2 | Should -BeFalse
+
+                Get-Module -ListAvailable -FullyQualifiedName missing.psm1 | Should -Be $null
+                Get-Module -ListAvailable -Name missing.psm1 | Should -Be $null
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -453,6 +453,18 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             Remove-Item $inPSModulePathLooseFilePath
             Remove-Item $inCwdFilePath
         }
+
+        It 'returns existing manifest modules under $env:PSModulePath when using the -Name parameter' {
+            $moduleManifestPath1 = Join-Path $env:PSModulePath existing 0.0.1,existing.psd1
+            $moduleManifestPath2 = Join-Path $env:PSModulePath existing2 0.0.1,existing2.psd1
+            Test-Path $moduleManifestPath1 | Should -BeTrue
+            Test-Path $moduleManifestPath2 | Should -BeTrue
+
+            $actual = Get-Module -ListAvailable -Name (Join-Path $env:PSModulePath 'existing*')
+            $actual | Should -HaveCount 2
+            $actual[0].Path | Should -BeExactly $moduleManifestPath1
+            $actual[1].Path | Should -BeExactly $moduleManifestPath2
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -469,6 +469,21 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             }
 
             Context 'Resolves to existing manifest modules' {
+                It 'returns modules' {
+                    $actual = Get-Module -ListAvailable -Name existing*
+                    $actual | Should -HaveCount 4
+                    $actual[0].Name | Should -BeExactly existing
+                    $actual[1].Name | Should -BeExactly existing.psm1
+                    $actual[2].Name | Should -BeExactly existing.xxx
+                    $actual[3].Name | Should -BeExactly existing2
+
+                    $actual = Get-Module -ListAvailable -FullyQualifiedName existing*
+                    $actual | Should -HaveCount 4
+                    $actual[0].Name | Should -BeExactly existing
+                    $actual[1].Name | Should -BeExactly existing.psm1
+                    $actual[2].Name | Should -BeExactly existing.xxx
+                    $actual[3].Name | Should -BeExactly existing2
+                }
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -471,6 +471,18 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual = Get-Module -ListAvailable -FullyQualifiedName (Join-Path $env:PSModulePath 'existing*')
             $actual | Should -Be $null
         }
+
+        It 'returns existing manifest modules when using the -Name parameter' {
+            $moduleManifestPath1 = Join-Path $pwd existing 0.0.1,existing.psd1
+            $moduleManifestPath2 = Join-Path $pwd existing2 0.0.1,existing2.psd1
+            Test-Path $moduleManifestPath1 | Should -BeTrue
+            Test-Path $moduleManifestPath2 | Should -BeTrue
+
+            $actual = Get-Module -ListAvailable -Name (Join-Path $pwd 'existing*')
+            $actual | Should -HaveCount 2
+            $actual[0].Path | Should -BeExactly $moduleManifestPath1
+            $actual[1].Path | Should -BeExactly $moduleManifestPath2
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -286,28 +286,28 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
     }
 
     It 'wrongly returns module information instead of $null or error for missing script module' {
-        $path = [System.IO.Path]::GetFullPath("$pwd\missing.psm1")
+        $path = [System.IO.Path]::GetFullPath((Join-Path $pwd missing.psm1))
         Test-Path $path | Should -BeFalse
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }
 
     It 'wrongly returns module information instead of $null or error for missing script module under $env:PSModulePath' {
-        $path = [System.IO.Path]::GetFullPath("$psModulePath\missing.psm1")
+        $path = [System.IO.Path]::GetFullPath((Join-Path $psModulePath missing.psm1))
         Test-Path $path | Should -BeFalse
         Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
         Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
     }
 
     It 'writes error for missing manifest module' {
-        $path = [System.IO.Path]::GetFullPath("$pwd\missing")
+        $path = [System.IO.Path]::GetFullPath((Join-Path $pwd missing))
         Test-Path $path | Should -BeFalse
         { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
     }
 
     It 'writes error for missing manifest module under $env:PSModulePath' {
-        $path = [System.IO.Path]::GetFullPath("$psModulePath\missing")
+        $path = [System.IO.Path]::GetFullPath((Join-Path $psModulePath missing))
         Test-Path $path | Should -BeFalse
         { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
@@ -335,16 +335,16 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
 
         # TODO: This looks like a bug.
         It 'wrongly writes error instead of returning module information for existing script module under $env:PSModulePath using basename' {
-            Test-Path "$psModulePath\loose.psm1" | Should -BeTrue
-            { Get-Module -ListAvailable -Name "$psModulePath\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
-            { Get-Module -ListAvailable -FullyQualifiedName "$psModulePath\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+            Test-Path (Join-Path $psModulePath loose.psm1) | Should -BeTrue
+            { Get-Module -ListAvailable -Name (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+            { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         }
 
         # TODO: This looks like a bug.
         It 'wrongly writes error instead of returning module information for existing script module using basename' {
-            Test-Path "$pwd\loose.psm1" | Should -BeTrue
-            { Get-Module -ListAvailable -Name "$pwd\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
-            { Get-Module -ListAvailable -FullyQualifiedName "$pwd\loose" -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+            Test-Path (Join-Path $pwd loose.psm1) | Should -BeTrue
+            { Get-Module -ListAvailable -Name (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+            { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -284,6 +284,13 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
     BeforeAll {
         $psModulePath = ($env:PSModulePath -split ';')[0]
     }
+
+    It 'wrongly returns module information instead of $null or error for missing script module' {
+        $path = [System.IO.Path]::GetFullPath("$pwd\missing.psm1")
+        Test-Path $path | Should -BeFalse
+        Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+        Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+    }
 }
 
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -282,7 +282,13 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
     BeforeAll {
-        $psModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator)[0]
+        $oldPSModulePath = $env:PSModulePath
+        $psModulePath = New-Item -ItemType Directory (Join-Path $TestDrive modules)
+        $env:PSModulePath = $psModulePath
+    }
+
+    AfterAll {
+        $env:PSModulePath = $oldPSModulePath
     }
 
     It 'wrongly returns module information instead of $null or error for missing script module' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -310,6 +310,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         $err = { Get-Module -ListAvailable -FullyQualifiedName $name -ErrorAction Stop } | Should -Throw -PassThru
         $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
     }
+
+    Context 'Locating existing script module' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -448,6 +448,15 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         }
 
         Context 'When argument has wildcards' {
+            It 'ignores existing script modules in working directory' {
+                Join-Path $pwd ignore.psm1 | Should -BeTrue
+
+                $actual = Get-Module -ListAvailable -Name ignore*
+                $actual | Should -Be $null
+
+                $actual = Get-Module -ListAvailable -FullyQualifiedName ignore*
+                $actual | Should -Be $null
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -363,6 +363,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual[0].Path | Should -BeExactly ([System.IO.Path]::GetFullPath($name2))
         }
     }
+
+    Context 'When argument contains wildcards' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -322,6 +322,23 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             Remove-Item $inPSModulePathLooseFilePath
             Remove-Item $inPSModulePathLooseFilePathParent
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly writes error instead of returning module information for existing script module using basename' {
+            $path1 = Join-Path . loose.psm1
+            $path2 = Join-Path .. loose.psm1
+            Test-Path $path1 | Should -BeTrue
+            Test-Path $path2 | Should -BeTrue
+
+            $name1 = Join-Path . loose
+            $name2 = Join-Path .. loose
+
+            $err = { Get-Module -ListAvailable -Name $name1 -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+
+            $err = { Get-Module -ListAvailable -Name $name2 -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -281,6 +281,17 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {
+    It 'wrongly returns module information instead of $null or error for missing script module' {
+        $path1 = Join-Path . missing.psm1
+        $path2 = Join-Path .. missing.psm1
+        Test-Path $path1 | Should -BeFalse
+        Test-Path $path2 | Should -BeFalse
+
+        Get-Module -ListAvailable -Name $path1 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+        Get-Module -ListAvailable -Name $path2 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+        Get-Module -ListAvailable -FullyQualifiedName $path1 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+        Get-Module -ListAvailable -FullyQualifiedName $path2 | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -281,6 +281,9 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 }
 
 Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
+    BeforeAll {
+        $psModulePath = ($env:PSModulePath -split ';')[0]
+    }
 }
 
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -465,6 +465,12 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual[0].Path | Should -BeExactly $moduleManifestPath1
             $actual[1].Path | Should -BeExactly $moduleManifestPath2
         }
+
+        # TODO: This looks like a bug.
+        It 'wrongly returns $null for existing manifest modules under $env:PSModulePath when using the -FullyQualifiedName parameter' {
+            $actual = Get-Module -ListAvailable -FullyQualifiedName (Join-Path $env:PSModulePath 'existing*')
+            $actual | Should -Be $null
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -312,6 +312,16 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
     }
 
     Context 'Locating existing script module' {
+        BeforeAll {
+            # Script modules
+            #
+            $inHomeLooseFilePath = Join-Path $HOME loose.psm1
+            New-Item -ItemType File -Force $inHomeLooseFilePath > $null
+        }
+
+        AfterAll {
+            Remove-Item $inHomeLooseFilePath
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -351,22 +351,24 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         # TODO: This looks like a bug.
         It 'wrongly writes error instead of returning module information for existing script module under $env:PSModulePath using basename' {
             Test-Path (Join-Path $env:PSModulePath loose.psm1) | Should -BeTrue
+            $path = Join-Path $env:PSModulePath loose
 
-            $err = { Get-Module -ListAvailable -Name (Join-Path $env:PSModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err = { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
 
-            $err = { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $env:PSModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err = { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
 
         # TODO: This looks like a bug.
         It 'wrongly writes error instead of returning module information for existing script module using basename' {
             Test-Path (Join-Path $pwd loose.psm1) | Should -BeTrue
+            $path = Join-Path $pwd loose
 
-            $err = { Get-Module -ListAvailable -Name (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err = { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
 
-            $err = { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err = { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -368,6 +368,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         Get-Module -ListAvailable -FullyQualifiedName ignore | Should -Be $null
         Get-Module -ListAvailable -Name ignore | Should -Be $null
     }
+
+    Context 'When path value has PS module extension, such as ''name.psm1''' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is home-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -377,6 +377,13 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         }
 
         Context 'Resolves to module under $env:PSModulePath' {
+            # Unclear whether this is correct behavior. Are loose modules allowed under $env:PSModulePath?
+            # Could resolve to:
+            #   - 'existing-loose.psm1' loose module
+            It 'wrongly/correctly returns $null instead of module information for loose module' {
+                Get-Module -ListAvailable -FullyQualifiedName existing-loose.psm1 | Should -Be $null
+                Get-Module -ListAvailable -Name existing-loose.psm1 | Should -Be $null
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -457,6 +457,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                 $actual = Get-Module -ListAvailable -FullyQualifiedName ignore*
                 $actual | Should -Be $null
             }
+
+            Context 'Resolves to existing script modules' {
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -302,15 +302,23 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
     It 'writes error for missing manifest module' {
         $path = [System.IO.Path]::GetFullPath((Join-Path $pwd missing))
         Test-Path $path | Should -BeFalse
-        { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
-        { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+
+        $err = { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -PassThru
+        $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+
+        $err = { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -PassThru
+        $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
     }
 
     It 'writes error for missing manifest module under $env:PSModulePath' {
         $path = [System.IO.Path]::GetFullPath((Join-Path $psModulePath missing))
         Test-Path $path | Should -BeFalse
-        { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
-        { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+
+        $err = { Get-Module -ListAvailable -FullyQualifiedName $path -ErrorAction Stop } | Should -Throw -PassThru
+        $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+
+        $err = { Get-Module -ListAvailable -Name $path -ErrorAction Stop } | Should -Throw -PassThru
+        $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
     }
 
     Context 'Locating existing script module' {
@@ -336,15 +344,23 @@ Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argume
         # TODO: This looks like a bug.
         It 'wrongly writes error instead of returning module information for existing script module under $env:PSModulePath using basename' {
             Test-Path (Join-Path $psModulePath loose.psm1) | Should -BeTrue
-            { Get-Module -ListAvailable -Name (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
-            { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+
+            $err = { Get-Module -ListAvailable -Name (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+
+            $err = { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $psModulePath loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
 
         # TODO: This looks like a bug.
         It 'wrongly writes error instead of returning module information for existing script module using basename' {
             Test-Path (Join-Path $pwd loose.psm1) | Should -BeTrue
-            { Get-Module -ListAvailable -Name (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
-            { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -Because '*Update the Name parameter*'
+
+            $err = { Get-Module -ListAvailable -Name (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
+
+            $err = { Get-Module -ListAvailable -FullyQualifiedName (Join-Path $pwd loose) -ErrorAction Stop } | Should -Throw -PassThru
+            $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -281,6 +281,88 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is module name or filename-like' -Tags "CI" {
+    BeforeAll {
+        $oldPSModulePath = $env:PSModulePath
+        $env:PSModulePath = New-Item -ItemType Directory (Join-Path $TestDrive modules)
+
+        # Manifest modules under $env:PSModulePath
+        #
+        # Versioned, manifest
+        $inPSModulePathWithManifestFileName = 'existing'
+        $inPSModulePatWithManifestDirectory = Join-Path $env:PSModulePath $inPSModulePathWithManifestFileName '0.0.1'
+        $inPSModulePathWithManifestFilePath = Join-Path $inPSModulePatWithManifestDirectory "$inPSModulePathWithManifestFileName.psm1"
+        New-Item -ItemType File -Force $inPSModulePathWithManifestFilePath > $null
+        New-ModuleManifest -Path (Join-Path $inPSModulePatWithManifestDirectory "$inPSModulePathWithManifestFileName.psd1")
+        #
+        # Versioned, manifest
+        $inPSModulePathWithManifestFileName2 = 'existing2'
+        $inPSModulePatWithManifestDirectory2 = Join-Path $env:PSModulePath $inPSModulePathWithManifestFileName2 '0.0.1'
+        $inPSModulePathWithManifestFilePath2 = Join-Path $inPSModulePatWithManifestDirectory2 "$inPSModulePathWithManifestFileName2.psm1"
+        New-Item -ItemType File -Force $inPSModulePathWithManifestFilePath2 > $null
+        New-ModuleManifest -Path (Join-Path $inPSModulePatWithManifestDirectory2 "$inPSModulePathWithManifestFileName2.psd1")
+        #
+        # Versioned, manifest, multiple components in name
+        $inPSModulePathWithManifestWithPathLikeNameFileName = 'existing.xxx'
+        $inPsModulePathWithManifestWithPathLikeNameDirectory = Join-Path $env:PSModulePath $inPSModulePathWithManifestWithPathLikeNameFileName '0.0.1'
+        $inPsModulePathWithManifestWithPathLikeNameFilePath = Join-Path $inPsModulePathWithManifestWithPathLikeNameDirectory "$inPSModulePathWithManifestWithPathLikeNameFileName.psm1"
+        New-Item -ItemType File -Force $inPsModulePathWithManifestWithPathLikeNameFilePath > $null
+        New-ModuleManifest -Path (Join-Path $inPsModulePathWithManifestWithPathLikeNameDirectory "$inPSModulePathWithManifestWithPathLikeNameFileName.psd1")
+        #
+        # Versioned, manifest, multiple components in name, name ending with PS module extension
+        $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionFileName = 'existing.psm1'
+        $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionDirectory = Join-Path $env:PSModulePath $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionFileName '0.0.1'
+        $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionFilePath = Join-Path $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionDirectory "$inPSModulePathWithManifestWithPathLikeNameAsPSExtensionFileName.psm1"
+        New-Item -ItemType File -Force $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionFilePath > $null
+        New-ModuleManifest -Path (Join-Path $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionDirectory "$inPSModulePathWithManifestWithPathLikeNameAsPSExtensionFileName.psd1")
+
+        # Script modules
+        #
+        # Under $env:PSModulePath. TODO: Is this a supported scenario?
+        $inPSModulePathLooseFilePath = Join-Path $env:PSModulePath 'existing-loose.psm1'
+        New-Item -ItemType File -Force $inPSModulePathLooseFilePath > $null
+        #
+        # Under $env:PSModulePath, multiple components in name. TODO: Is this a supported scenario?
+        $inPSModulePathLooseWithPathLikeFilePath = Join-Path $env:PSModulePath "existing-loose.xxx.psm1"
+        New-Item -ItemType File -Force $inPSModulePathLooseWithPathLikeFilePath > $null
+        #
+        # Under $env:PSModulePath, multiple components in name, name ending with PS module extension. TODO: Is this a supported scenario?
+        $inPSModulePathLooseWithPathLikeNameAsPSExtensionFilePath = Join-Path $env:PSModulePath "existing.psm1.psm1"
+        New-Item -ItemType File -Force $inPSModulePathLooseWithPathLikeNameAsPSExtensionFilePath > $null
+        #
+        # In working directory
+        $inWorkingDirectoryLooseFilePath = Join-Path . existing.psm1
+        New-Item -ItemType File -Force $inWorkingDirectoryLooseFilePath > $null
+        #
+        # In parent directory
+        $inParentDirectoryLooseFilePath = Join-Path .. existing.psm1
+        New-Item -ItemType File -Force $inParentDirectoryLooseFilePath > $null
+        #
+        # In working directory, ignored
+        'function foo { "_" }' > (Join-Path $pwd ignore.psm1)
+        'function foo { "_" }' > (Join-Path $pwd ignore.psm1.psm1)
+    }
+
+    AfterAll {
+        $env:PSModulePath = $oldPSModulePath
+
+        Remove-Item -ErrorAction Stop -Force -Recurse $inPSModulePatWithManifestDirectory
+        Remove-Item -ErrorAction Stop -Force -Recurse $inPSModulePatWithManifestDirectory2
+        Remove-Item -ErrorAction Stop -Force -Recurse $inPsModulePathWithManifestWithPathLikeNameDirectory
+        Remove-Item -ErrorAction Stop -Force -Recurse $inPSModulePathWithManifestWithPathLikeNameAsPSExtensionDirectory
+
+        Remove-Item -ErrorAction Stop $inPSModulePathLooseFilePath
+        Remove-Item -ErrorAction Stop $inPSModulePathLooseWithPathLikeFilePath
+        Remove-Item -ErrorAction Stop $inPSModulePathLooseWithPathLikeNameAsPSExtensionFilePath
+        Remove-Item -ErrorAction Stop $inWorkingDirectoryLooseFilePath
+        Remove-Item -ErrorAction Stop $inParentDirectoryLooseFilePath
+        Remove-Item -ErrorAction Stop ignore.psm1
+        Remove-Item -ErrorAction Stop ignore.psm1.psm1
+    }
+
+    It 'returns module information for manifest module' {
+        Get-Module -ListAvailable -FullyQualifiedName existing | ForEach-Object Path | Should -BeExactly (Join-Path $env:PSModulePath existing '0.0.1','existing.psd1')
+        Get-Module -ListAvailable -Name existing | ForEach-Object Path | Should -BeExactly (Join-Path $env:PSModulePath existing '0.0.1','existing.psd1')
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is home-rooted' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -336,6 +336,20 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $err = { Get-Module -ListAvailable -FullyQualifiedName $name -ErrorAction Stop } | Should -Throw -PassThru
             $err.Exception.Message | Should -BeLike '*Update the Name parameter*'
         }
+
+        It 'returns module information for existing script module using file name' {
+            $path = Join-Path ~ loose.psm1
+            Test-Path $path | Should -BeTrue
+
+            $actual = Get-Module -ListAvailable -Name $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly (Join-Path $HOME loose.psm1)
+
+            # TODO: This is a bug.
+            $actual = Get-Module -ListAvailable -FullyQualifiedName $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly (Join-Path $pwd $path)
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -338,13 +338,13 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             New-Item -ItemType File -Force $inPSModulePathLooseFilePath > $null
             #
             # Under $pwd
-            $inPSModulePathLooseFilePathPwd = Join-Path $pwd 'loose.psm1'
-            New-Item -ItemType File -Force $inPSModulePathLooseFilePathPwd > $null
+            $inCwdLooseFilePath = Join-Path $pwd 'loose.psm1'
+            New-Item -ItemType File -Force $inCwdLooseFilePath > $null
         }
 
         AfterAll {
             Remove-Item $inPSModulePathLooseFilePath
-            Remove-Item $inPSModulePathLooseFilePathPwd
+            Remove-Item $inCwdLooseFilePath
         }
 
         # TODO: This looks like a bug.

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -329,7 +329,7 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
 
     Context 'Locating existing script module' {
         BeforeAll {
-            $psModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator)[0]
+            $psModulePath = $env:PSModulePath
 
             # Script modules
             #

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -467,6 +467,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
                     $actual | Should -Be $null
                 }
             }
+
+            Context 'Resolves to existing manifest modules' {
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -396,6 +396,9 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual[0].Path | Should -BeExactly $path
         }
     }
+
+    Context 'When argument contains wildcards' {
+    }
 }
 
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -437,6 +437,14 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         }
 
         Context 'Resolves to manifest module under $env:PSModule' {
+            # Unclear whether only manifest modules are discovered under $env:PSModulePath.
+            It 'returns module information' {
+                $path = Join-Path $env:PSModulePath existing.xxx 0.0.1, existing.xxx.psm1
+                Test-Path $path | Should -BeTrue
+
+                Get-Module -ListAvailable -FullyQualifiedName existing.xxx | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+                Get-Module -ListAvailable -Name existing.xxx | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+            }
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -280,6 +280,9 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
     }
 }
 
+Describe 'Get-Module -ListAvaiable -(FullyQualifiedName|Name) <path> when argument is absolute path' -Tags "CI" {
+}
+
 Describe 'Get-Module -ListAvailable with path' -Tags "CI" {
     BeforeAll {
         $moduleName = 'Banana'

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -382,6 +382,19 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
             $actual | Should -HaveCount 1
             $actual[0].Path | Should -BeExactly $path
         }
+
+        It 'returns module information for existing script module under $env:PSModulePath using file name' {
+            $path = Join-Path $env:PSModulePath loose.psm1
+            Test-Path $path | Should -BeTrue
+
+            $actual = Get-Module -ListAvailable -Name $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly $path
+
+            $actual = Get-Module -ListAvailable -FullyQualifiedName $path
+            $actual | Should -HaveCount 1
+            $actual[0].Path | Should -BeExactly $path
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -289,6 +289,14 @@ Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argum
         # TODO: This is a bug.
         Get-Module -ListAvailable -FullyQualifiedName $path | ForEach-Object Path | Should -BeExactly (Join-Path $pwd $path)
     }
+
+    It 'wrongly returns module information instead of $null or error for missing script module' {
+        $path = Join-Path ~ missing.psm1
+        Test-Path $path | Should -BeFalse
+
+        Get-Module -ListAvailable -Name $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+        Get-Module -ListAvailable -FullyQualifiedName $path | Should -BeOfType ([System.Management.Automation.PSModuleInfo])
+    }
 }
 
 Describe 'Get-Module -ListAvailable -(FullyQualifiedName|Name) <path> when argument is relative-rooted' -Tags "CI" {


### PR DESCRIPTION
# PR Summary

A number of small pure refactors that aim to improve the code base without altering any existing behavior.

> [!CAUTION]
> This PR requires the following PRs to be merged first:
> - https://github.com/PowerShell/PowerShell/pull/27790
> - https://github.com/PowerShell/PowerShell/pull/27810
> - https://github.com/PowerShell/PowerShell/pull/27811
> - https://github.com/PowerShell/PowerShell/pull/27819
> - https://github.com/PowerShell/PowerShell/pull/27822
> - https://github.com/PowerShell/PowerShell/pull/27823

This is the full series of changes:

- https://github.com/PowerShell/PowerShell/pull/27847
- https://github.com/PowerShell/PowerShell/pull/27848
- https://github.com/PowerShell/PowerShell/pull/27853

## PR Context

These changes were made while I was getting familiar with this area of the code base and working on fixes based on

- #27716

...that will be submitted in future PRs.

> [!IMPORTANT]
> These changes are not required and can be dropped individually, but some of them may objectively improve the code base, like parameter validation, renames, and improved documentation.

To verify conformity with existing behavior, I've used the following tests:

- https://github.com/PowerShell/PowerShell/pull/27790
- https://github.com/PowerShell/PowerShell/pull/27810
- https://github.com/PowerShell/PowerShell/pull/27811
- https://github.com/PowerShell/PowerShell/pull/27819
- https://github.com/PowerShell/PowerShell/pull/27822
- https://github.com/PowerShell/PowerShell/pull/27823

I haven't run any other tests.

There's always a risk of inadvertently changing existing behavior, especially due to lack of sufficient test coverage, but I think the risk in this case is low to very low for all changes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
