### PR TITLE
Add the needed variable groups to the MSIX VPack pipeline to enforce using the production ADO feed

### DIFF
--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -51,6 +51,7 @@ variables:
   - group: certificate_logical_to_actual # used within signing task
   - group: MSIXSigningProfile
   - group: msixTools
+  - group: mscodehub-feed-read-general
 
 resources:
   repositories:

--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -52,6 +52,7 @@ variables:
   - group: MSIXSigningProfile
   - group: msixTools
   - group: mscodehub-feed-read-general
+  - group: mscodehub-feed-read-akv
 
 resources:
   repositories:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Add the needed variable groups to the MSIX VPack pipeline to enforce using the production ADO feed.

The MSIX VPack pipeline is using the public ADO feed without PAT for building PowerShell. This works fine before because all needed packages are already pulled to the ADO feed from the upstream by the `Coordinate Binary` build, so later when running MSIX VPack pipeline, there is no need to pull a NuGet package from upstream, and accessing available NuGet packages in that feed doesn't require authentication.

But with the early-access .NET feed work, e.g. in PowerShell v7.6.5, the `Coordinate Binary` build uses a different internal feed for build and thus when it gets to the MSIX VPack pipeline, it requires the needed packages to be pulled from upstream to the ADO feed, which requires authentication, and thus the build failed.

This change will make sure the `'Switch to production Azure DevOps feed for all nuget.configs'` step gets run from the `insert-nuget-config-azfeed.yml` template, to give the pipeline the permission to pull packages from upstream.