### PR TITLE
Use Azure CLI for early-access feed token

### DIFF
--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -46,17 +46,19 @@ steps:
     NugetConfigDir: ${{ parameters.repoRoot }}/src/Modules
     ob_restore_phase: ${{ parameters.ob_restore_phase }}
 
-- task: AzurePowerShell@5
+- task: AzureCLI@2
   inputs:
     azureSubscription: powershell-net-early-access
-    azurePowerShellVersion: LatestVersion
-    ScriptType: InlineScript
-    pwsh: true
-    inline: |
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
       Write-Verbose -Verbose "Getting an Azure DevOps access token"
       # Microsoft's well-known Entra resource ID for the Azure DevOps token audience.
       $azureDevOpsResourceUrl = '499b84ac-1321-427f-aa17-267ca6975798'
-      $azt = (Get-AzAccessToken -ResourceUrl $azureDevOpsResourceUrl).Token | ConvertFrom-SecureString -AsPlainText
+      $azt = az account get-access-token --resource $azureDevOpsResourceUrl --query accessToken --output tsv
+      if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($azt)) {
+        throw "Failed to get an Azure DevOps access token."
+      }
 
       Write-Host "##vso[task.setsecret]$azt"
       Write-Verbose -Verbose "Setting up Azure Artifacts Credential Provider token"


### PR DESCRIPTION
## Summary
- replace `AzurePowerShell@5` with `AzureCLI@2` when acquiring the early-access Azure DevOps feed token
- fail explicitly if Azure CLI cannot return a token
- remove the Linux agent dependency on a preinstalled `Az.Accounts` module

## Context
The Linux SDK validation in build 707180 failed before running the inline script because the `PowerShell1ES 3` image did not have a discoverable `Az.Accounts` module. The equivalent Windows and macOS jobs succeeded because those images had `Az.Accounts` installed.

Failing log: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=707180&view=logs&j=32463283-3482-5fcf-b4f1-bff946268a97&t=8121e543-1209-5880-8988-618789d8de73