### PR TITLE
Fix the regression in tab completing positional parameters

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1743,9 +1743,9 @@ namespace System.Management.Automation
 
             // Find all the parameters with the position closest to the specified position. Different parameter
             // sets can declare a parameter at the same position, so there can be more than one candidate.
-            // Only parameters from the still valid parameter sets are considered: 'GetMatchingParameterSetData'
-            // filters the parameter set data by 'validParameterSetFlags', and the default parameter set is
-            // given priority only when it's still valid.
+            // Only parameters from the still valid parameter sets are considered and the default parameter set
+            // is given priority if it's still valid.
+            //
             // The candidate from the default parameter set is tried first, and when it doesn't produce any
             // completion results, the candidates from the other parameter sets are tried in turn.
             // For example, 'Get-Process | ForEach-Object <Tab>' should complete member names for '-MemberName'

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1797,13 +1797,10 @@ namespace System.Management.Automation
                         addedToAltParamList = false;
                     }
 
-                    // Prioritize the parameter from the default set. A parameter in all sets is considered from the default set if the
-                    // default set is still valid. But, we prioritize it only if we have not found a default param yet.
+                    // Prioritize the parameter from the default set, but only if we have not found such a default param yet.
                     // If 'defaultSetParam' is not null, then that means there are 2 parameters in the default set with the same position.
                     // That would be invalid parameter declaration, but we tolerate that in tab completion.
-                    if (isDefaultParameterSetValid
-                        && (parameterSetData.IsInAllSets || parameterSetData.ParameterSetFlag == defaultParameterSetFlag)
-                        && defaultSetParam is null)
+                    if (isDefaultParameterSetValid && parameterSetData.ParameterSetFlag == defaultParameterSetFlag && defaultSetParam is null)
                     {
                         defaultSetParam = param;
 
@@ -1831,6 +1828,7 @@ namespace System.Management.Automation
                 }
             }
 
+            bool isProcessedAsPositional = false;
             if (defaultSetParam is not null)
             {
                 ProcessParameter(commandName, commandAst, context, result, defaultSetParam, boundArguments);
@@ -1838,44 +1836,45 @@ namespace System.Management.Automation
                 {
                     return;
                 }
+
+                isProcessedAsPositional = true;
             }
 
             if (alternativeParams?.Count > 0)
             {
-                // There are alternative parameters at the same best position.
-                // Process them in the discovery order.
+                // There are alternative parameters at the same best position. Process them in the discovery order.
                 foreach (MergedCompiledCommandParameter param in alternativeParams)
                 {
                     ProcessParameter(commandName, commandAst, context, result, param, boundArguments);
                     if (result.Count > 0)
                     {
-                        // Stop at the first one that we successfully get completion results.
-                        break;
+                        return;
                     }
                 }
 
-                // We will return here no matter we get completion results or not, because we did find
-                // applicable positional parameters, and we have done processing them.
-                return;
+                isProcessedAsPositional = true;
             }
 
