### PR TITLE
[release/v7.4.20] Use Custom Validation Policy for vPack Pipeline

### DIFF
--- a/.config/codesignpolicy.xml
+++ b/.config/codesignpolicy.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <SiPolicy xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:schemas-microsoft-com:sipolicy">
-  <VersionEx>10.3.0.0</VersionEx>
+  <VersionEx>10.4.0.0</VersionEx>
   <PolicyTypeID>{A244370E-44C9-4C06-B551-F6016E563076}</PolicyTypeID>
   <PlatformID>{2E07F7E4-194C-4D20-B7C9-6F44A6C5A234}</PlatformID>
-  <Rules>
-    <Rule>
-      <Option>Enabled:Inherit Default Policy</Option>
-    </Rule>
-  </Rules>
+  <!-- Do not inherit the default policy: this policy must accept only the signer below. -->
+  <Rules />
   <EKUs>
     <EKU ID="ID_EKU_WINDOWS" Value="010A2B0601040182370A0306" FriendlyName="Windows EKU - 1.3.6.1.4.1.311.10.3.6" />
     <EKU ID="ID_EKU_WHQL" Value="010A2B0601040182370A0305" FriendlyName="WHQL EKU - 1.3.6.1.4.1.311.10.3.5" />
@@ -22,105 +19,45 @@
   <FileRules>
     <FileAttrib ID="ID_FILEATTRIB_REFRESH_POLICY" FriendlyName="RefreshPolicy.exe FileAttribute" FileName="RefreshPolicy.exe" MinimumFileVersion="10.0.19042.0" />
   </FileRules>
+  <!--
+    The vPack pipeline signs every .dll, .exe and every signed .ps1/.psm1/.psd1/.ps1xml with the
+    Windows build tools certificate (windows_build_tools_cert_id / CP-458204). This policy therefore
+    allows the "Windows Internal Build Tools CodeSign" publisher and nothing else, so that any file
+    that is not signed with the tools certificate is reported by CodeSign Validation.
+    CodeSign Validation evaluates these payload files under the user mode (UMCI) scenario.
+  -->
   <Signers>
-    <Signer Name="Windows Internal Build Tools PCA 2020" ID="ID_SIGNER_S_14">
+    <Signer Name="Windows Internal Build Tools PCA 2020" ID="ID_SIGNER_S_0">
       <CertRoot Type="TBS" Value="0B0692273CF07E96C7A9EC4177E3044368B383CBF8E03BAC215C3E3BC5C203482262169804ACD1F473C57C2831A3F191" />
       <CertPublisher Value="Windows Internal Build Tools CodeSign" />
