### PR TITLE
[release/v7.6.6] Localized file check-in by OneLocBuild Task: Build definition ID 13420: Build ID 2670960

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/resources/it/TimeZoneResources.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/it/TimeZoneResources.it.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleMatchingTimeZones" xml:space="preserve">
-    <value>Cannot set the local time zone because the name '{0}' resolves to multiple entries.</value>
+    <value>Non è possibile impostare il fuso orario locale perché il nome "{0}" corrisponde a più voci.</value>
   </data>
   <data name="TimeZoneNameNotFound" xml:space="preserve">
-    <value>The time zone name '{0}' was not found on the local computer.</value>
+    <value>Il nome del fuso orario "{0}" non è stato trovato nel computer locale.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/fr/GetRandomCommandStrings.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/fr/GetRandomCommandStrings.fr.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>'maxValue' doit être supérieur à zéro.</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>La valeur minimale ({0}) ne peut pas être supérieure ou égale à la valeur maximale ({1}).</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>'minValue' ne peut pas être supérieur à maxValue.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/EventingStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/EventingStrings.it.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>L'evento con identificatore di origine "{0}" non esiste.</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>L'evento con identificatore "{0}" non esiste.</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>La sottoscrizione evento con identificatore di origine"{0}" non esiste.</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>La sottoscrizione evento con identificatore"{0}" non esiste.</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>Sottoscrizione evento "{0}"</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>Evento "{0}"</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>È necessario specificare un'azione per gli eventi non inoltrati.</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>Annulla la sottoscrizione</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/SelectObjectStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/SelectObjectStrings.it.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RenamingMultipleResults" xml:space="preserve">
-    <value>Cannot rename multiple results.</value>
+    <value>Non è possibile rinominare più risultati.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>Property "{0}" cannot be found.</value>
+    <value>Non è possibile trovare la proprietà "{0}".</value>
   </data>
   <data name="MutlipleExpandProperties" xml:space="preserve">
-    <value>Multiple properties cannot be expanded.</value>
+    <value>Non è possibile espandere più proprietà.</value>
   </data>
   <data name="AlreadyExistingProperty" xml:space="preserve">
-    <value>The property cannot be processed because the property "{0}" already exists.</value>
+    <value>La proprietà non può essere elaborata perché la proprietà "{0}" esiste già.</value>
   </data>
   <data name="EmptyScriptBlockAndNoName" xml:space="preserve">
-    <value>A property is an empty script block and does not provide a name.</value>
+    <value>Una proprietà è un blocco di script vuoto e non fornisce un nome.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/StartSleepStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/StartSleepStrings.it.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>Il valore del parametro "-Duration" non deve superare "{0}", il valore specificato era "{1}".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/TestJsonCmdletStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/TestJsonCmdletStrings.it.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidJsonSchema" xml:space="preserve">
-    <value>Cannot parse the JSON schema.</value>
+    <value>Non è possibile analizzare lo schema JSON.</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Cannot parse the JSON.</value>
+    <value>Non è possibile analizzare il JSON.</value>
   </data>
   <data name="InvalidJsonAgainstSchemaDetailed" xml:space="preserve">
-    <value>The JSON is not valid with the schema: {0} at '{1}'</value>
+    <value>Il JSON non è valido rispetto allo schema: {0} in "{1}"</value>
   </data>
   <data name="JsonSchemaFileOpenFailure" xml:space="preserve">
-    <value>Can not open JSON schema file: {0}</value>
+    <value>Non è possibile aprire il file di schema JSON: {0}</value>
   </data>
   <data name="InvalidUriScheme" xml:space="preserve">
-    <value>URI scheme '{0}' is not supported. Only HTTP(S) and local file system URIs are allowed.</value>
+    <value>Lo schema URI "{0}" non è supportato. Sono consentiti solo URI HTTP(S) e del file system locale.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/cs/CommandLineParameterParserStrings.cs.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/cs/CommandLineParameterParserStrings.cs.resx
@@ -228,4 +228,13 @@ Platné formáty jsou:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>Pro parametr {0} je nutné zadat argument.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/de/CommandLineParameterParserStrings.de.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/de/CommandLineParameterParserStrings.de.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/es/CommandLineParameterParserStrings.es.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/es/CommandLineParameterParserStrings.es.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/fr/CommandLineParameterParserStrings.fr.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/fr/CommandLineParameterParserStrings.fr.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/it/CommandLineParameterParserStrings.it.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/it/CommandLineParameterParserStrings.it.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ja/CommandLineParameterParserStrings.ja.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ja/CommandLineParameterParserStrings.ja.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ko/CommandLineParameterParserStrings.ko.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ko/CommandLineParameterParserStrings.ko.resx
@@ -228,4 +228,13 @@
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>'{0}' 매개 변수에 제공할 인수가 필요합니다.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/pl/CommandLineParameterParserStrings.pl.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/pl/CommandLineParameterParserStrings.pl.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/pt-BR/CommandLineParameterParserStrings.pt-BR.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/pt-BR/CommandLineParameterParserStrings.pt-BR.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ru/CommandLineParameterParserStrings.ru.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ru/CommandLineParameterParserStrings.ru.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/tr/CommandLineParameterParserStrings.tr.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/tr/CommandLineParameterParserStrings.tr.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/CommandLineParameterParserStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/CommandLineParameterParserStrings.zh-Hans.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hant/CommandLineParameterParserStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hant/CommandLineParameterParserStrings.zh-Hant.resx
@@ -228,4 +228,13 @@ Valid formats are:
   <data name="MissingMandatoryArgument" xml:space="preserve">
     <value>An argument is required to be supplied to the '{0}' parameter.</value>
   </data>
