### PR TITLE
Strip auth on rel links only when they leave the origin

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -554,7 +554,12 @@ namespace Microsoft.PowerShell.Commands
                 HttpClient client = GetHttpClient(handleRedirect);
 
                 int followedRelLink = 0;
-                Uri uri = Uri;
+
+                // A rel link is a URL the same server advertised in its own 'Link' header, not a redirect,
+                // so the credentials the caller supplied still apply. Treat a followed link as a credential
+                // boundary only when it leaves the origin the caller requested.
+                Uri uri = CheckProtocol(Uri);
+                string originAuthority = uri.GetLeftPart(UriPartial.Authority);
                 do
                 {
                     if (followedRelLink > 0)
@@ -567,7 +572,10 @@ namespace Microsoft.PowerShell.Commands
                         WriteVerbose(linkVerboseMsg);
                     }
 
-                    using (HttpRequestMessage request = GetRequest(uri, isRedirect: followedRelLink > 0))
+                    bool relLinkLeavesOrigin = followedRelLink > 0
+                                               && !string.Equals(originAuthority, uri.GetLeftPart(UriPartial.Authority), StringComparison.OrdinalIgnoreCase);
+
+                    using (HttpRequestMessage request = GetRequest(uri, isRedirect: relLinkLeavesOrigin))
                     {
                         FillRequestStream(request);
                         try

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -3029,7 +3029,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         1..$maxLinksToFollow | ForEach-Object { $result.Output[$_ - 1].linknumber | Should -BeExactly $_ }
     }
 
-    It "Validate Invoke-RestMethod -FollowRelLink strips the authorization header on followed relation links by default" {
+    It "Validate Invoke-RestMethod -FollowRelLink keeps the authorization header on relation links within the origin" {
         $uri = Get-WebListenerUrl -Test 'Link' -Query @{maxlinks = 3}
         $command = "Invoke-RestMethod -Uri '$uri' -FollowRelLink -Headers @{Authorization = 'test'}"
         $result = ExecuteWebCommand -command $command
@@ -3037,8 +3037,32 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.Error | Should -BeNullOrEmpty
         $result.Output.Count | Should -BeExactly 3
         $result.Output[0].headers.Authorization | Should -BeExactly 'test'
+        $result.Output[1].headers.Authorization | Should -BeExactly 'test'
+        $result.Output[2].headers.Authorization | Should -BeExactly 'test'
+    }
+
+    It "Validate Invoke-RestMethod -FollowRelLink strips the authorization header on a relation link that leaves the origin" {
+        $crossOrigin = Get-WebListenerUrl -Https
+        $uri = Get-WebListenerUrl -Test 'Link' -Query @{maxlinks = 2; nextauthority = $crossOrigin.GetLeftPart([System.UriPartial]::Authority)}
+        $command = "Invoke-RestMethod -Uri '$uri' -FollowRelLink -SkipCertificateCheck -Headers @{Authorization = 'test'}"
+        $result = ExecuteWebCommand -command $command
+
+        $result.Error | Should -BeNullOrEmpty
+        $result.Output.Count | Should -BeExactly 2
+        $result.Output[0].headers.Authorization | Should -BeExactly 'test'
         $result.Output[1].headers.Authorization | Should -BeNullOrEmpty
-        $result.Output[2].headers.Authorization | Should -BeNullOrEmpty
+    }
+
+    It "Validate Invoke-RestMethod -FollowRelLink -PreserveAuthorizationOnRedirect keeps the authorization header across origins" {
+        $crossOrigin = Get-WebListenerUrl -Https
+        $uri = Get-WebListenerUrl -Test 'Link' -Query @{maxlinks = 2; nextauthority = $crossOrigin.GetLeftPart([System.UriPartial]::Authority)}
+        $command = "Invoke-RestMethod -Uri '$uri' -FollowRelLink -PreserveAuthorizationOnRedirect -SkipCertificateCheck -Headers @{Authorization = 'test'}"
+        $result = ExecuteWebCommand -command $command
+
+        $result.Error | Should -BeNullOrEmpty
+        $result.Output.Count | Should -BeExactly 2
+        $result.Output[0].headers.Authorization | Should -BeExactly 'test'
+        $result.Output[1].headers.Authorization | Should -BeExactly 'test'
     }
 
     It "Validate Invoke-RestMethod quietly ignores invalid Link Headers if -FollowRelLink is specified: <type>" -TestCases @(

--- a/test/tools/WebListener/Controllers/LinkController.cs
+++ b/test/tools/WebListener/Controllers/LinkController.cs
@@ -78,7 +78,16 @@ namespace mvc.Controllers
 
             if (!skipNextLink && maxLinks > 1 && linkNumber < maxLinks)
             {
-                linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: linkNumber + 1, type: type, whitespace: whitespace, rel: "next"));
+                // 'nextauthority' advertises the next link on another scheme/host/port, which lets tests
+                // cover a rel link that crosses an origin. Pass it the authority of another listener port.
+                string nextBaseUri = baseUri;
+                if (Request.Query.TryGetValue("nextauthority", out StringValues nextAuthoritySV)
+                    && Uri.TryCreate(nextAuthoritySV.FirstOrDefault(), UriKind.Absolute, out Uri nextAuthority))
+                {
+                    nextBaseUri = new Uri(nextAuthority, new Uri(baseUri).AbsolutePath).AbsoluteUri;
+                }
+
+                linkList.Add(GetLink(baseUri: nextBaseUri, maxLinks: maxLinks, linkNumber: linkNumber + 1, type: type, whitespace: whitespace, rel: "next"));
             }
 
             StringValues linkHeader;


