### PR TITLE
[release/v7.6.6] Add support for new WLDP setting `EnableFileOnlyEntry`

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -14,6 +14,7 @@ using System.Management.Automation.Host;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
+using System.Management.Automation.Security;
 using System.Security;
 using System.Text;
 
@@ -878,10 +879,27 @@ namespace Microsoft.PowerShell
             ParseHelper(args);
         }
 
+        internal static bool IsFileOnlyEntryEnabled
+        {
+            get
+            {
+#if UNIX
+                return false;
+#else
+                return SystemPolicy.IsFileOnlyEntryEnabled();
+#endif
+            }
+        }
+
         private void ParseHelper(string[] args)
         {
             if (args.Length == 0)
             {
+                if (IsFileOnlyEntryEnabled)
+                {
+                    SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryRequired);
+                }
+
                 return;
             }
 
@@ -927,6 +945,12 @@ namespace Microsoft.PowerShell
                     _noExit = true;
                     noexitSeen = true;
                     ParametersUsed |= ParameterBitmap.NoExit;
+
+                    if (IsFileOnlyEntryEnabled)
+                    {
+                        SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryNoExitDisabled);
+                        break;
+                    }
                 }
                 else if (MatchSwitch(switchKey, "noprofile", "nop"))
                 {
@@ -948,6 +972,11 @@ namespace Microsoft.PowerShell
                     _socketServerMode = true;
                     _showBanner = false;
                     ParametersUsed |= ParameterBitmap.SocketServerMode;
+                    if (IsFileOnlyEntryEnabled)
+                    {
+                        SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryServerMode);
+                        break;
+                    }
                 }
 #if !UNIX
                 else if (MatchSwitch(switchKey, "v2socketservermode", "v2so"))
@@ -955,6 +984,11 @@ namespace Microsoft.PowerShell
                     _v2SocketServerMode = true;
                     _showBanner = false;
                     ParametersUsed |= ParameterBitmap.V2SocketServerMode;
+                    if (IsFileOnlyEntryEnabled)
+                    {
+                        SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryServerMode);
+                        break;
+                    }
                 }
 #endif
                 else if (MatchSwitch(switchKey, "servermode", "s"))
@@ -962,18 +996,33 @@ namespace Microsoft.PowerShell
                     _serverMode = true;
                     _showBanner = false;
                     ParametersUsed |= ParameterBitmap.ServerMode;
+                    if (IsFileOnlyEntryEnabled)
+                    {
+                        SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryServerMode);
+                        break;
+                    }
                 }
                 else if (MatchSwitch(switchKey, "namedpipeservermode", "nam"))
                 {
                     _namedPipeServerMode = true;
                     _showBanner = false;
                     ParametersUsed |= ParameterBitmap.NamedPipeServerMode;
+                    if (IsFileOnlyEntryEnabled)
+                    {
+                        SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryServerMode);
+                        break;
+                    }
                 }
                 else if (MatchSwitch(switchKey, "sshservermode", "sshs"))
                 {
                     _sshServerMode = true;
                     _showBanner = false;
                     ParametersUsed |= ParameterBitmap.SSHServerMode;
+                    if (IsFileOnlyEntryEnabled)
+                    {
+                        SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryServerMode);
+                        break;
+                    }
                 }
                 else if (MatchSwitch(switchKey, "noprofileloadtime", "noprofileloadtime"))
                 {
@@ -1263,6 +1312,15 @@ namespace Microsoft.PowerShell
                 }
             }
 
