### PR TITLE
Mark DSC Profile tests pending on MSIX test runs

### DIFF
--- a/test/powershell/dsc/dsc.profileresource.Tests.ps1
+++ b/test/powershell/dsc/dsc.profileresource.Tests.ps1
@@ -82,7 +82,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
     It 'DSC resource is located at $PSHome' {
 
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -95,7 +95,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
     It 'DSC resource can be found' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -104,7 +104,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
     It 'DSC resource can set current user current host profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -115,7 +115,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
     It 'DSC resource can get current user current host profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -126,7 +126,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
     It 'DSC resource can set content as empty for current user current host profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -136,7 +136,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
     It 'DSC resource can set current user all hosts profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -147,7 +147,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
     It 'DSC resource can get current user all hosts profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -158,7 +158,7 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
     It 'DSC resource can export all profiles' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -252,7 +252,7 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
 
     It 'DSC resource can set all users all hosts profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -262,6 +262,11 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
     }
 
     It 'DSC resource can get all users all hosts profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
+            return
+        }
+
         $getOutput = (& $dscExe config get --file $PSScriptRoot/psprofile_alluser_allhost.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - AllUsersAllHosts!'"
         $getOutput.results.result.actualState.content | Should -BeExactly $expectedContent
@@ -269,7 +274,7 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
 
     It 'DSC resource can set all users current hosts profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 
@@ -280,7 +285,7 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
 
     It 'DSC resource can get all users current hosts profile' {
         if ($isMsix) {
-            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            Set-ItResult -Pending -Because "Running in MSIX context. Skipping test."
             return
         }
 

--- a/test/powershell/dsc/dsc.profileresource.Tests.ps1
+++ b/test/powershell/dsc/dsc.profileresource.Tests.ps1
@@ -3,6 +3,13 @@
 
 Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
     BeforeAll {
+
+        $isMsix = $pshome -like '*WindowsApps*'
+        if ($isMsix) {
+            Write-Verbose "Running in MSIX context. Marking tests as pending." -Verbose
+            return
+        }
+
         $DSC_ROOT = $env:DSC_ROOT
         $skipCleanup = $false
 
@@ -46,6 +53,10 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
             return
         }
 
+        if ($isMsix) {
+            return
+        }
+
         # Restore original profile
         $testProfilePathCurrentUserCurrentHost = $PROFILE.CurrentUserCurrentHost
         if (Test-Path "$TestDrive/currentuser-currenthost-profile.bak") {
@@ -69,6 +80,12 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
     }
 
     It 'DSC resource is located at $PSHome' {
+
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $resourceFile = Join-Path -Path $PSHome -ChildPath 'pwsh.profile.resource.ps1'
         $resourceFile | Should -Exist
 
@@ -77,39 +94,74 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
     }
 
     It 'DSC resource can be found' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         (& $dscExe resource list -o json | ConvertFrom-Json  | Select-Object -Property type).type | Should -Contain 'Microsoft.PowerShell/Profile'
     }
 
     It 'DSC resource can set current user current host profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $setOutput = (& $dscExe config set --file $PSScriptRoot/psprofile_currentuser_currenthost.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - CurrentUserCurrentHost!'"
         $setOutput.results.result.afterState.content | Should -BeExactly $expectedContent
     }
 
     It 'DSC resource can get current user current host profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $getOutput = (& $dscExe config get --file $PSScriptRoot/psprofile_currentuser_currenthost.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - CurrentUserCurrentHost!'"
         $getOutput.results.result.actualState.content | Should -BeExactly $expectedContent
     }
 
