### PR TITLE
fix AvoidUsingEmptyCatchBlock rule violation

### DIFF
--- a/test/tools/Modules/HelpersRemoting/HelpersRemoting.psm1
+++ b/test/tools/Modules/HelpersRemoting/HelpersRemoting.psm1
@@ -8,7 +8,7 @@
 $Script:CIRemoteCred = $null
 
 if ($IsWindows) {
-    try { $Script:CIRemoteCred = Import-Clixml -Path "$env:TEMP\CIRemoteCred.xml" } catch { }
+    try { $Script:CIRemoteCred = Import-Clixml -Path "$env:TEMP\CIRemoteCred.xml" } catch { $Script:CIRemoteCred = $null }
 }
 
 function Get-DefaultEndPointName


### PR DESCRIPTION
Fix [`AvoidUsingEmptyCatchBlock.md`](https://github.com/PowerShell/PSScriptAnalyzer/blob/main/docs/Rules/AvoidUsingEmptyCatchBlock.md) PSScriptAnalyzer rule violation.