### PR TITLE
[release/v7.6.6] Fix install dotnet for non early access release

### DIFF
--- a/.pipelines/templates/release-validate-fxdpackages.yml
+++ b/.pipelines/templates/release-validate-fxdpackages.yml
@@ -62,6 +62,10 @@ jobs:
     - checkout: self
       clean: true
 
+    - template: /.pipelines/templates/SetVersionVariables.yml@self
+      parameters:
+        ReleaseTagVar: $(ReleaseTagVar)
+
     - template: release-SetReleaseTagandContainerName.yml@self
 
     - download: PSPackagesOfficial
@@ -80,7 +84,8 @@ jobs:
     - template: /.pipelines/templates/install-dotnet.yml@self
       parameters:
         architecture: ${{ parameters.dotnetArch }}
-        ob_restore_phase: false
+        ${{ if eq(parameters.IsEarlyAccess, true) }}:
+          ob_restore_phase: false
 
     - pwsh: |
         $artifactName = '$(artifactName)'

--- a/.pipelines/templates/release-validate-globaltools.yml
+++ b/.pipelines/templates/release-validate-globaltools.yml
@@ -49,6 +49,10 @@ jobs:
     - checkout: self
       clean: true
 
+    - template: /.pipelines/templates/SetVersionVariables.yml@self
+      parameters:
+        ReleaseTagVar: $(ReleaseTagVar)
+
     - template: release-SetReleaseTagandContainerName.yml@self
 
     - download: PSPackagesOfficial
@@ -66,7 +70,8 @@ jobs:
     - template: /.pipelines/templates/install-dotnet.yml@self
       parameters:
         architecture: ${{ parameters.dotnetArch }}
-        ob_restore_phase: false
+        ${{ if eq(parameters.IsEarlyAccess, true) }}:
+          ob_restore_phase: false
 
     - pwsh: |
         $repoRoot = "$(Build.SourcesDirectory)/PowerShell"


### PR DESCRIPTION
Backport of #27892 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27892$$$
-->

Triggered by @adityapatwardhan on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Corrects the release validation pipelines so non-early-access builds install .NET without forcing the early-access restore phase, while ensuring release version variables are initialized before package and global-tool validation.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-picked cleanly onto the latest upstream release/v7.6.6. Verified the worktree is clean, git diff --check passes, the commit changes only the two intended release-validation YAML templates, and .pipelines/templates/SetVersionVariables.yml exists on the target branch. The affected Azure Pipelines release-validation jobs require CI for end-to-end execution.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk because the change modifies shared release validation pipeline templates used for framework-dependent packages and global tools. The diff is narrowly scoped to version-variable initialization and conditional .NET installation parameters, and it matches the merged master change without conflict adaptations.
