### PR TITLE
Fix comments in `CmdletizationCoreResources.resx`

### DIFF
--- a/src/System.Management.Automation/resources/CmdletizationCoreResources.resx
+++ b/src/System.Management.Automation/resources/CmdletizationCoreResources.resx
@@ -123,10 +123,9 @@
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ScriptWriter_DuplicateQueryParameterName" xml:space="preserve">
-    <value>Two cmdlet parameters defined within the {0} element have the same name: {1}.  Resolve the conflict in the Cmdlet Definition XML and retry.</value>
-    <comment>{StrContains="CmdletParameterMetadata"} {StrContains="PSName"}
-{0} is a placeholder for a name of an XML element.  Example: &lt;GetCmdletParameters&gt;
-{1} is a placeholder for a cmdlet parameter name.  Example: Name</comment>
+    <value>Two cmdlet parameters defined within the {0} element have the same name: {1}. Resolve the conflict in the Cmdlet Definition XML and retry.</value>
+    <comment>{0} is a placeholder for a name of an XML element. Example: &lt;GetCmdletParameters&gt;
+{1} is a placeholder for a cmdlet parameter name. Example: Name</comment>
   </data>
   <data name="ExportCimCommand_ErrorInCmdletizationXmlFile" xml:space="preserve">
     <value>Cannot process Cmdlet Definition XML for the following file: {0}. {1}</value>
@@ -134,10 +133,9 @@
 {1} is an exception message copied from an XmlException or XmlSchemaException</comment>
   </data>
   <data name="ScriptWriter_DuplicateParameterSetInStaticCmdlet" xml:space="preserve">
-    <value>The {0} cmdlet defines the {1} parameter set more than once.  Verify that the Cmdlet Definition XML does not have duplicate parameter set names and retry.</value>
-    <comment>{StrContains="CmdletParameterSet"}
-{0} is a placeholder for a cmdlet name. Example: 'Get-Win32Process'
-{1} is a placeholder for a parameter set name.  Example: 'foo'</comment>
+    <value>The {0} cmdlet defines the {1} parameter set more than once. Verify that the Cmdlet Definition XML does not have duplicate parameter set names and retry.</value>
+    <comment>{0} is a placeholder for a cmdlet name. Example: 'Get-Win32Process'
+{1} is a placeholder for a parameter set name. Example: 'foo'</comment>
   </data>
   <data name="ScriptWriter_ObjectModelWrapperDefinesMultipleParameterSets" xml:space="preserve">
     <value>Cannot process the ObjectModelWrapper attribute. The {0} type defines multiple parameter sets. Verify that the Cmdlet Definition XML specifies a valid type in the ObjectModelWrapper attribute and retry.</value>
@@ -185,8 +183,8 @@
     <comment>{StrContains="EnumName"}</comment>
   </data>
   <data name="EnumWriter_InvalidValueName" xml:space="preserve">
-    <value>The value of the Name attribute is not a valid C# identifier: {0}.  Verify the Name attribute in the Cmdlet Definition XML, and then try again.</value>
-    <comment>{StrContains="Enum"} {StrContains="Value"} {StrContains="Name"}</comment>
+    <value>The value of the Name attribute is not a valid C# identifier: {0}. Verify the Name attribute in the Cmdlet Definition XML, and then try again.</value>
+    <comment>{StrContains="Name"}</comment>
   </data>
   <data name="ScriptWriter_InvalidEnum" xml:space="preserve">
     <value>Cannot process the &lt;Enum EnumName="{0}" ...&gt; element.  {1}</value>

--- a/src/System.Management.Automation/resources/CmdletizationCoreResources.resx
+++ b/src/System.Management.Automation/resources/CmdletizationCoreResources.resx
@@ -123,9 +123,9 @@
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ScriptWriter_DuplicateQueryParameterName" xml:space="preserve">
-    <value>Two cmdlet parameters defined within the {0} element have the same name: {1}. Resolve the conflict in the Cmdlet Definition XML and retry.</value>
-    <comment>{0} is a placeholder for a name of an XML element. Example: &lt;GetCmdletParameters&gt;
-{1} is a placeholder for a cmdlet parameter name. Example: Name</comment>
+    <value>Two cmdlet parameters defined within the {0} element have the same name: {1}.  Resolve the conflict in the Cmdlet Definition XML and retry.</value>
+    <comment>{0} is a placeholder for a name of an XML element.  Example: &lt;GetCmdletParameters&gt;
+{1} is a placeholder for a cmdlet parameter name.  Example: Name</comment>
   </data>
   <data name="ExportCimCommand_ErrorInCmdletizationXmlFile" xml:space="preserve">
     <value>Cannot process Cmdlet Definition XML for the following file: {0}. {1}</value>
@@ -133,9 +133,9 @@
 {1} is an exception message copied from an XmlException or XmlSchemaException</comment>
   </data>
   <data name="ScriptWriter_DuplicateParameterSetInStaticCmdlet" xml:space="preserve">
-    <value>The {0} cmdlet defines the {1} parameter set more than once. Verify that the Cmdlet Definition XML does not have duplicate parameter set names and retry.</value>
+    <value>The {0} cmdlet defines the {1} parameter set more than once.  Verify that the Cmdlet Definition XML does not have duplicate parameter set names and retry.</value>
     <comment>{0} is a placeholder for a cmdlet name. Example: 'Get-Win32Process'
-{1} is a placeholder for a parameter set name. Example: 'foo'</comment>
+{1} is a placeholder for a parameter set name.  Example: 'foo'</comment>
   </data>
   <data name="ScriptWriter_ObjectModelWrapperDefinesMultipleParameterSets" xml:space="preserve">
     <value>Cannot process the ObjectModelWrapper attribute. The {0} type defines multiple parameter sets. Verify that the Cmdlet Definition XML specifies a valid type in the ObjectModelWrapper attribute and retry.</value>
@@ -183,7 +183,7 @@
     <comment>{StrContains="EnumName"}</comment>
   </data>
   <data name="EnumWriter_InvalidValueName" xml:space="preserve">
-    <value>The value of the Name attribute is not a valid C# identifier: {0}. Verify the Name attribute in the Cmdlet Definition XML, and then try again.</value>
+    <value>The value of the Name attribute is not a valid C# identifier: {0}.  Verify the Name attribute in the Cmdlet Definition XML, and then try again.</value>
     <comment>{StrContains="Name"}</comment>
   </data>
   <data name="ScriptWriter_InvalidEnum" xml:space="preserve">


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The dev rules like `{StrContains="CmdletParameterMetadata"}` and `{StrContains="PSName"}` lock values that are missing in the resource string value. This PR fixes those dev rules.