+            if (_error is null
+                && !_showVersion
+                && !_showHelp
+                && !ParametersUsed.HasFlag(ParameterBitmap.File)
+                && IsFileOnlyEntryEnabled)
+            {
+                SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryRequired);
+            }
+
             Dbg.Assert(
                     ((_exitCode == ConsoleHost.ExitCodeBadCommandLineParameter) && _abortStartup)
                 || (_exitCode == ConsoleHost.ExitCodeSuccess),
@@ -1360,6 +1418,12 @@ namespace Microsoft.PowerShell
             // Process interactive input...
             if (args[i] == "-")
             {
+                if (IsFileOnlyEntryEnabled)
+                {
+                    SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryRequired);
+                    return false;
+                }
+
                 // the arg to -file is -, which is secret code for "read the commands from stdin with prompts"
 
                 _explicitReadCommandsFromStdin = true;
@@ -1492,6 +1556,12 @@ namespace Microsoft.PowerShell
 
         private bool ParseCommand(string[] args, ref int i, bool noexitSeen, bool isEncoded)
         {
+            if (IsFileOnlyEntryEnabled)
+            {
+                SetCommandLineError(CommandLineParameterParserStrings.FileOnlyEntryRequired);
+                return false;
+            }
+
             if (_commandLineCommand != null)
             {
                 // we've already set the command, so squawk

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -165,8 +165,6 @@ namespace Microsoft.PowerShell
                 // improve startup performance.
             }
 
-            uint exitCode = ExitCodeSuccess;
-
             Thread.CurrentThread.Name = "ConsoleHost main thread";
 
             try
@@ -192,7 +190,7 @@ namespace Microsoft.PowerShell
                     // or start up the engine and retrieve the information via $psversiontable.GitCommitId
                     // but this returns the semantic version and avoids executing a script
                     s_theConsoleHost.UI.WriteLine($"PowerShell {PSVersionInfo.GitCommitId}");
-                    return 0;
+                    return ExitCodeSuccess;
                 }
 
                 // Servermode parameter validation check.
@@ -223,6 +221,14 @@ namespace Microsoft.PowerShell
                     return ExitCodeBadCommandLineParameter;
                 }
 
+                if (serverModeCount is 1 && CommandLineParameterParser.IsFileOnlyEntryEnabled)
+                {
+                    // User facing error message should already be written by the parser,
+                    // so just trace and exit.
+                    s_tracer.TraceError("Server mode cannot be specified when FileOnlyEntry policy is in place.");
+                    return ExitCodeBadCommandLineParameter;
+                }
+
 #if !UNIX
                 TaskbarJumpList.CreateRunAsAdministratorJumpList();
 #endif
@@ -237,9 +243,10 @@ namespace Microsoft.PowerShell
                         configurationName: null,
                         configurationFile: s_cpp.ConfigurationFile,
                         combineErrOutStream: false);
-                    exitCode = 0;
+                    return ExitCodeSuccess;
                 }
-                else if (s_cpp.SSHServerMode)
+
+                if (s_cpp.SSHServerMode)
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SSHServer", s_cpp.ParametersUsedAsDouble);
                     ProfileOptimization.StartProfile("StartupProfileData-SSHServerMode");
@@ -249,18 +256,20 @@ namespace Microsoft.PowerShell
                         configurationName: null,
                         configurationFile: s_cpp.ConfigurationFile,
                         combineErrOutStream: true);
-                    exitCode = 0;
+                    return ExitCodeSuccess;
                 }
-                else if (s_cpp.NamedPipeServerMode)
+
+                if (s_cpp.NamedPipeServerMode)
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("NamedPipe", s_cpp.ParametersUsedAsDouble);
                     ProfileOptimization.StartProfile("StartupProfileData-NamedPipeServerMode");
                     RemoteSessionNamedPipeServer.RunServerMode(
                         configurationName: s_cpp.ConfigurationName);
-                    exitCode = 0;
+                    return ExitCodeSuccess;
                 }
 #if !UNIX
-                else if (s_cpp.V2SocketServerMode)
+
+                if (s_cpp.V2SocketServerMode)
                 {
                     if (s_cpp.Token == null)
                     {
@@ -284,50 +293,49 @@ namespace Microsoft.PowerShell
                         token: s_cpp.Token,
                         tokenCreationTime: s_cpp.UTCTimestamp.Value);
 
-                    exitCode = 0;
+                    return ExitCodeSuccess;
                 }
 #endif
