### PR TITLE
Improve validation for data fragments for PSRP frame headers

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
@@ -500,17 +500,46 @@ namespace System.Management.Automation.Remoting
                     }
 
                     int totalLengthOfFragment = 0;
+                    int totalSizeToBeReceived = 0;
 
                     try
                     {
                         totalLengthOfFragment = checked(FragmentedRemoteObject.HeaderLength + blobLength);
                     }
-                    catch (System.OverflowException)
+                    catch (OverflowException)
                     {
                         s_baseTracer.WriteLine("Fragment too big.");
                         ResetReceiveData();
                         PSRemotingTransportException e = new PSRemotingTransportException(RemotingErrorIdStrings.ObjectIsTooBig);
                         throw e;
+                    }
+
+                    // Ensure object size limit is not reached
+                    if (_maxReceivedObjectSize.HasValue)
+                    {
+                        totalSizeToBeReceived = unchecked(_totalReceivedObjectSizeSoFar + totalLengthOfFragment);
+                        if (totalSizeToBeReceived < 0 || totalSizeToBeReceived > _maxReceivedObjectSize.Value)
+                        {
+                            s_baseTracer.WriteLine("ObjectSize > MaxReceivedObjectSize. ObjectSize is {0}. MaxReceivedObjectSize is {1}",
+                                totalSizeToBeReceived, _maxReceivedObjectSize);
+                            PSRemotingTransportException e = null;
+
+                            if (_isCreateByClientTM)
+                            {
+                                e = new PSRemotingTransportException(PSRemotingErrorId.ReceivedObjectSizeExceededMaximumClient,
+                                    RemotingErrorIdStrings.ReceivedObjectSizeExceededMaximumClient,
+                                      totalSizeToBeReceived, _maxReceivedObjectSize);
+                            }
+                            else
+                            {
+                                e = new PSRemotingTransportException(PSRemotingErrorId.ReceivedObjectSizeExceededMaximumServer,
+                                    RemotingErrorIdStrings.ReceivedObjectSizeExceededMaximumServer,
+                                      totalSizeToBeReceived, _maxReceivedObjectSize);
+                            }
+
+                            ResetReceiveData();
+                            throw e;
+                        }
                     }
 
                     if (_pendingDataStream.Length < totalLengthOfFragment)
@@ -520,32 +549,10 @@ namespace System.Management.Automation.Remoting
                         return;
                     }
 
-                    // ensure object size limit is not reached
+                    // Update the real object size we received so far only when we have received the complete fragment.
                     if (_maxReceivedObjectSize.HasValue)
                     {
-                        _totalReceivedObjectSizeSoFar = unchecked(_totalReceivedObjectSizeSoFar + totalLengthOfFragment);
-                        if ((_totalReceivedObjectSizeSoFar < 0) || (_totalReceivedObjectSizeSoFar > _maxReceivedObjectSize.Value))
-                        {
-                            s_baseTracer.WriteLine("ObjectSize > MaxReceivedObjectSize. ObjectSize is {0}. MaxReceivedObjectSize is {1}",
-                                _totalReceivedObjectSizeSoFar, _maxReceivedObjectSize);
-                            PSRemotingTransportException e = null;
-
-                            if (_isCreateByClientTM)
-                            {
-                                e = new PSRemotingTransportException(PSRemotingErrorId.ReceivedObjectSizeExceededMaximumClient,
-                                    RemotingErrorIdStrings.ReceivedObjectSizeExceededMaximumClient,
-                                      _totalReceivedObjectSizeSoFar, _maxReceivedObjectSize);
-                            }
-                            else
-                            {
-                                e = new PSRemotingTransportException(PSRemotingErrorId.ReceivedObjectSizeExceededMaximumServer,
-                                    RemotingErrorIdStrings.ReceivedObjectSizeExceededMaximumServer,
-                                      _totalReceivedObjectSizeSoFar, _maxReceivedObjectSize);
-                            }
-
-                            ResetReceiveData();
-                            throw e;
-                        }
+                        _totalReceivedObjectSizeSoFar = totalSizeToBeReceived;
                     }
 
                     // appears like stream doesn't have individual position marker for read and write


### PR DESCRIPTION
This pull request refines the logic for handling received data fragments in the `ProcessRawData` method of `PriorityCollection.cs`. The main improvements are to the enforcement of the maximum object size limit and the order of checks, ensuring more accurate and robust processing of incoming data. These changes make the data processing logic more robust, especially in scenarios where large or incomplete data fragments are received.

Key changes to object size limit enforcement and data processing:

* The check for exceeding the maximum allowed object size (`_maxReceivedObjectSize`) is now performed before confirming that the complete data fragment has been received, using a new temporary variable (`totalSizeToBeReceived`) to avoid prematurely updating the running total. The running total (`_totalReceivedObjectSizeSoFar`) is only updated after the entire fragment has been received.
* The check for whether enough data has been received to process the packet (`_pendingDataStream.Length < totalLengthOfFragment`) has been moved after the object size limit check, ensuring that size limits are enforced even if the fragment is incomplete.
* Exception handling has been slightly improved by catching `OverflowException` directly (instead of `System.OverflowException`).

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