+  <data name="FileOnlyEntryRequired" xml:space="preserve">
+    <value>The parameter "-File" is required by policy.</value>
+  </data>
+  <data name="FileOnlyEntryNoExitDisabled" xml:space="preserve">
+    <value>The parameter "-NoExit" is disallowed by policy.</value>
+  </data>
+  <data name="FileOnlyEntryServerMode" xml:space="preserve">
+    <value>Server mode is disallowed by policy.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/it/DotNetEventingStrings.it.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/it/DotNetEventingStrings.it.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>Richiesto numero non negativo.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>Il parametro ID deve essere compreso tra {0} e {1}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>Il numero totale dei parametri non deve superare {0}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>Il numero dei parametri di stringa non deve superare {0}.</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>Il delimitatore non può essere una stringa vuota.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/CredUI.it.resx
+++ b/src/System.Management.Automation/resources/it/CredUI.it.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request </value>
+    <value>Richiesta di credenziali di PowerShell </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials. </value>
+    <value>Immettere le credenziali. </value>
   </data>
   <data name="PromptForCredential_DefaultTarget" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>Immettere le credenziali.</value>
   </data>
   <data name="PromptForCredential_InvalidCaption" xml:space="preserve">
-    <value>The maximum length of the caption is {0} characters.</value>
+    <value>La lunghezza massima della didascalia è {0} caratteri.</value>
   </data>
   <data name="PromptForCredential_InvalidMessage" xml:space="preserve">
-    <value>The maximum length of the message is {0} characters.</value>
+    <value>La lunghezza massima del messaggio è {0} caratteri.</value>
   </data>
   <data name="PromptForCredential_InvalidUserName" xml:space="preserve">
-    <value>The maximum length of the UserName value is {0} characters.</value>
+    <value>La lunghezza massima del valore UserName è {0} caratteri.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/EventingResources.it.resx
+++ b/src/System.Management.Automation/resources/it/EventingResources.it.resx
@@ -118,24 +118,24 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NonVoidDelegateNotSupported" xml:space="preserve">
-    <value>Cannot register for the specified event. Events that require a return value are not supported.</value>
+    <value>Non è possibile registrarsi per l'evento specificato. Gli eventi che richiedono un valore restituito non sono supportati.</value>
   </data>
   <data name="CouldNotFindEvent" xml:space="preserve">
-    <value>Cannot register for the specified event. An event with the name '{0}' does not exist.</value>
+    <value>Non è possibile registrarsi per l'evento specificato. Un evento con il nome "{0}" non esiste.</value>
   </data>
   <data name="WinRTEventsNotSupported" xml:space="preserve">
-    <value>PowerShell cannot subscribe to Windows RT events.</value>
+    <value>PowerShell non può sottoscrivere eventi di Windows RT.</value>
   </data>
   <data name="ReservedIdentifier" xml:space="preserve">
-    <value>Cannot register for the specified event. The event source identifier '{0}' is reserved for the PowerShell engine.</value>
+    <value>Non è possibile registrarsi per l'evento specificato. L'identificatore dell'origine eventi "{0}" è riservato al motore di PowerShell.</value>
   </data>
   <data name="RemoteOperationNotSupported" xml:space="preserve">
-    <value>This operation is not supported on remote instances.</value>
+    <value>Questa operazione non è supportata nelle istanze remote.</value>
   </data>
   <data name="ActionAndForwardNotSupported" xml:space="preserve">
-    <value>The action is not supported when you are forwarding events.</value>
+    <value>L'azione non è supportata durante l'inoltro degli eventi.</value>
   </data>
   <data name="SubscriberExists" xml:space="preserve">