-    </Signer>
-    <Signer Name="Microsoft Windows Third Party Component CA 2013" ID="ID_SIGNER_S_11">
-      <CertRoot Type="TBS" Value="C55EE44C6DE86FA9AC3FC90F84EF0D4A6CAD5AAC6A112047C88B997E7547AED1" />
-      <CertPublisher Value="Microsoft Windows Software Compatibility Publisher" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2024" ID="ID_SIGNER_S_12">
-      <CertRoot Type="TBS" Value="B52C1E712CF71D080614DDF95F8258BE0738C0722BD8A55F0AF4361BACEE35B6D73DCACB1B9DE10B5FD28508A3A50EAE" />
-      <CertPublisher Value="Microsoft 3rd Party Application Component" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2011" ID="ID_SIGNER_S_13">
-      <CertRoot Type="TBS" Value="F6F717A43AD9ABDDC8CEFDDE1C505462535E7D1307E630F9544A2D14FE8BF26E" />
-      <CertPublisher Value="Microsoft Corporation" />
-    </Signer>
-    <Signer Name="Microsoft Windows Code Signing PCA 2024" ID="ID_SIGNER_S_8">
-      <CertRoot Type="TBS" Value="C64CE3455898F871D11C14DA412AAC58FA2022D4213D8AC05F8DD6909B2FB0FCC76C19A1913DF5BC0CB1662229AD15D1" />
-      <CertPublisher Value="Microsoft Corporation" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2024" ID="ID_SIGNER_S_9">
-      <CertRoot Type="TBS" Value="B52C1E712CF71D080614DDF95F8258BE0738C0722BD8A55F0AF4361BACEE35B6D73DCACB1B9DE10B5FD28508A3A50EAE" />
-      <CertPublisher Value="Microsoft 3rd Party Application Component" />
-    </Signer>
-    <Signer Name="Microsoft Windows Production PCA 2011" ID="ID_SIGNER_S_10">
-      <CertRoot Type="TBS" Value="4E80BE107C860DE896384B3EFF50504DC2D76AC7151DF3102A4450637A032146" />
-      <CertPublisher Value="Microsoft Windows" />
-    </Signer>
-    <Signer Name="Microsoft Windows Code Signing PCA 2024" ID="ID_SIGNER_S_6">
-      <CertRoot Type="TBS" Value="C64CE3455898F871D11C14DA412AAC58FA2022D4213D8AC05F8DD6909B2FB0FCC76C19A1913DF5BC0CB1662229AD15D1" />
-      <CertPublisher Value=".NET DAC" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2024" ID="ID_SIGNER_S_7">
-      <CertRoot Type="TBS" Value="B52C1E712CF71D080614DDF95F8258BE0738C0722BD8A55F0AF4361BACEE35B6D73DCACB1B9DE10B5FD28508A3A50EAE" />
-      <CertPublisher Value="Microsoft 3rd Party Application Component" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA" ID="ID_SIGNER_S_4">
-      <CertRoot Type="TBS" Value="27543A3F7612DE2261C7228321722402F63A07DE" />
-      <CertPublisher Value="Microsoft Corporation" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2011" ID="ID_SIGNER_S_5">
-      <CertRoot Type="TBS" Value="F6F717A43AD9ABDDC8CEFDDE1C505462535E7D1307E630F9544A2D14FE8BF26E" />
-      <CertPublisher Value="Microsoft Corporation" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2011" ID="ID_SIGNER_S_2">
-      <CertRoot Type="TBS" Value="F6F717A43AD9ABDDC8CEFDDE1C505462535E7D1307E630F9544A2D14FE8BF26E" />
-      <CertPublisher Value="Microsoft Corporation" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2011" ID="ID_SIGNER_S_3">
-      <CertRoot Type="TBS" Value="F6F717A43AD9ABDDC8CEFDDE1C505462535E7D1307E630F9544A2D14FE8BF26E" />
-      <CertPublisher Value="Microsoft Corporation" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2010" ID="ID_SIGNER_S_1">
-      <CertRoot Type="TBS" Value="121AF4B922A74247EA49DF50DE37609CC1451A1FE06B2CB7E1E079B492BD8195" />
-      <CertPublisher Value="Microsoft Corporation" />
-    </Signer>
-    <Signer Name="Microsoft Code Signing PCA 2024" ID="ID_SIGNER_S_0">
-      <CertRoot Type="TBS" Value="B52C1E712CF71D080614DDF95F8258BE0738C0722BD8A55F0AF4361BACEE35B6D73DCACB1B9DE10B5FD28508A3A50EAE" />
-      <CertPublisher Value=".NET" />
     </Signer>
   </Signers>
   <SigningScenarios>
     <SigningScenario ID="ID_SIGNINGSCENARIO_KMCI" FriendlyName="Kernel Mode Signing Scenario" Value="131">
+      <ProductSigners />
+    </SigningScenario>
+    <SigningScenario ID="ID_SIGNINGSCENARIO_UMCI" FriendlyName="User Mode Signing Scenario" Value="12">
       <ProductSigners>
         <AllowedSigners>
-          <AllowedSigner SignerId="ID_SIGNER_S_14" />
-          <AllowedSigner SignerId="ID_SIGNER_S_11" />
-          <AllowedSigner SignerId="ID_SIGNER_S_12" />
-          <AllowedSigner SignerId="ID_SIGNER_S_13" />
-          <AllowedSigner SignerId="ID_SIGNER_S_8" />
-          <AllowedSigner SignerId="ID_SIGNER_S_9" />
-          <AllowedSigner SignerId="ID_SIGNER_S_10" />
-          <AllowedSigner SignerId="ID_SIGNER_S_6" />
-          <AllowedSigner SignerId="ID_SIGNER_S_7" />
-          <AllowedSigner SignerId="ID_SIGNER_S_4" />
-          <AllowedSigner SignerId="ID_SIGNER_S_5" />
-          <AllowedSigner SignerId="ID_SIGNER_S_2" />
-          <AllowedSigner SignerId="ID_SIGNER_S_3" />
-          <AllowedSigner SignerId="ID_SIGNER_S_1" />
           <AllowedSigner SignerId="ID_SIGNER_S_0" />
         </AllowedSigners>
       </ProductSigners>
     </SigningScenario>
