### PR TITLE
[release/v7.6.5] Use Azure CLI for early-access feed token

### DIFF
--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -46,17 +46,19 @@ steps:
     NugetConfigDir: ${{ parameters.repoRoot }}/src/Modules
     ob_restore_phase: ${{ parameters.ob_restore_phase }}
 
-- task: AzurePowerShell@5
+- task: AzureCLI@2
   inputs:
     azureSubscription: powershell-net-early-access
-    azurePowerShellVersion: LatestVersion
-    ScriptType: InlineScript
-    pwsh: true
-    inline: |
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
       Write-Verbose -Verbose "Getting an Azure DevOps access token"
       # Microsoft's well-known Entra resource ID for the Azure DevOps token audience.
       $azureDevOpsResourceUrl = '499b84ac-1321-427f-aa17-267ca6975798'
-      $azt = (Get-AzAccessToken -ResourceUrl $azureDevOpsResourceUrl).Token | ConvertFrom-SecureString -AsPlainText
+      $azt = az account get-access-token --resource $azureDevOpsResourceUrl --query accessToken --output tsv
+      if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($azt)) {
+        throw "Failed to get an Azure DevOps access token."
+      }
 
       Write-Host "##vso[task.setsecret]$azt"
       Write-Verbose -Verbose "Setting up Azure Artifacts Credential Provider token"


### PR DESCRIPTION
## Summary
Backport #27849 to `release/v7.6.5`.

- replace `AzurePowerShell@5` with `AzureCLI@2` for early-access feed token acquisition
- avoid requiring `Az.Accounts` on Linux agents
- fail explicitly if token acquisition fails

Source PR: https://github.com/PowerShell/PowerShell/pull/27849
Failing release run: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=707180&view=logs&j=32463283-3482-5fcf-b4f1-bff946268a97&t=8121e543-1209-5880-8988-618789d8de73