-    <value>Cannot subscribe to the specified event. A subscriber with the source identifier '{0}' already exists.</value>
+    <value>Non è possibile sottoscrivere l'evento specificato. Esiste già un sottoscrittore con l'identificatore di origine "{0}".</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/ExperimentalFeatureStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/ExperimentalFeatureStrings.it.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>Non è stata trovata alcuna funzionalità sperimentale corrispondente al nome "{0}".</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>L'attivazione e la disattivazione delle funzionalità sperimentali non hanno effetto fino al successivo avvio di PowerShell.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/GetErrorText.it.resx
+++ b/src/System.Management.Automation/resources/it/GetErrorText.it.resx
@@ -118,30 +118,30 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ResourceBaseNameFailure" xml:space="preserve">
-    <value>Cannot load a resource with base name "{0}".</value>
+    <value>Non è possibile caricare una risorsa con nome di base "{0}".</value>
   </data>
   <data name="ResourceIdFailure" xml:space="preserve">
-    <value>Cannot load a resource string with ID "{0}".</value>
+    <value>Non è possibile caricare una stringa di risorsa con ID "{0}".</value>
   </data>
   <data name="ActionPreferenceStop" xml:space="preserve">
-    <value>Running commands is prevented by Stop policy settings.</value>
+    <value>L'esecuzione dei comandi è impedita dalle impostazioni dei criteri di interruzione.</value>
   </data>
   <data name="AssemblyNotRegistered" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}" because an assembly was not registered.</value>
+    <value>Non è possibile recuperare il messaggio "{0}" "{1}" "{2}" perché un assembly non è stato registrato.</value>
   </data>
   <data name="BadTemplate" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}". A template string format is not valid in template string "{3}".</value>
+    <value>Non è possibile recuperare il messaggio "{0}" "{1}" "{2}". Il formato della stringa modello non è valido nella stringa modello "{3}".</value>
   </data>
   <data name="BlankTemplate" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}". A template string exists, but its value is empty or blank.</value>
+    <value>Non è possibile recuperare il messaggio "{0}" "{1}" "{2}". Esiste una stringa modello, ma il relativo valore è vuoto.</value>
   </data>
   <data name="PipelineStoppedException" xml:space="preserve">
-    <value>The pipeline has been stopped.</value>
+    <value>La pipeline è stata arrestata.</value>
   </data>
   <data name="ScriptCallDepthException" xml:space="preserve">
-    <value>The script failed due to call depth overflow.</value>
+    <value>Lo script non è riuscito a causa dell'overflow della profondità di chiamata.</value>
   </data>
   <data name="PipelineDepthException" xml:space="preserve">
-    <value>The pipeline failed due to call depth overflow.</value>
+    <value>La pipeline non è riuscita a causa dell'overflow della profondità di chiamata.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/PSConfigurationStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/PSConfigurationStrings.it.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell ha smesso di funzionare a causa di un problema di sicurezza: non è possibile leggere il file di configurazione: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/PSStyleStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/PSStyleStrings.it.resx
@@ -59,12 +59,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TextContainsContent" xml:space="preserve">
-    <value>The specified string contains printable content when it should only contain ANSI escape sequences: {0}</value>
+    <value>La stringa specificata presenta contenuto stampabile quando dovrebbe contenere solo sequenze di escape ANSI: {0}</value>
   </data>
   <data name="ProgressWidthTooSmall" xml:space="preserve">
-    <value>The MaxWidth for the Progress rendering must be at least 18 to render correctly.</value>
+    <value>MaxWidth per il rendering dello Stato deve essere almeno 18 per essere visualizzato correttamente.</value>
   </data>
   <data name="ExtensionNotStartingWithPeriod" xml:space="preserve">
-    <value>When adding or removing extensions, the extension must start with a period.</value>
+    <value>Quando si aggiungono o rimuovono estensioni, l'estensione deve iniziare con un punto.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/PSCommandStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/PSCommandStrings.zh-Hant.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ParameterRequiresCommand" xml:space="preserve">
-    <value>A command is required to add a parameter. A command must be added to {0} before adding a parameter.</value>
+    <value>需要命令才能新增參數。新增參數之前，必須先將命令新增至 {0}。</value>
   </data>
 </root>


### PR DESCRIPTION
Backport of #27802 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27802$$$
-->

Triggered by @SeeminglyScience on behalf of @olprod

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Checks in localized resource files generated by the downstream localization pipeline (OneLocBuild), keeping the release branch's localized resources current.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Automated localization check-in; cherry-picked cleanly with no conflicts.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Automated localized resource file check-in from the OneLocBuild pipeline. No code behavior changes, only translated resource content.
