### PR TITLE
Fix `Test-Connection` to report `BufferSize` 0 correctly

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -477,6 +477,9 @@ namespace Microsoft.PowerShell.Commands
 
                         if (!Quiet.IsPresent)
                         {
+                            // The buffer may be empty even when BufferSize is not 0 as sending
+                            // a custom buffer needs privileges on Unix (see GetSendBuffer),
+                            // so report the requested size.
                             var status = new PingStatus(
                                 Source,
                                 routerName,
@@ -484,10 +487,6 @@ namespace Microsoft.PowerShell.Commands
                                 reply.Status == IPStatus.Success
                                     ? reply.RoundtripTime
                                     : timer.ElapsedMilliseconds,
-
-                                // The buffer may be empty even when BufferSize is not 0 as sending
-                                // a custom buffer needs privileges on Unix (see GetSendBuffer),
-                                // so report the requested size.
                                 BufferSize,
                                 pingNum: i);
                             WriteObject(new TraceStatus(
@@ -728,14 +727,14 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
+                    // The buffer may be empty even when BufferSize is not 0 as sending
+                    // a custom buffer needs privileges on Unix (see GetSendBuffer),
+                    // so report the requested size.
                     WriteObject(new PingStatus(
                         Source,
                         resolvedTargetName,
                         reply,
                         reply.RoundtripTime,
-                        // The buffer may be empty even when BufferSize is not 0 as sending
-                        // a custom buffer needs privileges on Unix (see GetSendBuffer),
-                        // so report the requested size.
                         BufferSize,
                         pingNum: (uint)i));
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -888,9 +888,11 @@ namespace Microsoft.PowerShell.Commands
 
         // Users most often use the default buffer size so we cache the buffer.
         // Creates and fills a send buffer. This follows the ping.exe and CoreFX model.
+        // An explicit size of 0 also returns the shared empty buffer: when .NET falls back
+        // to the ping utility (unelevated Unix), it rejects any other buffer instance.
         private static byte[] GetSendBuffer(int bufferSize)
         {
-            if (bufferSize == DefaultSendBufferSize)
+            if (bufferSize == DefaultSendBufferSize || bufferSize == 0)
             {
                 return s_DefaultSendBuffer;
             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -485,9 +485,10 @@ namespace Microsoft.PowerShell.Commands
                                     ? reply.RoundtripTime
                                     : timer.ElapsedMilliseconds,
 
-                                // If we use the empty buffer, then .NET actually uses a 32 byte buffer so we want to show
-                                // as the result object the actual buffer size used instead of 0.
-                                buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length,
+                                // The buffer may be empty even when BufferSize is not 0 as sending
+                                // a custom buffer needs privileges on Unix (see GetSendBuffer),
+                                // so report the requested size.
+                                BufferSize,
                                 pingNum: i);
                             WriteObject(new TraceStatus(
                                 currentHop,
@@ -732,7 +733,11 @@ namespace Microsoft.PowerShell.Commands
                         resolvedTargetName,
                         reply,
                         reply.RoundtripTime,
-                        buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length,
+
+                        // The buffer may be empty even when BufferSize is not 0 as sending
+                        // a custom buffer needs privileges on Unix (see GetSendBuffer),
+                        // so report the requested size.
+                        BufferSize,
                         pingNum: (uint)i));
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -733,7 +733,6 @@ namespace Microsoft.PowerShell.Commands
                         resolvedTargetName,
                         reply,
                         reply.RoundtripTime,
-
                         // The buffer may be empty even when BufferSize is not 0 as sending
                         // a custom buffer needs privileges on Unix (see GetSendBuffer),
                         // so report the requested size.

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs
@@ -477,9 +477,9 @@ namespace Microsoft.PowerShell.Commands
 
                         if (!Quiet.IsPresent)
                         {
-                            // The buffer may be empty even when BufferSize is not 0 as sending
-                            // a custom buffer needs privileges on Unix (see GetSendBuffer),
-                            // so report the requested size.
+                            // The default send buffer is intentionally empty (see s_DefaultSendBuffer),
+                            // so buffer.Length cannot distinguish the default from an explicit
+                            // BufferSize of 0. Report the requested size instead.
                             var status = new PingStatus(
                                 Source,
                                 routerName,
@@ -727,9 +727,9 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    // The buffer may be empty even when BufferSize is not 0 as sending
-                    // a custom buffer needs privileges on Unix (see GetSendBuffer),
-                    // so report the requested size.
+                    // The default send buffer is intentionally empty (see s_DefaultSendBuffer),
+                    // so buffer.Length cannot distinguish the default from an explicit
+                    // BufferSize of 0. Report the requested size instead.
                     WriteObject(new PingStatus(
                         Source,
                         resolvedTargetName,

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -218,6 +218,18 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
             $result.BufferSize | Should -Be 2
         }
 
+        It "BufferSize 0 is reported as 0" {
+            $result = Test-Connection $targetName -Count 1 -BufferSize 0
+
+            $result.BufferSize | Should -Be 0
+        }
+
+        It "Default BufferSize is reported as 32" {
+            $result = Test-Connection $targetName -Count 1
+
+            $result.BufferSize | Should -Be 32
+        }
+
         It "ResolveDestination for address" {
             $result = Test-Connection $targetAddress -ResolveDestination -Count 1
             $resolvedName = [System.Net.DNS]::GetHostEntry($targetAddress).HostName

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -218,18 +218,6 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
             $result.BufferSize | Should -Be 2
         }
 
-        It "BufferSize 0 is reported as 0" {
-            $result = Test-Connection $targetName -Count 1 -BufferSize 0
-
-            $result.BufferSize | Should -Be 0
-        }
-
-        It "Default BufferSize is reported as 32" {
-            $result = Test-Connection $targetName -Count 1
-
-            $result.BufferSize | Should -Be 32
-        }
-
         It "ResolveDestination for address" {
             $result = Test-Connection $targetAddress -ResolveDestination -Count 1
             $resolvedName = [System.Net.DNS]::GetHostEntry($targetAddress).HostName
@@ -373,6 +361,26 @@ Describe "Test-Connection" -tags "CI", "RequireSudoOnUnix" {
             # Should get 4 pings (the default Count value)
             $pingResults.Count | Should -Be 4
         }
+    }
+}
+
+# Separate Describe without RequireSudoOnUnix: the default and the explicit-0 buffer are both the
+# shared empty buffer, which .NET accepts on its ping-utility fallback, so these need no privileges.
+Describe "Test-Connection BufferSize reporting" -Tag "CI" {
+    BeforeAll {
+        $targetName = "localhost"
+    }
+
+    It "BufferSize 0 is reported as 0" {
+        $result = Test-Connection $targetName -Count 1 -BufferSize 0
+
+        $result.BufferSize | Should -Be 0
+    }
+
+    It "Default BufferSize is reported as 32" {
+        $result = Test-Connection $targetName -Count 1
+
+        $result.BufferSize | Should -Be 32
     }
 }
 


### PR DESCRIPTION
# PR Summary

`Test-Connection -BufferSize 0` reported `BufferSize` as 32 even though a 0-byte payload is sent.

Since #20369 the default send buffer is intentionally empty (sending a custom buffer requires privileges on Unix), so the reporting fallback `buffer.Length == 0 ? DefaultSendBufferSize : buffer.Length` could not distinguish an explicit `-BufferSize 0` from the default. Both report sites (ping and traceroute) now report the requested `BufferSize` parameter instead:

- `-BufferSize 0` → 0 (fixed)
- default → 32 (unchanged)
- `-BufferSize n` → n (unchanged)

Tests added for the explicit-0 and default cases; the full `Test-Connection` Pester suite passes locally on Windows (28 passed, 0 failed, 5 pending).

`GetSendBuffer(0)` now returns the shared empty buffer as well. .NET's ping-utility fallback (unelevated Unix) rejects any buffer instance other than its default or `Array.Empty`, so `-BufferSize 0` used to throw `PlatformNotSupportedException` there; it now behaves like the default ping. That also lets the two new tests live in a Describe without `RequireSudoOnUnix`, so they run in the unelevated Linux/macOS passes too.

Note for reviewers: on Windows a default ping actually sends a 0-byte payload (the empty default buffer is passed through to `Ping.Send`; `Reply.Buffer.Length` is 0) while reporting 32. That is pre-existing behavior from #20369 and unchanged here — happy to file a separate issue if the working group wants to revisit it.

Supersedes #27657, which appears stalled on the CLA since July — credit to @raman118 for the earlier attempt.

## PR Context

Fixes #27656

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress)
