### PR TITLE
[release/v7.4.20] Fix OneBranch output variables for early .NET jobs

### DIFF
--- a/.pipelines/templates/downloadDotnetEarlyAccess.yml
+++ b/.pipelines/templates/downloadDotnetEarlyAccess.yml
@@ -13,8 +13,10 @@ jobs:
     value: ${{ parameters.DotnetRuntimeVersion }}
   - name: DOTNET_SDK_VERSION
     value: ${{ parameters.DotnetSdkVersion }}
-  - name: destinationPath
+  - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/pkgs'
+  - name: destinationPath
+    value: '$(ob_outputDirectory)'
 
   pool:
     name: PowerShell1ES

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -38,6 +38,9 @@ stages:
       displayName: 'Skip early access .NET setup'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET setup.'
 - stage: mac_package

--- a/.pipelines/templates/stages/PowerShell-Release-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Release-Stages.yml
@@ -41,6 +41,9 @@ stages:
       displayName: 'Skip early access .NET download'
       pool:
         type: windows
+      variables:
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
       steps:
       - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET download.'
 - stage: validateSdk


### PR DESCRIPTION
Backport of #27843 to release/v7.4.20

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27843$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes OneBranch pipeline expansion for PowerShell 7.4 package and release jobs by defining the required ob_outputDirectory variable for the shared early-access .NET job and the non-early Windows fallback jobs, and by using that output directory as the early-access download destination.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

Regression introduced by PR #27795, which added the affected early-access and fallback Windows jobs without the ob_outputDirectory variable required by the OneBranch Windows job template.

## Testing

Verified prerequisite backport PR #27910 is merged at the tip of upstream/release/v7.4.20, then cherry-picked the authoritative #27843 merge commit. Parsed all three changed YAML files successfully with PyYAML, confirmed the changed-file set exactly matches the original PR, ran git diff --check with no whitespace errors, scanned all changed files with no conflict markers found, and confirmed a clean worktree.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk because the change affects OneBranch build, package, and release pipeline job expansion on the servicing branch. Risk is reduced by the narrow three-file change, direct clean cherry-pick after its prerequisite, exact changed-file validation, successful YAML parsing, and clean whitespace and conflict-marker checks.
