### PR TITLE
[release/v7.5.11] Fix install dotnet for non early access release

### DIFF
--- a/.pipelines/templates/release-validate-fxdpackages.yml
+++ b/.pipelines/templates/release-validate-fxdpackages.yml
@@ -62,6 +62,10 @@ jobs:
     - checkout: self
       clean: true
 
+    - template: /.pipelines/templates/SetVersionVariables.yml@self
+      parameters:
+        ReleaseTagVar: $(ReleaseTagVar)
+
     - template: release-SetReleaseTagandContainerName.yml@self
 
     - download: PSPackagesOfficial
@@ -80,7 +84,8 @@ jobs:
     - template: /.pipelines/templates/install-dotnet.yml@self
       parameters:
         architecture: ${{ parameters.dotnetArch }}
-        ob_restore_phase: false
+        ${{ if eq(parameters.IsEarlyAccess, true) }}:
+          ob_restore_phase: false
 
     - pwsh: |
         $artifactName = '$(artifactName)'

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -49,6 +49,10 @@ jobs:
     - checkout: self
       clean: true
 
+    - template: /.pipelines/templates/SetVersionVariables.yml@self
+      parameters:
+        ReleaseTagVar: $(ReleaseTagVar)
+
     - template: release-SetReleaseTagandContainerName.yml@self
 
     - download: PSPackagesOfficial
@@ -66,7 +70,8 @@ jobs:
     - template: /.pipelines/templates/install-dotnet.yml@self
       parameters:
         architecture: ${{ parameters.dotnetArch }}
-        ob_restore_phase: false
+        ${{ if eq(parameters.IsEarlyAccess, true) }}:
+          ob_restore_phase: false
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"


### PR DESCRIPTION
Backport of #27892 to release/v7.5.11

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27892$$$
-->

Triggered by @adityapatwardhan on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Corrects release validation pipeline setup by initializing version variables before release tag/container setup and limiting ob_restore_phase: false to early-access builds, so non-early-access release validation installs .NET with the intended defaults.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-pick completed cleanly against the latest fetched upstream/release/v7.5.11. Verified the delta contains only the two intended release validation templates, git diff --check passes, tracked files contain no conflict markers, Prettier 3.6.2 parses both changed YAML files successfully, and the worktree is clean.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

This changes release validation pipelines for framework-dependent packages and global tools across release builds. The change is narrowly scoped to two template invocations and was validated for YAML syntax and exact diff content, but pipeline changes can affect release validation on multiple platforms.