-                else if (s_cpp.SocketServerMode)
+
+                if (s_cpp.SocketServerMode)
                 {
                     ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("SocketServerMode", s_cpp.ParametersUsedAsDouble);
                     ProfileOptimization.StartProfile("StartupProfileData-SocketServerMode");
                     HyperVSocketMediator.Run(
                         initialCommand: s_cpp.InitialCommand,
                         configurationName: s_cpp.ConfigurationName);
-                    exitCode = 0;
+                    return ExitCodeSuccess;
+                }
+
+                // Run PowerShell in normal console mode.
+                if (hostException != null)
+                {
+                    // Unable to create console host.
+                    throw hostException;
+                }
+
+                if (LoadPSReadline())
+                {
+                    ProfileOptimization.StartProfile("StartupProfileData-Interactive");
+
+                    if (UpdatesNotification.CanNotifyUpdates)
+                    {
+                        // Start a task in the background to check for the update release.
+                        _ = UpdatesNotification.CheckForUpdates();
+                    }
                 }
                 else
                 {
-                    // Run PowerShell in normal console mode.
-                    if (hostException != null)
-                    {
-                        // Unable to create console host.
-                        throw hostException;
-                    }
-
-                    if (LoadPSReadline())
-                    {
-                        ProfileOptimization.StartProfile("StartupProfileData-Interactive");
-
-                        if (UpdatesNotification.CanNotifyUpdates)
-                        {
-                            // Start a task in the background to check for the update release.
-                            _ = UpdatesNotification.CheckForUpdates();
-                        }
-                    }
-                    else
-                    {
-                        ProfileOptimization.StartProfile("StartupProfileData-NonInteractive");
-                    }
-
-                    s_theConsoleHost.BindBreakHandler();
-                    IsStdOutputRedirected = Console.IsOutputRedirected;
-
-                    // Send startup telemetry for ConsoleHost startup
-                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("Normal", s_cpp.ParametersUsedAsDouble);
-
-                    exitCode = s_theConsoleHost.Run(s_cpp, false);
+                    ProfileOptimization.StartProfile("StartupProfileData-NonInteractive");
                 }
+
+                s_theConsoleHost.BindBreakHandler();
+                IsStdOutputRedirected = Console.IsOutputRedirected;
+
+                // Send startup telemetry for ConsoleHost startup
+                ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry("Normal", s_cpp.ParametersUsedAsDouble);
+
+                return unchecked((int)s_theConsoleHost.Run(s_cpp, false));
             }
             finally
             {
@@ -348,11 +356,6 @@ namespace Microsoft.PowerShell
                     s_theConsoleHost.Dispose();
                 }
 #pragma warning restore IDE0031
