### PR TITLE
[release/v7.6.6] Localized file check-in by OneLocBuild Task: Build definition ID 13420: Build ID 2661935

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/resources/fr/ServiceResources.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/fr/ServiceResources.fr.resx
@@ -127,10 +127,10 @@
     <value>Nous ne pouvons pas trouver un service avec le nom d’affichage « {1} ».</value>
   </data>
   <data name="ServiceHasDependentServices" xml:space="preserve">
-    <value>Nous ne pouvons pas arrêter le service « {1} ({0}) », car il a des services dépendants. Il ne peut être arrêté que si l’indicateur Force est défini.</value>
+    <value>Nouss ne pouvons pas arrêter le service « {1} ({0}) », car il a des services dépendants. Il ne peut être arrêté que si l’indicateur Force est défini.</value>
   </data>
   <data name="ServiceHasDependentServicesNoForce" xml:space="preserve">
-    <value>Nous ne pouvons pas arrêter le service « {1} ({0}) », car il a des services dépendants.</value>
+    <value>Nouss ne pouvons pas arrêter le service « {1} ({0}) », car il a des services dépendants.</value>
   </data>
   <data name="CouldNotStopService" xml:space="preserve">
     <value>Nous ne pouvons pas arrêter le service « {1} ({0}) » en raison de l’erreur suivante : {2}</value>
@@ -181,7 +181,7 @@
     <value>Nous ne pouvons pas supprimer le service « {1} ({0}) » en raison de l’erreur suivante : {2}</value>
   </data>
   <data name="CouldNotAccessDependentServices" xml:space="preserve">
-    <value>Nous ne pouvons pas accéder aux services dépendants de « {1} ({0}) »</value>
+    <value>« Nous ne pouvons pas accéder aux services dépendants de « {1} ({0}) »</value>
   </data>
   <data name="StartingService" xml:space="preserve">
     <value>Attente de le début du service. « {1} ({0}) »...</value>

--- a/src/System.Management.Automation/resources/fr/FormatAndOutXmlLoadingStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/FormatAndOutXmlLoadingStrings.fr.resx
@@ -208,7 +208,7 @@
     <value>Erreur XPath {0} dans le fichier {1} : La chaîne de caractères {2} de la ressource {3} dans l'assembly {4} est introuvable.</value>
   </data>
   <data name="ResourceNotFound" xml:space="preserve">
-    <value>Erreur XPath {0} dans le fichier {1} : La ressource {2} dans l'assembly {3} est introuvable.</value>
+    <value>Erreur XPath {0} dans le fichier {1} : La chaîne de caractères {2} de la ressource {3} dans l'assembly est introuvable.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
     <value>Erreur XPath {0} dans le fichier {1} : l'assembly {2} est introuvable.</value>
@@ -292,16 +292,16 @@
     <value>Erreur lors de la mise en forme des données «{0}» : {1}</value>
   </data>
   <data name="IncorrectHeaderItemCountInFormattingData" xml:space="preserve">
-    <value>Erreur dans les données d’affichage avec le nom de type {0} à l’index {1}: le nombre d’éléments d’en-tête = {2} ne correspond pas au nombre d’éléments de ligne par défaut = {3}.</value>
+    <value>Erreur dans les données d’affichage avec le nom de type {0} à l’index {1} : le nombre d’éléments d’en-tête = {2} ne correspond pas au nombre d’éléments de ligne par défaut = {3}.</value>
   </data>
   <data name="InvalidFormattingData" xml:space="preserve">
-    <value>Erreur dans les données d’affichage avec le nom de type {0} à l’index {1}: les données de mise en forme «{2}» ne sont pas valides.</value>
+    <value>Erreur dans les données d’affichage avec le nom de type {0} à l’index {1} : le bloc de script «{2}» n’est pas valide.</value>
   </data>
   <data name="InvalidScriptBlockInFormattingData" xml:space="preserve">
     <value>Erreur dans les données d’affichage avec le nom de type {0} à l’index {1}: le bloc de script «{2}» n’est pas valide.</value>
   </data>
   <data name="LoadTagFailedInFormattingData" xml:space="preserve">
