### PR TITLE
[release/v7.5.11] Fix OneBranch output variables for early .NET jobs

### DIFF
--- a/.pipelines/templates/downloadDotnetEarlyAccess.yml
+++ b/.pipelines/templates/downloadDotnetEarlyAccess.yml
@@ -13,8 +13,10 @@ jobs:
     value: ${{ parameters.DotnetRuntimeVersion }}
   - name: DOTNET_SDK_VERSION
     value: ${{ parameters.DotnetSdkVersion }}
-  - name: destinationPath
+  - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/pkgs'
+  - name: destinationPath
+    value: '$(ob_outputDirectory)'
 
   pool:
     name: PowerShell1ES

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -38,6 +38,9 @@ stages:
       displayName: 'Skip early access .NET setup'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET setup.'
 - stage: mac_package

--- a/.pipelines/templates/stages/PowerShell-Release-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Release-Stages.yml
@@ -41,6 +41,9 @@ stages:
       displayName: 'Skip early access .NET download'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET download.'
 - stage: validateSdk


### PR DESCRIPTION
Backport of #27843 to release/v7.5.11

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27843$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Defines the OneBranch ob_outputDirectory required by the shared early-access .NET download job and the non-early fallback Windows jobs, preventing pipeline template expansion failures after prerequisite backport #27909.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

Fixes the pipeline expansion regression introduced by #27795; its prerequisite backport to release/v7.5.11 was merged as #27909 before this branch was created.

## Testing

The original PR was verified in ADO preview build 707888 and validated by parsing the modified YAML. For this backport, prerequisite PR #27909 was verified merged into release/v7.5.11, upstream/release/v7.5.11 was refreshed to its merge commit, and the cherry-pick completed cleanly. All three modified files parsed successfully with PyYAML; git diff --check passed; conflict-marker scans were empty; the diff was limited to the expected three pipeline YAML files; and the worktree was clean. Release pipeline CI provides the authoritative end-to-end validation.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk because the change affects OneBranch build, package, and release pipeline definitions. Risk is constrained by the narrow three-file variable fix, clean cherry-pick onto the merged prerequisite, successful YAML and whitespace validation, and prior validation on master.
