### PR TITLE
Fix build to remove PowerShell satellite assemblies properly

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -565,9 +565,11 @@ Fix steps:
     # as well as .zip packages, we only support the default en-US culture.
     # Therefore, we only produce satellite assemblies for win7-x64, win7-x86, and win-arm64 by default (excluding min-size build),
     # unless the caller wants to force produce localized resources.
+    $RemovePowerShellSatelliteAssemblies = $false
     if (!$ForceProduceLocalizedResources -and ($Options.Runtime -notmatch '^(win7-x64|win7-x86|win-arm64)$' -or $ForMinimalSize)) {
-        # Disable satellite assemblies for other cultures.
+        # Disable satellite assemblies from package/runtime assets for other cultures.
         $Arguments += "/property:SatelliteResourceLanguages=en"
+        $RemovePowerShellSatelliteAssemblies = $true
     }
 
     if ($Output -or $SMAOnly) {
@@ -743,6 +745,21 @@ Fix steps:
     } finally {
         Pop-Location
     }
+
+    if ($RemovePowerShellSatelliteAssemblies) {
+        $smaResDll = 'System.Management.Automation.resources.dll'
+        $resDirs = Get-ChildItem -Path $publishPath -Filter $smaResDll -Recurse -Depth 1 | ForEach-Object DirectoryName
+
+        if ($resDirs) {
+            Write-Log -message "PowerShell satellite assemblies found under '$publishPath':"
+            $relatives = $resDirs | ForEach-Object { Resolve-Path $_ -Relative -RelativeBasePath $publishPath }
+            Write-Log -message ($relatives -join ", ")
+
+            $resDirs | Remove-Item -Recurse -Force -ErrorAction Stop
+            Write-Log -message "Removed PowerShell satellite assemblies under '$publishPath'."
+        }
+    }
+
     Write-LogGroupEnd -Title "Build PowerShell"
 
     # No extra post-building task will run if '-SMAOnly' is specified, because its purpose is for a quick update of S.M.A.dll after full build.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update `Start-PSBuild` to only produce localized resources (satellite assemblies) for `win7-x64`, `win7-x86`, and `win-arm64` by default. This is because we will only ship localized resources for MSIX package. For the rest packages, we only support the default `en-US`, because this can **reduce the package size by `27 mb` today, and another `8 mb` after PowerShell resources are localized**.

We applied `/property:SatelliteResourceLanguages=en` in #27725, but it turned out that can only suppress the package/runtime assets, not the PowerShell satellite assemblies produced in the build. It was not caught because when validating the changes in Coordinate Binaries build and Package build, I didn't know `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` was set at the pipeline level, which prevents the PowerShell satellite assemblies from being produced.

A more reliable solution is to explicitly remove all PowerShell satellite assemblies after the build, if we are not supposed to include them for the build.