### PR DESCRIPTION
# PR Summary

Fixes #27861.

`-FollowRelLink` exists so web cmdlets can page an API that advertises its next page in a `Link` header — GitHub's and GitLab's paginated endpoints are the canonical case, and those APIs need the caller's `Authorization` header on every page. Since e209aea1d ("Strip authorization on redirect if `-PreserveAuthorizationOnRedirect` is not specified") the rel-link loop passes `isRedirect: followedRelLink > 0`, so `GetRequest` drops that header on every page after the first.

The result is silent truncation rather than an error: against a server that permits anonymous reads, the un-authenticated follows still return HTTP 200, just with a visibility-filtered result set. The reporter's GitLab group of 43 projects came back as 39 at every page size, through `Get-GitlabProject -Recurse -All`, with no warning and no non-zero status.

## PR Context

A rel link is not a redirect. It is a client-initiated GET to a URL the *same server* advertised in its own `Link` header, and in practice it is same-origin. The conventional rule for credential stripping is to drop at an origin boundary, not on every hop — applied on every hop it removes credentials the caller supplied deliberately for the API being paged, which leaves `-FollowRelLink` unable to serve the case it was added for.

This compares the followed link's scheme, host and port against the origin the caller requested, and strips only when they differ. Genuine 3xx redirects are untouched, and `-PreserveAuthorizationOnRedirect` still overrides both.

**`release/v7.5.11` carries the identical call site and needs the same change.** The bug shipped in **v7.5.10 and v7.6.5** — the sibling commit is 0c59ffd11 (`Merged PR 41045: [release/v7.5.10] …`). It is absent from `master`, which has no `isRedirect` parameter at all, so there is nothing to fix there and no `master` PR to open; the origin check should ride along whenever this change ports forward.

### Review guide

**Start here — the fix.** [`WebRequestPSCmdlet.Common.cs` L558-562](https://github.com/PowerShell/PowerShell/pull/27862/changes#diff-9e8673bc737d91c9712fa4e7e5fef6aac6690999bcbd0777759563afd015c50dR558) captures the requested origin once; [L575-578](https://github.com/PowerShell/PowerShell/pull/27862/changes#diff-9e8673bc737d91c9712fa4e7e5fef6aac6690999bcbd0777759563afd015c50dR575) is the per-iteration comparison feeding `isRedirect`.

`CheckProtocol` is what makes the comparison safe for a scheme-less `-Uri` (the *"URI without scheme"* case in the existing rel-link tests) — it is the same normalization `GetRequest` applies via `PrepareUri`, so passing the normalized URI on is a no-op for the request itself. Every rel link is already absolute, coming from `new Uri(_relationLink["next"])`.

**The contract change.** [`WebCmdlets.Tests.ps1` L3032](https://github.com/PowerShell/PowerShell/pull/27862/changes#diff-1b256250c40f42b7c01f2695c0c908112a4eead87e3ef3ff534768ad930e7ca1R3032) is e209aea1d's own `-FollowRelLink` assertion, inverted: WebListener is same-origin, so what it pinned was the case this PR argues is wrong. Two cases replace it at [L3040](https://github.com/PowerShell/PowerShell/pull/27862/changes#diff-1b256250c40f42b7c01f2695c0c908112a4eead87e3ef3ff534768ad930e7ca1R3040) and [L3054](https://github.com/PowerShell/PowerShell/pull/27862/changes#diff-1b256250c40f42b7c01f2695c0c908112a4eead87e3ef3ff534768ad930e7ca1R3054) — a cross-origin link still strips, and `-PreserveAuthorizationOnRedirect` still overrides across origins.

The other four tests e209aea1d touched (the `-PreserveHttpMethodOnRedirect` pairs for both cmdlets) are untouched and pass.

**Test-tool support.** [`LinkController.cs` L81-90](https://github.com/PowerShell/PowerShell/pull/27862/changes#diff-3d1d387df13351a7f117cfd212209f0cf6e280abefeecb961a1f7ae7e2c5dacaR81) adds a `nextauthority` query param so a `rel="next"` can point at another listener port. WebListener generated every link from the request's own display URL, so nothing in this suite could reach a second origin — the redirect tests included, which is why *"strips on redirect"* was only ever proven same-origin.

## Testing

`WebCmdlets.Tests.ps1` on macOS arm64, verified red then green:

| Build | Result |
| --- | --- |
| Fix reverted, tests present | 612 passed, **1 failed** — `…keeps the authorization header on relation links within the origin`, page 2 arriving with no `Authorization` |
| Fix applied | 613 passed, 0 failed, 17 skipped, 36 pending |

The repro from #27861 (a standalone `HttpListener` serving three linked pages, no external service) prints `test` on all three pages against the fixed build, matching its 7.6.4 output.

<details>
<summary>Build note for anyone reproducing this locally</summary>

`dotnet restore` on this branch fails against the repo's single NuGet source — the PowerShell Azure DevOps feed returns `401 Unauthorized - No local versions of package 'microsoft.netcore.app.runtime.osx-arm64'` for `10.0.11`, which is public on nuget.org. Adding nuget.org with a `packageSourceMapping` for `Microsoft.NETCore.App.Runtime.*` and `Microsoft.AspNetCore.App.Runtime.*` gets a clean restore. Not part of this PR.

</details>

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests)
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
    - This restores the 7.6.4 behavior of `-FollowRelLink`; the strip it narrows shipped in v7.6.5.
- **User-facing changes**
  - [x] Not Applicable
- **Testing - New and feature**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