-    <SigningScenario ID="ID_SIGNINGSCENARIO_UMCI" FriendlyName="User Mode Signing Scenario" Value="12">
-      <ProductSigners />
-    </SigningScenario>
   </SigningScenarios>
   <UpdatePolicySigners />
+  <CiSigners>
+    <CiSigner SignerId="ID_SIGNER_S_0" />
+  </CiSigners>
   <HvciOptions>0</HvciOptions>
   <Settings>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Name">
       <Value>
-        <String>CodeSignCustomPolicy_2026-08-14</String>
+        <String>CodeSignCustomPolicy_2026-08-31</String>
       </Value>
     </Setting>
     <Setting Provider="PolicyInfo" Key="Information" ValueName="Id">
       <Value>
-        <String>2026-08-14</String>
+        <String>2026-08-31</String>
       </Value>
     </Setting>
   </Settings>

--- a/.pipelines/PowerShell-vPack-Official.yml
+++ b/.pipelines/PowerShell-vPack-Official.yml
@@ -61,9 +61,6 @@ extends:
       enabled: false
 
     globalSdl:
-      useCustomPolicy: true # for signing code
-      codeSignValidation:
-        policyFile: $(Build.SourcesDirectory)\.config\codesignpolicy.xml
       disableLegacyManifest: true
       # disabled Armory as we dont have any ARM templates to scan. It fails on some sample ARM templates.
       armory:

--- a/.pipelines/templates/obp-file-signing.yml
+++ b/.pipelines/templates/obp-file-signing.yml
@@ -2,6 +2,8 @@ parameters:
   binPath: '$(ob_outputDirectory)'
   globalTool: 'false'
   SigningProfile: 'external_distribution'
+  ThirdPartySigningProfile: '$(msft_3rd_party_cert_id)'
+  SignAllBinariesWithThirdPartyProfile: false
   OfficialBuild: true
   vPackScenario: false
 
@@ -112,7 +114,12 @@ steps:
     $signatures = $dlls | Get-AuthenticodeSignature
     $officialIssuerPattern = '^CN=(Microsoft Code Signing PCA|Microsoft Root Certificate Authority|Microsoft Corporation).*'
     $testCert = '^CN=(Microsoft|TestAzureEngBuildCodeSign).*'
-    $missingSignatures = $signatures | Where-Object { $_.status -eq 'notsigned' -or $_.SignerCertificate.Issuer -notmatch $testCert -or $_.SignerCertificate.Issuer -notmatch $officialIssuerPattern} | select-object -ExpandProperty Path
+    $signAllBinaries = [System.Convert]::ToBoolean('${{ parameters.SignAllBinariesWithThirdPartyProfile }}')
+    if ($signAllBinaries) {
+      $missingSignatures = $signatures | Select-Object -ExpandProperty Path
+    } else {
+      $missingSignatures = $signatures | Where-Object { $_.status -eq 'notsigned' -or $_.SignerCertificate.Issuer -notmatch $testCert -or $_.SignerCertificate.Issuer -notmatch $officialIssuerPattern} | Select-Object -ExpandProperty Path
+    }
 
     Write-Verbose -verbose "to be signed:`r`n $($missingSignatures | Out-String)"
 
@@ -140,7 +147,7 @@ steps:
   displayName: Sign 3rd Party files
   inputs:
     command: 'sign'
-    signing_profile: $(msft_3rd_party_cert_id)
+    signing_profile: ${{ parameters.ThirdPartySigningProfile }}
     files_to_sign: '**\*.dll;**\*.exe'
     search_root: $(Pipeline.Workspace)/thirdPartyToBeSigned
 

--- a/.pipelines/templates/stages/PowerShell-vPack-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-vPack-Stages.yml
@@ -11,6 +11,14 @@ stages:
     pool:
       type: windows
 
+    templateContext:
+      sdl:
+        codeSignValidation:
+          enabled: false
+          justificationForDisabling: >-
+            This job validates the signed payload with the repository-managed
+            tools-only policy.
+
     strategy:
       matrix:
         x86:
@@ -33,6 +41,9 @@ stages:
       ob_createvpack_verbose: true
       ob_createvpack_packagename: '${{ parameters.vPackName }}.$(architecture)'
       ob_createvpack_description: PowerShell $(architecture) $(version)
