### PR TITLE
Add the group 'mscodehub-feed-read-general' for MSIXBundle-vpack pipeline

### DIFF
--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -51,6 +51,7 @@ variables:
   - group: certificate_logical_to_actual # used within signing task
   - group: MSIXSigningProfile
   - group: msixTools
+  - group: mscodehub-feed-read-general
 
 resources:
   repositories:


### PR DESCRIPTION
### PR Summary

Add the group 'mscodehub-feed-read-general' for MSIXBundle-vpack pipeline, so that the `UseAzDevOpsFeed` environment variable will be available and we will run the "Switch to production Azure DevOps feed for all nuget.configs" step from `insert-nuget-config-azfeed.yml`.