-    It 'DSC resource can set content as empty for current user current host profile' -Pending {
+    It 'DSC resource can set content as empty for current user current host profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $setOutput = (& $dscExe config set --file $PSScriptRoot/psprofile_currentuser_currenthost_emptycontent.dsc.yaml -o json) | ConvertFrom-Json
         $setOutput.results.result.afterState.content | Should -BeExactly ''
     }
 
     It 'DSC resource can set current user all hosts profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $setOutput = (& $dscExe config set --file $PSScriptRoot/psprofile_currentuser_allhosts.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - CurrentUserAllHosts!'"
         $setOutput.results.result.afterState.content | Should -BeExactly $expectedContent
     }
 
     It 'DSC resource can get current user all hosts profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $getOutput = (& $dscExe config get --file $PSScriptRoot/psprofile_currentuser_allhosts.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - CurrentUserAllHosts!'"
         $getOutput.results.result.actualState.content | Should -BeExactly $expectedContent
     }
 
     It 'DSC resource can export all profiles' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $exportOutput = (& $dscExe config export --file $PSScriptRoot/psprofile_export.dsc.yaml -o json) | ConvertFrom-Json
 
         $exportOutput.resources | Should -HaveCount 4
@@ -123,6 +175,12 @@ Describe "DSC PowerShell Profile Resource Tests" -Tag "CI" {
 
 Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdminOnWindows', 'RequireSudoOnUnix' {
     BeforeAll {
+        $isMsix = $pshome -like '*WindowsApps*'
+        if ($isMsix) {
+            Write-Verbose "Running in MSIX context. Marking tests as pending." -Verbose
+            return
+        }
+
         $DSC_ROOT = $env:DSC_ROOT
         $skipCleanup = $false
 
@@ -166,6 +224,10 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
             return
         }
 
+        if ($isMsix) {
+            return
+        }
+
         $env:PATH = $originalPath
 
         $testProfilePathAllUsersCurrentHost = $PROFILE.AllUsersCurrentHost
@@ -189,6 +251,11 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
     }
 
     It 'DSC resource can set all users all hosts profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $setOutput = (& $dscExe config set --file $PSScriptRoot/psprofile_alluser_allhost.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - AllUsersAllHosts!'"
         $setOutput.results.result.afterState.content | Should -BeExactly $expectedContent
@@ -201,12 +268,22 @@ Describe "DSC PowerShell Profile resource elevated tests" -Tag "CI", 'RequireAdm
     }
 
     It 'DSC resource can set all users current hosts profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $setOutput = (& $dscExe config set --file $PSScriptRoot/psprofile_allusers_currenthost.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - AllUsersCurrentHost!'"
         $setOutput.results.result.afterState.content | Should -BeExactly $expectedContent
     }
 
     It 'DSC resource can get all users current hosts profile' {
+        if ($isMsix) {
+            Set-ItResult -Pending -Reason "Running in MSIX context. Skipping test."
+            return
+        }
+
         $getOutput = (& $dscExe config get --file $PSScriptRoot/psprofile_allusers_currenthost.dsc.yaml -o json) | ConvertFrom-Json
         $expectedContent = "Write-Host 'Welcome to your PowerShell profile - AllUsersCurrentHost!'"
         $getOutput.results.result.actualState.content | Should -BeExactly $expectedContent


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates the `dsc.profileresource.Tests.ps1` test suite to improve compatibility with MSIX-packaged PowerShell environments. The main enhancement is the detection of the MSIX context, which results in tests being marked as pending and skipped when running in this environment. This prevents false failures due to known limitations of MSIX installations.

Key changes:

**MSIX Context Detection and Handling:**
* Added logic at the start of each test group (`BeforeAll`) to detect if the tests are running in an MSIX context by checking if `$pshome` contains `WindowsApps`. If so, a verbose message is logged and the tests are marked as pending or skipped. [[1]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R6-R12) [[2]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R178-R183)
* Inserted checks at the beginning of each test case to skip the test and mark it as pending with a clear reason if running in MSIX context. This is done using `Set-ItResult -Pending`. [[1]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R83-R88) [[2]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R97-R164) [[3]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R254-R258) [[4]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R271-R286)

**Test Flow Adjustments:**
* Ensured that cleanup and restoration logic in `AfterAll` and `BeforeAll` blocks also respect the MSIX context and exit early if detected. [[1]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R56-R59) [[2]](diffhunk://#diff-88f342bb0b6e12c796eb45bee8e0a7779d15d8d82455114adbc1f23a8cee6107R227-R230)

These changes make the test suite more robust and prevent unnecessary test failures when running under MSIX-packaged PowerShell.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
