### PR TITLE
Restore ReadOnly after failed Set-Variable option updates

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -973,7 +973,6 @@ namespace Microsoft.PowerShell.Commands
                         if (ShouldProcess(target, action))
                         {
                             object result = null;
-                            ScopedItemOptions originalOptions = matchingVariable.Options;
                             bool wasReadOnly = false;
 
                             try
@@ -986,7 +985,7 @@ namespace Microsoft.PowerShell.Commands
                                 // we have to temporarily mark the variable writable.
 
                                 wasReadOnly = Force &&
-                                    (originalOptions & ScopedItemOptions.ReadOnly) != 0;
+                                    (matchingVariable.Options & ScopedItemOptions.ReadOnly) != 0;
                                 if (wasReadOnly)
                                 {
                                     matchingVariable.SetOptions(matchingVariable.Options & ~ScopedItemOptions.ReadOnly, true);
@@ -1039,7 +1038,7 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 if (wasReadOnly)
                                 {
-                                    matchingVariable.SetOptions(originalOptions, true);
+                                    matchingVariable.SetOptions(matchingVariable.Options | ScopedItemOptions.ReadOnly, true);
                                 }
 
                                 WriteError(
@@ -1052,7 +1051,7 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 if (wasReadOnly)
                                 {
-                                    matchingVariable.SetOptions(originalOptions, true);
+                                    matchingVariable.SetOptions(matchingVariable.Options | ScopedItemOptions.ReadOnly, true);
                                 }
 
                                 WriteError(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -983,53 +983,65 @@ namespace Microsoft.PowerShell.Commands
                                 // If we want to force setting over a readonly variable
                                 // we have to temporarily mark the variable writable.
 
-                                bool wasReadOnly = false;
-                                if (Force &&
-                                    (matchingVariable.Options & ScopedItemOptions.ReadOnly) != 0)
+                                bool wasReadOnly = Force &&
+                                    (matchingVariable.Options & ScopedItemOptions.ReadOnly) != 0;
+                                ScopedItemOptions originalOptions = matchingVariable.Options;
+                                if (wasReadOnly)
                                 {
                                     matchingVariable.SetOptions(matchingVariable.Options & ~ScopedItemOptions.ReadOnly, true);
-                                    wasReadOnly = true;
                                 }
 
-                                // Now change the value, options, or description
-                                // and set the variable
-
-                                if (varValue != AutomationNull.Value)
+                                try
                                 {
-                                    matchingVariable.Value = varValue;
+                                    // Now change the value, options, or description
+                                    // and set the variable.
 
-                                    if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
+                                    if (varValue != AutomationNull.Value)
                                     {
-                                        // In 'ConstrainedLanguage' we want to monitor untrusted values assigned to 'Global:' variables
-                                        // and 'Script:' variables, because they may be set from 'ConstrainedLanguage' environment and
-                                        // referenced within trusted script block, and thus result in security issues.
-                                        // Here we are setting the value of an existing variable and don't know what scope this variable
-                                        // is from, so we mark the value as untrusted, regardless of the scope.
-                                        ExecutionContext.MarkObjectAsUntrusted(matchingVariable.Value);
+                                        matchingVariable.Value = varValue;
+
+                                        if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
+                                        {
+                                            // In 'ConstrainedLanguage' we want to monitor untrusted values assigned to 'Global:' variables
+                                            // and 'Script:' variables, because they may be set from 'ConstrainedLanguage' environment and
+                                            // referenced within trusted script block, and thus result in security issues.
+                                            // Here we are setting the value of an existing variable and don't know what scope this variable
+                                            // is from, so we mark the value as untrusted, regardless of the scope.
+                                            ExecutionContext.MarkObjectAsUntrusted(matchingVariable.Value);
+                                        }
                                     }
-                                }
 
-                                if (Description != null)
-                                {
-                                    matchingVariable.Description = Description;
-                                }
+                                    if (Description != null)
+                                    {
+                                        matchingVariable.Description = Description;
+                                    }
 
-                                if (_options != null)
-                                {
-                                    matchingVariable.Options = (ScopedItemOptions)_options;
-                                }
-                                else
-                                {
-                                    if (wasReadOnly)
+                                    if (_options != null)
+                                    {
+                                        matchingVariable.Options = (ScopedItemOptions)_options;
+                                    }
+                                    else if (wasReadOnly)
                                     {
                                         matchingVariable.SetOptions(matchingVariable.Options | ScopedItemOptions.ReadOnly, true);
                                     }
                                 }
-
-                                // If visibility was specified, set it on the variable
-                                if (_visibility != null)
+                                catch (SessionStateException)
                                 {
-                                    matchingVariable.Visibility = Visibility;
+                                    if (wasReadOnly)
+                                    {
+                                        matchingVariable.SetOptions(originalOptions, true);
+                                    }
+
+                                    throw;
+                                }
+                                catch (PSArgumentException)
+                                {
+                                    if (wasReadOnly)
+                                    {
+                                        matchingVariable.SetOptions(originalOptions, true);
+                                    }
+
+                                    throw;
                                 }
 
                                 result = matchingVariable;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -983,71 +983,64 @@ namespace Microsoft.PowerShell.Commands
                                 // If we want to force setting over a readonly variable
                                 // we have to temporarily mark the variable writable.
 
-                                bool wasReadOnly = Force &&
-                                    (matchingVariable.Options & ScopedItemOptions.ReadOnly) != 0;
                                 ScopedItemOptions originalOptions = matchingVariable.Options;
+                                bool wasReadOnly = Force &&
+                                    (originalOptions & ScopedItemOptions.ReadOnly) != 0;
                                 if (wasReadOnly)
                                 {
                                     matchingVariable.SetOptions(matchingVariable.Options & ~ScopedItemOptions.ReadOnly, true);
                                 }
 
-                                try
+                                // Now change the value, options, or description
+                                // and set the variable
+
+                                if (varValue != AutomationNull.Value)
                                 {
-                                    // Now change the value, options, or description
-                                    // and set the variable.
+                                    matchingVariable.Value = varValue;
 
-                                    if (varValue != AutomationNull.Value)
+                                    if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
                                     {
-                                        matchingVariable.Value = varValue;
-
-                                        if (Context.LanguageMode == PSLanguageMode.ConstrainedLanguage)
-                                        {
-                                            // In 'ConstrainedLanguage' we want to monitor untrusted values assigned to 'Global:' variables
-                                            // and 'Script:' variables, because they may be set from 'ConstrainedLanguage' environment and
-                                            // referenced within trusted script block, and thus result in security issues.
-                                            // Here we are setting the value of an existing variable and don't know what scope this variable
-                                            // is from, so we mark the value as untrusted, regardless of the scope.
-                                            ExecutionContext.MarkObjectAsUntrusted(matchingVariable.Value);
-                                        }
+                                        // In 'ConstrainedLanguage' we want to monitor untrusted values assigned to 'Global:' variables
+                                        // and 'Script:' variables, because they may be set from 'ConstrainedLanguage' environment and
+                                        // referenced within trusted script block, and thus result in security issues.
+                                        // Here we are setting the value of an existing variable and don't know what scope this variable
+                                        // is from, so we mark the value as untrusted, regardless of the scope.
+                                        ExecutionContext.MarkObjectAsUntrusted(matchingVariable.Value);
                                     }
+                                }
 
-                                    if (Description != null)
-                                    {
-                                        matchingVariable.Description = Description;
-                                    }
+                                if (Description != null)
+                                {
+                                    matchingVariable.Description = Description;
+                                }
 
-                                    if (_options != null)
-                                    {
-                                        matchingVariable.Options = (ScopedItemOptions)_options;
-                                    }
-                                    else if (wasReadOnly)
+                                if (_options != null)
+                                {
+                                    matchingVariable.Options = (ScopedItemOptions)_options;
+                                }
+                                else
+                                {
+                                    if (wasReadOnly)
                                     {
                                         matchingVariable.SetOptions(matchingVariable.Options | ScopedItemOptions.ReadOnly, true);
                                     }
                                 }
-                                catch (SessionStateException)
-                                {
-                                    if (wasReadOnly)
-                                    {
-                                        matchingVariable.SetOptions(originalOptions, true);
-                                    }
 
-                                    throw;
-                                }
-                                catch (PSArgumentException)
+                                // If visibility was specified, set it on the variable
+                                if (_visibility != null)
                                 {
-                                    if (wasReadOnly)
-                                    {
-                                        matchingVariable.SetOptions(originalOptions, true);
-                                    }
-
-                                    throw;
+                                    matchingVariable.Visibility = Visibility;
                                 }
 
                                 result = matchingVariable;
                             }
                             catch (SessionStateException sessionStateException)
                             {
+                                if (wasReadOnly)
+                                {
+                                    matchingVariable.SetOptions(originalOptions, true);
+                                }
+
                                 WriteError(
                                     new ErrorRecord(
                                         sessionStateException.ErrorRecord,
@@ -1056,6 +1049,11 @@ namespace Microsoft.PowerShell.Commands
                             }
                             catch (PSArgumentException argException)
                             {
+                                if (wasReadOnly)
+                                {
+                                    matchingVariable.SetOptions(originalOptions, true);
+                                }
+
                                 WriteError(
                                     new ErrorRecord(
                                         argException.ErrorRecord,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -973,7 +973,8 @@ namespace Microsoft.PowerShell.Commands
                         if (ShouldProcess(target, action))
                         {
                             object result = null;
-                            bool wasReadOnly = false;
+                            bool wasReadOnly = Force &&
+                                (matchingVariable.Options & ScopedItemOptions.ReadOnly) != 0;
 
                             try
                             {
@@ -984,8 +985,6 @@ namespace Microsoft.PowerShell.Commands
                                 // If we want to force setting over a readonly variable
                                 // we have to temporarily mark the variable writable.
 
-                                wasReadOnly = Force &&
-                                    (matchingVariable.Options & ScopedItemOptions.ReadOnly) != 0;
                                 if (wasReadOnly)
                                 {
                                     matchingVariable.SetOptions(matchingVariable.Options & ~ScopedItemOptions.ReadOnly, true);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -973,6 +973,8 @@ namespace Microsoft.PowerShell.Commands
                         if (ShouldProcess(target, action))
                         {
                             object result = null;
+                            ScopedItemOptions originalOptions = matchingVariable.Options;
+                            bool wasReadOnly = false;
 
                             try
                             {
@@ -983,8 +985,7 @@ namespace Microsoft.PowerShell.Commands
                                 // If we want to force setting over a readonly variable
                                 // we have to temporarily mark the variable writable.
 
-                                ScopedItemOptions originalOptions = matchingVariable.Options;
-                                bool wasReadOnly = Force &&
+                                wasReadOnly = Force &&
                                     (originalOptions & ScopedItemOptions.ReadOnly) != 0;
                                 if (wasReadOnly)
                                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -125,20 +125,38 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		{ Set-Variable abcaVar -Option None -Scope 1 -ErrorAction Stop } | Should -Throw -ErrorId "VariableNotWritable,Microsoft.PowerShell.Commands.SetVariableCommand"
 	}
 
-	It "Set-Variable of ReadOnly variable with force preserves original state when option update fails"{
+	It "Set-Variable of ReadOnly variable with force preserves expected options when option update fails for <ExpectedOptions>" -TestCases @(
+		@{
+			Name = "SetVariableIssue27679Case3ReadOnly"
+			Options = [System.Management.Automation.ScopedItemOptions]::ReadOnly
+			ExpectedOptions = "ReadOnly"
+		}
+		@{
+			Name = "SetVariableIssue27679Case3ReadOnlyPrivate"
+			Options = [System.Management.Automation.ScopedItemOptions]::ReadOnly -bor [System.Management.Automation.ScopedItemOptions]::Private
+			ExpectedOptions = "ReadOnly, Private"
+		}
+		@{
+			Name = "SetVariableIssue27679Case3ReadOnlyAllScope"
+			Options = [System.Management.Automation.ScopedItemOptions]::ReadOnly -bor [System.Management.Automation.ScopedItemOptions]::AllScope
+			ExpectedOptions = "ReadOnly, AllScope"
+		}
+	) {
+		param($Name, $Options, $ExpectedOptions)
+
 		try
 		{
-			Set-Variable -Name x -Value 1 -Option ReadOnly
+			Set-Variable -Name $Name -Value 1 -Option $Options
 
-			{ Set-Variable -Name x -Force -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+			{ Set-Variable -Name $Name -Force -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
 
-			$var1 = Get-Variable -Name x
+			$var1 = Get-Variable -Name $Name
 			$var1.Value | Should -Be 1
-			$var1.Options | Should -BeExactly "ReadOnly"
+			$var1.Options.ToString() | Should -BeExactly $ExpectedOptions
 		}
 		finally
 		{
-			Remove-Variable -Name x -Force -ErrorAction SilentlyContinue
+			Remove-Variable -Name $Name -Force -ErrorAction SilentlyContinue
 		}
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -125,6 +125,45 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		{ Set-Variable abcaVar -Option None -Scope 1 -ErrorAction Stop } | Should -Throw -ErrorId "VariableNotWritable,Microsoft.PowerShell.Commands.SetVariableCommand"
 	}
 
+	# Issue #27679 cases 1 and 2 intentionally retain value mutation for backward compatibility.
+	It "Set-Variable preserves value mutation when setting Constant on an existing writable variable fails"{
+		$name = "SetVariableIssue27679Case1"
+
+		try
+		{
+			Set-Variable -Name $name -Value 1
+
+			{ Set-Variable -Name $name -Value 2 -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+
+			$var1 = Get-Variable -Name $name
+			$var1.Value | Should -Be 2
+			$var1.Options | Should -BeExactly "None"
+		}
+		finally
+		{
+			Remove-Variable -Name $name -Force -ErrorAction SilentlyContinue
+		}
+	}
+
+	It "Set-Variable preserves value mutation and restores ReadOnly when setting Constant fails with force"{
+		$name = "SetVariableIssue27679Case2"
+
+		try
+		{
+			Set-Variable -Name $name -Value 1 -Option ReadOnly
+
+			{ Set-Variable -Name $name -Value 2 -Force -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+
+			$var1 = Get-Variable -Name $name
+			$var1.Value | Should -Be 2
+			$var1.Options | Should -BeExactly "ReadOnly"
+		}
+		finally
+		{
+			Remove-Variable -Name $name -Force -ErrorAction SilentlyContinue
+		}
+	}
+
 	It "Set-Variable of ReadOnly variable with force preserves expected options when option update fails for <ExpectedOptions>" -TestCases @(
 		@{
 			Name = "SetVariableIssue27679Case3ReadOnly"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -125,6 +125,23 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		{ Set-Variable abcaVar -Option None -Scope 1 -ErrorAction Stop } | Should -Throw -ErrorId "VariableNotWritable,Microsoft.PowerShell.Commands.SetVariableCommand"
 	}
 
+	It "Set-Variable of ReadOnly variable with force preserves original state when option update fails"{
+		try
+		{
+			Set-Variable -Name x -Value 1 -Option ReadOnly
+
+			{ Set-Variable -Name x -Force -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+
+			$var1 = Get-Variable -Name x
+			$var1.Value | Should -Be 1
+			$var1.Options | Should -BeExactly "ReadOnly"
+		}
+		finally
+		{
+			Remove-Variable -Name x -Force -ErrorAction SilentlyContinue
+		}
+	}
+
 	It "Set-Variable of ReadOnly variable with private scope should work"{
 		Set-Variable foo bar -Description "new description" -Option ReadOnly -Scope "private"
 		$var1=Get-Variable -Name foo

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -148,7 +148,18 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		{
 			Set-Variable -Name $Name -Value 1 -Option $Options
 
-			{ Set-Variable -Name $Name -Force -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+			$exception = $null
+			try
+			{
+				Set-Variable -Name $Name -Force -Option Constant -ErrorAction Stop
+			}
+			catch
+			{
+				$exception = $_
+			}
+
+			$exception | Should -Not -BeNullOrEmpty
+			$exception.FullyQualifiedErrorId | Should -BeExactly "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
 
 			$var1 = Get-Variable -Name $Name
 			$var1.Value | Should -Be 1

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Variable.Tests.ps1
@@ -133,7 +133,18 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		{
 			Set-Variable -Name $name -Value 1
 
-			{ Set-Variable -Name $name -Value 2 -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+			$exception = $null
+			try
+			{
+				Set-Variable -Name $name -Value 2 -Option Constant -ErrorAction Stop
+			}
+			catch
+			{
+				$exception = $_
+			}
+
+			$exception | Should -Not -BeNullOrEmpty
+			$exception.FullyQualifiedErrorId | Should -BeExactly "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
 
 			$var1 = Get-Variable -Name $name
 			$var1.Value | Should -Be 2
@@ -152,7 +163,18 @@ Describe "Set-Variable DRT Unit Tests" -Tags "CI" {
 		{
 			Set-Variable -Name $name -Value 1 -Option ReadOnly
 
-			{ Set-Variable -Name $name -Value 2 -Force -Option Constant -ErrorAction Stop } | Should -Throw -ErrorId "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
+			$exception = $null
+			try
+			{
+				Set-Variable -Name $name -Value 2 -Force -Option Constant -ErrorAction Stop
+			}
+			catch
+			{
+				$exception = $_
+			}
+
+			$exception | Should -Not -BeNullOrEmpty
+			$exception.FullyQualifiedErrorId | Should -BeExactly "VariableCannotBeMadeConstant,Microsoft.PowerShell.Commands.SetVariableCommand"
 
 			$var1 = Get-Variable -Name $name
 			$var1.Value | Should -Be 2


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Restore the `ReadOnly` option when `Set-Variable -Force` temporarily removes it and a subsequent option update fails.

Add regression coverage for `ReadOnly`, `ReadOnly | Private`, and `ReadOnly | AllScope`, plus compatibility tests documenting the intentionally retained behavior for cases 1 and 2 of #27679.

## PR Context

When `Set-Variable -Force` operates on a ReadOnly variable, it temporarily removes `ReadOnly` before applying the requested changes. If applying `-Option Constant` fails with `VariableCannotBeMadeConstant`, the temporary removal was not reverted, leaving the variable writable.

This change restores `ReadOnly` in the existing handled exception paths while preserving other current option flags. It addresses case 3 of #27679, as agreed by the PowerShell cmdlets working group.

For backward compatibility, cases 1 and 2 continue to retain value and description changes made before the option update fails. Tests document this behavior explicitly.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [x] This PR is ready to merge
- **Breaking changes**
  - [x] None
  - **OR**
  - [ ] Experimental feature(s) needed
    - [ ] Experimental feature name(s):
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] Documentation needed
    - [ ] Issue filed:
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] Added regression and compatibility tests