-    <value>Erreur dans les données d’affichage avec le nom de type {0} à l’index {1}: échec du chargement de {2}.</value>
+    <value>Erreur dans les données d’affichage avec le nom de type {0} à l’index {1}: échec du chargement de {2} .</value>
   </data>
   <data name="MultipleRowEntriesFoundInFormattingData" xml:space="preserve">
     <value>Erreur lors de l'affichage des données avec le nom {0} de type à l'index {1} : Un TableControl ne doit contenir qu'un seul {2}.</value>

--- a/src/System.Management.Automation/resources/it/CmdletizationCoreResources.it.resx
+++ b/src/System.Management.Automation/resources/it/CmdletizationCoreResources.it.resx
@@ -163,7 +163,7 @@
 {2} is a placeholder for a name of a property of ParameterAttribute class. Example: ValueFromPipelineByPropertyName </comment>
   </data>
   <data name="ScriptWriter_ParameterNameConflictsWithCommonParameters" xml:space="preserve">
-    <value>Non è possibile definire il parametro {0} per il cmdlet {1}.  Il nome del parametro è già definito dalla classe {2}.  Modificare il nome del parametro in Cmdlet Definition XML e riprovare.</value>
+    <value>Non è possibile definire il parametro {0} per il cmdlet {1}.  Il nome del parametro è già definito dalla classe {2}.  Modificare il nome del parametro in mdlet Definition XML e riprovare.</value>
     <comment>{0} is a placeholder for a cmdlet parameter name.  Example: 'ProcessId'
 {1} is a placeholder for a cmdlet name. Example: 'Get-Win32Process'
 {2} is a placeholder for a .NET class name.  Example: 'Microsoft.PowerShell.Cmdletization.Cim.CimWrapper'</comment>

--- a/src/System.Management.Automation/resources/it/MshSnapinInfo.it.resx
+++ b/src/System.Management.Automation/resources/it/MshSnapinInfo.it.resx
@@ -145,7 +145,7 @@
     <value>Non è possibile trovare le informazioni necessarie nel Registro di sistema oppure mancano i file delle chiavi.  Non è possibile caricare alcuni cmdlet.</value>
   </data>
   <data name="NoMshSnapinPresentForVersion" xml:space="preserve">
-    <value>Non sono stati registrati snap-in per la versione {0} di PowerShell.</value>
+    <value>Non sono stati registrati snap-in per la versione {0}di PowerShell.</value>
   </data>
   <data name="ResourceReaderDisposed" xml:space="preserve">
     <value>Non è possibile recuperare la risorsa stringa perché è stato eliminato il lettore.</value>

--- a/src/System.Management.Automation/resources/pl/TypesXmlStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/TypesXmlStrings.pl.resx
@@ -169,7 +169,7 @@
     <value>Następująca nazwa elementu członkowskiego jest zarezerwowana: {0}</value>
   </data>
   <data name="Exception" xml:space="preserve">
-    <value>Wyjątek: {0}</value>
+    <value>Wyjątek:{0}</value>
   </data>
   <data name="ScriptPropertyShouldHaveGetterOrSetter" xml:space="preserve">
     <value>Właściwość ScriptProperty powinna mieć metodę pobierającą lub ustawiającą.</value>
@@ -205,7 +205,7 @@
     <value>{0}, {1}: plik został pominięty z powodu następującego wyjątku walidacji: {2}.</value>
   </data>
   <data name="MemberShouldBeNote" xml:space="preserve">
-    <value>Element członkowski „{0}” musi być notatką.</value>
+    <value>Element członkowski „{0}”" musi być notatką.</value>
   </data>
   <data name="ErrorConvertingNote" xml:space="preserve">
     <value>Nie można przekonwertować notatki „{0}” na „{1}”.</value>


### PR DESCRIPTION
Backport of #27766 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27766$$$
-->

Triggered by @SeeminglyScience on behalf of @olprod

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Checks in localized resource files generated by the downstream localization pipeline (OneLocBuild), keeping the release branch's localized resources current.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Automated localization check-in; cherry-picked cleanly with no conflicts.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Automated localized resource file check-in from the OneLocBuild pipeline. No code behavior changes, only translated resource content.