-            // If we found no applicable positional parameter, then try the remaining argument parameters.
-            foreach (MergedCompiledCommandParameter param in parameters)
+            if (!isProcessedAsPositional)
             {
-                bool isInParameterSet = (param.Parameter.ParameterSetFlags & validParameterSetFlags) != 0 || param.Parameter.IsInAllSets;
-                if (!isInParameterSet)
+                // If we found no applicable positional parameter, then try the remaining argument parameters.
+                foreach (MergedCompiledCommandParameter param in parameters)
                 {
-                    continue;
-                }
-
-                var parameterSetDataCollection = param.Parameter.GetMatchingParameterSetData(validParameterSetFlags);
-                foreach (ParameterSetSpecificMetadata parameterSetData in parameterSetDataCollection)
-                {
-                    // in the second pass, we check the remaining argument ones
-                    if (parameterSetData.ValueFromRemainingArguments)
+                    bool isInParameterSet = (param.Parameter.ParameterSetFlags & validParameterSetFlags) != 0 || param.Parameter.IsInAllSets;
+                    if (!isInParameterSet)
                     {
-                        ProcessParameter(commandName, commandAst, context, result, param, boundArguments);
-                        break;
+                        continue;
+                    }
+
+                    var parameterSetDataCollection = param.Parameter.GetMatchingParameterSetData(validParameterSetFlags);
+                    foreach (ParameterSetSpecificMetadata parameterSetData in parameterSetDataCollection)
+                    {
+                        // in the second pass, we check the remaining argument ones
+                        if (parameterSetData.ValueFromRemainingArguments)
+                        {
+                            ProcessParameter(commandName, commandAst, context, result, param, boundArguments);
+                            break;
+                        }
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1738,15 +1738,22 @@ namespace System.Management.Automation
             int position,
             Dictionary<string, AstParameterArgumentPair> boundArguments = null)
         {
-            bool isProcessedAsPositional = false;
             bool isDefaultParameterSetValid = defaultParameterSetFlag != 0 &&
                                               (defaultParameterSetFlag & validParameterSetFlags) != 0;
-            MergedCompiledCommandParameter positionalParam = null;
 
-            MergedCompiledCommandParameter bestMatchParam = null;
-            ParameterSetSpecificMetadata bestMatchSet = null;
+            // Find all the parameters with the position closest to the specified position. Different parameter
+            // sets can declare a parameter at the same position, so there can be more than one candidate.
+            // Only parameters from the still valid parameter sets are considered: 'GetMatchingParameterSetData'
+            // filters the parameter set data by 'validParameterSetFlags', and the default parameter set is
+            // given priority only when it's still valid.
+            // The candidate from the default parameter set is tried first, and when it doesn't produce any
+            // completion results, the candidates from the other parameter sets are tried in turn.
+            // For example, 'Get-Process | ForEach-Object <Tab>' should complete member names for '-MemberName'
+            // (PropertyAndMethodSet) because '-Process' (the default 'ScriptBlockSet') has nothing to offer.
+            int bestPosition = int.MaxValue;
+            MergedCompiledCommandParameter defaultSetParam = null;
+            List<MergedCompiledCommandParameter> alternativeParams = null;
 
-            // Finds the parameter with the position closest to the specified position
             foreach (MergedCompiledCommandParameter param in parameters)
             {
                 bool isInParameterSet = (param.Parameter.ParameterSetFlags & validParameterSetFlags) != 0 || param.Parameter.IsInAllSets;
@@ -1755,6 +1762,7 @@ namespace System.Management.Automation
                     continue;
                 }
 
+                bool addedToAltParamList = false;
                 var parameterSetDataCollection = param.Parameter.GetMatchingParameterSetData(validParameterSetFlags);
 
                 foreach (ParameterSetSpecificMetadata parameterSetData in parameterSetDataCollection)
@@ -1774,64 +1782,100 @@ namespace System.Management.Automation
                         continue;
                     }
 
-                    if (bestMatchSet is null
-                        || bestMatchSet.Position > positionInParameterSet
-                        || (isDefaultParameterSetValid && positionInParameterSet == bestMatchSet.Position && defaultParameterSetFlag == parameterSetData.ParameterSetFlag))
+                    if (positionInParameterSet > bestPosition)
                     {
-                        bestMatchParam = param;
-                        bestMatchSet = parameterSetData;
-                        if (positionInParameterSet == position)
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (bestMatchParam is not null)
-            {
-                if (isDefaultParameterSetValid)
-                {
-                    if (bestMatchSet.ParameterSetFlag == defaultParameterSetFlag)
-                    {
-                        ProcessParameter(commandName, commandAst, context, result, bestMatchParam, boundArguments);
-                        isProcessedAsPositional = result.Count > 0;
-                    }
-                    else
-                    {
-                        positionalParam ??= bestMatchParam;
-                    }
-                }
-                else
-                {
-                    isProcessedAsPositional = true;
-                    ProcessParameter(commandName, commandAst, context, result, bestMatchParam, boundArguments);
-                }
-            }
-
-            if (!isProcessedAsPositional && positionalParam != null)
-            {
-                isProcessedAsPositional = true;
-                ProcessParameter(commandName, commandAst, context, result, positionalParam, boundArguments);
-            }
-
-            if (!isProcessedAsPositional)
-            {
-                foreach (MergedCompiledCommandParameter param in parameters)
-                {
-                    bool isInParameterSet = (param.Parameter.ParameterSetFlags & validParameterSetFlags) != 0 || param.Parameter.IsInAllSets;
-                    if (!isInParameterSet)
+                        // A parameter closer to the specified position was already found.
                         continue;
+                    }
 
-                    var parameterSetDataCollection = param.Parameter.GetMatchingParameterSetData(validParameterSetFlags);
-                    foreach (ParameterSetSpecificMetadata parameterSetData in parameterSetDataCollection)
+                    if (positionInParameterSet < bestPosition)
                     {
-                        // in the second pass, we check the remaining argument ones
-                        if (parameterSetData.ValueFromRemainingArguments)
+                        // This parameter is closer to the specified position, so the candidates found so far are no longer relevant.
+                        bestPosition = positionInParameterSet;
+                        defaultSetParam = null;
+                        alternativeParams?.Clear();
+                        addedToAltParamList = false;
+                    }
+
+                    // Prioritize the parameter from the default set. A parameter in all sets is considered from the default set if the
+                    // default set is still valid. But, we prioritize it only if we have not found a default param yet.
+                    // If 'defaultSetParam' is not null, then that means there are 2 parameters in the default set with the same position.
+                    // That would be invalid parameter declaration, but we tolerate that in tab completion.
+                    if (isDefaultParameterSetValid
+                        && (parameterSetData.IsInAllSets || parameterSetData.ParameterSetFlag == defaultParameterSetFlag)
+                        && defaultSetParam is null)
+                    {
+                        defaultSetParam = param;
+
+                        if (addedToAltParamList)
                         {
-                            ProcessParameter(commandName, commandAst, context, result, param, boundArguments);
+                            // If we already added the param to the list when processing a previous set, remove it from the list.
+                            alternativeParams.RemoveAt(alternativeParams.Count - 1);
+                        }
+
+                        if (bestPosition == position)
+                        {
+                            // If it's the exact position, no need to go through the rest of the sets for this parameter.
                             break;
                         }
+
+                        // We still need to go through the rest of the sets in case that the position in any of them is closer.
+                        // But for the same position from a different set, no need to add the param to the list anymore.
+                        addedToAltParamList = true;
+                    }
+                    else if (!addedToAltParamList)
+                    {
+                        addedToAltParamList = true;
+                        (alternativeParams ??= new()).Add(param);
+                    }
+                }
+            }
+
+            if (defaultSetParam is not null)
+            {
+                ProcessParameter(commandName, commandAst, context, result, defaultSetParam, boundArguments);
+                if (result.Count > 0)
+                {
+                    return;
+                }
+            }
+
+            if (alternativeParams?.Count > 0)
+            {
+                // There are alternative parameters at the same best position.
+                // Process them in the discovery order.
+                foreach (MergedCompiledCommandParameter param in alternativeParams)
+                {
+                    ProcessParameter(commandName, commandAst, context, result, param, boundArguments);
+                    if (result.Count > 0)
+                    {
+                        // Stop at the first one that we successfully get completion results.
+                        break;
+                    }
+                }
+
+                // We will return here no matter we get completion results or not, because we did find
+                // applicable positional parameters, and we have done processing them.
+                return;
+            }
+
+            // If we found no applicable positional parameter, then try the remaining argument parameters.
+            foreach (MergedCompiledCommandParameter param in parameters)
+            {
+                bool isInParameterSet = (param.Parameter.ParameterSetFlags & validParameterSetFlags) != 0 || param.Parameter.IsInAllSets;
+                if (!isInParameterSet)
+                {
+                    continue;
+                }
+
+                var parameterSetDataCollection = param.Parameter.GetMatchingParameterSetData(validParameterSetFlags);
+                foreach (ParameterSetSpecificMetadata parameterSetData in parameterSetDataCollection)
+                {
+                    // in the second pass, we check the remaining argument ones
+                    if (parameterSetData.ValueFromRemainingArguments)
+                    {
+                        ProcessParameter(commandName, commandAst, context, result, param, boundArguments);
+                        break;
                     }
                 }
             }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -51,7 +51,7 @@ Describe "TabCompletion" -Tags CI {
                 New-ModuleManifest -Path "$($NewDir.FullName)\$ModuleName.psd1" -RootModule "$ModuleName.psm1" -FunctionsToExport "MyTestFunction" -ModuleVersion $NewDir.Name
             }
 
-            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir            
+            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir
             $Res = TabExpansion2 -inputScript MyTestFunction
             $Res.CompletionMatches.Count | Should -Be 2
             $SortedMatches = $Res.CompletionMatches.CompletionText | Sort-Object
@@ -82,7 +82,7 @@ Describe "TabCompletion" -Tags CI {
                 New-ModuleManifest -Path "$($NewDir.FullName)\$ModuleName.psd1" -RootModule "$ModuleName.psm1" -FunctionsToExport "MyTestFunction" -ModuleVersion $NewDir.Name
             }
 
-            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir            
+            $env:PSModulePath += [System.IO.Path]::PathSeparator + $tempDir
             $Res = TabExpansion2 -inputScript 'Import-Module -Name TestModule'
             $Res.CompletionMatches.Count | Should -Be 1
             $Res.CompletionMatches[0].CompletionText | Should -Be TestModule1
@@ -165,21 +165,21 @@ Describe "TabCompletion" -Tags CI {
         $res = TabExpansion2 -inputScript 'param($PS = $P'
         $res.CompletionMatches.Count | Should -BeGreaterThan 0
     }
-    
+
     It 'Should complete variable with description and value <Value>' -TestCases @(
         @{ Value = 1; Expected = '[int]$VariableWithDescription - Variable description' }
         @{ Value = 'string'; Expected = '[string]$VariableWithDescription - Variable description' }
         @{ Value = $null; Expected = 'VariableWithDescription - Variable description' }
     ) {
         param ($Value, $Expected)
-        
+
         New-Variable -Name VariableWithDescription -Value $Value -Description 'Variable description' -Force
         $res = TabExpansion2 -inputScript '$VariableWithDescription'
         $res.CompletionMatches.Count | Should -Be 1
         $res.CompletionMatches[0].CompletionText | Should -BeExactly '$VariableWithDescription'
         $res.CompletionMatches[0].ToolTip | Should -BeExactly $Expected
     }
-    
+
     It 'Should complete environment variable' {
         try {
             $env:PWSH_TEST_1 = 'value 1'
@@ -226,7 +226,7 @@ Describe "TabCompletion" -Tags CI {
         @{ Value = $null; Expected = 'VariableWithDescription - Variable description' }
     ) {
         param ($Value, $Expected)
-        
+
         New-Variable -Name VariableWithDescription -Value $Value -Description 'Variable description' -Force
         $res = TabExpansion2 -inputScript '$local:VariableWithDescription'
         $res.CompletionMatches.Count | Should -Be 1
@@ -1191,7 +1191,7 @@ param([ValidatePattern(
                 [Parameter(ParameterSetName = 'SetWithoutHelp')]
                 [string]
                 $ParamWithHelp,
-                
+
                 [Parameter(ParameterSetName = 'SetWithHelp')]
                 [switch]
                 $ParamWithoutHelp
@@ -1733,7 +1733,7 @@ param([ValidatePattern(
 
             $commaSeparators = "',' ', '"
             $semiColonSeparators = "';' '; '"
-            
+
             $squareBracketFormatString = "'[{0}]'"
             $curlyBraceFormatString = "'{0:N2}'"
         }
@@ -2097,6 +2097,90 @@ Verb-Noun -Param1 Hello ^
         $res.CompletionMatches[0].CompletionText | Should -Be "Attributes"
     }
 
+    it 'Should fall back to a positional parameter in another parameterset when the default parameterset has no completions' {
+        $ScriptInput = 'Get-Process | ForEach-Object '
+        $res = TabExpansion2 -inputScript $ScriptInput -cursorColumn $ScriptInput.Length
+        # '-Process' is positional in the default 'ScriptBlockSet' but has no completions to offer,
+        # so the completion should fall back to '-MemberName' in the 'PropertyAndMethodSet'.
+        $res.CompletionMatches.CompletionText | Should -Contain "ProcessName"
+        # Make sure we didn't fall through to file name completion.
+        $res.CompletionMatches.ResultType | Should -Not -Contain ([System.Management.Automation.CompletionResultType]::ProviderItem)
+    }
+
+    it 'Should keep trying the positional parameters from other parameter sets until completions are found' {
+        $TestString = @'
+function Verb-Noun
+{
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlockSet')]
+    Param
+    (
+        [Parameter(ParameterSetName = 'ScriptBlockSet', Position = 0)]
+        [scriptblock]
+        $ScriptBlockParam,
+        [Parameter(ParameterSetName = 'StringSet', Position = 0)]
+        [string]
+        $StringParam,
+        [Parameter(ParameterSetName = 'ValidateSetSet', Position = 0)]
+        [ValidateSet('Alpha', 'Beta')]
+        [string]
+        $ValidateSetParam
+    )
+}
+Verb-Noun ^
+'@
+        $CursorIndex = $TestString.IndexOf('^')
+        $res = TabExpansion2 -inputScript $TestString.Remove($CursorIndex, 1) -cursorColumn $CursorIndex
+        # Neither the default set nor the 'StringSet' parameter has completions to offer,
+        # so we should keep going until the 'ValidateSetSet' parameter is reached.
+        $res.CompletionMatches.CompletionText -join ',' | Should -BeExactly 'Alpha,Beta'
+    }
+
+    it 'Should complete a positional parameter declared at different positions in different parameter sets' {
+        $TestString = @'
+function Verb-Noun
+{
+    [CmdletBinding(DefaultParameterSetName = 'SetB')]
+    Param
+    (
+        [Parameter(ParameterSetName = 'SetB', Position = 0)]
+        [Parameter(ParameterSetName = 'SetA', Position = 1)]
+        [ValidateSet('Alpha', 'Beta')]
+        [string]
+        $Param1
+    )
+}
+Verb-Noun ^
+'@
+        $CursorIndex = $TestString.IndexOf('^')
+        $res = TabExpansion2 -inputScript $TestString.Remove($CursorIndex, 1) -cursorColumn $CursorIndex
+        # The parameter set data is enumerated in the reverse order of the declaration, so 'SetA' with the
+        # position 1 is seen first, and then 'SetB' with the closer position 0. The parameter must still be
+        # a candidate after the closer position is found.
+        $res.CompletionMatches.CompletionText -join ',' | Should -BeExactly 'Alpha,Beta'
+    }
+
+    it 'Should complete a positional parameter declared at different positions when there is no default parameterset' {
+        $TestString = @'
+function Verb-Noun
+{
+    Param
+    (
+        [Parameter(ParameterSetName = 'SetB', Position = 0)]
+        [Parameter(ParameterSetName = 'SetA', Position = 1)]
+        [ValidateSet('Alpha', 'Beta')]
+        [string]
+        $Param1
+    )
+}
+Verb-Noun ^
+'@
+        $CursorIndex = $TestString.IndexOf('^')
+        $res = TabExpansion2 -inputScript $TestString.Remove($CursorIndex, 1) -cursorColumn $CursorIndex
+        # Same as above, but without a default parameter set the parameter is tracked as an alternative
+        # candidate instead, and it must survive finding the closer position.
+        $res.CompletionMatches.CompletionText -join ',' | Should -BeExactly 'Alpha,Beta'
+    }
+
     it 'Should complete base class members of types without type definition AST' {
         $res = TabExpansion2 -inputScript @'
 class InheritedClassTest : System.Attribute
@@ -2408,7 +2492,7 @@ param ($Param1)
             $null = New-Item -Path $TestFile
             $res = TabExpansion2 -ast $scriptAst -tokens $tokens -positionOfCursor $cursorPosition
             Pop-Location
-                        
+
             $ExpectedPath = Join-Path -Path '.\' -ChildPath $ExpectedFileName
             $res.CompletionMatches.CompletionText | Where-Object {$_ -Like "*$ExpectedFileName"} | Should -Be $ExpectedPath
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

The PR #17796 and #18755 introduced a regression in tab completion -- `dir | % <tab>` completes with member names of `FileInfo` object before that change (v7.2 v7.3 behavior), but after that PR, it completes with file names within the current directory (v7.4 + behavior).

This is because the original code that handled positional parameter completion was able to preserve an alternative non-default-set positional parameter, which it would fall back when the default-set positional parameter had no completion result. For `ForEach <tab>`, the default-set positional parameter applicable for the position is `-Process [ScriptBlock]`, which has no completion result, so it falls back to the non-default-set parameter `-MemberName [string]`.

However, the PR #17796 + #18755 removed the alternative positional parameter preservation, so for `ForEach <tab>`, it will complete for `-Process [ScriptBlock]` only. That caused the regression.

### Improvements to positional parameter completion

The implementation before #17796 + #18755 is also inconsistent:
1. Only 1 non-default-set parameter is preserved. That means if there are more than 1 non-default parameter sets and all contain positional parameter with the same position, only one parameter of them will be considered in completion, depending on the discovery order, and the rest will be ignored.
2. If we only find a non-default set parameter, then we will not fall back to the remaining-argument parameters no matter that parameter has completion results or not; but if we only find a default-set parameter, we will fall back to the remaining-argument parameters if there is no completion result.

This pull request improves the logic for positional parameter completion in PowerShell. It fixed the regression and those inconsistencies. It keeps the improvement by #17796 + #18755 -- find the positional parameter with the closest position instead of the exact position. In addition, it prioritizes the default-set positional parameter and preserve non-default-set parameters with the same best position.

It refactored the logic in `CompletePositionalArgument` (in `CompletionCompleters.cs`) to:
  * Find all parameters at the closest position across valid parameter sets, prioritizing the default set when available, but falling back to alternatives if needed.
  * Continue through alternative parameters for completions if the default-set parameter yields no results. Process all candidates at the best position until a completion is found.
  * Only fall back to remaining-argument parameters when no applicable positional parameter is found.

### Enhanced test coverage

Added new tests in `TabCompletion.Tests.ps1` to verify:
  * Fallback to positional parameters from alternative parameter sets when the default set has no completions.
  * Iterative attempts across parameter sets until completions are found.
  * Correct completion behavior for parameters declared at different positions in different parameter sets, with and without a default parameter set.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
