### PR TITLE
Fix flaky Debug-Runspace attach event test

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
@@ -55,7 +55,7 @@ Describe "Debug-Runspace" -Tag "CI" {
             # 'BeginInvoke' only queues the work. Wait until the 'Wait-Event' pipeline is actually
             # running in the target runspace before attaching the debugger, so the attach event is
             # never generated against a runspace that has not started executing the waiter.
-            $ready = Wait-UntilTrue -IntervalInMilliseconds 20 -TimeoutInMilliseconds 30000 -sb {
+            $ready = Wait-UntilTrue -IntervalInMilliseconds 20 -TimeoutInMilliseconds 5000 -sb {
                 $debugTarget.InvocationStateInfo.State -eq [System.Management.Automation.PSInvocationState]::Running -and
                 $targetRunspace.RunspaceAvailability -eq [System.Management.Automation.Runspaces.RunspaceAvailability]::Busy
             }
@@ -67,7 +67,7 @@ Describe "Debug-Runspace" -Tag "CI" {
             $null = $debugger.AddCommand('Debug-Runspace').AddParameter('Id', $targetRunspace.Id)
             $debugTask = $debugger.BeginInvoke()
 
-            $waitTask.AsyncWaitHandle.WaitOne(30000) | Should -BeTrue
+            $waitTask.AsyncWaitHandle.WaitOne(5000) | Should -BeTrue
             $waitInfo = $debugTarget.EndInvoke($waitTask)
             $waitInfo.SourceIdentifier | Should -Be $onAttachName
 
@@ -81,7 +81,7 @@ Describe "Debug-Runspace" -Tag "CI" {
 
             # 'IsRemoteDebuggerAttached' is reset by the cmdlet as it unwinds, which happens
             # asynchronously with respect to 'Stop' completing.
-            $detached = Wait-UntilTrue -IntervalInMilliseconds 20 -TimeoutInMilliseconds 30000 -sb {
+            $detached = Wait-UntilTrue -IntervalInMilliseconds 20 -TimeoutInMilliseconds 5000 -sb {
                 -not $targetRunspace.IsRemoteDebuggerAttached
             }
             $detached | Should -BeTrue
@@ -90,12 +90,12 @@ Describe "Debug-Runspace" -Tag "CI" {
         }
         finally {
             if ($debugger) {
-                try { $debugger.Stop() } catch { }
+                $debugger.Stop()
                 $debugger.Dispose()
             }
 
             if ($debugTarget) {
-                try { $debugTarget.Stop() } catch { }
+                $debugTarget.Stop()
                 $debugTarget.Dispose()
             }
 
@@ -103,4 +103,3 @@ Describe "Debug-Runspace" -Tag "CI" {
         }
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
@@ -90,12 +90,12 @@ Describe "Debug-Runspace" -Tag "CI" {
         }
         finally {
             if ($debugger) {
-                $debugger.Stop()
+                try { $debugger.Stop() } catch { Write-Warning "Failed to stop the debugger during cleanup: $_" }
                 $debugger.Dispose()
             }
 
             if ($debugTarget) {
-                $debugTarget.Stop()
+                try { $debugTarget.Stop() } catch { Write-Warning "Failed to stop the debug target during cleanup: $_" }
                 $debugTarget.Dispose()
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
@@ -34,30 +34,73 @@ Describe "Debug-Runspace" -Tag "CI" {
     
     It "Should write attach event and mark runspace as having a remote debugger attached" {
         $onAttachName = [System.Management.Automation.PSEngineEvent]::OnDebugAttach
-        
-        $debugTarget = [PowerShell]::Create()
-        $null = $debugTarget.AddCommand('Wait-Event').AddParameter('SourceIdentifier', $onAttachName)
-        $waitTask = $debugTarget.BeginInvoke()
 
-        $debugTarget.Runspace.IsRemoteDebuggerAttached | Should -BeFalse
+        $targetRunspace = $null
+        $debugTarget = $null
+        $debugger = $null
+        $debugTask = $null
 
-        $debugger = [PowerShell]::Create()
-        $null = $debugger.AddCommand('Debug-Runspace').AddParameter('Id', $debugTarget.Runspace.Id)
-        $debugTask = $debugger.BeginInvoke()
-        
-        $waitTask.AsyncWaitHandle.WaitOne(5000) | Should -BeTrue
-        $waitInfo = $debugTarget.EndInvoke($waitTask)
-        $waitInfo.SourceIdentifier | Should -Be $onAttachName
+        try {
+            # Open the target runspace up front so that 'Debug-Runspace' can never observe it in a
+            # non-Opened state, and so that its event manager is guaranteed to exist when the
+            # OnDebugAttach event is generated.
+            $targetRunspace = [runspacefactory]::CreateRunspace()
+            $targetRunspace.Open()
 
-        $debugTarget.Runspace.IsRemoteDebuggerAttached | Should -BeTrue
+            $debugTarget = [PowerShell]::Create()
+            $debugTarget.Runspace = $targetRunspace
+            $null = $debugTarget.AddCommand('Wait-Event').AddParameter('SourceIdentifier', $onAttachName)
+            $waitTask = $debugTarget.BeginInvoke()
 
-        $debugger.Stop()
-        $exp = {
-            $debugger.EndInvoke($debugTask)
-        } | Should -Throw -PassThru
-        $exp.FullyQualifiedErrorId | Should -Be "PipelineStoppedException"
+            # 'BeginInvoke' only queues the work. Wait until the 'Wait-Event' pipeline is actually
+            # running in the target runspace before attaching the debugger, so the attach event is
+            # never generated against a runspace that has not started executing the waiter.
+            $ready = Wait-UntilTrue -IntervalInMilliseconds 20 -TimeoutInMilliseconds 30000 -sb {
+                $debugTarget.InvocationStateInfo.State -eq [System.Management.Automation.PSInvocationState]::Running -and
+                $targetRunspace.RunspaceAvailability -eq [System.Management.Automation.Runspaces.RunspaceAvailability]::Busy
+            }
+            $ready | Should -BeTrue -Because "the 'Wait-Event' pipeline should be running in the target runspace"
 
-        $debugTarget.Runspace.IsRemoteDebuggerAttached | Should -BeFalse
+            $targetRunspace.IsRemoteDebuggerAttached | Should -BeFalse
+
+            $debugger = [PowerShell]::Create()
+            $null = $debugger.AddCommand('Debug-Runspace').AddParameter('Id', $targetRunspace.Id)
+            $debugTask = $debugger.BeginInvoke()
+
+            $waitTask.AsyncWaitHandle.WaitOne(30000) | Should -BeTrue
+            $waitInfo = $debugTarget.EndInvoke($waitTask)
+            $waitInfo.SourceIdentifier | Should -Be $onAttachName
+
+            $targetRunspace.IsRemoteDebuggerAttached | Should -BeTrue
+
+            $debugger.Stop()
+            $exp = {
+                $debugger.EndInvoke($debugTask)
+            } | Should -Throw -PassThru
+            $exp.FullyQualifiedErrorId | Should -Be "PipelineStoppedException"
+
+            # 'IsRemoteDebuggerAttached' is reset by the cmdlet as it unwinds, which happens
+            # asynchronously with respect to 'Stop' completing.
+            $detached = Wait-UntilTrue -IntervalInMilliseconds 20 -TimeoutInMilliseconds 30000 -sb {
+                -not $targetRunspace.IsRemoteDebuggerAttached
+            }
+            $detached | Should -BeTrue
+
+            $targetRunspace.IsRemoteDebuggerAttached | Should -BeFalse
+        }
+        finally {
+            if ($debugger) {
+                try { $debugger.Stop() } catch { }
+                $debugger.Dispose()
+            }
+
+            if ($debugTarget) {
+                try { $debugTarget.Stop() } catch { }
+                $debugTarget.Dispose()
+            }
+
+            if ($targetRunspace) { $targetRunspace.Dispose() }
+        }
     }
 }
 


### PR DESCRIPTION
# PR Summary

Make the `Debug-Runspace` attach-event test deterministic by opening the target runspace explicitly and waiting for the asynchronous `Wait-Event` pipeline to reach a running, busy state before invoking the debugger. Ensure the debugger, target pipeline, and runspace are cleaned up in all outcomes, while warning if best-effort stop cleanup fails.

## PR Context

The test could start `Debug-Runspace` before the target runspace had opened and registered its event waiter, causing intermittent Windows CI failures when `OnDebugAttach` was not observed. This is a test-only synchronization fix; production code is unchanged. The original attach, attached-state, stop, and detach-state assertions remain intact.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-on-pull-requests/about-pull-requests#pull-requests)
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s):
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed:
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)

## Test Results

- `Debug-Runspace.Tests.ps1`: 5 passed, 0 failed
- Ten consecutive standalone runs: 5 passed, 0 failed on every run
- Related debugger tests via `Start-PSPester`: 25 passed, 0 failed