-            }
-
-            unchecked
-            {
-                return (int)exitCode;
             }
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileOnlyEntry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileOnlyEntry.Tests.ps1
@@ -1,0 +1,79 @@
+using namespace System.Diagnostics.CodeAnalysis
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+##
+## ----------
+## Test Note:
+## ----------
+## Since these tests change system state (the "FileOnlyEntry" setting)
+## they will all use try/finally blocks instead of Pester AfterEach/AfterAll to
+## ensure system state is restored.
+##
+
+Import-Module HelpersSecurity
+
+try
+{
+    $defaultParamValues = $PSDefaultParameterValues.Clone()
+    $PSDefaultParameterValues["it:Skip"] = !$IsWindows
+
+    Describe "File Only Entry throws for interactive or non-file scenarios" -Tags 'CI','RequireAdminOnWindows' {
+
+        BeforeAll {
+            function MakeTestCase {
+                param([Parameter(ValueFromRemainingArguments)] [string[]] $ArgumentList)
+                end {
+                    @{
+                        Arguments = $ArgumentList
+                        TestName = 'With args "{0}"' -f ($ArgumentList -join ' ')
+                    }
+                }
+            }
+
+            [SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'PwshParameterTestCases')]
+            $PwshParameterTestCases = @(
+                MakeTestCase -NoExit -Command Get-ChildItem
+                MakeTestCase -Command Get-ChildItem
+                # File validation should come after `FileOnlyEntry` check, so
+                # this file should not need to exist for us to get the error
+                # we expect.
+                MakeTestCase -NoExit -File this_file_does_not_exist.ps1
+                MakeTestCase -File -
+                MakeTestCase -EncodedCommand RwBlAHQALQBDAGgAaQBsAGQASQB0AGUAbQA= <# < Get-ChildItem #>
+                MakeTestCase -CommandWithArgs Get-ChildItem
+                MakeTestCase
+            )
+        }
+
+        It "<TestName>" -TestCases $PwshParameterTestCases {
+            param($Arguments)
+
+            $results = $null
+            try {
+                Invoke-LanguageModeTestingSupportCmdlet -SetFileOnlyEntry
+                if ($Arguments -and $Arguments[-1] -eq '-') {
+                    $results = 'Get-ChildItem' | & "$PSHOME\pwsh.exe" @Arguments 2>&1
+                } else {
+                    $results = & "$PSHOME\pwsh.exe" @Arguments 2>&1
+                }
+            } finally {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertFileOnlyEntry
+            }
+
+            if ($Arguments -contains '-NoExit') {
+                $results.Exception.Message | Should -Be 'The parameter "-NoExit" is disallowed by policy.'
+            } else {
+                $results.Exception.Message | Should -Be 'The parameter "-File" is required by policy.'
+            }
+        }
+    }
+}
+finally
+{
+    if ($null -ne $defaultParamValues)
+    {
+        $Global:PSDefaultParameterValues = $defaultParamValues
+    }
+}

--- a/test/tools/Modules/HelpersSecurity/HelpersSecurity.psm1
+++ b/test/tools/Modules/HelpersSecurity/HelpersSecurity.psm1
@@ -27,6 +27,12 @@ if ($IsWindows)
         [Parameter()]
         public SwitchParameter RevertLockdownMode { get; set; }
 
+        [Parameter()]
+        public SwitchParameter SetFileOnlyEntry { get; set; }
+
+        [Parameter()]
+        public SwitchParameter RevertFileOnlyEntry { get; set; }
+
         protected override void BeginProcessing()
         {
             if (EnableFullLanguageMode)
@@ -42,6 +48,16 @@ if ($IsWindows)
             if (RevertLockdownMode)
             {
                 Environment.SetEnvironmentVariable("__PSLockdownPolicy", null, EnvironmentVariableTarget.Machine);
+            }
+
+            if (SetFileOnlyEntry)
+            {
+                Environment.SetEnvironmentVariable("__PSLockdownPolicy_FileOnlyEntry", "1", EnvironmentVariableTarget.Machine);
+            }
+
+            if (RevertFileOnlyEntry)
+            {
+                Environment.SetEnvironmentVariable("__PSLockdownPolicy_FileOnlyEntry", null, EnvironmentVariableTarget.Machine);
             }
         }
     }


### PR DESCRIPTION
Backport of #26752 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:26752$$$
-->

Triggered by @SeeminglyScience on behalf of @SeeminglyScience

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [x] Optional tooling change (include reasoning)

Adds support for a new WLDP (Windows Lockdown Policy) setting enabling `FileOnlyEntry` restriction, for use in managed/locked-down deployments.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-picked cleanly with no conflicts. Original PR validated with a companion policy manifest change; this is a prerequisite for the FileOnlyEntry crash fix (PR #27880) also queued for backport.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Adds a new opt-in WLDP setting check that only affects behavior when the setting is explicitly enabled in a managed environment; default behavior is unchanged. Windows-specific security-adjacent code path, but additive and gated behind the new setting.
