### PR TITLE
Document the three return shapes of PSSerializer.Deserialize

### DIFF
--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -168,7 +168,7 @@ namespace System.Management.Automation
         /// <returns>
         /// The shape of the returned value depends on how many objects the CliXml contains:
         /// <see langword="null"/> if it contains no objects, the single deserialized object if it
-        /// contains exactly one, or an <see cref="object"/> array if it contains more than one.
+        /// contains exactly one, or an <see cref="object"/>[] if it contains more than one.
         /// Use <see cref="DeserializeAsList(string)"/> instead if a consistent return type is needed.
         /// </returns>
         public static object Deserialize(string source)

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -164,7 +164,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Deserializes PowerShell CliXml into an object.
         /// </summary>
-        /// <param name="source">The CliXml the represents the object to deserialize.</param>
+        /// <param name="source">The CliXml that represents the object to deserialize.</param>
         /// <returns>
         /// The shape of the returned value depends on how many objects the CliXml contains:
         /// <see langword="null"/> if it contains no objects, the single deserialized object if it

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -193,8 +193,8 @@ namespace System.Management.Automation
         /// <summary>
         /// Deserializes PowerShell CliXml into a list of objects.
         /// </summary>
-        /// <param name="source">The CliXml the represents the object to deserialize.</param>
-        /// <returns>An object array represents the serialized content.</returns>
+        /// <param name="source">The CliXml that represents the object to deserialize.</param>
+        /// <returns>An object array that represents the serialized content.</returns>
         public static object[] DeserializeAsList(string source)
         {
             List<object> results = new List<object>();

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -165,7 +165,12 @@ namespace System.Management.Automation
         /// Deserializes PowerShell CliXml into an object.
         /// </summary>
         /// <param name="source">The CliXml the represents the object to deserialize.</param>
-        /// <returns>An object that represents the serialized content.</returns>
+        /// <returns>
+        /// The shape of the returned value depends on how many objects the CliXml contains:
+        /// <see langword="null"/> if it contains no objects, the single deserialized object if it
+        /// contains exactly one, or an <see cref="object"/> array if it contains more than one.
+        /// Use <see cref="DeserializeAsList(string)"/> instead if a consistent return type is needed.
+        /// </returns>
         public static object Deserialize(string source)
         {
             object[] results = DeserializeAsList(source);


### PR DESCRIPTION
## PR Summary

`PSSerializer.Deserialize` returns one of three different shapes depending on how many objects the CliXml holds. It returns `null` when there are none, the bare object when there is exactly one, and an `object[]` when there are several. The doc comment only said it returns "an object that represents the serialized content", so a caller expecting a collection gets a scalar back for single item input and has to find that out by running into it.

This updates the XML doc comment to state the three shapes and to point at `DeserializeAsList`, which always returns an array, for callers who want a stable return type.

Documentation only. No behaviour change.

## PR Context

The behaviour itself is intentional and matches how a single item pipeline behaves in PowerShell, so I have not touched the implementation. The only problem is that none of it was written down, while the alternative method that avoids the collapse is public and went unmentioned.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] **Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header**
- [x] This PR is ready to merge and is not [work in progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress)
  - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title and remove the prefix when the PR is ready.
- **Breaking changes**
  - [x] None
- **User-facing changes**
  - [x] Not Applicable
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
- **Tooling**
  - [x] N/A
