### PR TITLE
Handle ESRP signing summaries

### DIFF
--- a/.pipelines/1ES/templates/obp-file-signing.yml
+++ b/.pipelines/1ES/templates/obp-file-signing.yml
@@ -278,7 +278,14 @@ steps:
     $signatures = $dlls | Get-AuthenticodeSignature
     $officialIssuerPattern = '^CN=(Microsoft Code Signing PCA|Microsoft Root Certificate Authority|Microsoft Corporation).*'
     $testCert = '^CN=(Microsoft|TestAzureEngBuildCodeSign).*'
-    $missingSignatures = $signatures | Where-Object { $_.status -eq 'notsigned' -or $_.SignerCertificate.Issuer -notmatch $testCert -or $_.SignerCertificate.Issuer -notmatch $officialIssuerPattern} | select-object -ExpandProperty Path
+    $missingSignatures = $signatures | Where-Object {
+      $_.Status -eq 'NotSigned' -or
+      $null -eq $_.SignerCertificate -or
+      (
+        $_.SignerCertificate.Issuer -notmatch $testCert -and
+        $_.SignerCertificate.Issuer -notmatch $officialIssuerPattern
+      )
+    } | Select-Object -ExpandProperty Path
 
     Write-Verbose -verbose "to be signed:`r`n $($missingSignatures | Out-String)"
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -929,6 +929,11 @@ function Update-PSSignedBuildFolder
 
     $signedFilesList = Get-ChildItem -Path $signedFilesFilter -Recurse -File
     foreach ($signedFileObject in $signedFilesList) {
+        if ($signedFileObject.Name -like 'CodeSignSummary-*.md') {
+            Write-Verbose -Verbose "Skipping ESRP signing summary $signedFileObject"
+            continue
+        }
+
         # completely skip replacing pwsh on non-windows systems (there is no .exe extension here)
         # and it may not be signed correctly
 


### PR DESCRIPTION
## Summary
- ignore ESRP-generated CodeSignSummary Markdown files while restoring signed binaries
- classify a file as third-party only when it matches neither accepted Microsoft issuer family
- fail clearly when a signed file has no signer certificate

This unblocks the third-party signing handoff after the first ESRP signing task succeeds.