+      # Some official-build adapters force the injected validator on despite templateContext.
+      # Exclude this payload from that validator; it is validated below with the tools-only policy.
+      ob_sdl_codeSignValidation_excludes: '-|**\*.ps1;-|**\*.psm1;-|**\*.ps1xml;-|**\*.psd1;-|**\*.exe;-|**\*.dll'
       # I think the variables reload after we transition back to the host so this works. 🤷‍♂️
       ob_createvpack_majorVer: $(pwshMajorVersion)
       ob_createvpack_minorVer: $(pwshMinorVersion)
@@ -209,8 +220,69 @@ stages:
         parameters:
           binPath: '$(Pipeline.Workspace)/Symbols_$(Architecture)'
           SigningProfile: $(windows_build_tools_cert_id)
+          ThirdPartySigningProfile: $(windows_build_tools_cert_id)
+          SignAllBinariesWithThirdPartyProfile: true
           OfficialBuild: false
           vPackScenario: true
+
+      # obp-file-signing.yml signs only the scripts and manifests selected for normal PowerShell
+      # packages. The validation below intentionally covers every potentially signed file in the
+      # vPack, so overwrite every matching signature with the tools certificate first.
+      - task: onebranch.pipeline.signing@1
+        displayName: Sign all vPack files with Windows build tools certificate
+        inputs:
+          command: sign
+          signing_profile: $(windows_build_tools_cert_id)
+          files_to_sign: '**\*.ps1;**\*.psm1;**\*.ps1xml;**\*.psd1;**\*.exe;**\*.dll'
+          search_root: $(ob_outputDirectory)
+
+      # The injected CodeSign validation is disabled for this job, so validate the signed payload
+      # here against the repository policy, which allows only the Windows build tools certificate.
+      - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodeSign@1
+        displayName: Validate signed files with PowerShell CodeSign policy
+        inputs:
+          Path: $(ob_outputDirectory)
+          PolicyType: Custom
+          PolicyFile: $(Build.SourcesDirectory)\.config\codesignpolicy.xml
+          MaxThreads: 16
+          FailIfNoTargetsFound: true
+          ExcludePassesFromLog: false
+          Targets: '**\*.ps1;**\*.psm1;**\*.ps1xml;**\*.psd1;**\*.exe;**\*.dll'
+
+      - pwsh: |
+          $codesignResultsRoot = Join-Path '$(Pipeline.Workspace)' '.gdn\.r\codesign'
+          if (-not (Test-Path -LiteralPath $codesignResultsRoot -PathType Container)) {
+              throw "CodeSign Validation did not produce its expected results directory: $codesignResultsRoot"
+          }
+
+          $sarifFile = Get-ChildItem -LiteralPath $codesignResultsRoot -Recurse -File -Filter 'Phalanx.Plugins.CodeSignValidation.dll.sarif' |
+              Sort-Object -Property LastWriteTimeUtc -Descending |
+              Select-Object -First 1
+          if (-not $sarifFile) {
+              throw "CodeSign Validation did not produce its expected SARIF file under: $codesignResultsRoot"
+          }
+
+          $sarif = Get-Content -LiteralPath $sarifFile.FullName -Raw | ConvertFrom-Json -Depth 100
+          $failures = @(
+              foreach ($run in $sarif.runs) {
+                  foreach ($result in $run.results) {
+                      if ($result.ruleId -ne 'CodeSign.MatchingPolicy') {
+                          $result
+                      }
+                  }
+              }
+          )
+
+          if ($failures.Count -gt 0) {
+              $failures |
+                  ForEach-Object {
+                      Write-Host "##vso[task.logissue type=error]$($_.ruleId): $($_.locations.physicalLocation.artifactLocation.uri -join ', ') - $($_.message.text)"
+                  }
+              throw "CodeSign Validation found $($failures.Count) policy violation(s)."
+          }
+
+          Write-Verbose -Verbose 'All signed files matched the PowerShell CodeSign policy.'
+        displayName: Check PowerShell CodeSign validation results
 
       ### END OF BUILD ###
 


### PR DESCRIPTION
Backport of #27911 to `release/v7.4.20`.

This replaces the branch's superseded broad custom CodeSign policy with the merged tools-only policy and signs the complete vPack payload with the Windows build tools certificate before explicit validation.